### PR TITLE
correction of the torso file for missing name robot param

### DIFF
--- a/iCubNancy01/hardware/skin/torso-cfw2_can9-skin.xml
+++ b/iCubNancy01/hardware/skin/torso-cfw2_can9-skin.xml
@@ -3,9 +3,9 @@
 
 <devices robot="iCubNancy01" build="1"> 
   <device name="torso_skin" type="canBusSkin">
-      <params file="general.xml" >
+      <params file="general.xml" />
 
-	 
+	 <params robot="iCubNancy01" build="1" >
         <param name="canDeviceNum"> 9         </param>  
         <param name="skinCanIds">   7 8 9 10  </param>   
         <param name="period"> 10              </param>


### PR DESCRIPTION
Missing tag was causing yarprobotinterface to abort.