### PR TITLE
Updated legs, torso and head joints calibration offsets using the auto-calibrator

### DIFF
--- a/iCubGenova04/calibrators/head-calib.xml
+++ b/iCubGenova04/calibrators/head-calib.xml
@@ -28,7 +28,7 @@
         <param name="calibration5">         0           0           0           0            0          0           </param>        
         
         <param name="calibrationZero">      180.0       -180.0      180.0       180.0       45.0        45.0        </param>
-        <param name="calibrationDelta">     0.0         0.0         0.0         0.0         0.0         0.0         </param>
+        <param name="calibrationDelta">    -2.6         1.4         2.1         0.0         0.0         0.0         </param>
        
         <param name="startupPosition">      0.0         0.0         0.0         0.0         0.0         0.0         </param>        
         <param name="startupVelocity">      10          10          20.0        20.0        20.0        20.0        </param>        

--- a/iCubGenova04/calibrators/left_leg-calib.xml
+++ b/iCubGenova04/calibrators/left_leg-calib.xml
@@ -26,7 +26,7 @@
 <param name="calibration4">                       0.0            0.0        0.0          0.0         0.0       0.0         </param>
 <param name="calibration5">                       0.0            0.0        0.0          0.0         0.0       0.0         </param>
 <param name="calibrationZero">                    180.00         180.00     180.00       -180.00     -180.00   180.00      </param>
-<param name="calibrationDelta">                   -3             0           2              0       -3      2         </param>
+<param name="calibrationDelta">                   0.6           -5.5        0.2         -2.9         0.8      -0.9         </param>
 
 <param name="startupPosition">                    0              10          0            0           0         0           </param>
 <param name="startupVelocity">                    10.0           10.0       10.0         10.0        10.0      10.0        </param>

--- a/iCubGenova04/calibrators/right_leg-calib.xml
+++ b/iCubGenova04/calibrators/right_leg-calib.xml
@@ -27,7 +27,7 @@
 <param name="calibration4">                       0.0             0.0         0.0       0.0            0.0           0.0           </param>
 <param name="calibration5">                       0.0             0.0         0.0       0.0            0.0           0.0           </param>
 <param name="calibrationZero">                    -180.00         -180.00     -180.00   180.00         180.00        -180.00       </param>
-<param name="calibrationDelta">                   -2.2             -2        -3.1      -0.3           2.0          1.9           </param>
+<param name="calibrationDelta">                  -0.7            -5.0         4.4      -3.5           -1.2           1.5           </param>
 
 <param name="startupPosition">                    0               10           0         0              0             0             </param>
 <param name="startupVelocity">                    10.0            10.0        10.0      10.0           10.0          10.0          </param>

--- a/iCubGenova04/calibrators/torso-calib.xml
+++ b/iCubGenova04/calibrators/torso-calib.xml
@@ -28,7 +28,7 @@
 <param name="calibration4">                       0.0                     0.0                       0.0                                 </param>
 <param name="calibration5">                       0.0                     0.0                       0.0                                 </param>
 <param name="calibrationZero">                    180.00                  180.00                    180.00                              </param>
-<param name="calibrationDelta">                   0                         0                      0                               </param>
+<param name="calibrationDelta">                   1.7                    -0.6                      -1.7                               </param>
 
 <param name="startupPosition">                    0.0                     0.0                       0.0                                </param>
 <param name="startupVelocity">                    10.0                    10.0                      10.0                                </param>


### PR DESCRIPTION
The offsets were generated by a new automatic self-calibration tool and validated manually using a level, and following the usual procedure (http://wiki.icub.org/wiki/LegsFineCalibration,...).
For the record, the new self-calibration tool is using accelerometers measurements in a least-squares optimisation method, and is about to be released.