### PR TITLE
Update right_arm_calib to avoid pulley rewinding

### DIFF
--- a/iCubGenova04/calibrators/right_arm-calib.xml
+++ b/iCubGenova04/calibrators/right_arm-calib.xml
@@ -21,7 +21,7 @@
 <param name="calibration1">          0         0        0         0    1500    0      0     0     0     0     0     0     0      0      0     0 </param>
 <param name="calibration2">	     0         0        0         0      0     0      0     0     0  9102  9102  9102  9102   9102   9102  3640 </param>
 <param name="calibration3">       19711.1  40623.0   5855.08   4975.08   0  35438   55518   0     0    -1     1    -1     1     -1     1     -1 </param>
-<param name="calibration4">          0         0        0         0      0     0      0  1800  1720   255   510   255   508    237    483   750 </param>
+<param name="calibration4">          0         0        0         0      0     0      0  1800  1720   255   510   255   488    237    483   750 </param>
 <param name="calibration5">          0         0        0         0      0     0      0  2000  4090     0     0     5     0      0     10   170 </param>
 <param name="calibrationZero">     180.00    45.00   -180.00    180.00   90  180   -180     0     0     0     0     0     0      0      0     0 </param>
 <param name="calibrationDelta">      0        5         1        -2      0     0      0     0     0     0     0     0     0      0      0     0 </param>


### PR DESCRIPTION
This avoid the rewind of the right index distal pulley during calibration. This issue was due to a wrong reading of motor encoders (see https://github.com/robotology/icub-support/issues/418), thus this is a workaround to avoid https://github.com/robotology/icub-support/issues/447 .