### PR TITLE
Remove repetition of TORQUE_CONTROL parameters

### DIFF
--- a/iCubGenova02/hardware/motorControl/right_upper_arm-ems3-mc.xml
+++ b/iCubGenova02/hardware/motorControl/right_upper_arm-ems3-mc.xml
@@ -59,24 +59,6 @@
         <param name="filterType">      0          0          0          0     </param>     
         <param name="ktau">           -204     -481       -466       -500     </param>   
     </group>
-	
-    <group name="TORQUE_CONTROL">
-        <param name="controlLaw">    motor_pid_with_friction_v1 </param> 
-        <param name="controlUnits">  metric_units               </param> 
-        <param name="kp">             -50      -200       -250       -300     </param>       
-        <param name="kd">              0          0          0          0     </param>       
-        <param name="ki">              0          0          0          0     </param> 
-        <param name="maxOutput">    8000       8000       8000       8000     </param>       
-        <param name="maxInt">        500        500        500        500     </param>       
-        <param name="shift">           0          0          0          0     </param>       
-        <param name="ko">              0          0          0          0     </param>       
-        <param name="stictionUp">     -0.5       -0.2       -0.5       -2     </param>       
-        <param name="stictionDwn">     1.4        1          0.6        2     </param>       
-        <param name="kff">             1          1          1          1     </param>  
-        <param name="kbemf">     -0.0032    -0.0007    -0.0007    -0.0007     </param>            
-        <param name="filterType">      0          0          0          0     </param>     
-        <param name="ktau">           -204     -481       -466       -500     </param>   
-    </group>
     
     <group name="CURRENT_CONTROL">
         <param name="controlLaw">       2foc_feedback          </param> 


### PR DESCRIPTION
TORQUE_CONTROL parameters were set twice in iCubGenova02/hardware/motorControl/right_upper_arm-ems3-mc.xml. Would it be better if we keep only one set of parameters?