### PR TITLE
iCubLisboa01: increase right arm startup velocities

### DIFF
--- a/iCubLisboa01/calibrators/right_arm_calib.xml
+++ b/iCubLisboa01/calibrators/right_arm_calib.xml
@@ -16,7 +16,7 @@
 <param name="calibration2">               10.00         10.00         10.00         10.00         -20.00        10.00         10.00         100.00        </param>       
 <param name="calibration3">               425.50        513.13        2023.13       578.99        0.00          0.00          0.00          0.00          </param>       
 <param name="startupPosition">               -30           30            0             45            0             0             0             15            </param>       
-<param name="startupVelocity">               10            10            10            10            30            10            10            100           </param>       
+<param name="startupVelocity">               10            10            10            10            30            30            30            100           </param>       
 <param name="startupMaxPwm">                     120           120           120           120           0             0             0             0             </param>       
 <param name="startupPosThreshold">           2             2             2             2             2             2             90            90            </param>       
 </group>       


### PR DESCRIPTION
Increase right arm startup velocities to have the same values of the left arm.