### PR TITLE
iCubLisboa01: update j5 limit for both arms

### DIFF
--- a/iCubLisboa01/hardware/motorControl/icub_left_arm.xml
+++ b/iCubLisboa01/hardware/motorControl/icub_left_arm.xml
@@ -56,7 +56,7 @@
  
 <group name="LIMITS">        
 <param name="jntPosMin">          -95.5         0             -30           15            -90           -80           -20           0             </param>       
-<param name="jntPosMax">          10            160.8         75            106           90            25            25            60            </param>       
+<param name="jntPosMax">          10            160.8         75            106           90            15            25            60            </param>       
 <param name="motorOverloadCurrents">     7000          7000          7000          7000          500           800           800           800           </param>       
 <param name="motorPwmLimit">             1333          1333          1333          1333         1333          1333          1333          1333    </param>
 </group>       

--- a/iCubLisboa01/hardware/motorControl/icub_right_arm.xml
+++ b/iCubLisboa01/hardware/motorControl/icub_right_arm.xml
@@ -56,7 +56,7 @@
  
 <group name="LIMITS">        
 <param name="jntPosMin">          -95.5         0             -30           15            -90           -80           -20           0             </param>       
-<param name="jntPosMax">          10            161           75            106           90            25            25            60            </param>       
+<param name="jntPosMax">          10            161           75            106           90            15            25            60            </param>       
 <param name="motorOverloadCurrents">     7000          7000          7000          7000          500           800           800           800           </param>       
 <param name="motorPwmLimit">             1333          1333          1333          1333         1333          1333          1333          1333    </param>
 </group>       


### PR DESCRIPTION
Sorry @pattacini for the number of PRs today :)

This prevents the problem of affecting j6 when controlling j5 near the positive limit (wrist slipping, coupled joints).