### PR TITLE
Updated iCubGenova04 arms, legs, torso and neck joints calibration offsets

### DIFF
--- a/iCubGenova04/calibrators/head-calib.xml
+++ b/iCubGenova04/calibrators/head-calib.xml
@@ -16,8 +16,8 @@
             <param name="velocityHome">     10          10          10          10          10          10         </param>
         </group>
 
-        <!-- joint logical number               0           1           2           3           4           5           -->
-        <!-- joint name                         neck-pitch  neck-roll   neck-yaw    eyes-tilt   eyes-vers   eyes-verg   -->  <!-- j4 is right-eye, j5 is left-eye -->
+        <!-- joint logical number           0           1           2           3           4           5           -->
+        <!-- joint name                 neck-pitch  neck-roll   neck-yaw    eyes-tilt   eyes-vers   eyes-verg   -->  <!-- j4 is right-eye, j5 is left-eye -->
         <group name="CALIBRATION">
         <param name="calibrationType">      3           3           3           3           5           5           </param>
         <param name="calibration1">   	    0	        0           0	        0	    3000        3000	    </param>
@@ -28,7 +28,7 @@
         <param name="calibration5">         0           0           0           0            0          0           </param>        
         
         <param name="calibrationZero">      180.0       -180.0      180.0       180.0       0           0           </param>
-        <param name="calibrationDelta">    -1.0         1.2         3.3         -9.0        -5.0        -10.0       </param>
+        <param name="calibrationDelta">    -1.5         0           5.3        -9.0        -5.0        -10.0        </param>
        
         <param name="startupPosition">      0.0         0.0         0.0         0.0         0.0         0.0         </param>        
         <param name="startupVelocity">      10          10          20.0        20.0        20.0        20.0        </param>        

--- a/iCubGenova04/calibrators/head-calib.xml
+++ b/iCubGenova04/calibrators/head-calib.xml
@@ -28,7 +28,7 @@
         <param name="calibration5">         0           0           0           0            0          0           </param>        
         
         <param name="calibrationZero">      180.0       -180.0      180.0       180.0       0           0           </param>
-        <param name="calibrationDelta">    -1.5         0           5.3        -9.0        -5.0        -10.0        </param>
+        <param name="calibrationDelta">    -2.0         1.1         3.4        -9.0        -5.0        -10.0        </param>
        
         <param name="startupPosition">      0.0         0.0         0.0         0.0         0.0         0.0         </param>        
         <param name="startupVelocity">      10          10          20.0        20.0        20.0        20.0        </param>        

--- a/iCubGenova04/calibrators/left_arm-calib.xml
+++ b/iCubGenova04/calibrators/left_arm-calib.xml
@@ -20,10 +20,10 @@
 <param name="calibration1">           0   	 0          0          0        -1500     0      0     0     0     0     0     0     0      0      0     0 </param>
 <param name="calibration2">	      0          0          0          0	16384     0      0     0     0  9102  9102  9102  9102   9102   9102  3640 </param>
 <param name="calibration3">         30431.08  3135.14    6479.08     64526.92       0  5635    351     0     0    -1     1    -1     1     -1     1     -1 </param>
-<param name="calibration4">           0          0          0          0            0     0      0  2170   200   241   499   255   465    226    480  694 </param>
-<param name="calibration5">           0          0          0          0            0     0      0  2580  2372   46    22     16   10     33      0   135 </param>
+<param name="calibration4">           0          0          0          0            0     0      0  2170   200   241   499   255   465    226    485  694 </param>
+<param name="calibration5">           0          0          0          0            0     0      0  2580  2372   46    22     16   10     33      5   135 </param>
 <param name="calibrationZero">        -180.00    -315.00    180.00     -180.00      0  -180    180     0     0     0     0     0     0      0      0     0 </param>
-<param name="calibrationDelta">        -66.5      -10.4     -16.2        -1.8       0     0      0     0     0     0     0     0     0      0      0     0 </param>
+<param name="calibrationDelta">       -68.5      -11.0     -17.5      -0.8         0     0      0     0     0     0     0     0     0      0      0     0 </param>
                                                                                 
 <param name="startupPosition">        -35.97     29.97      0.06       50.00        0     0      0    25    65     0     0     0     0      0      0     0       </param>
 <param name="startupVelocity">        10.0       10.0       10.0       10.0        30    30     30    60    100   100   100   100    100   100    100  100       </param>

--- a/iCubGenova04/calibrators/left_leg-calib.xml
+++ b/iCubGenova04/calibrators/left_leg-calib.xml
@@ -26,7 +26,7 @@
 <param name="calibration4">                       0.0            0.0        0.0          0.0         0.0       0.0         </param>
 <param name="calibration5">                       0.0            0.0        0.0          0.0         0.0       0.0         </param>
 <param name="calibrationZero">                    180.00         180.00     180.00       -180.00     -180.00   180.00      </param>
-<param name="calibrationDelta">                   1.2           -5.6        1.8         -3.9         0.3      -2.5         </param>
+<param name="calibrationDelta">                   0.6           -5.4        1.2         -4.1         0.1      -2.2         </param>
 
 <param name="startupPosition">                    0              10          0            0           0         0           </param>
 <param name="startupVelocity">                    10.0           10.0       10.0         10.0        10.0      10.0        </param>

--- a/iCubGenova04/calibrators/left_leg-calib.xml
+++ b/iCubGenova04/calibrators/left_leg-calib.xml
@@ -11,7 +11,7 @@
 		</group>
 		
 <group name="HOME">
-<param name="positionHome">                       0.00           10.00       0.00         0.00        0.00      0.00        </param>
+<param name="positionHome">                       15.6            6.8       -1.4        -30.0       -14.4     -12.4        </param>
 <param name="velocityHome">                       10.00          10.00      10.00        10.00       10.00     10.00       </param>
 </group>
 
@@ -26,9 +26,9 @@
 <param name="calibration4">                       0.0            0.0        0.0          0.0         0.0       0.0         </param>
 <param name="calibration5">                       0.0            0.0        0.0          0.0         0.0       0.0         </param>
 <param name="calibrationZero">                    180.00         180.00     180.00       -180.00     -180.00   180.00      </param>
-<param name="calibrationDelta">                   0.6           -5.4        1.2         -4.1         0.1      -2.2         </param>
+<param name="calibrationDelta">                   0.4           -5.0        2.9         -3.9        -0.1      -3.5         </param>
 
-<param name="startupPosition">                    0              10          0            0           0         0           </param>
+<param name="startupPosition">                    15.6            6.8       -1.4        -30.0       -14.4     -12.4        </param>
 <param name="startupVelocity">                    10.0           10.0       10.0         10.0        10.0      10.0        </param>
 <param name="startupMaxPwm">                      1200           1200       1200         1200        1200      1200        </param>
 <param name="startupPosThreshold">                2              2          2            2           2         2           </param>

--- a/iCubGenova04/calibrators/right_arm-calib.xml
+++ b/iCubGenova04/calibrators/right_arm-calib.xml
@@ -20,11 +20,11 @@
 <param name="calibrationType">       3         3        3         3     5      3      3     7     7     6     6     6     6      6      6     6 </param>
 <param name="calibration1">          0         0        0         0    1500    0      0     0     0     0     0     0     0      0      0     0 </param>
 <param name="calibration2">	     0         0        0         0   16384     0      0     0     0  9102  9102  9102  9102   9102   9102  3640 </param>
-<param name="calibration3">       19711.1  40623.0   5855.08   4975.08   0  35438   55518   0     0    -1     1    -1     1     -1     1     -1 </param>
-<param name="calibration4">          0         0        0         0      0     0      0  1800  1720   255   495   255   488    237    483   750 </param>
-<param name="calibration5">          0         0        0         0      0     0      0  2000  4090     0     0     5     0      0     10   170 </param>
+<param name="calibration3">       21631.1  40063.0   5167.08   4975.08   0  35438   55518   0     0    -1     1    -1     1     -1     1     -1 </param>
+<param name="calibration4">          0         0        0         0      0     0      0  1800  1720   255   495   255   508    237    483   750 </param>
+<param name="calibration5">          0         0        0         0      0     0      0  2000  4090     0     0     5    5      0     10   170 </param>
 <param name="calibrationZero">     180.00    45.00   -180.00    180.00   0   180   -180     0     0     0     0     0     0      0      0     0 </param>
-<param name="calibrationDelta">    -16.0    -13.7     -12.0      -2.3    0    2.9   -34     0     0     0     0     0     0      0      0     0 </param>
+<param name="calibrationDelta">     2.2       -9.3       -17.2      -1.3    0    2.9    -34     0     0     0     0     0     0      0      0     0 </param>
 
 <param name="startupPosition">      -35       30        0        50      0     0      0    25    65     0     0     0      0      0     0     0     </param>
 <param name="startupVelocity">      10.0      10.0     10        10     30    30     30    60   100   100   100     100    100    100  100  100     </param>

--- a/iCubGenova04/calibrators/right_arm-calib.xml
+++ b/iCubGenova04/calibrators/right_arm-calib.xml
@@ -24,7 +24,7 @@
 <param name="calibration4">          0         0        0         0      0     0      0  1800  1720   255   495   255   508    237    483   750 </param>
 <param name="calibration5">          0         0        0         0      0     0      0  2000  4090     0     0     5    5      0     10   170 </param>
 <param name="calibrationZero">     180.00    45.00   -180.00    180.00   0   180   -180     0     0     0     0     0     0      0      0     0 </param>
-<param name="calibrationDelta">     2.2       -9.3       -17.2      -1.3    0    2.9    -34     0     0     0     0     0     0      0      0     0 </param>
+<param name="calibrationDelta">     2.2       -9.3       -17.2      -1.3    0    2.9    -17     0     0     0     0     0     0      0      0     0 </param>
 
 <param name="startupPosition">      -35       30        0        50      0     0      0    25    65     0     0     0      0      0     0     0     </param>
 <param name="startupVelocity">      10.0      10.0     10        10     30    30     30    60   100   100   100     100    100    100  100  100     </param>

--- a/iCubGenova04/calibrators/right_leg-calib.xml
+++ b/iCubGenova04/calibrators/right_leg-calib.xml
@@ -27,9 +27,8 @@
 <param name="calibration4">                       0.0             0.0         0.0       0.0            0.0           0.0           </param>
 <param name="calibration5">                       0.0             0.0         0.0       0.0            0.0           0.0           </param>
 <param name="calibrationZero">                    -180.00         -180.00     -180.00   180.00         180.00        -180.00       </param>
-<param name="calibrationDelta">                  -0.6            -5.5         6.4      -3.6           -1.2           1.1           </param>
-
-<param name="startupPosition">                    0               10           0         0              0             0             </param>
+<param name="calibrationDelta">                  -0.6            -5.3         5.8      -4.1           -2.3           1.4           </param>
+<param name="startupPosition">                    0               10          0         0              0             0             </param>
 <param name="startupVelocity">                    10.0            10.0        10.0      10.0           10.0          10.0          </param>
 <param name="startupMaxPwm">                      1200            1200        1200      1200           1200          1200          </param>
 <param name="startupPosThreshold">                2               2           2         2              2             2             </param>

--- a/iCubGenova04/calibrators/right_leg-calib.xml
+++ b/iCubGenova04/calibrators/right_leg-calib.xml
@@ -11,7 +11,7 @@
 		</group>
 
 <group name="HOME">
-<param name="positionHome">                       0.00            10.00        0.00      0.00           0.00          0.00          </param>
+<param name="positionHome">                       15.6            6.8         -1.40    -30.0          -14.4         -12.4          </param>
 <param name="velocityHome">                       10.00           10.00       10.00     10.00          10.00         10.00         </param>
 </group>
 
@@ -27,8 +27,8 @@
 <param name="calibration4">                       0.0             0.0         0.0       0.0            0.0           0.0           </param>
 <param name="calibration5">                       0.0             0.0         0.0       0.0            0.0           0.0           </param>
 <param name="calibrationZero">                    -180.00         -180.00     -180.00   180.00         180.00        -180.00       </param>
-<param name="calibrationDelta">                  -0.6            -5.3         5.8      -4.1           -2.3           1.4           </param>
-<param name="startupPosition">                    0               10          0         0              0             0             </param>
+<param name="calibrationDelta">                   0.5            -4.8         4.6      -2.7           -1.3           0.7           </param>
+<param name="startupPosition">                    15.6            6.8        -1.4      -30.0          -14.4         -12.4          </param>
 <param name="startupVelocity">                    10.0            10.0        10.0      10.0           10.0          10.0          </param>
 <param name="startupMaxPwm">                      1200            1200        1200      1200           1200          1200          </param>
 <param name="startupPosThreshold">                2               2           2         2              2             2             </param>

--- a/iCubGenova04/calibrators/torso-calib.xml
+++ b/iCubGenova04/calibrators/torso-calib.xml
@@ -28,8 +28,7 @@
 <param name="calibration4">                       0.0                     0.0                       0.0                                 </param>
 <param name="calibration5">                       0.0                     0.0                       0.0                                 </param>
 <param name="calibrationZero">                    180.00                  180.00                    180.00                              </param>
-<param name="calibrationDelta">                   0.9                    -0.4                      -1.9                                 </param>
-
+<param name="calibrationDelta">                   0.9                    -0.8                      -1.8                                 </param>
 <param name="startupPosition">                    0.0                     0.0                       0.0                                 </param>
 <param name="startupVelocity">                    10.0                    10.0                      10.0                                </param>
 <param name="startupMaxPwm">                      5500                    5500                      5500                                </param>

--- a/iCubGenova04/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
+++ b/iCubGenova04/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
@@ -13,7 +13,7 @@
 
     <group name="LIMITS">
         <param name="jntPosMax">                      85            85            70            0     </param>
-        <param name="jntPosMin">                     -30             0           -70         -100     </param>
+        <param name="jntPosMin">                     -30           -12           -70         -100     </param>
         <param name="jntVelMax">                    1000          1000          1000         1000     </param>
         <param name="motorNominalCurrents">         5000          5000          5000         5000     </param>
         <param name="motorPeakCurrents">            6000         10000          6000        10000     </param>
@@ -53,7 +53,7 @@
         <param name="controlUnits">  metric_units                              </param>
         <param name="pos_kp">            -1066.66     2066.66    -711.11    -1066.66 </param>
         <param name="pos_kd">             -100.00        0.00       0.00       0.00 </param>
-        <param name="pos_ki">           -11000.00    14000.00       0.00    1000.00 </param>
+        <param name="pos_ki">           -11000.00    14000.00       0.00    -1000.00 </param>
         <param name="pos_maxOutput">         8000        8000       8000       8000 </param>
         <param name="pos_maxInt">            1500        1500        750       1000 </param>
         <param name="pos_shift">                0           0          0          0 </param>

--- a/iCubGenova04/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
+++ b/iCubGenova04/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
@@ -15,7 +15,7 @@
     <group name="LIMITS">
         <!--                                    0             	1            2          3         -->
         <param name="jntPosMax">               85              85           70          0    </param>
-        <param name="jntPosMin">              -30               0          -70       -100    </param>
+        <param name="jntPosMin">              -30             -12          -70       -100    </param>
         <param name="motorNominalCurrents">  5000          5000          5000         5000     </param>
 	    <param name="motorPeakCurrents">     6000         10000          6000        10000     </param>
         <param name="motorOverloadCurrents"> 15000         15000         15000        15000     </param>


### PR DESCRIPTION
Calibrated all the offsets manually, using the level. Also fixed left knee position PID integration param and left and right hip roll joint limits.