### PR TITLE
Added fullscalePWM and ampsToSensor parameters to iCubRome02

### DIFF
--- a/iCubRome02/hardware/motorControl/icub_head.xml
+++ b/iCubRome02/hardware/motorControl/icub_head.xml
@@ -34,7 +34,8 @@
 <param name="AxisType">       "revolute"    "revolute"    "revolute"    "revolute"   "revolute"       "revolute"     </param>    
 <param name="Encoder">	-1951.29	-1951.29	-1399.46	-1093.33	-586.66	293.33							</param>
 <param name="Zeros">  	40	48	59.45	-46.4	47.35	8.96							</param>
-
+<param name="fullscalePWM"> 1333          1333          1333          1333          1333          1333          </param>
+<param name="ampsToSensor"> 1000.0        1000.0        1000.0        1000.0        1000.0        1000.0        </param>
 <param name="TorqueId">     0             0             0             0             0             0             </param>       
 <param name="TorqueChan">   0             0             0             0             0             0             </param>       
 <param name="TorqueMax">    0             0             0             0             0             0             </param>       

--- a/iCubRome02/hardware/motorControl/icub_left_arm.xml
+++ b/iCubRome02/hardware/motorControl/icub_left_arm.xml
@@ -34,7 +34,8 @@
 <param name="AxisType"> "revolute"           "revolute"             "revolute"           "revolute"      "revolute"       "revolute"      "revolute"        "revolute"    </param>   
 <param name="Encoder">	-11.375	-11.375	-11.375	-11.375	-706.67	-978.46	-978.46	5.5	</param>
 <param name="Zeros">  	-186	-322	11.257819104	-190	94	-20	-42	316.3636363636	</param>
-
+<param name="fullscalePWM">  800          800           800           800           1333          1333          1333          1333          </param>
+<param name="ampsToSensor">  1000.0       1000.0        1000.0        1000.0        1000.0        1000.0        1000.0        1000.0        </param>
 <param name="TorqueId">     0x0C                0x0C                   0x0C                 0x0C          0x0C             0                  0                 0         </param>       
 <param name="TorqueChan">   0                   1                       2                    3             4                0                  0                 0        </param>       
 <param name="TorqueMax">    8                   8                       8                    8             2                2                  2                 2        </param>       

--- a/iCubRome02/hardware/motorControl/icub_left_hand.xml
+++ b/iCubRome02/hardware/motorControl/icub_left_hand.xml
@@ -34,7 +34,8 @@
 <param name="AxisType">       "revolute"    "revolute"    "revolute"    "revolute"   "revolute"       "revolute"     "revolute"    "revolute"  </param>
 <param name="Encoder">	15.56	-2.78	-2.44	-2.58	-2.30	-2.67	-2.61	-2.21	</param>
 <param name="Zeros">  	13.50	-90.00	-180.00	-90.00	-191.30	-93.75	-180.00	-317.81	</param>
-     
+<param name="fullscalePWM"> 1333          1333          1333          1333          1333          1333          1333          1333          </param>
+<param name="ampsToSensor"> 1000.0        1000.0        1000.0        1000.0        1000.0        1000.0        1000.0        1000.0        </param>
 <param name="TorqueId">     0             0             0             0             0             0             0             0             </param>       
 <param name="TorqueChan">   0             0             0             0             0             0             0             0             </param>       
 <param name="TorqueMax">    0             0             0             0             0             0             0             0             </param>       

--- a/iCubRome02/hardware/motorControl/icub_right_arm.xml
+++ b/iCubRome02/hardware/motorControl/icub_right_arm.xml
@@ -34,7 +34,8 @@
 <param name="AxisType"> "revolute"           "revolute"             "revolute"           "revolute"     "revolute"       "revolute"       "revolute"        "revolute"    </param>   
 <param name="Encoder">	11.375	11.375	11.375	11.375	706.67	978.46	978.46	7.9166666667	</param>
 <param name="Zeros">  	182	35	232.742180896	173	94	-11	-42	184.4	</param>
-
+<param name="fullscalePWM"> 800           800           800           800           1333          1333          1333          1333          </param>
+<param name="ampsToSensor"> 1000.0        1000.0        1000.0        1000.0        1000.0        1000.0        1000.0        1000.0        </param> 
 <param name="TorqueId">     0x0C          0x0C          0x0C          0x0C          0x0C          0             0             0             </param>       
 <param name="TorqueChan">   0             1             2             3             4             0             0             0             </param>       
 <param name="TorqueMax">    8             8             8             8             2             2             2             2             </param>       

--- a/iCubRome02/hardware/motorControl/icub_right_hand.xml
+++ b/iCubRome02/hardware/motorControl/icub_right_hand.xml
@@ -34,7 +34,8 @@
 <param name="AxisType">       "revolute"    "revolute"    "revolute"    "revolute"   "revolute"       "revolute"     "revolute"    "revolute"  </param>
 <param name="Encoder">	18.83	-2.56	-2.75	-2.26	-2.64	-2.32	-2.56	-2.42	</param>
 <param name="Zeros">  	38.23	-97.83	-183.64	-112.17	-189.47	-107.66	-194.87	-309.92	</param>
-   
+<param name="fullscalePWM"> 1333          1333          1333          1333          1333          1333          1333          1333          </param>
+<param name="ampsToSensor"> 1000.0        1000.0        1000.0        1000.0        1000.0        1000.0        1000.0        1000.0        </param>
 <param name="TorqueId">     0             0             0             0             0             0             0             0             </param>       
 <param name="TorqueChan">   0             0             0             0             0             0             0             0             </param>       
 <param name="TorqueMax">    0             0             0             0             0             0             0             0             </param>       

--- a/iCubRome02/hardware/motorControl/icub_torso.xml
+++ b/iCubRome02/hardware/motorControl/icub_torso.xml
@@ -34,7 +34,8 @@
 <param name="AxisType">       "revolute"    "revolute" "revolute"   "null"          </param>   
 <param name="Encoder">	11.375	11.375	11.375	0			</param>
 <param name="Zeros">  	180	180	180	0			</param>
-
+<param name="fullscalePWM"> 800           800           800           800           </param>
+<param name="ampsToSensor"> 1000.0        1000.0        1000.0        1000.0        </param>
      
 <param name="TorqueId">     0x0C          0x0C          0x0C          0x0C          </param>       
 <param name="TorqueChan">   0             1             2             0             </param>       


### PR DESCRIPTION
We had to update iCubRome02 configuration after installing latest Yarp/iCub-main releases, as reported here: https://github.com/robotology/icub-support/issues/637
