### PR TITLE
Install all .ini and .xml files in the root folder of iCubGenova02 config files

### DIFF
--- a/iCubGenova02/CMakeLists.txt
+++ b/iCubGenova02/CMakeLists.txt
@@ -1,8 +1,10 @@
 set(appname iCubGenova02)
 
-set(scripts icub_all.xml yarprobotinterface.ini firmwareupdater.ini general.xml iKinGazeCtrl.ini icubEyes_ATIS.ini icubEyes_DVS.ini)
+file(GLOB xml ${CMAKE_CURRENT_SOURCE_DIR}/*.xml)
+file(GLOB ini ${CMAKE_CURRENT_SOURCE_DIR}/*.ini)
 
-yarp_install(FILES ${scripts} DESTINATION ${ICUBCONTRIB_ROBOTS_INSTALL_DIR}/${appname})
+yarp_install(FILES ${xml} DESTINATION ${ICUBCONTRIB_ROBOTS_INSTALL_DIR}/${appname})
+yarp_install(FILES ${ini} DESTINATION ${ICUBCONTRIB_ROBOTS_INSTALL_DIR}/${appname})
 yarp_install(DIRECTORY calibrators DESTINATION ${ICUBCONTRIB_ROBOTS_INSTALL_DIR}/${appname})  
 yarp_install(DIRECTORY cartesian DESTINATION ${ICUBCONTRIB_ROBOTS_INSTALL_DIR}/${appname})
 yarp_install(DIRECTORY wrappers DESTINATION ${ICUBCONTRIB_ROBOTS_INSTALL_DIR}/${appname})


### PR DESCRIPTION
Please refer to issue https://github.com/robotology/icub-support/issues/684 and to comment https://github.com/robotology/icub-support/issues/684#issuecomment-403755826.

This is not fixing a bug, but just changing the way new robot interface configuration files like `icub_all_inertials`, `icub_wbd_yoga` are handle by **CMake**. The changes in these config files need to be properly tracked and installed in the `ICUBCONTRIB_ROBOTS_INSTALL_DIR` folder, while it was done only for `icub_all.xml`.