### PR TITLE
iCubGenova02: Fixed typo in skinSpec xml file inclusions

### DIFF
--- a/iCubGenova02/hardware/skin/left_arm-eb2-j4_15-skin.xml
+++ b/iCubGenova02/hardware/skin/left_arm-eb2-j4_15-skin.xml
@@ -33,7 +33,7 @@
         <group name="patches">
             <param name="skinCanAddrsPatch2"> 14 13 12 11 10 9 8 </param> 
         </group>
-        <xi:include href="./left_arm-eb2-j4_15-SkinSpec.xml" />
+        <xi:include href="./left_arm-eb2-j4_15-skinSpec.xml" />
     </device>
 
   

--- a/iCubGenova02/hardware/skin/left_leg-eb10-skin.xml
+++ b/iCubGenova02/hardware/skin/left_leg-eb10-skin.xml
@@ -34,7 +34,7 @@
             <param name="skinCanAddrsPatch1"> 1 2 3 4 5 6 7 </param> 
             <param name="skinCanAddrsPatch2"> 13 12 8 9 10 11 </param> 
         </group>
-        <xi:include href="./left_leg-eb10-SkinSpec.xml" />
+        <xi:include href="./left_leg-eb10-skinSpec.xml" />
     </device>
 
   

--- a/iCubGenova02/hardware/skin/right_arm-eb4-j4_15-skin.xml
+++ b/iCubGenova02/hardware/skin/right_arm-eb4-j4_15-skin.xml
@@ -33,6 +33,6 @@
         <group name="patches">
             <param name="skinCanAddrsPatch2"> 14 13 12 11 10 9 8</param> 
         </group>
-        <xi:include href="./right_arm-eb4-j4_15-SkinSpec.xml" /> 
+        <xi:include href="./right_arm-eb4-j4_15-skinSpec.xml" /> 
     </device>  
 

--- a/iCubGenova02/hardware/skin/right_leg-eb11-skin.xml
+++ b/iCubGenova02/hardware/skin/right_leg-eb11-skin.xml
@@ -34,7 +34,7 @@
             <param name="skinCanAddrsPatch1"> 1 2 3 4 5 6 7 </param> 
             <param name="skinCanAddrsPatch2"> 13 12 8 9 10 11 </param> 
         </group>
-        <xi:include href="./right_leg-eb11-SkinSpec.xml" /> 
+        <xi:include href="./right_leg-eb11-skinSpec.xml" /> 
     </device>
 
   

--- a/iCubGenova02/hardware/skin/torso-eb22-skin.xml
+++ b/iCubGenova02/hardware/skin/torso-eb22-skin.xml
@@ -33,6 +33,6 @@
         <group name="patches">
             <param name="skinCanAddrsPatch1"> 7 8 9 10 </param> 
         </group>
-        <xi:include href="./torso-eb22-SkinSpec.xml" />
+        <xi:include href="./torso-eb22-skinSpec.xml" />
     </device>
 


### PR DESCRIPTION
Fixed typo in config file xxxx-skinSpec.xml inclusions, introduced by https://github.com/robotology/robots-configuration/pull/70.