### PR TITLE
Fix Gyroscopes full-scale configuration to get the expected default FS of 250 deg/s

### DIFF
--- a/iCubGenova02/hardware/inertials/left_arm-eb2-j4_15-inertials.xml
+++ b/iCubGenova02/hardware/inertials/left_arm-eb2-j4_15-inertials.xml
@@ -40,7 +40,7 @@
                                             eoas_accel_mtb_int      eoas_accel_mtb_int      eoas_accel_mtb_int      eoas_gyros_mtb_ext        
                     </param>
 
-                    <param name="location"> ETH:0                   ETH:0                     
+                    <param name="location"> ETH:0                   ETH:1                     
                                             CAN2:8                  CAN2:9                  CAN2:10                 CAN2:11              
                                             CAN2:12                 CAN2:13                 CAN2:14                 CAN2:14
                     </param>            

--- a/iCubGenova02/hardware/inertials/left_leg-eb10-inertials.xml
+++ b/iCubGenova02/hardware/inertials/left_leg-eb10-inertials.xml
@@ -42,7 +42,7 @@
                                             eoas_accel_mtb_int      eoas_accel_mtb_int      eoas_accel_mtb_int      eoas_accel_mtb_int           
                     </param>
 
-                    <param name="location"> ETH:0                   ETH:0                   CAN1:1             
+                    <param name="location"> ETH:0                   ETH:1                   CAN1:1             
                                             CAN1:2                  CAN1:3                  CAN1:4                  CAN1:5              
                                             CAN1:6                  CAN1:7                  CAN2:8                  CAN2:9              
                                             CAN2:10                 CAN2:11                 CAN2:13                 CAN2:12             

--- a/iCubGenova02/hardware/inertials/right_arm-eb4-j4_15-inertials.xml
+++ b/iCubGenova02/hardware/inertials/right_arm-eb4-j4_15-inertials.xml
@@ -40,7 +40,7 @@
                                             eoas_accel_mtb_int      eoas_accel_mtb_int      eoas_accel_mtb_int      eoas_gyros_mtb_ext        
                     </param>
 
-                    <param name="location"> ETH:0                   ETH:0                     
+                    <param name="location"> ETH:0                   ETH:1                     
                                             CAN2:8                  CAN2:9                  CAN2:10                 CAN2:11              
                                             CAN2:12                 CAN2:13                 CAN2:14                 CAN2:14
                     </param>            

--- a/iCubGenova02/hardware/inertials/right_leg-eb11-inertials.xml
+++ b/iCubGenova02/hardware/inertials/right_leg-eb11-inertials.xml
@@ -42,7 +42,7 @@
                                             eoas_accel_mtb_int      eoas_accel_mtb_int      eoas_accel_mtb_int      eoas_accel_mtb_int           
                     </param>
 
-                    <param name="location"> ETH:0                   ETH:0                   CAN1:1             
+                    <param name="location"> ETH:0                   ETH:1                   CAN1:1             
                                             CAN1:2                  CAN1:3                  CAN1:4                  CAN1:5              
                                             CAN1:6                  CAN1:7                  CAN2:8                  CAN2:9              
                                             CAN2:10                 CAN2:11                 CAN2:12                 CAN2:13             

--- a/iCubGenova04/hardware/inertials/left_leg-eb10-inertials.xml
+++ b/iCubGenova04/hardware/inertials/left_leg-eb10-inertials.xml
@@ -43,7 +43,7 @@
                                             eoas_accel_mtb_int      eoas_accel_mtb_int      eoas_accel_mtb_int      eoas_accel_mtb_int
                     </param>
 
-                    <param name="location"> ETH:0                   ETH:0                   CAN1:1
+                    <param name="location"> ETH:0                   ETH:1                   CAN1:1
                                             CAN1:2                  CAN1:3                  CAN1:4                  CAN1:5
                                             CAN1:6                  CAN1:7                  CAN2:8                  CAN2:9
                                             CAN2:10                 CAN2:11                 CAN2:13                 CAN2:12

--- a/iCubGenova04/hardware/inertials/left_leg-eb6-inertials.xml
+++ b/iCubGenova04/hardware/inertials/left_leg-eb6-inertials.xml
@@ -36,7 +36,7 @@
                     <param name="type">     eoas_gyros_st_l3g4200d
                     </param>
 
-                    <param name="location"> ETH:0
+                    <param name="location"> ETH:1
                     </param>
                 </group>
 

--- a/iCubGenova04/hardware/inertials/left_leg-eb7-inertials.xml
+++ b/iCubGenova04/hardware/inertials/left_leg-eb7-inertials.xml
@@ -36,7 +36,7 @@
                     <param name="type">     eoas_gyros_st_l3g4200d
                     </param>
 
-                    <param name="location"> ETH:0
+                    <param name="location"> ETH:1
                     </param>
                 </group>
 

--- a/iCubGenova04/hardware/inertials/right_leg-eb11-inertials.xml
+++ b/iCubGenova04/hardware/inertials/right_leg-eb11-inertials.xml
@@ -43,7 +43,7 @@
                                             eoas_accel_mtb_int      eoas_accel_mtb_int      eoas_accel_mtb_int      eoas_accel_mtb_int
                     </param>
 
-                    <param name="location"> ETH:0                   ETH:0                   CAN1:1
+                    <param name="location"> ETH:0                   ETH:1                   CAN1:1
                                             CAN1:2                  CAN1:3                  CAN1:4                  CAN1:5
                                             CAN1:6                  CAN1:7                  CAN2:8                  CAN2:9
                                             CAN2:10                 CAN2:11                 CAN2:12                 CAN2:13

--- a/iCubGenova04/hardware/inertials/right_leg-eb8-inertials.xml
+++ b/iCubGenova04/hardware/inertials/right_leg-eb8-inertials.xml
@@ -36,7 +36,7 @@
                     <param name="type">     eoas_gyros_st_l3g4200d
                     </param>
 
-                    <param name="location"> ETH:0
+                    <param name="location"> ETH:1
                     </param>
                 </group>
 

--- a/iCubGenova04/hardware/inertials/right_leg-eb9-inertials.xml
+++ b/iCubGenova04/hardware/inertials/right_leg-eb9-inertials.xml
@@ -36,7 +36,7 @@
                     <param name="type">     eoas_gyros_st_l3g4200d
                     </param>
 
-                    <param name="location"> ETH:0
+                    <param name="location"> ETH:1
                     </param>
                 </group>
 

--- a/iCubGenova04/hardware/inertials/torso-eb1-inertials.xml
+++ b/iCubGenova04/hardware/inertials/torso-eb1-inertials.xml
@@ -36,7 +36,7 @@
                     <param name="type">     eoas_gyros_st_l3g4200d
                     </param>
 
-                    <param name="location"> ETH:0
+                    <param name="location"> ETH:1
                     </param>
                 </group>
 

--- a/iCubGenova04/hardware/inertials/torso-eb3-inertials.xml
+++ b/iCubGenova04/hardware/inertials/torso-eb3-inertials.xml
@@ -36,7 +36,7 @@
                     <param name="type">     eoas_gyros_st_l3g4200d
                     </param>
 
-                    <param name="location"> ETH:0
+                    <param name="location"> ETH:1
                     </param>
                 </group>
 

--- a/iCubGenova04/hardware/inertials/waist-eb5-inertials.xml
+++ b/iCubGenova04/hardware/inertials/waist-eb5-inertials.xml
@@ -36,7 +36,7 @@
                     <param name="type">     eoas_gyros_st_l3g4200d
                     </param>
 
-                    <param name="location"> ETH:0
+                    <param name="location"> ETH:1
                     </param>
                 </group>
 


### PR DESCRIPTION
Fix Gyroscopes full-scale configuration through the parameter ETH:X in order to get the expected default FS = 250 deg/s.

| ETH | CTRL_REG4 FS1-FS0 | Full-scale |
| --- | --- | ---------- |
|  0  | 01  | 500 deg/s |
|  1  | 00  | 250 deg/s |
|  2  | 01  | 500 deg/s |
|  3  | 10  | 2000 deg/s |

Refer to [l3gd20 datasheet](https://www.st.com/resource/en/datasheet/l3gd20.pdf) and https://github.com/robotology/icub-main/pull/543#issuecomment-416299969.