### PR TITLE
Migrate configuration files motion control v4 to v5 erzelli02

### DIFF
--- a/iCubErzelli02/hardware/mechanicals/head-eb20-j0_1-mec.xml
+++ b/iCubErzelli02/hardware/mechanicals/head-eb20-j0_1-mec.xml
@@ -5,7 +5,7 @@
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="iCubErzelli02" build="1">
 
     <group name="GENERAL">
-        <param name="MotioncontrolVersion">  4 </param>
+        <param name="MotioncontrolVersion">  5 </param>
         <param name="Joints"> 2 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0              1           -->

--- a/iCubErzelli02/hardware/mechanicals/head-eb21-j2_5-mec.xml
+++ b/iCubErzelli02/hardware/mechanicals/head-eb21-j2_5-mec.xml
@@ -3,7 +3,7 @@
 
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="iCubErzelli02" build="1">
     <group name="GENERAL">
-        <param name="MotioncontrolVersion">  4 </param>
+        <param name="MotioncontrolVersion">  5 </param>
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0             1               2               3           -->

--- a/iCubErzelli02/hardware/mechanicals/left_arm-eb1-j0_3-mec.xml
+++ b/iCubErzelli02/hardware/mechanicals/left_arm-eb1-j0_3-mec.xml
@@ -3,7 +3,7 @@
 
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="iCubErzelli02" build="1">
     <group name="GENERAL">
-        <param name="MotioncontrolVersion">  4 </param>
+        <param name="MotioncontrolVersion">  5 </param>
         <param name="Joints"> 4 </param> 
         <param name="AxisMap">               0           1             2             3          </param>
         <param name="AxisName"> "l_shoulder_pitch" "l_shoulder_roll" "l_shoulder_yaw" "l_elbow" </param>

--- a/iCubErzelli02/hardware/mechanicals/left_arm-eb24-j4_7-mec.xml
+++ b/iCubErzelli02/hardware/mechanicals/left_arm-eb24-j4_7-mec.xml
@@ -3,7 +3,7 @@
  
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="iCubErzelli02" build="1">
     <group name="GENERAL">
-        <param name="MotioncontrolVersion">  4 </param>
+        <param name="MotioncontrolVersion">  5 </param>
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1              2              3           -->

--- a/iCubErzelli02/hardware/mechanicals/left_arm-eb25-j8_11-mec.xml
+++ b/iCubErzelli02/hardware/mechanicals/left_arm-eb25-j8_11-mec.xml
@@ -3,7 +3,7 @@
  
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="iCubErzelli02" build="1">
     <group name="GENERAL">
-        <param name="MotioncontrolVersion">  4 </param>
+        <param name="MotioncontrolVersion">  5 </param>
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                 2                3           -->

--- a/iCubErzelli02/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubErzelli02/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -3,7 +3,7 @@
  
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="iCubErzelli02" build="1">
     <group name="GENERAL">
-        <param name="MotioncontrolVersion">  4 </param>
+        <param name="MotioncontrolVersion">  5 </param>
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->

--- a/iCubErzelli02/hardware/mechanicals/left_leg-eb6-j0_3-mec.xml
+++ b/iCubErzelli02/hardware/mechanicals/left_leg-eb6-j0_3-mec.xml
@@ -3,7 +3,7 @@
 
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="iCubErzelli02" build="1">
     <group name="GENERAL">
-        <param name="MotioncontrolVersion">  4 </param>
+        <param name="MotioncontrolVersion">  5 </param>
         <param name="Joints"> 4 </param> 
         <param name="AxisMap">               0             1             2             3       </param>
         <param name="AxisName">     "l_hip_pitch"   "l_hip_roll"    "l_hip_yaw"   "l_knee"     </param>

--- a/iCubErzelli02/hardware/mechanicals/left_leg-eb7-j4_5-mec.xml
+++ b/iCubErzelli02/hardware/mechanicals/left_leg-eb7-j4_5-mec.xml
@@ -3,7 +3,7 @@
 
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="iCubErzelli02" build="1">
     <group name="GENERAL">
-        <param name="MotioncontrolVersion">  4 </param>
+        <param name="MotioncontrolVersion">  5 </param>
         <param name="Joints">  2  </param>  
         <param name="AxisMap">               0             1   </param>
         <param name="AxisName">   "l_ankle_pitch"  "l_ankle_roll"  </param>

--- a/iCubErzelli02/hardware/mechanicals/right_arm-eb27-j4_7-mec.xml
+++ b/iCubErzelli02/hardware/mechanicals/right_arm-eb27-j4_7-mec.xml
@@ -3,7 +3,7 @@
  
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="iCubErzelli02" build="1">
     <group name="GENERAL">
-        <param name="MotioncontrolVersion">  4 </param>
+        <param name="MotioncontrolVersion">  5 </param>
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1              2              3           -->

--- a/iCubErzelli02/hardware/mechanicals/right_arm-eb28-j8_11-mec.xml
+++ b/iCubErzelli02/hardware/mechanicals/right_arm-eb28-j8_11-mec.xml
@@ -3,7 +3,7 @@
  
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="iCubErzelli02" build="1">
     <group name="GENERAL">
-        <param name="MotioncontrolVersion">  4 </param>
+        <param name="MotioncontrolVersion">  5 </param>
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                 2                3           -->

--- a/iCubErzelli02/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubErzelli02/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -3,7 +3,7 @@
  
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="iCubErzelli02" build="1">
     <group name="GENERAL">
-        <param name="MotioncontrolVersion">  4 </param>
+        <param name="MotioncontrolVersion">  5 </param>
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->

--- a/iCubErzelli02/hardware/mechanicals/right_arm-eb3-j0_3-mec.xml
+++ b/iCubErzelli02/hardware/mechanicals/right_arm-eb3-j0_3-mec.xml
@@ -3,7 +3,7 @@
 
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="iCubErzelli02" build="1">
     <group name="GENERAL">
-        <param name="MotioncontrolVersion">  4 </param>
+        <param name="MotioncontrolVersion">  5 </param>
         <param name="Joints"> 4 </param> 
         <param name="AxisMap">               0           1             2             3          </param>
         <param name="AxisName"> "r_shoulder_pitch" "r_shoulder_roll" "r_shoulder_yaw" "r_elbow" </param>

--- a/iCubErzelli02/hardware/mechanicals/right_leg-eb8-j0_3-mec.xml
+++ b/iCubErzelli02/hardware/mechanicals/right_leg-eb8-j0_3-mec.xml
@@ -3,7 +3,7 @@
 
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="iCubErzelli02" build="1">
     <group name="GENERAL">
-        <param name="MotioncontrolVersion">  4 </param>
+        <param name="MotioncontrolVersion">  5 </param>
         <param name="Joints"> 4 </param> 
 
         <param name="AxisMap">               0             1             2             3   </param>

--- a/iCubErzelli02/hardware/mechanicals/right_leg-eb9-j4_5-mec.xml
+++ b/iCubErzelli02/hardware/mechanicals/right_leg-eb9-j4_5-mec.xml
@@ -3,7 +3,7 @@
 
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="iCubErzelli02" build="1">
     <group name="GENERAL">
-        <param name="MotioncontrolVersion">  4 </param>
+        <param name="MotioncontrolVersion">  5 </param>
         <param name="Joints">  2  </param>  
         <param name="AxisMap">               0             1       </param>
         <param name="AxisName">   "r_ankle_pitch"  "r_ankle_roll"  </param>

--- a/iCubErzelli02/hardware/mechanicals/torso-eb5-j0_2-mec.xml
+++ b/iCubErzelli02/hardware/mechanicals/torso-eb5-j0_2-mec.xml
@@ -3,7 +3,7 @@
 
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="iCubErzelli02" build="1">
     <group name="GENERAL">
-        <param name="MotioncontrolVersion">  4 </param>
+        <param name="MotioncontrolVersion">  5 </param>
         <param name="Joints"> 3 </param> 
         <param name="AxisMap">               2             0             1           </param>   
         <param name="AxisName">      "torso_yaw" "torso_roll" "torso_pitch"          </param>

--- a/iCubErzelli02/hardware/motorControl/head-eb20-j0_1-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/head-eb20-j0_1-mc.xml
@@ -45,7 +45,8 @@
     
         <group name="POS_PID_DEFAULT">
             <param name="controlLaw">       Pid_inPos_outPwm                </param>    
-            <param name="controlUnits">     metric_units                </param> 
+            <param name="fbkControlUnits">  machine_units   </param>
+            <param name="outputControlUnits">  machine_units      </param> 
             <param name="pos_kp">                 -300        +300        </param>       
             <param name="pos_kd">                 -10.0       +10.0       </param>     
             <param name="pos_ki">                 -100.0      +100        </param>          

--- a/iCubErzelli02/hardware/motorControl/head-eb20-j0_1-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/head-eb20-j0_1-mc.xml
@@ -45,7 +45,7 @@
     
         <group name="POS_PID_DEFAULT">
             <param name="controlLaw">       Pid_inPos_outPwm                </param>    
-            <param name="fbkControlUnits">  machine_units   </param>
+            <param name="fbkControlUnits">  metric_units   </param>
             <param name="outputControlUnits">  machine_units      </param> 
             <param name="pos_kp">                 -300        +300        </param>       
             <param name="pos_kd">                 -10.0       +10.0       </param>     

--- a/iCubErzelli02/hardware/motorControl/head-eb21-j2_5-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/head-eb21-j2_5-mc.xml
@@ -46,7 +46,8 @@
     
         <group name="POS_PID_DEFAULT">
 	        <param name="controlLaw">    Pid_inPos_outPwm </param> 
-            <param name="controlUnits">     metric_units                                        </param> 
+            <param name="fbkControlUnits">  machine_units   </param>
+            <param name="outputControlUnits">  machine_units      </param> 
             <param name="pos_kp">                    1100.00     -1000       3500        3500       </param>       
             <param name="pos_kd">                    0.0         0.0         0.0         0.0        </param>     
             <param name="pos_ki">                    0.0         -100         600.0       600.0      </param>          

--- a/iCubErzelli02/hardware/motorControl/head-eb21-j2_5-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/head-eb21-j2_5-mc.xml
@@ -46,7 +46,7 @@
     
         <group name="POS_PID_DEFAULT">
 	        <param name="controlLaw">    Pid_inPos_outPwm </param> 
-            <param name="fbkControlUnits">  machine_units   </param>
+            <param name="fbkControlUnits">  metric_units   </param>
             <param name="outputControlUnits">  machine_units      </param> 
             <param name="pos_kp">                    1100.00     -1000       3500        3500       </param>       
             <param name="pos_kd">                    0.0         0.0         0.0         0.0        </param>     

--- a/iCubErzelli02/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
@@ -68,12 +68,12 @@
         <param name="trq_maxInt">        500        500        500        500      </param>
         <param name="trq_shift">           0          0          0          0      </param>
         <param name="trq_ko">              0          0          0          0      </param>
-        <param name="trq_stictionUp">      0.5        0.5        1          1.7    </param>
-        <param name="trq_stictionDwn">    -0.7       -0.7       -0.8       -1.2    </param>
+        <param name="trq_stictionUp">0 0 0 0</param>
+        <param name="trq_stictionDwn">0 0 0 0</param>
         <param name="trq_kff">             1          1          1          1      </param>
-        <param name="trq_kbemf">        0.0030     0.0006     0.0007     0.0007    </param>
+        <param name="trq_kbemf">0 0 0 0</param>
         <param name="trq_filterType">      0          0          0          0      </param>
-        <param name="trq_ktau">          180        464        463        449      </param>
+        <param name="trq_ktau">0 0 0 0</param>
     </group>
 
     <group name="TRQ_PID_CUSTOM">
@@ -87,12 +87,12 @@
         <param name="trq_maxInt">        500        500        500        500      </param>
         <param name="trq_shift">           0          0          0          0      </param>
         <param name="trq_ko">              0          0          0          0      </param>
-        <param name="trq_stictionUp">      0.5        0.5        1          1.7    </param>
-        <param name="trq_stictionDwn">    -0.7       -0.7       -0.8       -1.2    </param>
+        <param name="trq_stictionUp">0 0 0 0</param>
+        <param name="trq_stictionDwn">0 0 0 0</param>
         <param name="trq_kff">             1          1          1          1      </param>
-        <param name="trq_kbemf">        0.0030     0.0006     0.0007     0.00       </param>
+        <param name="trq_kbemf">0 0 0 0</param>
         <param name="trq_filterType">      0          0          0          0      </param>
-        <param name="trq_ktau">          180        464        463        449      </param>
+        <param name="trq_ktau">0 0 0 0</param>
     </group>
 
    <group name="2FOC_CUR_CONTROL">

--- a/iCubErzelli02/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
@@ -43,7 +43,7 @@
 
 	<group name="POS_PID_DEFAULT">
 	    <param name="controlLaw">    Pid_inPos_outPwm </param>
-        <param name="fbkControlUnits">  machine_units   </param>
+        <param name="fbkControlUnits">  metric_units   </param>
         <param name="outputControlUnits">  machine_units      </param>
         <param name="pos_kp">           711.11    1066.66     711.11    1066.66</param>
         <param name="pos_kd">             0.00       0.00       0.00       0.00</param>

--- a/iCubErzelli02/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
@@ -43,7 +43,8 @@
 
 	<group name="POS_PID_DEFAULT">
 	    <param name="controlLaw">    Pid_inPos_outPwm </param>
-        <param name="controlUnits">  metric_units               </param>
+        <param name="fbkControlUnits">  machine_units   </param>
+        <param name="outputControlUnits">  machine_units      </param>
         <param name="pos_kp">           711.11    1066.66     711.11    1066.66</param>
         <param name="pos_kd">             0.00       0.00       0.00       0.00</param>
         <param name="pos_ki">          7111.09   10666.64    7111.09   10666.64</param>
@@ -58,7 +59,8 @@
 
     <group name="TRQ_PID_DEFAULT">
         <param name="controlLaw">    Pid_inTrq_outPwm </param>
-        <param name="controlUnits">  metric_units               </param>
+        <param name="fbkControlUnits">  machine_units   </param>
+        <param name="outputControlUnits">  machine_units      </param>
         <param name="trq_kp">            200        200        250        300      </param>
         <param name="trq_kd">              0          0          0          0      </param>
         <param name="trq_ki">              0          0          0          0      </param>
@@ -94,7 +96,8 @@
 
    <group name="2FOC_CUR_CONTROL">
         <param name="controlLaw">       limitscurrent          </param>
-        <param name="controlUnits">     metric_units           </param>
+        <param name="fbkControlUnits">  machine_units   </param>
+        <param name="outputControlUnits">  machine_units      </param>
         <param name="cur_kp">              8           8          8         8     </param>
         <param name="cur_kd">              0           0          0         0     </param>
         <param name="cur_ki">              2           2          2         2     </param>

--- a/iCubErzelli02/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
@@ -78,7 +78,8 @@
 
     <group name="TRQ_PID_CUSTOM">
         <param name="controlLaw">    Pid_inTrq_outPwm </param>
-        <param name="controlUnits">  metric_units               </param>
+        <param name="fbkControlUnits">  machine_units   </param>
+        <param name="outputControlUnits">  machine_units      </param>
         <param name="trq_kp">            200        200        250        300      </param>
         <param name="trq_kd">              0          0          0          0      </param>
         <param name="trq_ki">              0          0          0          0      </param>

--- a/iCubErzelli02/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
@@ -68,12 +68,12 @@
             <param name="trq_maxInt">        500           0           0           0      </param>
             <param name="trq_shift">           0           0           0           0      </param>
             <param name="trq_ko">              0           0           0           0      </param>
-            <param name="trq_stictionUp">      0           0           0           0      </param>
-            <param name="trq_stictionDwn">     0           0           0           0      </param>
+            <param name="trq_stictionUp">0 0 0 0</param>
+            <param name="trq_stictionDwn">0 0 0 0</param>
             <param name="trq_kff">             0           0           0           0      </param>
-            <param name="trq_kbemf">           0           0           0           0      </param>
+            <param name="trq_kbemf">0 0 0 0</param>
             <param name="trq_filterType">      0           0           0           0      </param>
-            <param name="trq_ktau">            1           0           0           0      </param>
+            <param name="trq_ktau">0 0 0 0</param>
         </group>
 
     </device>

--- a/iCubErzelli02/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
@@ -43,7 +43,8 @@
         <!-- ATTENTION: PID VALUES are not safe!!! -->
         <group name="POS_PID_DEFAULT">
             <param name="controlLaw">       Pid_inPos_outPwm                          </param>
-            <param name="controlUnits">     metric_units                                         </param>
+            <param name="fbkControlUnits">  machine_units   </param>
+            <param name="outputControlUnits">  machine_units      </param>
             <param name="pos_kp">              -200.0     -500.0      -500.0      -500.0      </param>
             <param name="pos_kd">                 0.0        0.0         0.0         0.0      </param>
             <param name="pos_ki">              -200.0      -50.0       -50.0       -50.0      </param>
@@ -58,7 +59,8 @@
 
         <group name="TRQ_PID_DEFAULT">
             <param name="controlLaw">    Pid_inTrq_outPwm </param>
-            <param name="controlUnits">  metric_units                   </param>
+            <param name="fbkControlUnits">  machine_units   </param>
+            <param name="outputControlUnits">  machine_units      </param>
             <param name="trq_kp">          -1000           0           0           0      </param>
             <param name="trq_kd">              0           0           0           0      </param>
             <param name="trq_ki">              0           0           0           0      </param>

--- a/iCubErzelli02/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
@@ -43,7 +43,7 @@
         <!-- ATTENTION: PID VALUES are not safe!!! -->
         <group name="POS_PID_DEFAULT">
             <param name="controlLaw">       Pid_inPos_outPwm                          </param>
-            <param name="fbkControlUnits">  machine_units   </param>
+            <param name="fbkControlUnits">  metric_units   </param>
             <param name="outputControlUnits">  machine_units      </param>
             <param name="pos_kp">              -200.0     -500.0      -500.0      -500.0      </param>
             <param name="pos_kd">                 0.0        0.0         0.0         0.0      </param>

--- a/iCubErzelli02/hardware/motorControl/left_arm-eb25-j8_11-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/left_arm-eb25-j8_11-mc.xml
@@ -43,7 +43,8 @@
 
 	<group name="POS_PID_DEFAULT">
 	    <param name="controlLaw">    Pid_inPos_outPwm                          </param> 
-            <param name="controlUnits">     metric_units                                      </param> 
+            <param name="fbkControlUnits">  machine_units   </param>
+            <param name="outputControlUnits">  machine_units      </param> 
             <param name="pos_kp">               -500.0       500.0       500.0       500.0    </param>      
             <param name="pos_kd">                  0.0         0.0         0.0         0.0    </param>     
             <param name="pos_ki">                -50.0        50.0        50.0        50.0    </param>       

--- a/iCubErzelli02/hardware/motorControl/left_arm-eb25-j8_11-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/left_arm-eb25-j8_11-mc.xml
@@ -43,7 +43,7 @@
 
 	<group name="POS_PID_DEFAULT">
 	    <param name="controlLaw">    Pid_inPos_outPwm                          </param> 
-            <param name="fbkControlUnits">  machine_units   </param>
+            <param name="fbkControlUnits">  metric_units   </param>
             <param name="outputControlUnits">  machine_units      </param> 
             <param name="pos_kp">               -500.0       500.0       500.0       500.0    </param>      
             <param name="pos_kd">                  0.0         0.0         0.0         0.0    </param>     

--- a/iCubErzelli02/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
@@ -43,7 +43,8 @@
 
 	    <group name="POS_PID_DEFAULT">
 	        <param name="controlLaw">    Pid_inPos_outPwm                          </param> 
-            <param name="controlUnits">     metric_units                                        </param> 
+            <param name="fbkControlUnits">  machine_units   </param>
+            <param name="outputControlUnits">  machine_units      </param> 
             <param name="pos_kp">                  -500.0       500.0       500.0      -200.0       </param>
             <param name="pos_kd">                   0.0         0.0         0.0         0.0         </param>      
             <param name="pos_ki">                  -50.0        50.0        50.0       -20.0        </param>        

--- a/iCubErzelli02/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
@@ -43,7 +43,7 @@
 
 	    <group name="POS_PID_DEFAULT">
 	        <param name="controlLaw">    Pid_inPos_outPwm                          </param> 
-            <param name="fbkControlUnits">  machine_units   </param>
+            <param name="fbkControlUnits">  metric_units   </param>
             <param name="outputControlUnits">  machine_units      </param> 
             <param name="pos_kp">                  -500.0       500.0       500.0      -200.0       </param>
             <param name="pos_kd">                   0.0         0.0         0.0         0.0         </param>      

--- a/iCubErzelli02/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
@@ -81,12 +81,12 @@
         <param name="trq_maxInt">        500        500        500        500     </param>
         <param name="trq_shift">           0          0          0          0     </param>
         <param name="trq_ko">              0          0          0          0     </param>
-        <param name="trq_stictionUp">     -2.0        2.0       -1.0       -1.0   </param>
-        <param name="trq_stictionDwn">     1.4       -2.0        1.3        0.2   </param>
+        <param name="trq_stictionUp">0 0 0 0</param>
+        <param name="trq_stictionDwn">0 0 0 0</param>
         <param name="trq_kff">             1          1          1          1     </param>
-        <param name="trq_kbemf">           0          0          0          0     </param>
+        <param name="trq_kbemf">0 0 0 0</param>
         <param name="trq_filterType">      0          0          0          0     </param>
-        <param name="trq_ktau">         -162        178       -197       -167     </param>
+        <param name="trq_ktau">0 0 0 0</param>
     </group>
 
     <group name="2FOC_CUR_CONTROL">

--- a/iCubErzelli02/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
@@ -35,7 +35,8 @@
 
     <group name="POS_PID_DEFAULT">
     <param name="controlLaw">    Pid_inPos_outPwm                          </param>
-      <param name="controlUnits">  metric_units                              </param>
+      <param name="fbkControlUnits">  machine_units   </param>
+      <param name="outputControlUnits">  machine_units      </param>
       <param name="pos_kp">            -1066.66     2066.66    -711.11    -1066.66 </param>
       <param name="pos_kd">                0.00        0.00       0.00       0.00 </param>
       <param name="pos_ki">           -10666.64    14222.18   -7111.09    -1066.64 </param>
@@ -70,7 +71,8 @@
 
     <group name="TRQ_PID_DEFAULT">
         <param name="controlLaw">    Pid_inTrq_outPwm                         </param>
-        <param name="controlUnits">  metric_units                             </param>
+        <param name="fbkControlUnits">  machine_units   </param>
+        <param name="outputControlUnits">  machine_units      </param>
         <param name="trq_kp">           -200        200          0       -200     </param>      <!--        -200        200       -200        200      -->
         <param name="trq_kd">              0          0          0          0     </param>
         <param name="trq_ki">              0          0          0          0     </param>
@@ -88,7 +90,8 @@
 
     <group name="2FOC_CUR_CONTROL">
         <param name="controlLaw">       limitscurrent          </param>
-        <param name="controlUnits">     metric_units           </param>
+        <param name="fbkControlUnits">  machine_units   </param>
+        <param name="outputControlUnits">  machine_units      </param>
         <param name="cur_kp">               8           8          8         8      </param>
         <param name="cur_kd">               0           0          0         0      </param>
         <param name="cur_ki">               2           2          2         2      </param>

--- a/iCubErzelli02/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
@@ -35,7 +35,7 @@
 
     <group name="POS_PID_DEFAULT">
     <param name="controlLaw">    Pid_inPos_outPwm                          </param>
-      <param name="fbkControlUnits">  machine_units   </param>
+      <param name="fbkControlUnits">  metric_units   </param>
       <param name="outputControlUnits">  machine_units      </param>
       <param name="pos_kp">            -1066.66     2066.66    -711.11    -1066.66 </param>
       <param name="pos_kd">                0.00        0.00       0.00       0.00 </param>
@@ -51,7 +51,7 @@
 
 	<group name="POS_PID_CUSTOM">
 	    <param name="controlLaw">    Pid_inPos_outPwm                          </param>
-        <param name="fbkControlUnits">  machine_units   </param>
+        <param name="fbkControlUnits">  metric_units   </param>
         <param name="outputControlUnits">  machine_units      </param>
         <param name="pos_kp">            -1066.66     2066.66    -711.11    -1066.66 </param>
         <param name="pos_kd">             -100.00        0.00       0.00       0.00 </param>

--- a/iCubErzelli02/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
@@ -51,7 +51,8 @@
 
 	<group name="POS_PID_CUSTOM">
 	    <param name="controlLaw">    Pid_inPos_outPwm                          </param>
-        <param name="controlUnits">  metric_units                              </param>
+        <param name="fbkControlUnits">  machine_units   </param>
+        <param name="outputControlUnits">  machine_units      </param>
         <param name="pos_kp">            -1066.66     2066.66    -711.11    -1066.66 </param>
         <param name="pos_kd">             -100.00        0.00       0.00       0.00 </param>
         <param name="pos_ki">           -11000.00    14000.00       0.00    1000.00 </param>

--- a/iCubErzelli02/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
@@ -36,7 +36,8 @@
 
     <group name="POS_PID_DEFAULT">
   	    <param name="controlLaw">    Pid_inPos_outPwm </param>
-          <param name="controlUnits">  metric_units              </param>
+          <param name="fbkControlUnits">  machine_units   </param>
+          <param name="outputControlUnits">  machine_units      </param>
           <param name="pos_kp">          2200.00     2200.00      </param>
           <param name="pos_kd">            0.00         0.00      </param>
           <param name="pos_ki">            0.09         0.09      </param>
@@ -71,7 +72,8 @@
 
     <group name="TRQ_PID_DEFAULT">
         <param name="controlLaw">    Pid_inTrq_outPwm           </param>
-        <param name="controlUnits">  metric_units               </param>
+        <param name="fbkControlUnits">  machine_units   </param>
+        <param name="outputControlUnits">  machine_units      </param>
         <param name="trq_kp">         200          200              </param>
         <param name="trq_kd">           0            0              </param>
         <param name="trq_ki">           0            0              </param>
@@ -89,7 +91,8 @@
 
     <group name="2FOC_CUR_CONTROL">
         <param name="controlLaw">       limitscurrent           </param>
-        <param name="controlUnits">     metric_units            </param>
+        <param name="fbkControlUnits">  machine_units   </param>
+        <param name="outputControlUnits">  machine_units      </param>
         <param name="cur_kp">               8           8           </param>
         <param name="cur_kd">               0           0           </param>
         <param name="cur_ki">               2           2           </param>

--- a/iCubErzelli02/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
@@ -36,7 +36,7 @@
 
     <group name="POS_PID_DEFAULT">
   	    <param name="controlLaw">    Pid_inPos_outPwm </param>
-          <param name="fbkControlUnits">  machine_units   </param>
+          <param name="fbkControlUnits">  metric_units   </param>
           <param name="outputControlUnits">  machine_units      </param>
           <param name="pos_kp">          2200.00     2200.00      </param>
           <param name="pos_kd">            0.00         0.00      </param>
@@ -52,7 +52,7 @@
 
 	<group name="POS_PID_CUSTOM">
 	    <param name="controlLaw">    Pid_inPos_outPwm </param>
-        <param name="fbkControlUnits">  machine_units   </param>
+        <param name="fbkControlUnits">  metric_units   </param>
         <param name="outputControlUnits">  machine_units      </param>
         <param name="pos_kp">          3200.00     2200.00      </param>
         <param name="pos_kd">            0.00         0.00      </param>

--- a/iCubErzelli02/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
@@ -82,12 +82,12 @@
         <param name="trq_maxInt">      500          500             </param>
         <param name="trq_shift">        0            0              </param>
         <param name="trq_ko">           0            0              </param>
-        <param name="trq_stictionUp">   1.7	     0.8            </param>
-        <param name="trq_stictionDwn"> -1.7         -1.8            </param>
+        <param name="trq_stictionUp">0 0</param>
+        <param name="trq_stictionDwn">0 0</param>
         <param name="trq_kff">          1            1              </param>
-        <param name="trq_kbemf">        0            0              </param>
+        <param name="trq_kbemf">0 0</param>
         <param name="trq_filterType">   0            0              </param>
-        <param name="trq_ktau">         209          160            </param>
+        <param name="trq_ktau">0 0</param>
     </group>
 
     <group name="2FOC_CUR_CONTROL">

--- a/iCubErzelli02/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
@@ -52,7 +52,8 @@
 
 	<group name="POS_PID_CUSTOM">
 	    <param name="controlLaw">    Pid_inPos_outPwm </param>
-        <param name="controlUnits">  metric_units              </param>
+        <param name="fbkControlUnits">  machine_units   </param>
+        <param name="outputControlUnits">  machine_units      </param>
         <param name="pos_kp">          3200.00     2200.00      </param>
         <param name="pos_kd">            0.00         0.00      </param>
         <param name="pos_ki">            0.09         0.09      </param>

--- a/iCubErzelli02/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
@@ -68,12 +68,12 @@
             <param name="trq_maxInt">        500           0           0           0    </param>
             <param name="trq_shift">           0           0           0           0    </param>
             <param name="trq_ko">              0           0           0           0    </param>
-            <param name="trq_stictionUp">      0           0           0           0    </param>
-            <param name="trq_stictionDwn">     0           0           0           0    </param>
+            <param name="trq_stictionUp">0 0 0 0</param>
+            <param name="trq_stictionDwn">0 0 0 0</param>
             <param name="trq_kff">             0           0           0           0    </param>
-            <param name="trq_kbemf">           0           0           0           0    </param>
+            <param name="trq_kbemf">0 0 0 0</param>
             <param name="trq_filterType">      0           0           0           0    </param>
-            <param name="trq_ktau">            1           0           0           0    </param>
+            <param name="trq_ktau">0 0 0 0</param>
         </group>
 
     </device>

--- a/iCubErzelli02/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
@@ -43,7 +43,8 @@
         <!-- ATTENTION: PID VALUES are not safe!!! -->
         <group name="POS_PID_DEFAULT">
             <param name="controlLaw">       Pid_inPos_outPwm                          </param>
-            <param name="controlUnits">     metric_units                                         </param>
+            <param name="fbkControlUnits">  machine_units   </param>
+            <param name="outputControlUnits">  machine_units      </param>
             <param name="pos_kp">               200.0     500.0       500.0       500.0           </param>
             <param name="pos_kd">                 0.0       0.0         0.0         0.0           </param>
             <param name="pos_ki">               200.0      50.0        50.0        50.0           </param>
@@ -58,7 +59,8 @@
 
         <group name="TRQ_PID_DEFAULT">
             <param name="controlLaw">    Pid_inTrq_outPwm </param>
-            <param name="controlUnits">  metric_units                   </param>
+            <param name="fbkControlUnits">  machine_units   </param>
+            <param name="outputControlUnits">  machine_units      </param>
             <param name="trq_kp">           1000           0           0           0    </param>
             <param name="trq_kd">              0           0           0           0    </param>
             <param name="trq_ki">              0           0           0           0    </param>

--- a/iCubErzelli02/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
@@ -43,7 +43,7 @@
         <!-- ATTENTION: PID VALUES are not safe!!! -->
         <group name="POS_PID_DEFAULT">
             <param name="controlLaw">       Pid_inPos_outPwm                          </param>
-            <param name="fbkControlUnits">  machine_units   </param>
+            <param name="fbkControlUnits">  metric_units   </param>
             <param name="outputControlUnits">  machine_units      </param>
             <param name="pos_kp">               200.0     500.0       500.0       500.0           </param>
             <param name="pos_kd">                 0.0       0.0         0.0         0.0           </param>

--- a/iCubErzelli02/hardware/motorControl/right_arm-eb28-j8_11-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/right_arm-eb28-j8_11-mc.xml
@@ -43,7 +43,8 @@
 
 	<group name="POS_PID_DEFAULT">
 	    <param name="controlLaw">    Pid_inPos_outPwm                          </param> 
-            <param name="controlUnits">     metric_units                                        </param> 
+            <param name="fbkControlUnits">  machine_units   </param>
+            <param name="outputControlUnits">  machine_units      </param> 
             <param name="pos_kp">              -500.0       500.0      -500.0       500.0           </param>       
             <param name="pos_kd">                 0.0         0.0         0.0         0.0           </param>     
             <param name="pos_ki">               -50.0        50.0       -50.0        50.0           </param>       

--- a/iCubErzelli02/hardware/motorControl/right_arm-eb28-j8_11-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/right_arm-eb28-j8_11-mc.xml
@@ -43,7 +43,7 @@
 
 	<group name="POS_PID_DEFAULT">
 	    <param name="controlLaw">    Pid_inPos_outPwm                          </param> 
-            <param name="fbkControlUnits">  machine_units   </param>
+            <param name="fbkControlUnits">  metric_units   </param>
             <param name="outputControlUnits">  machine_units      </param> 
             <param name="pos_kp">              -500.0       500.0      -500.0       500.0           </param>       
             <param name="pos_kd">                 0.0         0.0         0.0         0.0           </param>     

--- a/iCubErzelli02/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
@@ -42,7 +42,8 @@
 
 	    <group name="POS_PID_DEFAULT">
 	        <param name="controlLaw">    Pid_inPos_outPwm                          </param> 
-            <param name="controlUnits">     metric_units                                        </param> 
+            <param name="fbkControlUnits">  machine_units   </param>
+            <param name="outputControlUnits">  machine_units      </param> 
             <param name="pos_kp">                500.0       500.0      -500.0       200.0       </param>
             <param name="pos_kd">                0.0         0.0         0.0         0.0         </param>  
             <param name="pos_ki">                50.0        50.0       -50.0        20.0        </param>    

--- a/iCubErzelli02/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
@@ -42,7 +42,7 @@
 
 	    <group name="POS_PID_DEFAULT">
 	        <param name="controlLaw">    Pid_inPos_outPwm                          </param> 
-            <param name="fbkControlUnits">  machine_units   </param>
+            <param name="fbkControlUnits">  metric_units   </param>
             <param name="outputControlUnits">  machine_units      </param> 
             <param name="pos_kp">                500.0       500.0      -500.0       200.0       </param>
             <param name="pos_kd">                0.0         0.0         0.0         0.0         </param>  

--- a/iCubErzelli02/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
@@ -66,12 +66,12 @@
         <param name="trq_maxInt">        500        500        500        500     </param>
         <param name="trq_shift">           0          0          0          0     </param>
         <param name="trq_ko">              0          0          0          0     </param>
-        <param name="trq_stictionUp">     -0.5       -0.5       -1         -1.7   </param>
-        <param name="trq_stictionDwn">     0.7        0.7        0.8        1.2   </param>
+        <param name="trq_stictionUp">0 0 0 0</param>
+        <param name="trq_stictionDwn">0 0 0 0</param>
         <param name="trq_kff">             1          1          1          1     </param>
-        <param name="trq_kbemf">        -0.0030    -0.0006    -0.0007     0.0007  </param>
+        <param name="trq_kbemf">0 0 0 0</param>
         <param name="trq_filterType">      0          0          0          0     </param>
-        <param name="trq_ktau">         -180       -464       -463       -449     </param>
+        <param name="trq_ktau">0 0 0 0</param>
     </group>
 
     <group name="TRQ_PID_CUSTOM">
@@ -85,12 +85,12 @@
         <param name="trq_maxInt">        500        500        500        500     </param>
         <param name="trq_shift">           0          0          0          0     </param>
         <param name="trq_ko">              0          0          0          0     </param>
-        <param name="trq_stictionUp">     -0.5       -0.5       -1         -1.7   </param>
-        <param name="trq_stictionDwn">     0.7        0.7        0.8        1.2   </param>
+        <param name="trq_stictionUp">0 0 0 0</param>
+        <param name="trq_stictionDwn">0 0 0 0</param>
         <param name="trq_kff">             1          1          1          1     </param>
-        <param name="trq_kbemf">        -0.0030    -0.0006    -0.0007     0.00     </param>
+        <param name="trq_kbemf">0 0 0 0</param>
         <param name="trq_filterType">      0          0          0          0     </param>
-        <param name="trq_ktau">         -180       -464       -463       -449     </param>
+        <param name="trq_ktau">0 0 0 0</param>
     </group>
 
    <group name="2FOC_CUR_CONTROL">

--- a/iCubErzelli02/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
@@ -76,7 +76,8 @@
 
     <group name="TRQ_PID_CUSTOM">
         <param name="controlLaw">    Pid_inTrq_outPwm </param>
-        <param name="controlUnits">  metric_units               </param>
+        <param name="fbkControlUnits">  machine_units   </param>
+        <param name="outputControlUnits">  machine_units      </param>
         <param name="trq_kp">            -50       -200       -250       -300     </param>
         <param name="trq_kd">              0          0          0          0     </param>
         <param name="trq_ki">              0          0          0          0     </param>

--- a/iCubErzelli02/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
@@ -36,7 +36,7 @@
 
 	<group name="POS_PID_DEFAULT">
 	    <param name="controlLaw">    Pid_inPos_outPwm </param>
-        <param name="fbkControlUnits">  machine_units   </param>
+        <param name="fbkControlUnits">  metric_units   </param>
         <param name="outputControlUnits">  machine_units      </param>
         <param name="pos_kp">          -711.11   -1066.66    -711.11   -1066.66 </param>
         <param name="pos_kd">             0.00       0.00       0.00       0.00 </param>

--- a/iCubErzelli02/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
@@ -36,7 +36,8 @@
 
 	<group name="POS_PID_DEFAULT">
 	    <param name="controlLaw">    Pid_inPos_outPwm </param>
-        <param name="controlUnits">  metric_units               </param>
+        <param name="fbkControlUnits">  machine_units   </param>
+        <param name="outputControlUnits">  machine_units      </param>
         <param name="pos_kp">          -711.11   -1066.66    -711.11   -1066.66 </param>
         <param name="pos_kd">             0.00       0.00       0.00       0.00 </param>
         <param name="pos_ki">         -7111.09  -10666.64   -7111.09  -10666.64 </param>
@@ -56,7 +57,8 @@
 
     <group name="TRQ_PID_DEFAULT">
         <param name="controlLaw">    Pid_inTrq_outPwm </param>
-        <param name="controlUnits">  metric_units               </param>
+        <param name="fbkControlUnits">  machine_units   </param>
+        <param name="outputControlUnits">  machine_units      </param>
         <param name="trq_kp">            -50       -200       -250       -300     </param>
         <param name="trq_kd">              0          0          0          0     </param>
         <param name="trq_ki">              0          0          0          0     </param>
@@ -92,7 +94,8 @@
 
    <group name="2FOC_CUR_CONTROL">
         <param name="controlLaw">       limitscurrent          </param>
-        <param name="controlUnits">     metric_units           </param>
+        <param name="fbkControlUnits">  machine_units   </param>
+        <param name="outputControlUnits">  machine_units      </param>
         <param name="cur_kp">               8           8          8         8      </param>
         <param name="cur_kd">               0           0          0         0      </param>
         <param name="cur_ki">               2           2          2         2      </param>

--- a/iCubErzelli02/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
@@ -84,12 +84,12 @@
         <param name="trq_maxInt">        500        500        500        500     </param>
         <param name="trq_shift">           0          0          0          0     </param>
         <param name="trq_ko">              0          0          0          0     </param>
-        <param name="trq_stictionUp">      2.3       -1.79       1.8        1.2   </param>
-        <param name="trq_stictionDwn">    -3.3        1.76      -1.4       -1.7   </param>
+        <param name="trq_stictionUp">0 0 0 0</param>
+        <param name="trq_stictionDwn">0 0 0 0</param>
         <param name="trq_kff">             1          1          1          1     </param>
-        <param name="trq_kbemf">           0          0          0          0     </param>
+        <param name="trq_kbemf">0 0 0 0</param>
         <param name="trq_filterType">      0          0          0          0     </param>
-        <param name="trq_ktau">          147       -180        217        282     </param>
+        <param name="trq_ktau">0 0 0 0</param>
     </group>
 
    <group name="2FOC_CUR_CONTROL">

--- a/iCubErzelli02/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
@@ -53,7 +53,8 @@
 
 	<group name="POS_PID_CUSTOM">
 	    <param name="controlLaw">    Pid_inPos_outPwm                          </param>
-        <param name="controlUnits">  metric_units                              </param>
+        <param name="fbkControlUnits">  machine_units   </param>
+        <param name="outputControlUnits">  machine_units      </param>
         <param name="pos_kp">           1066.66    -2066.66     711.11   1066.66 </param>
         <param name="pos_kd">            100.00        0.00       0.00       0.00 </param>
         <param name="pos_ki">          11000.00   -14000.00       0.00   1066.64 </param>

--- a/iCubErzelli02/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
@@ -37,7 +37,7 @@
 
     <group name="POS_PID_DEFAULT">
   	    <param name="controlLaw">    Pid_inPos_outPwm                          </param>
-          <param name="fbkControlUnits">  machine_units   </param>
+          <param name="fbkControlUnits">  metric_units   </param>
           <param name="outputControlUnits">  machine_units      </param>
           <param name="pos_kp">           1066.66    -2066.66     711.11   1066.66 </param>
           <param name="pos_kd">              0.00        0.00       0.00       0.00 </param>
@@ -53,7 +53,7 @@
 
 	<group name="POS_PID_CUSTOM">
 	    <param name="controlLaw">    Pid_inPos_outPwm                          </param>
-        <param name="fbkControlUnits">  machine_units   </param>
+        <param name="fbkControlUnits">  metric_units   </param>
         <param name="outputControlUnits">  machine_units      </param>
         <param name="pos_kp">           1066.66    -2066.66     711.11   1066.66 </param>
         <param name="pos_kd">            100.00        0.00       0.00       0.00 </param>

--- a/iCubErzelli02/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
@@ -37,7 +37,8 @@
 
     <group name="POS_PID_DEFAULT">
   	    <param name="controlLaw">    Pid_inPos_outPwm                          </param>
-          <param name="controlUnits">  metric_units                              </param>
+          <param name="fbkControlUnits">  machine_units   </param>
+          <param name="outputControlUnits">  machine_units      </param>
           <param name="pos_kp">           1066.66    -2066.66     711.11   1066.66 </param>
           <param name="pos_kd">              0.00        0.00       0.00       0.00 </param>
           <param name="pos_ki">          10666.64   -14222.18    7111.09   1066.64 </param>
@@ -73,7 +74,8 @@
 
     <group name="TRQ_PID_DEFAULT">
         <param name="controlLaw">    Pid_inTrq_outPwm                         </param>
-        <param name="controlUnits">  metric_units                             </param>
+        <param name="fbkControlUnits">  machine_units   </param>
+        <param name="outputControlUnits">  machine_units      </param>
         <param name="trq_kp">            200       -200          0        300     </param>      <!--    200       -300        300       -300    -->
         <param name="trq_kd">              0          0          0          0     </param>
         <param name="trq_ki">              0          0          0          0     </param>
@@ -91,7 +93,8 @@
 
    <group name="2FOC_CUR_CONTROL">
         <param name="controlLaw">       limitscurrent          </param>
-        <param name="controlUnits">     metric_units           </param>
+        <param name="fbkControlUnits">  machine_units   </param>
+        <param name="outputControlUnits">  machine_units      </param>
         <param name="cur_kp">               8           8          8         8      </param>
         <param name="cur_kd">               0           0          0         0      </param>
         <param name="cur_ki">               2           2          2         2      </param>

--- a/iCubErzelli02/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
@@ -81,12 +81,12 @@
         <param name="trq_maxInt">      500         500             </param>
         <param name="trq_shift">         0           0             </param>
         <param name="trq_ko">            0           0             </param>
-        <param name="trq_stictionUp">   -1.4        -1.5           </param>
-        <param name="trq_stictionDwn">   2.4         1.6           </param>
+        <param name="trq_stictionUp">0 0</param>
+        <param name="trq_stictionDwn">0 0</param>
         <param name="trq_kff">           1           1             </param>
-        <param name="trq_kbemf">         0           0             </param>
+        <param name="trq_kbemf">0 0</param>
         <param name="trq_filterType">    0           0             </param>
-        <param name="trq_ktau">       -231        -180             </param>
+        <param name="trq_ktau">0 0</param>
     </group>
 
     <group name="2FOC_CUR_CONTROL">

--- a/iCubErzelli02/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
@@ -35,7 +35,8 @@
 
     <group name="POS_PID_DEFAULT">
   	    <param name="controlLaw">    Pid_inPos_outPwm </param>
-          <param name="controlUnits">  metric_units                     </param>
+          <param name="fbkControlUnits">  machine_units   </param>
+          <param name="outputControlUnits">  machine_units      </param>
           <param name="pos_kp">           -2105.00     -2310.00         </param>
           <param name="pos_kd">               0.00         0.00         </param>
           <param name="pos_ki">              -0.09        -0.09         </param>
@@ -70,7 +71,8 @@
 
     <group name="TRQ_PID_DEFAULT">
         <param name="controlLaw">    Pid_inTrq_outPwm           </param>
-        <param name="controlUnits">  metric_units               </param>
+        <param name="fbkControlUnits">  machine_units   </param>
+        <param name="outputControlUnits">  machine_units      </param>
         <param name="trq_kp">          -200        -200            </param>
         <param name="trq_kd">            0           0             </param>
         <param name="trq_ki">            0           0             </param>
@@ -88,7 +90,8 @@
 
     <group name="2FOC_CUR_CONTROL">
         <param name="controlLaw">       limitscurrent           </param>
-        <param name="controlUnits">     metric_units            </param>
+        <param name="fbkControlUnits">  machine_units   </param>
+        <param name="outputControlUnits">  machine_units      </param>
         <param name="cur_kp">               8           8           </param>
         <param name="cur_kd">               0           0           </param>
         <param name="cur_ki">               2           2           </param>

--- a/iCubErzelli02/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
@@ -51,7 +51,8 @@
 
 	<group name="POS_PID_CUSTOM">
 	    <param name="controlLaw">    Pid_inPos_outPwm </param>
-        <param name="controlUnits">  metric_units                     </param>
+        <param name="fbkControlUnits">  machine_units   </param>
+        <param name="outputControlUnits">  machine_units      </param>
         <param name="pos_kp">           -3105.00     -2310.00         </param>
         <param name="pos_kd">               0.00         0.00         </param>
         <param name="pos_ki">              -0.09        -0.09         </param>

--- a/iCubErzelli02/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
@@ -35,7 +35,7 @@
 
     <group name="POS_PID_DEFAULT">
   	    <param name="controlLaw">    Pid_inPos_outPwm </param>
-          <param name="fbkControlUnits">  machine_units   </param>
+          <param name="fbkControlUnits">  metric_units   </param>
           <param name="outputControlUnits">  machine_units      </param>
           <param name="pos_kp">           -2105.00     -2310.00         </param>
           <param name="pos_kd">               0.00         0.00         </param>
@@ -51,7 +51,7 @@
 
 	<group name="POS_PID_CUSTOM">
 	    <param name="controlLaw">    Pid_inPos_outPwm </param>
-        <param name="fbkControlUnits">  machine_units   </param>
+        <param name="fbkControlUnits">  metric_units   </param>
         <param name="outputControlUnits">  machine_units      </param>
         <param name="pos_kp">           -3105.00     -2310.00         </param>
         <param name="pos_kd">               0.00         0.00         </param>

--- a/iCubErzelli02/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -60,12 +60,12 @@
      <param name="trq_maxInt">        500        500        500  </param>
      <param name="trq_shift">           0          0          0  </param>
      <param name="trq_ko">              0          0          0  </param>
-     <param name="trq_stictionUp">      2          2          2  </param>
-     <param name="trq_stictionDwn">    -2         -2         -2  </param>
+     <param name="trq_stictionUp">0 0 0</param>
+     <param name="trq_stictionDwn">0 0 0</param>
      <param name="trq_kff">             1          1          1  </param>
-     <param name="trq_kbemf">          -0.0016    -0.003     -0.003  </param>
+     <param name="trq_kbemf">0 0 0</param>
      <param name="trq_filterType">      0          0          0  </param>
-     <param name="trq_ktau">          -200       -200       -200  </param>
+     <param name="trq_ktau">0 0 0</param>
  </group>
 
 	 <group name="TRQ_PID_CUSTOM">
@@ -79,12 +79,12 @@
         <param name="trq_maxInt">        500        500        500  </param>
         <param name="trq_shift">           0          0          0  </param>
         <param name="trq_ko">              0          0          0  </param>
-        <param name="trq_stictionUp">      2          2          2  </param>
-        <param name="trq_stictionDwn">    -2         -2         -2  </param>
+        <param name="trq_stictionUp">0 0 0</param>
+        <param name="trq_stictionDwn">0 0 0</param>
         <param name="trq_kff">             1          1          1  </param>
-        <param name="trq_kbemf">          -0.0016     0.00       0.00  </param>
+        <param name="trq_kbemf">0 0 0</param>
         <param name="trq_filterType">      0          0          0  </param>
-        <param name="trq_ktau">          -200       -200       -200  </param>
+        <param name="trq_ktau">0 0 0</param>
     </group>
 
     <group name="IMPEDANCE">

--- a/iCubErzelli02/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -35,7 +35,7 @@
 
 	<group name="POS_PID_DEFAULT">
 	    <param name="controlLaw">    Pid_inPos_outPwm                          </param>
-        <param name="fbkControlUnits">  machine_units   </param>
+        <param name="fbkControlUnits">  metric_units   </param>
         <param name="outputControlUnits">  machine_units      </param>
         <param name="pos_kp">            -711.11    -1066.66    -1066.66 </param>
         <param name="pos_kd">              0.00        0.00        0.00 </param>

--- a/iCubErzelli02/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -35,7 +35,8 @@
 
 	<group name="POS_PID_DEFAULT">
 	    <param name="controlLaw">    Pid_inPos_outPwm                          </param>
-        <param name="controlUnits">  metric_units               </param>
+        <param name="fbkControlUnits">  machine_units   </param>
+        <param name="outputControlUnits">  machine_units      </param>
         <param name="pos_kp">            -711.11    -1066.66    -1066.66 </param>
         <param name="pos_kd">              0.00        0.00        0.00 </param>
         <param name="pos_ki">           -7111.09   -10666.64   -14222.18 </param>
@@ -50,7 +51,8 @@
 
     <group name="TRQ_PID_DEFAULT">
      <param name="controlLaw">    Pid_inTrq_outPwm                         </param>
-     <param name="controlUnits">  metric_units               </param>
+     <param name="fbkControlUnits">  machine_units   </param>
+     <param name="outputControlUnits">  machine_units      </param>
      <param name="trq_kp">            -450       -400       -400  </param>
      <param name="trq_kd">              0          0          0  </param>
      <param name="trq_ki">              0          0          0  </param>
@@ -91,7 +93,8 @@
 
     <group name="2FOC_CUR_CONTROL">
         <param name="controlLaw">       limitscurrent          </param>
-        <param name="controlUnits">     metric_units           </param>
+        <param name="fbkControlUnits">  machine_units   </param>
+        <param name="outputControlUnits">  machine_units      </param>
         <param name="cur_kp">               8           8          8         </param>
         <param name="cur_kd">               0           0          0         </param>
         <param name="cur_ki">               2           2          2         </param>

--- a/iCubErzelli02/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -70,7 +70,8 @@
 
 	 <group name="TRQ_PID_CUSTOM">
         <param name="controlLaw">    Pid_inTrq_outPwm                         </param>
-        <param name="controlUnits">  metric_units               </param>
+        <param name="fbkControlUnits">  machine_units   </param>
+        <param name="outputControlUnits">  machine_units      </param>
         <param name="trq_kp">            -450       -400       -400  </param>
         <param name="trq_kd">              0          0          0  </param>
         <param name="trq_ki">              0          0          0  </param>


### PR DESCRIPTION
I followed the steps from 1 to 4 in the document that @julijenv sent me to migrate the configuration files.

In the commit messages there are the sed commands (credits @drdanz).


13b2c7c was not in the guide, @randaz81 should I remove it?

I skipped the step 5 and 6, which problem can I encounter?

Please review code.  