### PR TITLE
iCubGenova04: Bosch IMU, Strain2 updates and multiple joint offsets calibrations

### DIFF
--- a/iCubGenova04/calibrators/head-calib.xml
+++ b/iCubGenova04/calibrators/head-calib.xml
@@ -28,7 +28,7 @@
         <param name="calibration5">         0           0           0           0            0          0           </param>        
         
         <param name="calibrationZero">      180.0      -180.0       180.0       180.0       0           0           </param>
-        <param name="calibrationDelta">     8.3        -2.4         3.4        -9.0        -5.0        -10.0        </param>
+        <param name="calibrationDelta">     10.3       -1.6         3.4        -9.0        -5.0        -10.0        </param>
        
         <param name="startupPosition">      0.0         0.0         0.0         0.0         0.0         0.0         </param>        
         <param name="startupVelocity">      10          10          20.0        20.0        20.0        20.0        </param>        

--- a/iCubGenova04/calibrators/head-calib.xml
+++ b/iCubGenova04/calibrators/head-calib.xml
@@ -28,7 +28,7 @@
         <param name="calibration5">         0           0           0           0            0          0           </param>        
         
         <param name="calibrationZero">      180.0      -180.0       180.0       180.0       0           0           </param>
-        <param name="calibrationDelta">     0.0         0.0         3.4        -9.0        -5.0        -10.0        </param>
+        <param name="calibrationDelta">     8.3        -2.4         3.4        -9.0        -5.0        -10.0        </param>
        
         <param name="startupPosition">      0.0         0.0         0.0         0.0         0.0         0.0         </param>        
         <param name="startupVelocity">      10          10          20.0        20.0        20.0        20.0        </param>        

--- a/iCubGenova04/calibrators/left_arm-calib.xml
+++ b/iCubGenova04/calibrators/left_arm-calib.xml
@@ -18,14 +18,14 @@
 </group>                                                                        
                                                                                 
 <group name="CALIBRATION">                                                      
-<param name="calibrationType">        3          3          3          3            5     3      3     7     7     6     6     6     6      6      6     6 </param>
-<param name="calibration1">           0   	 0          0          0        -1500     0      0     0     0     0     0     0     0      0      0     0 </param>
-<param name="calibration2">	      0          0          0          0	16384     0      0     0     0  9102  9102  9102  9102   9102   9102  3640 </param>
-<param name="calibration3">         30431.08  3135.14    6479.08     64526.92       0  5635    351     0     0    -1     1    -1     1     -1     1     -1 </param>
-<param name="calibration4">           0          0          0          0            0     0      0  2130   200   241   499   254   465    226    485  694  </param>
-<param name="calibration5">           0          0          0          0            0     0      0  2530  2372   46    22     9   10     33      5   135  </param>
-<param name="calibrationZero">        -180.00   -315.00    180.00     -180.00       0  -180    180     0     0     0     0     0     0      0      0     0 </param>
-<param name="calibrationDelta">       106.4     -11.0      -17.0       -0.8         0     0      0     0     0     0     0     0     0      0      0     0 </param>
+<param name="calibrationType">        3          3          3          3            5     12     12       7     7     6     6     6     6      6      6     6 </param>
+<param name="calibration1">           0   	 0          0          0        -1500    38300  25230     0     0     0     0     0     0      0      0     0 </param>
+<param name="calibration2">	      0          0          0          0	16384     0      0        0     0  9102  9102  9102  9102   9102   9102  3640 </param>
+<param name="calibration3">         30431.08  3135.14    6479.08     64526.92       0     0      0        0     0    -1     1    -1     1     -1     1     -1 </param>
+<param name="calibration4">           0          0          0          0            0     0      0     2130   200   241   499   254   465    226    485  694  </param>
+<param name="calibration5">           0          0          0          0            0     0      0     2530  2372   46    22     9   10     33      5   135  </param>
+<param name="calibrationZero">        -180.00   -315.00    180.00     -180.00       0     0      0        0     0     0     0     0     0      0      0     0 </param>
+<param name="calibrationDelta">       106.4     -11.0      -17.0       -0.8         0     0      0        0     0     0     0     0     0      0      0     0 </param>
                                                                                 
 <param name="startupPosition">        -35.97     29.97      0.06       50.00        0     0      0    25    65     0     0     0     0      0      0     0       </param>
 <param name="startupVelocity">        10.0       10.0       10.0       10.0        30    30     30    60    100   100   100   100    100   100    100  100       </param>

--- a/iCubGenova04/calibrators/right_arm-calib.xml
+++ b/iCubGenova04/calibrators/right_arm-calib.xml
@@ -18,13 +18,13 @@
 
 <group name="CALIBRATION">
 <param name="calibrationType">       3         3        3         3     5      12      12     7     7     6     6     6     6      6      6     6 </param>
-<param name="calibration1">          0         0        0         0    1500   3030   28500     0     0     0     0     0     0      0      0     0 </param>
-<param name="calibration2">	     0         0        0         0   16384    0      0     0     0  9102  9102  9102  9102   9102   9102  3640 </param>
-<param name="calibration3">       21631.1  40063.0   5167.08   4975.08   0     0      0    0     0    -1     1    -1     1     -1     1     -1 </param>
-<param name="calibration4">          0         0        0         0      0     0      0  1840  1180   255   495   255   506    237    483   750 </param>
-<param name="calibration5">          0         0        0         0      0     0      0  2050  3912     0     0     5    3      0     10   170 </param>
-<param name="calibrationZero">     180.00    45.00   -180.00    180.00   0     0      0     0     0     0     0     0     0      0      0     0 </param>
-<param name="calibrationDelta">    17.5      -8.3    -17.2      -1.3    0    0.0    0.0   0     0     0     0     0     0      0      0     0 </param>
+<param name="calibration1">          0         0        0         0    1500   2255   -56943   0     0     0     0     0     0      0      0     0 </param>
+<param name="calibration2">	     0         0        0         0   16384    0      0       0     0  9102  9102  9102  9102   9102   9102  3640 </param>
+<param name="calibration3">       21631.1  40063.0   5167.08   4975.08   0     0      0       0     0    -1     1    -1     1     -1     1     -1 </param>
+<param name="calibration4">          0         0        0         0      0     0      0     1820  1180   255   495   255   506    237    483   750 </param>
+<param name="calibration5">          0         0        0         0      0     0      0     2024  3912     0     0     5    3      0     10   170 </param>
+<param name="calibrationZero">     180.00    45.00   -180.00    180.00   0     0      0       0     0     0     0     0     0      0      0     0 </param>
+<param name="calibrationDelta">    17.5      -8.3    -17.2      -1.3    0    0.0    0.0       0     0     0     0     0     0      0      0     0 </param>
 
 <param name="startupPosition">      -35       30        0        50      0     0      0    25    65     0     0     0      0      0     0     0     </param>
 <param name="startupVelocity">      10.0      10.0     10        10     30    30     30    60   100   100   100     100    100    100  100  100     </param>
@@ -32,7 +32,7 @@
 <param name="startupPosThreshold">  2         2        90        90     90    90     90    90    90    90    90     90     90    90     90   90     </param>
 </group>
 
-<param name="CALIB_ORDER">(0 1 2 3) (4) (5 6 7) (8 9 11 13) (10 12 14 15) </param>
+<param name="CALIB_ORDER">(0 1 2 3) (4) (5 6) (7) (8 9 11 13) (10 12 14 15) </param>
 		<action phase="startup" level="10" type="calibrate">
 		    <param name="target">right_arm-mc_wrapper</param>
 		</action>

--- a/iCubGenova04/estimators/wholebodydynamics_standup.xml
+++ b/iCubGenova04/estimators/wholebodydynamics_standup.xml
@@ -9,6 +9,9 @@
         <param name="defaultContactFrames">(l_hand,r_hand,root_link,l_sole,r_sole,r_upper_leg,l_upper_leg,l_elbow_1,r_elbow_1)</param>
         <param name="imuFrameName">imu_frame</param>
         <param name="publishOnROS">true</param>
+	<param name="forceTorqueEstimateConfidence">2</param>
+        <param name="useJointVelocity">true</param>
+        <param name="useJointAcceleration">false</param>
 
         <!-- map between iDynTree links (identified by a name)
              and skinDynLib links (identified by their frame name, a BodyPart enum
@@ -17,11 +20,11 @@
             <param name="root_link">(root_link,1,0)</param>
             <param name="chest"> (chest,1,2)</param>
             <param name="l_upper_arm">(l_upper_arm,3,2)</param>
+            <param name="l_hand">(l_hand_dh_frame,3,6)</param>
+            <param name="r_hand">(r_hand_dh_frame,4,6)</param>
             <param name="l_elbow_1">(l_elbow_1, 3, 4)</param>
             <param name="r_upper_arm">(r_upper_arm,4,2)</param>
-            <param name="l_hand">(l_hand_dh_frame,3,6)</param>
             <param name="r_elbow_1">(r_elbow_1, 4, 4)</param>
-            <param name="r_hand">(r_hand_dh_frame,4,6)</param>
             <param name="l_upper_leg">(l_upper_leg,5,2)</param>
             <param name="l_lower_leg">(l_lower_leg,5,3)</param>
             <param name="l_ankle_1">(l_ankle_1,5,4)</param>
@@ -37,16 +40,26 @@
             <param name="gravityCompensationBaseLink">root_link</param>
             <param name="gravityCompensationAxesNames">(torso_pitch,torso_roll,torso_yaw,neck_pitch,neck_roll,neck_yaw,l_shoulder_pitch,l_shoulder_roll,l_shoulder_yaw,l_elbow,r_shoulder_pitch,r_shoulder_roll,r_shoulder_yaw,r_elbow,l_hip_pitch,l_hip_roll,l_hip_yaw,l_knee,l_ankle_pitch,l_ankle_roll,r_hip_pitch,r_hip_roll,r_hip_yaw,r_knee,r_ankle_pitch,r_ankle_roll)</param>
         </group>
-        
-       <group name="FT_SECONDARY_CALIBRATION">
+       
+        <group name="FT_SECONDARY_CALIBRATION">
+             <param name="l_leg_ft_sensor"> 
+                   (5.969361e-01,2.428213e-02,-5.463457e-02,4.254463e-01,1.123516e+00,-1.303151e-01 
+                    ,-2.818578e-02,6.863783e-01,2.028274e-02,6.585433e-01,1.573658e-01,1.544577e+00 
+                    ,-3.915223e-02,3.971615e-02,9.679746e-01,-3.150958e-03,3.718397e-01,-8.653098e-02 
+                    ,-8.647321e-03,-2.836473e-02,-1.840247e-04,8.261000e-01,4.659817e-02,3.751658e-02 
+                    ,5.671831e-03,6.968371e-03,4.892937e-03,5.396529e-02,9.499420e-01,-1.575216e-01 
+                    ,3.469447e-18,0,-7.993503e-20,0,0,1.000000e+00)</param>     
 
-           <param name="r_leg_ft_sensor"> (1.165043e-01,-4.824760e-02,-2.838516e-03,-4.063452e-01,3.829723e+00,-4.049686e+00
-           ,-1.646781e-02,1.028508e-01,1.218741e-03,-3.860480e+00,6.586313e-02,1.079024e-01
-           ,-1.223875e-01,-1.720457e-01,9.950911e-01,-1.332774e+00,4.882303e-01,1.109860e+00
-           ,-2.690149e-03,-1.097413e-02,1.942506e-03,9.459466e-01,2.006043e-02,4.074997e-02
-           ,1.949960e-02,-1.769210e-02,-3.291195e-03,-1.505223e-01,8.921250e-01,-1.064398e-01
-           ,9.882410e-03,5.137381e-03,-5.774219e-05,4.049618e-04,-4.992196e-02,9.255909e-01)</param>
-        </group>
+             <param name="r_leg_ft_sensor">
+                   (7.619710e-01,-9.833019e-02,-5.603709e-02,-7.503703e-01,4.654638e-01,-2.100801e+00 
+                   ,2.708629e-02,8.108288e-01,-3.377881e-03,8.122805e-01,4.181660e-02,8.531041e-01 
+                   ,-7.067404e-02,-3.179978e-02,9.888732e-01,-4.080758e-02,5.046211e-01,-5.754858e-01 
+                   ,7.021926e-03,-2.948727e-02,-1.022865e-03,8.566027e-01,-3.532611e-02,-8.280662e-02 
+                   ,3.959038e-02,1.290493e-03,-6.796986e-04,-6.866659e-02,8.221872e-01,-6.964079e-03 
+                   ,-1.542292e-04,3.264395e-04,-6.124671e-04,-2.551378e-02,5.215466e-03,7.234167e-01)</param> 
+
+         </group>
+
 
         <group name="WBD_OUTPUT_EXTERNAL_WRENCH_PORTS">
             <param name="/wholeBodyDynamics/left_arm/endEffectorWrench:o">(l_hand,l_hand_dh_frame,l_sole)</param>

--- a/iCubGenova04/hardware/inertials/head-inertial.xml
+++ b/iCubGenova04/hardware/inertials/head-inertial.xml
@@ -5,6 +5,6 @@
  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="inertial" type="inertial">
       <param name="name">  /icub/inertial  </param>
       <param name="subdevice">  imuBosch_BNO055  </param>
-      <param name="i2c">  /dev/i2c-1   </param>
+      <param name="i2c">  /dev/icub-i2c-imu   </param>
 </device>
 

--- a/iCubGenova04/hardware/mechanicals/left_arm-eb24-j4_7-mec.xml
+++ b/iCubGenova04/hardware/mechanicals/left_arm-eb24-j4_7-mec.xml
@@ -22,7 +22,7 @@
     
     <group name="LIMITS">
         <param name="hardwareJntPosMax">         90          30             35             60          </param>
-        <param name="hardwareJntPosMin">        -90         -80            -15             10          </param> 
+        <param name="hardwareJntPosMin">        -90         -80            -35             10          </param> 
         <param name="rotorPosMax">              0           0               0              0           </param>
         <param name="rotorPosMin">              0           0               0              0           </param> 
    </group>

--- a/iCubGenova04/hardware/mechanicals/right_arm-eb27-j4_7-mec.xml
+++ b/iCubGenova04/hardware/mechanicals/right_arm-eb27-j4_7-mec.xml
@@ -22,7 +22,7 @@
     
     <group name="LIMITS">
         <param name="hardwareJntPosMax">         90          30             35             60          </param>
-        <param name="hardwareJntPosMin">        -90         -80            -15             10          </param> 
+        <param name="hardwareJntPosMin">        -90         -80            -35             10          </param> 
         <param name="rotorPosMax">              0           0               0              0           </param>
         <param name="rotorPosMin">              0           0               0              0           </param> 
     </group>

--- a/iCubGenova04/icub_standup.xml
+++ b/iCubGenova04/icub_standup.xml
@@ -43,6 +43,7 @@
 
     <!-- INERTIAL SENSOR-->
     <xi:include href="hardware/inertials/head-inertial.xml" />
+    <xi:include href="hardware/inertials/waist-inertial.xml" /> 
 
     <!-- ANALOG SENSOR MAIS -->
     <xi:include href="wrappers/MAIS/left_arm-mais_wrapper.xml" />
@@ -51,13 +52,13 @@
     <xi:include href="hardware/MAIS/right_arm-eb29-j12_15-mais.xml" />
 
     <!--  SKINS -->
-   <!-- <xi:include href="wrappers/skin/left_arm-skin_wrapper.xml" />
-        <xi:include href="hardware/skin/left_arm-eb24-j4_7-skin.xml" />-->
+    <xi:include href="wrappers/skin/left_arm-skin_wrapper.xml" />
+    <xi:include href="hardware/skin/left_arm-eb24-j4_7-skin.xml" />
     <xi:include href="wrappers/skin/right_arm-skin_wrapper.xml" />
     <xi:include href="hardware/skin/right_arm-eb27-j4_7-skin.xml" />
-    <xi:include href="wrappers/skin/left_leg-skin_wrapper.xml" />
+<!--    <xi:include href="wrappers/skin/left_leg-skin_wrapper.xml" />
+    <xi:include href="hardware/skin/left_leg-eb10-skin.xml" />-->
     <xi:include href="wrappers/skin/right_leg-skin_wrapper.xml" />
-    <xi:include href="hardware/skin/left_leg-eb10-skin.xml" />
     <xi:include href="hardware/skin/right_leg-eb11-skin.xml" />
     <xi:include href="wrappers/skin/torso-skin_wrapper.xml" />
     <xi:include href="hardware/skin/torso-eb22-skin.xml" />
@@ -69,12 +70,16 @@
     <xi:include href="wrappers/FT/left_leg-FT_wrapper.xml" />
     <xi:include href="wrappers/FT/right_foot-FT_wrapper.xml" />
     <xi:include href="wrappers/FT/left_foot-FT_wrapper.xml" />
+    <xi:include href="wrappers/FT/right_foot-FT_wrapper_multipleSens.xml" />
+    <xi:include href="wrappers/FT/right_leg-FT_wrapper_multipleSens.xml" />
+    <xi:include href="wrappers/FT/left_leg-FT_wrapper_multipleSens.xml" />
+    <xi:include href="wrappers/FT/left_foot-FT_wrapper_multipleSens.xml" />
     <xi:include href="hardware/FT/left_arm-eb1-j0_3-strain.xml" />
     <xi:include href="hardware/FT/right_arm-eb3-j0_3-strain.xml" />
-    <xi:include href="hardware/FT/left_leg-eb6-j0_3-strain.xml" />
-    <xi:include href="hardware/FT/left_leg-eb7-j4_5-strain.xml" />
-    <xi:include href="hardware/FT/right_leg-eb8-j0_3-strain.xml" />
-    <xi:include href="hardware/FT/right_leg-eb9-j4_5-strain.xml" />
+    <xi:include href="hardware/FT/left_leg-eb6-j0_3-strain2.xml" />
+    <xi:include href="hardware/FT/left_leg-eb7-j4_5-strain2.xml" />
+    <xi:include href="hardware/FT/right_leg-eb8-j0_3-strain2.xml" />
+    <xi:include href="hardware/FT/right_leg-eb9-j4_5-strain2.xml" />
 
     <!-- VIRTUAL ANALOG SENSORS (WRAPPER ONLY) -->
     <xi:include href="wrappers/VFT/left_arm-VFT_wrapper.xml" />

--- a/iCubGenova04/icub_wbd.xml
+++ b/iCubGenova04/icub_wbd.xml
@@ -70,12 +70,16 @@
     <xi:include href="wrappers/FT/left_leg-FT_wrapper.xml" />
     <xi:include href="wrappers/FT/right_foot-FT_wrapper.xml" />
     <xi:include href="wrappers/FT/left_foot-FT_wrapper.xml" />
+    <xi:include href="wrappers/FT/right_foot-FT_wrapper_multipleSens.xml" />
+    <xi:include href="wrappers/FT/right_leg-FT_wrapper_multipleSens.xml" />
+    <xi:include href="wrappers/FT/left_leg-FT_wrapper_multipleSens.xml" />
+    <xi:include href="wrappers/FT/left_foot-FT_wrapper_multipleSens.xml" />
     <xi:include href="hardware/FT/left_arm-eb1-j0_3-strain.xml" />
     <xi:include href="hardware/FT/right_arm-eb3-j0_3-strain.xml" />
-    <xi:include href="hardware/FT/left_leg-eb6-j0_3-strain.xml" />
-    <xi:include href="hardware/FT/left_leg-eb7-j4_5-strain.xml" />
-    <xi:include href="hardware/FT/right_leg-eb8-j0_3-strain.xml" />
-    <xi:include href="hardware/FT/right_leg-eb9-j4_5-strain.xml" />
+    <xi:include href="hardware/FT/left_leg-eb6-j0_3-strain2.xml" />
+    <xi:include href="hardware/FT/left_leg-eb7-j4_5-strain2.xml" />
+    <xi:include href="hardware/FT/right_leg-eb8-j0_3-strain2.xml" />
+    <xi:include href="hardware/FT/right_leg-eb9-j4_5-strain2.xml" />
 
     <!-- VIRTUAL ANALOG SENSORS (WRAPPER ONLY) -->
     <xi:include href="wrappers/VFT/left_arm-VFT_wrapper.xml" />

--- a/iCubGenova04/icub_wbd_noskin_noxsens_wfeetimu_strain2.xml
+++ b/iCubGenova04/icub_wbd_noskin_noxsens_wfeetimu_strain2.xml
@@ -47,7 +47,7 @@
 
 
     <!--inertials3-->
-    <xi:include href="hardware/inertials/left_leg-eb7-IMU.xml" /> 
+   <!-- <xi:include href="hardware/inertials/left_leg-eb7-IMU.xml" /> 
     <xi:include href="wrappers/inertials/left_foot-imu_wrapper.xml" /> 
     <xi:include href="hardware/inertials/right_leg-eb9-IMU.xml" /> 
     <xi:include href="wrappers/inertials/right_foot-imu_wrapper.xml" /> 
@@ -76,10 +76,10 @@
     <!-- ANALOG SENSOR FT -->
     <xi:include href="wrappers/FT/left_arm-FT_wrapper.xml" />
     <xi:include href="wrappers/FT/right_arm-FT_wrapper.xml" />
-    <xi:include href="wrappers/FT/right_leg-FT_wrapper.xml" />
+   <!-- <xi:include href="wrappers/FT/right_leg-FT_wrapper.xml" />
     <xi:include href="wrappers/FT/left_leg-FT_wrapper.xml" />
     <xi:include href="wrappers/FT/left_foot-FT_wrapper.xml" />
-    <xi:include href="wrappers/FT/right_foot-FT_wrapper.xml" />
+    <xi:include href="wrappers/FT/right_foot-FT_wrapper.xml" /> -->
     <xi:include href="wrappers/FT/right_foot-FT_wrapper_multipleSens.xml" />
     <xi:include href="wrappers/FT/right_leg-FT_wrapper_multipleSens.xml" />
     <xi:include href="wrappers/FT/left_leg-FT_wrapper_multipleSens.xml" />

--- a/iCubGenova04/yarprobotinterface.ini
+++ b/iCubGenova04/yarprobotinterface.ini
@@ -1,2 +1,2 @@
-config ./icub_all.xml
+config ./icub_wbd_noskin_noxsens.xml
 


### PR DESCRIPTION
The overall changes are listed below:
- Using symbolic link for Bosch IMU instead of the real device name,
- joint offsets calibration of the neck,
- right and left wrists calibration after mechanical design change and mounting of the wrist parts used for attaching external links (pRRI task),
- Updated startup files to use strain2 (including startup files of the "standup" demo),
- Update left and right legs FT_SECONDARY_CALIBRATION matrices in the wholebody dynamics estimator for the "standup" demo.

This PR impacts only iCubGenova04 ("Green" iCub).