### PR TITLE
icubgenova02: fixed signs of pids of head-jo/j1

### DIFF
--- a/iCubGenova02/hardware/motorControl/head-eb20-j0_1-mc.xml
+++ b/iCubGenova02/hardware/motorControl/head-eb20-j0_1-mc.xml
@@ -46,9 +46,9 @@
             <param name="controlLaw">       Pid_inPos_outPwm                </param>    
             <param name="fbkControlUnits">  metric_units                    </param> 
             <param name="outputControlUnits">  machine_units                </param> 
-            <param name="pos_kp">                 +300        -300          </param>       
-            <param name="pos_kd">                 +10         -10           </param>     
-            <param name="pos_ki">                 +100        -100          </param>         
+            <param name="pos_kp">                 -300        +300          </param>       
+            <param name="pos_kd">                 -10         +10           </param>     
+            <param name="pos_ki">                 -100        +100          </param>         
             <param name="pos_maxOutput">          3360        3360          </param>  
             <param name="pos_maxInt">             3360        3360          </param> 
             <param name="pos_shift">              0           0             </param>       


### PR DESCRIPTION
now the signs are finally equal to those of other similar robots (eg, genova04)
because the wiring of motors of joints 0-1 of head was found exchanged in genova02
and corrected.

full stop.