### PR TITLE
iCubLisboa01: update DTD format to 3.0

### DIFF
--- a/iCubLisboa01/icub_all.xml
+++ b/iCubLisboa01/icub_all.xml
@@ -1,79 +1,78 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE robot PUBLIC "-//YARP//DTD robotInterface 3.0//EN" "http://www.yarp.it/DTD/robotInterfaceV3.0.dtd">
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 <robot name="iCubLisboa01" build="1" portprefix="icub" xmlns:xi="http://www.w3.org/2001/XInclude">
 <devices>
-    <!-- cartesian --> 
+    <!-- cartesian -->
     <xi:include href="cartesian/left_arm_cartesian.xml" />
     <xi:include href="cartesian/right_arm_cartesian.xml" />
-    
+
     <!-- motor controllers wrappers -->
-    <xi:include href="wrappers/motorControl/left_arm_mc_wrapper.xml" /> 
+    <xi:include href="wrappers/motorControl/left_arm_mc_wrapper.xml" />
     <xi:include href="wrappers/motorControl/right_arm_mc_wrapper.xml" />
-    <xi:include href="wrappers/motorControl/left_leg_mc_wrapper.xml" /> 
-    <xi:include href="wrappers/motorControl/right_leg_mc_wrapper.xml" /> 
+    <xi:include href="wrappers/motorControl/left_leg_mc_wrapper.xml" />
+    <xi:include href="wrappers/motorControl/right_leg_mc_wrapper.xml" />
     <xi:include href="wrappers/motorControl/head_mc_wrapper.xml" />
     <xi:include href="wrappers/motorControl/torso_mc_wrapper.xml" />
-    <xi:include href="hardware/motorControl/icub_left_arm.xml" /> 
-    <xi:include href="hardware/motorControl/icub_left_hand.xml" /> 
+    <xi:include href="hardware/motorControl/icub_left_arm.xml" />
+    <xi:include href="hardware/motorControl/icub_left_hand.xml" />
     <xi:include href="hardware/motorControl/icub_right_arm.xml" />
     <xi:include href="hardware/motorControl/icub_right_hand.xml" />
-    <xi:include href="hardware/motorControl/icub_left_leg.xml" /> 
-    <xi:include href="hardware/motorControl/icub_right_leg.xml" /> 
+    <xi:include href="hardware/motorControl/icub_left_leg.xml" />
+    <xi:include href="hardware/motorControl/icub_right_leg.xml" />
     <xi:include href="hardware/motorControl/icub_head.xml" />
     <xi:include href="hardware/motorControl/icub_torso.xml" />
-    
+
     <!-- VIRTUAL ANALOG SERVERs -->
-    <xi:include href="wrappers/VFT/left_arm_VFT_wrapper.xml" /> 
-    <xi:include href="wrappers/VFT/left_leg_VFT_wrapper.xml" /> 
-    <xi:include href="wrappers/VFT/right_arm_VFT_wrapper.xml" /> 
-    <xi:include href="wrappers/VFT/right_leg_VFT_wrapper.xml" /> 
-     <xi:include href="wrappers/VFT/torso_VFT_wrapper.xml" /> 
-    <xi:include href="hardware/VFT/left_arm_virtual_strain.xml" /> 
-    <xi:include href="hardware/VFT/left_leg_virtual_strain.xml" /> 
-    <xi:include href="hardware/VFT/right_arm_virtual_strain.xml" /> 
-    <xi:include href="hardware/VFT/right_leg_virtual_strain.xml" /> 
-    <xi:include href="hardware/VFT/torso_virtual_strain.xml" /> 
+    <xi:include href="wrappers/VFT/left_arm_VFT_wrapper.xml" />
+    <xi:include href="wrappers/VFT/left_leg_VFT_wrapper.xml" />
+    <xi:include href="wrappers/VFT/right_arm_VFT_wrapper.xml" />
+    <xi:include href="wrappers/VFT/right_leg_VFT_wrapper.xml" />
+     <xi:include href="wrappers/VFT/torso_VFT_wrapper.xml" />
+    <xi:include href="hardware/VFT/left_arm_virtual_strain.xml" />
+    <xi:include href="hardware/VFT/left_leg_virtual_strain.xml" />
+    <xi:include href="hardware/VFT/right_arm_virtual_strain.xml" />
+    <xi:include href="hardware/VFT/right_leg_virtual_strain.xml" />
+    <xi:include href="hardware/VFT/torso_virtual_strain.xml" />
 
     <!-- REAL ANALOG SENSORS -->
-    <xi:include href="wrappers/FT/left_arm_FT_wrapper.xml" /> 
-    <xi:include href="wrappers/FT/left_leg_FT_wrapper.xml" /> 
-    <xi:include href="wrappers/FT/right_arm_FT_wrapper.xml" /> 
-    <xi:include href="wrappers/FT/right_leg_FT_wrapper.xml" /> 
-    <xi:include href="wrappers/MAIS/left_hand_mais_wrapper.xml" /> 
-    <xi:include href="wrappers/MAIS/right_hand_mais_wrapper.xml" /> 
-    <xi:include href="hardware/FT/left_arm_strain.xml" /> 
-    <xi:include href="hardware/FT/left_leg_strain.xml" /> 
-    <xi:include href="hardware/FT/right_arm_strain.xml" /> 
-    <xi:include href="hardware/FT/right_leg_strain.xml" /> 
-    <xi:include href="hardware/MAIS/left_hand_mais.xml" /> 
-    <xi:include href="hardware/MAIS/right_hand_mais.xml" /> 
-   
+    <xi:include href="wrappers/FT/left_arm_FT_wrapper.xml" />
+    <xi:include href="wrappers/FT/left_leg_FT_wrapper.xml" />
+    <xi:include href="wrappers/FT/right_arm_FT_wrapper.xml" />
+    <xi:include href="wrappers/FT/right_leg_FT_wrapper.xml" />
+    <xi:include href="wrappers/MAIS/left_hand_mais_wrapper.xml" />
+    <xi:include href="wrappers/MAIS/right_hand_mais_wrapper.xml" />
+    <xi:include href="hardware/FT/left_arm_strain.xml" />
+    <xi:include href="hardware/FT/left_leg_strain.xml" />
+    <xi:include href="hardware/FT/right_arm_strain.xml" />
+    <xi:include href="hardware/FT/right_leg_strain.xml" />
+    <xi:include href="hardware/MAIS/left_hand_mais.xml" />
+    <xi:include href="hardware/MAIS/right_hand_mais.xml" />
+
     <!-- SKIN -->
     <xi:include href="wrappers/skin/left_arm_skin_wrapper.xml" />
-    <xi:include href="wrappers/skin/right_arm_skin_wrapper.xml" />  
-    <xi:include href="wrappers/skin/torso_skin_wrapper.xml" />  
+    <xi:include href="wrappers/skin/right_arm_skin_wrapper.xml" />
+    <xi:include href="wrappers/skin/torso_skin_wrapper.xml" />
     <xi:include href="hardware/skin/left_arm.xml" />
-    <xi:include href="hardware/skin/right_arm.xml" />  
-    <xi:include href="hardware/skin/torso.xml" />  
+    <xi:include href="hardware/skin/right_arm.xml" />
+    <xi:include href="hardware/skin/torso.xml" />
 
     <!-- MTX INERTIAL SENSOR & SKIN INERTIAL SENSOR-->
     <xi:include href="hardware/inertial.xml" />
     <!--
-    <xi:include href="wrappers/skin/left_hand_inertial_wrapper.xml" />  
-    <xi:include href="wrappers/skin/right_hand_inertial_wrapper.xml" />  
-    <xi:include href="hardware/skin/left_hand_inertial_mtb.xml" />  
-    <xi:include href="hardware/skin/right_hand_inertial_mtb.xml" />  
+    <xi:include href="wrappers/skin/left_hand_inertial_wrapper.xml" />
+    <xi:include href="wrappers/skin/right_hand_inertial_wrapper.xml" />
+    <xi:include href="hardware/skin/left_hand_inertial_mtb.xml" />
+    <xi:include href="hardware/skin/right_hand_inertial_mtb.xml" />
     -->
 
     <!-- CALIBRATORS -->
-    <xi:include href="calibrators/head_calib.xml" /> 
+    <xi:include href="calibrators/head_calib.xml" />
     <xi:include href="calibrators/torso_calib.xml" />
     <xi:include href="calibrators/right_leg_calib.xml" />
-    <xi:include href="calibrators/left_leg_calib.xml" /> 
-    <xi:include href="calibrators/left_arm_calib.xml" /> 
+    <xi:include href="calibrators/left_leg_calib.xml" />
+    <xi:include href="calibrators/left_arm_calib.xml" />
     <xi:include href="calibrators/right_arm_calib.xml" />
-    <xi:include href="calibrators/left_hand_calib.xml" /> 
+    <xi:include href="calibrators/left_hand_calib.xml" />
     <xi:include href="calibrators/right_hand_calib.xml" />
 </devices>
-</robot> 
-
+</robot>


### PR DESCRIPTION
Tested on the robot pc104 with YARP version 3.2.0+20190622.5+giteb0d831c8.
See also https://github.com/robotology/yarp/pull/2042