### PR TITLE
Update configuration files to be compatible with the inclined soles

### DIFF
--- a/iCubGenova02/calibrators/left_leg-calib.xml
+++ b/iCubGenova02/calibrators/left_leg-calib.xml
@@ -26,7 +26,7 @@
 <param name="calibration4">              0.0        0.0          0.0         0.0       0.0       0.0         </param>
 <param name="calibration5">              0.0        0.0          0.0         0.0       0.0       0.0         </param>
 <param name="calibrationZero">           0.0        0.00         0.00        0.00      0.0       0.00        </param>
-<param name="calibrationDelta">          2.0       -3.9         -2.5        -3.7       0.0       2.3         </param>
+<param name="calibrationDelta">          2.0       -3.9         -2.5        -3.7       15.0       2.3         </param>
                                                                 
 <param name="startupPosition">           0          10.0         0           0         0         0           </param>
 <param name="startupVelocity">           10.0       10.0         10.0        10.0      10.0      10.0        </param>

--- a/iCubGenova02/calibrators/right_leg-calib.xml
+++ b/iCubGenova02/calibrators/right_leg-calib.xml
@@ -25,7 +25,7 @@
 <param name="calibration4">             0.0          0.0         0.0         0.0         0.0        0.0      </param>
 <param name="calibration5">             0.0          0.0         0.0         0.0         0.0        0.0      </param>
 <param name="calibrationZero">          0.0          0.0         0.0         0.0         0.0        0.0      </param>
-<param name="calibrationDelta">        -2.0         -1.9         0.7         0.4         1.1        0.7      </param>
+<param name="calibrationDelta">        -2.0         -1.9         0.7         0.4         16.1        0.7      </param>
                                                                              
 <param name="startupPosition">            0          10.0        0           0           0          0        </param>
 <param name="startupVelocity">            10.0       10.0        10.0        10.0        10.0       10.0     </param>

--- a/iCubGenova02/hardware/mechanicals/left_leg-eb7-j4_5-mec.xml
+++ b/iCubGenova02/hardware/mechanicals/left_leg-eb7-j4_5-mec.xml
@@ -19,8 +19,8 @@
     </group>
 
     <group name="LIMITS">
-        <param name="hardwareJntPosMax">          30.00         20.00   </param>
-        <param name="hardwareJntPosMin">         -30.00        -20.00   </param>
+        <param name="hardwareJntPosMax">          15.00         20.00   </param>
+        <param name="hardwareJntPosMin">         -45.00        -20.00   </param>
         <param name="rotorPosMin">                 0             0      </param> 
         <param name="rotorPosMax">                 0             0      </param>
     </group>

--- a/iCubGenova02/hardware/mechanicals/right_leg-eb9-j4_5-mec.xml
+++ b/iCubGenova02/hardware/mechanicals/right_leg-eb9-j4_5-mec.xml
@@ -19,8 +19,8 @@
     </group>
     
     <group name="LIMITS">
-        <param name="hardwareJntPosMax">              30            20     </param>
-        <param name="hardwareJntPosMin">             -30           -20     </param>
+        <param name="hardwareJntPosMax">              15            20     </param>
+        <param name="hardwareJntPosMin">             -45           -20     </param>
         <param name="rotorPosMin">                     0             0     </param> 
         <param name="rotorPosMax">                     0             0     </param>
     </group>

--- a/iCubGenova02/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
+++ b/iCubGenova02/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
@@ -12,8 +12,8 @@
       <xi:include href="./left_leg-eb7-j4_5-mc_service.xml" />
 
     <group name="LIMITS">
-        <param name="jntPosMax">               30.00         20.00      </param>
-        <param name="jntPosMin">              -30.00        -20.00      </param>
+        <param name="jntPosMax">               15.00         20.00      </param>
+        <param name="jntPosMin">              -45.00        -20.00      </param>
         <param name="motorNominalCurrents">      5000         5000      </param>
         <param name="motorPeakCurrents">        10000        10000      </param>
         <param name="motorOverloadCurrents">    15000        15000      </param>

--- a/iCubGenova02/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
+++ b/iCubGenova02/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
@@ -10,8 +10,8 @@
     <xi:include href="./right_leg-eb9-j4_5-mc_service.xml" />
 
     <group name="LIMITS">
-        <param name="jntPosMax">                      30            20     </param>
-        <param name="jntPosMin">                     -30           -20     </param>
+        <param name="jntPosMax">                      15            20     </param>
+        <param name="jntPosMin">                     -45           -20     </param>
         <param name="motorNominalCurrents">         5000          5000     </param>
         <param name="motorPeakCurrents">           10000         10000     </param>
         <param name="motorOverloadCurrents">       15000         15000     </param>


### PR DESCRIPTION
This PR is required because we mount the inclined soles on iCubGenova02. In details:
1. changes the offset of the ankles pitch joints 
2. changes the limits 


@fiorisi @fjandrad