### PR TITLE
iCubGenova04 - Activate all FT-IMU sensors on the legs and feet

### DIFF
--- a/iCubGenova04/hardware/inertials/left_leg-eb6-IMU.xml
+++ b/iCubGenova04/hardware/inertials/left_leg-eb6-IMU.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">       l_upper_leg_imu_acc_1    l_upper_leg_imu_gyro_1    l_upper_leg_imu_eul_1    l_upper_leg_imu_mag_1    l_upper_leg_imu_stat_1
+                    <param name="id">       l_upper_leg_ft_acc_3b12    l_upper_leg_ft_gyro_3b12    l_upper_leg_ft_eul_3b12    l_upper_leg_ft_mag_3b12    l_upper_leg_ft_stat_3b12
                     </param>
 
                     <param name="type">     eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status
@@ -47,7 +47,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">      50      </param>
-                <param name="enabledSensors">       l_upper_leg_imu_acc_1    l_upper_leg_imu_gyro_1    l_upper_leg_imu_eul_1    l_upper_leg_imu_mag_1    l_upper_leg_imu_stat_1
+                <param name="enabledSensors">       l_upper_leg_ft_acc_3b12    l_upper_leg_ft_gyro_3b12    l_upper_leg_ft_eul_3b12    l_upper_leg_ft_mag_3b12    l_upper_leg_ft_stat_3b12
                 </param>
             </group>
 

--- a/iCubGenova04/hardware/inertials/left_leg-eb7-IMU.xml
+++ b/iCubGenova04/hardware/inertials/left_leg-eb7-IMU.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">       l_lower_leg_imu_acc_2    l_lower_leg_imu_gyro_2    l_lower_leg_imu_eul_2    l_lower_leg_imu_mag_2    l_lower_leg_imu_stat_2
+                    <param name="id">       l_lower_leg_ft_acc_3b13    l_lower_leg_ft_gyro_3b13    l_lower_leg_ft_eul_3b13    l_lower_leg_ft_mag_3b13    l_lower_leg_ft_stat_3b13
                     </param>
 
                     <param name="type">     eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status
@@ -47,7 +47,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">      50      </param>
-                <param name="enabledSensors">       l_lower_leg_imu_acc_2    l_lower_leg_imu_gyro_2    l_lower_leg_imu_eul_2    l_lower_leg_imu_mag_2    l_lower_leg_imu_stat_2
+                <param name="enabledSensors">       l_lower_leg_ft_acc_3b13    l_lower_leg_ft_gyro_3b13    l_lower_leg_ft_eul_3b13    l_lower_leg_ft_mag_3b13    l_lower_leg_ft_stat_3b13
                 </param>
             </group>
 

--- a/iCubGenova04/hardware/inertials/right_leg-eb8-IMU.xml
+++ b/iCubGenova04/hardware/inertials/right_leg-eb8-IMU.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">       r_upper_leg_imu_acc_1    r_upper_leg_imu_gyro_1    r_upper_leg_imu_eul_1    r_upper_leg_imu_mag_1    r_upper_leg_imu_stat_1
+                    <param name="id">       r_upper_leg_ft_acc_3b11    r_upper_leg_ft_gyro_3b11    r_upper_leg_ft_eul_3b11    r_upper_leg_ft_mag_3b11    r_upper_leg_ft_stat_3b11
                     </param>
 
                     <param name="type">     eoas_imu_acc  eoas_imu_gyr  eoas_imu_eul  eoas_imu_mag   eoas_imu_status
@@ -47,7 +47,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">      50      </param>
-                <param name="enabledSensors">   r_upper_leg_imu_acc_1    r_upper_leg_imu_gyro_1    r_upper_leg_imu_eul_1    r_upper_leg_imu_mag_1    r_upper_leg_imu_stat_1   </param>
+                <param name="enabledSensors">   r_upper_leg_ft_acc_3b11    r_upper_leg_ft_gyro_3b11    r_upper_leg_ft_eul_3b11    r_upper_leg_ft_mag_3b11    r_upper_leg_ft_stat_3b11   </param>
             </group>
 
         </group>

--- a/iCubGenova04/hardware/inertials/right_leg-eb9-IMU.xml
+++ b/iCubGenova04/hardware/inertials/right_leg-eb9-IMU.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">       r_lower_leg_imu_acc_2    r_lower_leg_imu_gyro_2    r_lower_leg_imu_eul_2    r_lower_leg_imu_mag_2    r_lower_leg_imu_stat_2
+                    <param name="id">       r_lower_leg_ft_acc_3b14    r_lower_leg_ft_gyro_3b14    r_lower_leg_ft_eul_3b14    r_lower_leg_ft_mag_3b14    r_lower_leg_ft_stat_3b14
                     </param>
 
                     <param name="type">     eoas_imu_acc  eoas_imu_gyr  eoas_imu_eul  eoas_imu_mag   eoas_imu_status
@@ -47,7 +47,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">      50      </param>
-                <param name="enabledSensors">   r_lower_leg_imu_acc_2    r_lower_leg_imu_gyro_2    r_lower_leg_imu_eul_2    r_lower_leg_imu_mag_2    r_lower_leg_imu_stat_2   </param>                
+                <param name="enabledSensors">   r_lower_leg_ft_acc_3b14    r_lower_leg_ft_gyro_3b14    r_lower_leg_ft_eul_3b14    r_lower_leg_ft_mag_3b14    r_lower_leg_ft_stat_3b14   </param>                
             </group>
 
         </group>

--- a/iCubGenova04/icub_wbd_inertials.xml
+++ b/iCubGenova04/icub_wbd_inertials.xml
@@ -76,6 +76,19 @@
     <!-- WRAPPERS FOR INERTIAL SENSORS ON MTB, EMS AND FT STRAIN BOARDS -->
     <xi:include href="wrappers/inertials/left_leg-inertials_wrapper.xml" />
 
+    <!-- DEVICES FOR INERTIAL SENSORS ON MTB, EMS AND FT STRAIN BOARDS -->
+    <devices file="hardware/inertials/right_leg-eb8-IMU.xml" />
+    <devices file="hardware/inertials/right_leg-eb8-inertials.xml" />
+    <devices file="hardware/inertials/right_leg-eb9-IMU.xml" />
+    <devices file="hardware/inertials/right_leg-eb9-inertials.xml" />
+    <devices file="hardware/inertials/right_leg-eb11-inertials.xml" />
+
+    <!-- REMAPPERS FOR INERTIAL SENSORS ON MTB, EMS AND FT STRAIN BOARDS -->
+    <devices file="wrappers/inertials/right_leg-inertials_remapper.xml" />
+
+    <!-- WRAPPERS FOR INERTIAL SENSORS ON MTB, EMS AND FT STRAIN BOARDS -->
+    <devices file="wrappers/inertials/right_leg-inertials_wrapper.xml" />
+
     <!-- ANALOG SENSOR FT -->
     <xi:include href="wrappers/FT/left_arm-FT_wrapper.xml" />
     <xi:include href="wrappers/FT/right_arm-FT_wrapper.xml" />

--- a/iCubGenova04/wrappers/inertials/left_leg-inertials_remapper.xml
+++ b/iCubGenova04/wrappers/inertials/left_leg-inertials_remapper.xml
@@ -7,18 +7,18 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="ThreeAxisGyroscopesNames">
-          (l_upper_leg_imu_gyro_1
+          (l_upper_leg_ft_gyro_3b12
            l_upper_leg_ems_gyro_eb6
            l_upper_leg_ems_gyro_eb10
            l_lower_leg_ems_gyro_eb7
-           l_lower_leg_imu_gyro_2)
+           l_lower_leg_ft_gyro_3b13)
         </param>
         <param name="ThreeAxisLinearAccelerometersNames">
-          (l_upper_leg_imu_acc_1
+          (l_upper_leg_ft_acc_3b12
            l_upper_leg_mtb_acc_10b1   l_upper_leg_mtb_acc_10b2   l_upper_leg_mtb_acc_10b3   l_upper_leg_mtb_acc_10b4
            l_upper_leg_mtb_acc_10b5   l_upper_leg_mtb_acc_10b6   l_upper_leg_mtb_acc_10b7
            l_lower_leg_mtb_acc_10b8   l_lower_leg_mtb_acc_10b9   l_lower_leg_mtb_acc_10b10  l_lower_leg_mtb_acc_10b11
-           l_lower_leg_imu_acc_2
+           l_lower_leg_ft_acc_3b13
            l_foot_mtb_acc_10b12       l_foot_mtb_acc_10b13)
         </param>
 

--- a/iCubGenova04/wrappers/inertials/right_leg-inertials_remapper.xml
+++ b/iCubGenova04/wrappers/inertials/right_leg-inertials_remapper.xml
@@ -7,18 +7,18 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="ThreeAxisGyroscopesNames">
-          (r_upper_leg_imu_gyro_1
+          (r_upper_leg_ft_gyro_3b11
            r_upper_leg_ems_gyro_eb8
            r_upper_leg_ems_gyro_eb11
            r_lower_leg_ems_gyro_eb9
-           r_lower_leg_imu_gyro_2)
+           r_lower_leg_ft_gyro_3b14)
         </param>
         <param name="ThreeAxisLinearAccelerometersNames">
-          (r_upper_leg_imu_acc_1
+          (r_upper_leg_ft_acc_3b11
            r_upper_leg_mtb_acc_11b1   r_upper_leg_mtb_acc_11b2   r_upper_leg_mtb_acc_11b3   r_upper_leg_mtb_acc_11b4
            r_upper_leg_mtb_acc_11b5   r_upper_leg_mtb_acc_11b6   r_upper_leg_mtb_acc_11b7
            r_lower_leg_mtb_acc_11b8   r_lower_leg_mtb_acc_11b9   r_lower_leg_mtb_acc_11b10  r_lower_leg_mtb_acc_11b11
-           r_lower_leg_imu_acc_2
+           r_lower_leg_ft_acc_3b14
            r_foot_mtb_acc_11b12       r_foot_mtb_acc_11b13)
         </param>
         <action phase="startup" level="5" type="attach">


### PR DESCRIPTION
This completes the activation of the IMU sensors embedded in the legs and feet FT sensor boards as a dependency of the walking on inclined plane implementations, typically https://github.com/dic-iit/element_walking-on-inclined-plane/issues/40.

## PR changes
- update the names of IMUs on the left and right legs, matching the names used in the PR https://github.com/robotology/icub-model-generator/pull/113. All the `xml` files configuring the devices of type `embObjIMU`, the remappers and wrappers already existed, only the names were updated.
- add the respective configuration files to the startup config `icub_wbd_inertials`.

CC @lia2790 @S-Dafarra @fiorisi @fjandrad @prashanthr05