### PR TITLE
iCubGenova04: arms, legs and torso joint offsets recalibration

### DIFF
--- a/iCubGenova04/calibrators/left_arm-calib.xml
+++ b/iCubGenova04/calibrators/left_arm-calib.xml
@@ -25,7 +25,7 @@
 <param name="calibration4">           0          0          0          0            0     0      0     2130   200   241   499   254   465    226    485  694  </param>
 <param name="calibration5">           0          0          0          0            0     0      0     2530  2372   46    22     9   10     33      5   135  </param>
 <param name="calibrationZero">        -180.00   -315.00    180.00     -180.00       0     0      0        0     0     0     0     0     0      0      0     0 </param>
-<param name="calibrationDelta">       106.4     -11.0      -17.0       -0.8         0     0      0        0     0     0     0     0     0      0      0     0 </param>
+<param name="calibrationDelta">       106.4      -9.6      -17.0       -0.8         0     0      0        0     0     0     0     0     0      0      0     0 </param>
                                                                                 
 <param name="startupPosition">        -35.97     29.97      0.06       50.00        0     0      0    25    65     0     0     0     0      0      0     0       </param>
 <param name="startupVelocity">        10.0       10.0       10.0       10.0        30    30     30    60    100   100   100   100    100   100    100  100       </param>

--- a/iCubGenova04/calibrators/left_leg-calib.xml
+++ b/iCubGenova04/calibrators/left_leg-calib.xml
@@ -26,7 +26,7 @@
 <param name="calibration4">                       0.0            0.0        0.0          0.0         0.0       0.0         </param>
 <param name="calibration5">                       0.0            0.0        0.0          0.0         0.0       0.0         </param>
 <param name="calibrationZero">                    180.00         180.00     180.00       -180.00     -180.00   180.00      </param>
-<param name="calibrationDelta">                   1.7           -5.7        2.4         -3.8         0.0      -1.7         </param>
+<param name="calibrationDelta">                   1.2           -5.7        2.4         -3.8         0.0      -1.7         </param>
 
 <param name="startupPosition">                    15.60           6.80      -1.400      -30.00       -14.400   -12.400     </param>
 <param name="startupVelocity">                    10.0           10.0       10.0         10.0        10.0      10.0        </param>

--- a/iCubGenova04/calibrators/left_leg-calib.xml
+++ b/iCubGenova04/calibrators/left_leg-calib.xml
@@ -26,7 +26,7 @@
 <param name="calibration4">                       0.0            0.0        0.0          0.0         0.0       0.0         </param>
 <param name="calibration5">                       0.0            0.0        0.0          0.0         0.0       0.0         </param>
 <param name="calibrationZero">                    180.00         180.00     180.00       -180.00     -180.00   180.00      </param>
-<param name="calibrationDelta">                   0.4           -6.0        1.0         -3.8         0.0      -1.7         </param>
+<param name="calibrationDelta">                   1.7           -5.7        2.4         -3.8         0.0      -1.7         </param>
 
 <param name="startupPosition">                    15.60           6.80      -1.400      -30.00       -14.400   -12.400     </param>
 <param name="startupVelocity">                    10.0           10.0       10.0         10.0        10.0      10.0        </param>

--- a/iCubGenova04/calibrators/right_arm-calib.xml
+++ b/iCubGenova04/calibrators/right_arm-calib.xml
@@ -24,7 +24,7 @@
 <param name="calibration4">          0         0        0         0      0     0      0     1820  1180   255   495   255   506    237    483   750 </param>
 <param name="calibration5">          0         0        0         0      0     0      0     2024  3912     0     0     5    3      0     10   170 </param>
 <param name="calibrationZero">     180.00    45.00   -180.00    180.00   0     0      0       0     0     0     0     0     0      0      0     0 </param>
-<param name="calibrationDelta">    17.5      -8.3    -17.2      -1.3    0    0.0    0.0       0     0     0     0     0     0      0      0     0 </param>
+<param name="calibrationDelta">    23.8      -7.8    -17.2      -1.3    0    0.0    0.0       0     0     0     0     0     0      0      0     0 </param>
 
 <param name="startupPosition">      -35       30        0        50      0     0      0    25    65     0     0     0      0      0     0     0     </param>
 <param name="startupVelocity">      10.0      10.0     10        10     30    30     30    60   100   100   100     100    100    100  100  100     </param>

--- a/iCubGenova04/calibrators/right_leg-calib.xml
+++ b/iCubGenova04/calibrators/right_leg-calib.xml
@@ -27,7 +27,7 @@
 <param name="calibration4">                       0.0             0.0         0.0       0.0            0.0           0.0           </param>
 <param name="calibration5">                       0.0             0.0         0.0       0.0            0.0           0.0           </param>
 <param name="calibrationZero">                    -180.00         -180.00     -180.00   180.00         180.00        -180.00       </param>
-<param name="calibrationDelta">                   0.4            -5.3         3.0       -3.5           -1.4           1.4           </param>
+<param name="calibrationDelta">                   1.5            -5.3         3.0       -3.5           -1.4           1.4           </param>
 <param name="startupPosition">                    15.60           6.80        -1.400    -30.00       -14.400       -12.400         </param>
 <param name="startupVelocity">                    10.0            10.0        10.0      10.0           10.0          10.0          </param>
 <param name="startupMaxPwm">                      1200            1200        1200      1200           1200          1200          </param>

--- a/iCubGenova04/calibrators/right_leg-calib.xml
+++ b/iCubGenova04/calibrators/right_leg-calib.xml
@@ -18,16 +18,16 @@
 
 
 <group name="CALIBRATION">
-<param name="calibrationType">                    3               3           3         3              3             3             </param>
-<param name="calibration1">	32767.9	32767.9	32767.9	32767.9	32767.9	32767.9	</param> 
-<param name="calibration2">	10.0	10.0	10.0	10.0	10.0	10.0	</param> 
-<param name="calibration3">	61502.9	18079.1	59902.9	5679.1	51198.9	35790.9	</param> 
+<param name="calibrationType">                    3               3          12         3              3             3             </param>
+<param name="calibration1">	                32767.9	        32767.9	     -25543	32767.9	 32767.9	32767.9	</param> 
+<param name="calibration2">             	10.0    	10.0	      0 	10.0	10.0	10.0	</param> 
+<param name="calibration3">	                61502.9	        18079.1	      0 	5679.1	51198.9	35790.9	</param> 
 
 
 <param name="calibration4">                       0.0             0.0         0.0       0.0            0.0           0.0           </param>
 <param name="calibration5">                       0.0             0.0         0.0       0.0            0.0           0.0           </param>
-<param name="calibrationZero">                    -180.00         -180.00     -180.00   180.00         180.00        -180.00       </param>
-<param name="calibrationDelta">                   1.5            -5.3         3.0       -3.5           -1.4           1.4           </param>
+<param name="calibrationZero">                    -180.00         -180.00     0.00   180.00         180.00        -180.00       </param>
+<param name="calibrationDelta">                   0.8            -5.3        -4.6       -3.5           -1.4           1.4           </param>
 <param name="startupPosition">                    15.60           6.80        -1.400    -30.00       -14.400       -12.400         </param>
 <param name="startupVelocity">                    10.0            10.0        10.0      10.0           10.0          10.0          </param>
 <param name="startupMaxPwm">                      1200            1200        1200      1200           1200          1200          </param>

--- a/iCubGenova04/calibrators/torso-calib.xml
+++ b/iCubGenova04/calibrators/torso-calib.xml
@@ -27,8 +27,8 @@
 
 <param name="calibration4">                       0.0                     0.0                       0.0                                 </param>
 <param name="calibration5">                       0.0                     0.0                       0.0                                 </param>
-<param name="calibrationZero">                    180.00                  180.00                    180.00                              </param>
-<param name="calibrationDelta">                   0.8                    -1.2                      -1.7                                 </param>
+<param name="calibrationZero">                    270.00                  180.00                    180.00                              </param>
+<param name="calibrationDelta">                   0.8                    -0.3                      -1.7                                 </param>
 <param name="startupPosition">                    0.0                     0.0                       0.0                                 </param>
 <param name="startupVelocity">                    10.0                    10.0                      10.0                                </param>
 <param name="startupMaxPwm">                      5500                    5500                      5500                                </param>


### PR DESCRIPTION
These changes update the joint offsets calibration:
- left and right arms
- Recalibrated left and right legs after r_hip_yaw encoder replacement
- Recalibrated the torso after ironbot tests

These offsets have been used for at least a couple of months on the Green iCub(Genova04), and run on all the demos.