### PR TITLE
iCubGenova04: Apply and validate JTCVC feed-forward gains on the firmware torque controller with Current output

### DIFF
--- a/iCubGenova04/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
+++ b/iCubGenova04/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
@@ -30,7 +30,7 @@
        <param name="positionControl">  POS_PID_DEFAULT           POS_PID_DEFAULT          POS_PID_DEFAULT          POS_PID_DEFAULT         </param>
        <param name="velocityControl">  POS_PID_DEFAULT           POS_PID_DEFAULT          POS_PID_DEFAULT          POS_PID_DEFAULT         </param>
        <param name="mixedControl">     POS_PID_DEFAULT           POS_PID_DEFAULT          POS_PID_DEFAULT          POS_PID_DEFAULT         </param>
-       <param name="torqueControl">    TRQ_PID_OUTPUT_CURR       TRQ_PID_OUTPUT_CURR      TRQ_PID_OUTPUT_CURR      TRQ_PID_OUTPUT_CURR     </param>
+       <param name="torqueControl">    TRQ_PID_TUNED             TRQ_PID_TUNED            TRQ_PID_TUNED            TRQ_PID_TUNED           </param>
        <param name="currentPid">       2FOC_CUR_CONTROL          2FOC_CUR_CONTROL         2FOC_CUR_CONTROL         2FOC_CUR_CONTROL        </param>
        <param name="speedPid">         2FOC_VEL_CONTROL          2FOC_VEL_CONTROL         2FOC_VEL_CONTROL         2FOC_VEL_CONTROL        </param>
     </group>

--- a/iCubGenova04/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
+++ b/iCubGenova04/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
@@ -143,7 +143,7 @@
         <param name="kff">             1          1          1          1     </param>
         <param name="kbemf">          -0.0003     0.0004    -0.0003    -0.0002</param>
         <param name="filterType">      0          0          0          0     </param>
-        <param name="ktau">         -176        178       -176       -230     </param>
+        <param name="ktau">         -175.56     177.83    -175.74    -230.10  </param>
     </group>
 
     <group name="2FOC_CUR_CONTROL">

--- a/iCubGenova04/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
+++ b/iCubGenova04/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
@@ -30,7 +30,7 @@
        <param name="positionControl">  POS_PID_DEFAULT           POS_PID_DEFAULT          POS_PID_DEFAULT          POS_PID_DEFAULT         </param>
        <param name="velocityControl">  POS_PID_DEFAULT           POS_PID_DEFAULT          POS_PID_DEFAULT          POS_PID_DEFAULT         </param>
        <param name="mixedControl">     POS_PID_DEFAULT           POS_PID_DEFAULT          POS_PID_DEFAULT          POS_PID_DEFAULT         </param>
-       <param name="torqueControl">    TRQ_PID_TUNED             TRQ_PID_TUNED            TRQ_PID_TUNED            TRQ_PID_TUNED           </param>
+       <param name="torqueControl">    TRQ_PID_OUTPUT_CURR       TRQ_PID_OUTPUT_CURR      TRQ_PID_OUTPUT_CURR      TRQ_PID_OUTPUT_CURR     </param>
        <param name="currentPid">       2FOC_CUR_CONTROL          2FOC_CUR_CONTROL         2FOC_CUR_CONTROL         2FOC_CUR_CONTROL        </param>
        <param name="speedPid">         2FOC_VEL_CONTROL          2FOC_VEL_CONTROL         2FOC_VEL_CONTROL         2FOC_VEL_CONTROL        </param>
     </group>
@@ -132,16 +132,16 @@
         <param name="outputType">          current                      </param>
         <param name="fbkControlUnits">     metric_units                 </param>
         <param name="outputControlUnits">  machine_units                </param>
-        <param name="kp">            0.00       0.00       0.00       0.00    </param>      <!--   -200        200       0       -200    -->
+        <param name="kp">            0.00       0.00       0.00      -0.47    </param>
         <param name="kd">              0          0          0          0     </param>
         <param name="ki">              0          0          0          0     </param>
-        <param name="maxOutput">      25         25         25         25     </param>
-        <param name="maxInt">       1.56       1.56       1.56       1.56     </param>
+        <param name="maxOutput">    2500       2500       2500       2500     </param>
+        <param name="maxInt">        750        750        750        750     </param>
         <param name="ko">              0          0          0          0     </param>
         <param name="stictionUp">      0          0          0          0     </param>
         <param name="stictionDown">    0          0          0          0     </param>
         <param name="kff">             1          1          1          1     </param>
-        <param name="kbemf">           0          0          0          0     </param>
+        <param name="kbemf">           0.66       0.26       0.44       0.35  </param>
         <param name="filterType">      0          0          0          0     </param>
         <param name="ktau">         -176        178       -176       -230     </param>
     </group>

--- a/iCubGenova04/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
+++ b/iCubGenova04/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
@@ -132,7 +132,7 @@
         <param name="outputType">          current                      </param>
         <param name="fbkControlUnits">     metric_units                 </param>
         <param name="outputControlUnits">  machine_units                </param>
-        <param name="kp">            0.00       0.00       0.00      -0.47    </param>
+        <param name="kp">            0.00       0.00       0.00      0.00     </param>
         <param name="kd">              0          0          0          0     </param>
         <param name="ki">              0          0          0          0     </param>
         <param name="maxOutput">    2500       2500       2500       2500     </param>

--- a/iCubGenova04/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
+++ b/iCubGenova04/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
@@ -132,7 +132,7 @@
         <param name="outputType">          current                      </param>
         <param name="fbkControlUnits">     metric_units                 </param>
         <param name="outputControlUnits">  machine_units                </param>
-        <param name="kp">            0.00       0.00       0.00      0.00     </param>
+        <param name="kp">            0.00       0.00       0.00       -68.13  </param>
         <param name="kd">              0          0          0          0     </param>
         <param name="ki">              0          0          0          0     </param>
         <param name="maxOutput">    2500       2500       2500       2500     </param>

--- a/iCubGenova04/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
+++ b/iCubGenova04/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
@@ -141,7 +141,7 @@
         <param name="stictionUp">      0          0          0          0     </param>
         <param name="stictionDown">    0          0          0          0     </param>
         <param name="kff">             1          1          1          1     </param>
-        <param name="kbemf">           0.66       0.26       0.44       0.35  </param>
+        <param name="kbemf">          -0.0003     0.0004    -0.0003    -0.0002</param>
         <param name="filterType">      0          0          0          0     </param>
         <param name="ktau">         -176        178       -176       -230     </param>
     </group>

--- a/iCubGenova04/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
+++ b/iCubGenova04/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
@@ -132,11 +132,11 @@
         <param name="outputType">          current                      </param>
         <param name="fbkControlUnits">     metric_units                 </param>
         <param name="outputControlUnits">  machine_units                </param>
-        <param name="kp">            0.00       0.00       0.00       -68.13  </param>
+        <param name="kp">           -150.00     150.00    -200.00    -150.00  </param>
         <param name="kd">              0          0          0          0     </param>
-        <param name="ki">              0          0          0          0     </param>
+        <param name="ki">            -80         50        -80        -80.00  </param>
         <param name="maxOutput">    2500       2500       2500       2500     </param>
-        <param name="maxInt">        750        750        750        750     </param>
+        <param name="maxInt">        200        200        200        200     </param>
         <param name="ko">              0          0          0          0     </param>
         <param name="stictionUp">      0          0          0          0     </param>
         <param name="stictionDown">    0          0          0          0     </param>

--- a/iCubGenova04/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
+++ b/iCubGenova04/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
@@ -31,7 +31,7 @@
        <param name="positionControl">           POS_PID_DEFAULT           POS_PID_DEFAULT           </param>
        <param name="velocityControl">           POS_PID_DEFAULT           POS_PID_DEFAULT           </param>
        <param name="mixedControl">              POS_PID_DEFAULT           POS_PID_DEFAULT           </param>
-       <param name="torqueControl">             TRQ_PID_OUTPUT_CURR       TRQ_PID_OUTPUT_CURR       </param>
+       <param name="torqueControl">             TRQ_PID_TUNED             TRQ_PID_TUNED             </param>
        <param name="currentPid">                2FOC_CUR_CONTROL          2FOC_CUR_CONTROL          </param>
        <param name="speedPid">                  2FOC_VEL_CONTROL          2FOC_VEL_CONTROL          </param>
     </group>

--- a/iCubGenova04/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
+++ b/iCubGenova04/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
@@ -125,7 +125,7 @@
         <param name="kff">             1           1            </param>
         <param name="kbemf">           0.0008      0.0014       </param>
         <param name="filterType">      0           0            </param>
-        <param name="ktau">          162         163            </param>
+        <param name="ktau">          162.24      163.96         </param>
     </group>
 
     <group name="TRQ_PID_NO_FRICTION">

--- a/iCubGenova04/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
+++ b/iCubGenova04/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
@@ -118,7 +118,7 @@
         <param name="kd">             0            0            </param>
         <param name="ki">             0            0            </param>
         <param name="maxOutput">    2500        2500            </param>
-        <param name="maxInt">        750         750            </param>
+        <param name="maxInt">        200         200            </param>
         <param name="ko">              0           0            </param>
         <param name="stictionUp">      0           0            </param>
         <param name="stictionDown">    0           0            </param>

--- a/iCubGenova04/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
+++ b/iCubGenova04/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
@@ -123,7 +123,7 @@
         <param name="stictionUp">      0           0            </param>
         <param name="stictionDown">    0           0            </param>
         <param name="kff">             1           1            </param>
-        <param name="kbemf">           0.66        1.02         </param>
+        <param name="kbemf">           0.0008      0.0014       </param>
         <param name="filterType">      0           0            </param>
         <param name="ktau">          162         163            </param>
     </group>

--- a/iCubGenova04/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
+++ b/iCubGenova04/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
@@ -114,7 +114,7 @@
         <param name="outputType">          current                      </param>
         <param name="fbkControlUnits">     metric_units                 </param>
         <param name="outputControlUnits">  machine_units                </param>
-        <param name="kp">             0.31         0.31         </param>
+        <param name="kp">             0            0            </param>
         <param name="kd">             0            0            </param>
         <param name="ki">             0            0            </param>
         <param name="maxOutput">    2500        2500            </param>
@@ -123,7 +123,7 @@
         <param name="stictionUp">      0           0            </param>
         <param name="stictionDown">    0           0            </param>
         <param name="kff">             1           1            </param>
-        <param name="kbemf">           0.0008      0.0014       </param>
+        <param name="kbemf">           0.0003      0.0003       </param>
         <param name="filterType">      0           0            </param>
         <param name="ktau">          162.24      163.96         </param>
     </group>

--- a/iCubGenova04/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
+++ b/iCubGenova04/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
@@ -31,7 +31,7 @@
        <param name="positionControl">           POS_PID_DEFAULT           POS_PID_DEFAULT           </param>
        <param name="velocityControl">           POS_PID_DEFAULT           POS_PID_DEFAULT           </param>
        <param name="mixedControl">              POS_PID_DEFAULT           POS_PID_DEFAULT           </param>
-       <param name="torqueControl">             TRQ_PID_TUNED             TRQ_PID_TUNED             </param>
+       <param name="torqueControl">             TRQ_PID_OUTPUT_CURR       TRQ_PID_OUTPUT_CURR       </param>
        <param name="currentPid">                2FOC_CUR_CONTROL          2FOC_CUR_CONTROL          </param>
        <param name="speedPid">                  2FOC_VEL_CONTROL          2FOC_VEL_CONTROL          </param>
     </group>
@@ -114,16 +114,16 @@
         <param name="outputType">          current                      </param>
         <param name="fbkControlUnits">     metric_units                 </param>
         <param name="outputControlUnits">  machine_units                </param>
-        <param name="kp">             0            0            </param>
+        <param name="kp">             0.31         0.31         </param>
         <param name="kd">             0            0            </param>
         <param name="ki">             0            0            </param>
-        <param name="maxOutput">      25          25            </param>
-        <param name="maxInt">       1.56          1.56          </param>
+        <param name="maxOutput">    2500        2500            </param>
+        <param name="maxInt">        750         750            </param>
         <param name="ko">              0           0            </param>
         <param name="stictionUp">      0           0            </param>
         <param name="stictionDown">    0           0            </param>
         <param name="kff">             1           1            </param>
-        <param name="kbemf">           0           0            </param>
+        <param name="kbemf">           0.66        1.02         </param>
         <param name="filterType">      0           0            </param>
         <param name="ktau">          162         163            </param>
     </group>

--- a/iCubGenova04/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
+++ b/iCubGenova04/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
@@ -114,7 +114,7 @@
         <param name="outputType">          current                      </param>
         <param name="fbkControlUnits">     metric_units                 </param>
         <param name="outputControlUnits">  machine_units                </param>
-        <param name="kp">             0            0            </param>
+        <param name="kp">            36.21        26.77         </param>
         <param name="kd">             0            0            </param>
         <param name="ki">             0            0            </param>
         <param name="maxOutput">    2500        2500            </param>

--- a/iCubGenova04/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
+++ b/iCubGenova04/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
@@ -32,7 +32,7 @@
        <param name="positionControl">  POS_PID_DEFAULT           POS_PID_DEFAULT          POS_PID_DEFAULT          POS_PID_DEFAULT         </param>
        <param name="velocityControl">  POS_PID_DEFAULT           POS_PID_DEFAULT          POS_PID_DEFAULT          POS_PID_DEFAULT         </param>
        <param name="mixedControl">     POS_PID_DEFAULT           POS_PID_DEFAULT          POS_PID_DEFAULT          POS_PID_DEFAULT         </param>
-       <param name="torqueControl">    TRQ_PID_OUTPUT_CURR       TRQ_PID_OUTPUT_CURR      TRQ_PID_OUTPUT_CURR      TRQ_PID_OUTPUT_CURR     </param>
+       <param name="torqueControl">    TRQ_PID_TUNED             TRQ_PID_TUNED            TRQ_PID_TUNED            TRQ_PID_TUNED           </param>
        <param name="currentPid">       2FOC_CUR_CONTROL          2FOC_CUR_CONTROL         2FOC_CUR_CONTROL         2FOC_CUR_CONTROL        </param>
        <param name="speedPid">         2FOC_VEL_CONTROL          2FOC_VEL_CONTROL         2FOC_VEL_CONTROL         2FOC_VEL_CONTROL        </param>
     </group>

--- a/iCubGenova04/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
+++ b/iCubGenova04/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
@@ -143,7 +143,7 @@
         <param name="stictionUp">      0          0          0          0     </param>
         <param name="stictionDown">    0          0          0          0     </param>
         <param name="kff">             1          1          1          1     </param>
-        <param name="kbemf">           0.59       0.18       0.57       0.40  </param>
+        <param name="kbemf">           0.0002    -0.0003     0.0003     0.0001</param>
         <param name="filterType">      0          0          0          0     </param>
         <param name="ktau">          196.52    -185.41     185.70     270.78  </param>
     </group>

--- a/iCubGenova04/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
+++ b/iCubGenova04/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
@@ -32,7 +32,7 @@
        <param name="positionControl">  POS_PID_DEFAULT           POS_PID_DEFAULT          POS_PID_DEFAULT          POS_PID_DEFAULT         </param>
        <param name="velocityControl">  POS_PID_DEFAULT           POS_PID_DEFAULT          POS_PID_DEFAULT          POS_PID_DEFAULT         </param>
        <param name="mixedControl">     POS_PID_DEFAULT           POS_PID_DEFAULT          POS_PID_DEFAULT          POS_PID_DEFAULT         </param>
-       <param name="torqueControl">    TRQ_PID_TUNED             TRQ_PID_TUNED            TRQ_PID_TUNED            TRQ_PID_TUNED           </param>
+       <param name="torqueControl">    TRQ_PID_OUTPUT_CURR       TRQ_PID_OUTPUT_CURR      TRQ_PID_OUTPUT_CURR      TRQ_PID_OUTPUT_CURR     </param>
        <param name="currentPid">       2FOC_CUR_CONTROL          2FOC_CUR_CONTROL         2FOC_CUR_CONTROL         2FOC_CUR_CONTROL        </param>
        <param name="speedPid">         2FOC_VEL_CONTROL          2FOC_VEL_CONTROL         2FOC_VEL_CONTROL         2FOC_VEL_CONTROL        </param>
     </group>
@@ -127,6 +127,25 @@
         <param name="kbemf">           0          0          0          0     </param>
         <param name="filterType">      0          0          0          0     </param>
         <param name="ktau">          0.44      -0.56       0.68       0.63    </param>
+    </group>
+
+    <group name="TRQ_PID_OUTPUT_CURR">
+        <param name="controlLaw">          torque                       </param>
+        <param name="outputType">          current                      </param>
+        <param name="fbkControlUnits">     metric_units                 </param>
+        <param name="outputControlUnits">  machine_units                </param>
+        <param name="kp">            0.00       0.00       0.00       0.47    </param>
+        <param name="kd">              0          0          0          0     </param>
+        <param name="ki">              0          0          0          0     </param>
+        <param name="maxOutput">    2500       2500       2500       2500     </param>
+        <param name="maxInt">        750        750        750        750     </param>
+        <param name="ko">              0          0          0          0     </param>
+        <param name="stictionUp">      0          0          0          0     </param>
+        <param name="stictionDown">    0          0          0          0     </param>
+        <param name="kff">             1          1          1          1     </param>
+        <param name="kbemf">           0.59       0.18       0.57       0.40  </param>
+        <param name="filterType">      0          0          0          0     </param>
+        <param name="ktau">          196.52    -185.41     185.70     270.78  </param>
     </group>
 
     <group name="2FOC_CUR_CONTROL">

--- a/iCubGenova04/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
+++ b/iCubGenova04/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
@@ -134,7 +134,7 @@
         <param name="outputType">          current                      </param>
         <param name="fbkControlUnits">     metric_units                 </param>
         <param name="outputControlUnits">  machine_units                </param>
-        <param name="kp">            0.00       0.00       0.00       0.00    </param>
+        <param name="kp">            0.00       0.00       0.00        80.18  </param>
         <param name="kd">              0          0          0          0     </param>
         <param name="ki">              0          0          0          0     </param>
         <param name="maxOutput">    2500       2500       2500       2500     </param>

--- a/iCubGenova04/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
+++ b/iCubGenova04/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
@@ -134,7 +134,7 @@
         <param name="outputType">          current                      </param>
         <param name="fbkControlUnits">     metric_units                 </param>
         <param name="outputControlUnits">  machine_units                </param>
-        <param name="kp">            0.00       0.00       0.00       0.47    </param>
+        <param name="kp">            0.00       0.00       0.00       0.00    </param>
         <param name="kd">              0          0          0          0     </param>
         <param name="ki">              0          0          0          0     </param>
         <param name="maxOutput">    2500       2500       2500       2500     </param>

--- a/iCubGenova04/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
+++ b/iCubGenova04/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
@@ -134,11 +134,11 @@
         <param name="outputType">          current                      </param>
         <param name="fbkControlUnits">     metric_units                 </param>
         <param name="outputControlUnits">  machine_units                </param>
-        <param name="kp">            0.00       0.00       0.00        80.18  </param>
+        <param name="kp">            150.00    -150.00     200.00     150.00  </param>
         <param name="kd">              0          0          0          0     </param>
-        <param name="ki">              0          0          0          0     </param>
+        <param name="ki">             80        -50         80         80.00  </param>
         <param name="maxOutput">    2500       2500       2500       2500     </param>
-        <param name="maxInt">        750        750        750        750     </param>
+        <param name="maxInt">        200        200        200        200     </param>
         <param name="ko">              0          0          0          0     </param>
         <param name="stictionUp">      0          0          0          0     </param>
         <param name="stictionDown">    0          0          0          0     </param>

--- a/iCubGenova04/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
+++ b/iCubGenova04/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
@@ -30,7 +30,7 @@
        <param name="positionControl">           POS_PID_DEFAULT           POS_PID_DEFAULT           </param>
        <param name="velocityControl">           POS_PID_DEFAULT           POS_PID_DEFAULT           </param>
        <param name="mixedControl">              POS_PID_DEFAULT           POS_PID_DEFAULT           </param>
-       <param name="torqueControl">             TRQ_PID_OUTPUT_CURR       TRQ_PID_OUTPUT_CURR       </param>
+       <param name="torqueControl">             TRQ_PID_TUNED             TRQ_PID_TUNED             </param>
        <param name="currentPid">                2FOC_CUR_CONTROL          2FOC_CUR_CONTROL          </param>
        <param name="speedPid">                  2FOC_VEL_CONTROL          2FOC_VEL_CONTROL          </param>
     </group>

--- a/iCubGenova04/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
+++ b/iCubGenova04/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
@@ -132,7 +132,7 @@
         <param name="outputType">          current                      </param>
         <param name="fbkControlUnits">     metric_units                 </param>
         <param name="outputControlUnits">  machine_units                </param>
-        <param name="kp">             -0.31      -0.31    </param>
+        <param name="kp">              0          0       </param>
         <param name="kd">              0          0       </param>
         <param name="ki">              0          0       </param>
         <param name="maxOutput">    2500       2500       </param>
@@ -141,7 +141,7 @@
         <param name="stictionUp">      0          0       </param>
         <param name="stictionDown">    0          0       </param>
         <param name="kff">             1          1       </param>
-        <param name="kbemf">          -0.0001    -0.0001  </param>
+        <param name="kbemf">          -0.0003    -0.0003  </param>
         <param name="filterType">      0          0       </param>
         <param name="ktau">         -181.17    -172.08    </param>
     </group>

--- a/iCubGenova04/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
+++ b/iCubGenova04/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
@@ -141,9 +141,9 @@
         <param name="stictionUp">      0          0       </param>
         <param name="stictionDown">    0          0       </param>
         <param name="kff">             1          1       </param>
-        <param name="kbemf">          -0.0003    -0.0003  </param>
+        <param name="kbemf">          -0.0003    -0.0004  </param>
         <param name="filterType">      0          0       </param>
-        <param name="ktau">         -181.17    -172.08    </param>
+        <param name="ktau">         -181.17    -230.00    </param>
     </group>
 
     <group name="2FOC_CUR_CONTROL">

--- a/iCubGenova04/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
+++ b/iCubGenova04/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
@@ -136,7 +136,7 @@
         <param name="kd">              0          0       </param>
         <param name="ki">              0          0       </param>
         <param name="maxOutput">    2500       2500       </param>
-        <param name="maxInt">        750        750       </param>
+        <param name="maxInt">        200        200       </param>
         <param name="ko">              0          0       </param>
         <param name="stictionUp">      0          0       </param>
         <param name="stictionDown">    0          0       </param>

--- a/iCubGenova04/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
+++ b/iCubGenova04/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
@@ -30,7 +30,7 @@
        <param name="positionControl">           POS_PID_DEFAULT           POS_PID_DEFAULT           </param>
        <param name="velocityControl">           POS_PID_DEFAULT           POS_PID_DEFAULT           </param>
        <param name="mixedControl">              POS_PID_DEFAULT           POS_PID_DEFAULT           </param>
-       <param name="torqueControl">             TRQ_PID_TUNED             TRQ_PID_TUNED             </param>
+       <param name="torqueControl">             TRQ_PID_OUTPUT_CURR       TRQ_PID_OUTPUT_CURR       </param>
        <param name="currentPid">                2FOC_CUR_CONTROL          2FOC_CUR_CONTROL          </param>
        <param name="speedPid">                  2FOC_VEL_CONTROL          2FOC_VEL_CONTROL          </param>
     </group>
@@ -125,6 +125,25 @@
         <param name="kbemf">           0          0             </param>
         <param name="filterType">      0          0             </param>
         <param name="ktau">          -0.72      -0.53           </param>
+    </group>
+
+    <group name="TRQ_PID_OUTPUT_CURR">
+        <param name="controlLaw">          torque                       </param>
+        <param name="outputType">          current                      </param>
+        <param name="fbkControlUnits">     metric_units                 </param>
+        <param name="outputControlUnits">  machine_units                </param>
+        <param name="kp">             -0.31      -0.31    </param>
+        <param name="kd">              0          0       </param>
+        <param name="ki">              0          0       </param>
+        <param name="maxOutput">    2500       2500       </param>
+        <param name="maxInt">        750        750       </param>
+        <param name="ko">              0          0       </param>
+        <param name="stictionUp">      0          0       </param>
+        <param name="stictionDown">    0          0       </param>
+        <param name="kff">             1          1       </param>
+        <param name="kbemf">           0.61       0.52    </param>
+        <param name="filterType">      0          0       </param>
+        <param name="ktau">         -181.17    -172.08    </param>
     </group>
 
     <group name="2FOC_CUR_CONTROL">

--- a/iCubGenova04/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
+++ b/iCubGenova04/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
@@ -141,7 +141,7 @@
         <param name="stictionUp">      0          0       </param>
         <param name="stictionDown">    0          0       </param>
         <param name="kff">             1          1       </param>
-        <param name="kbemf">           0.61       0.52    </param>
+        <param name="kbemf">          -0.0001    -0.0001  </param>
         <param name="filterType">      0          0       </param>
         <param name="ktau">         -181.17    -172.08    </param>
     </group>

--- a/iCubGenova04/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
+++ b/iCubGenova04/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
@@ -132,7 +132,7 @@
         <param name="outputType">          current                      </param>
         <param name="fbkControlUnits">     metric_units                 </param>
         <param name="outputControlUnits">  machine_units                </param>
-        <param name="kp">              0          0       </param>
+        <param name="kp">            -40.44     -28.27    </param>
         <param name="kd">              0          0       </param>
         <param name="ki">              0          0       </param>
         <param name="maxOutput">    2500       2500       </param>

--- a/iCubGenova04/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubGenova04/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -112,7 +112,7 @@
         <param name="outputType">          current                      </param>
         <param name="fbkControlUnits">     metric_units                 </param>
         <param name="outputControlUnits">  machine_units                </param>
-        <param name="kp">          -0.31      -0.31      -0.31      </param>
+        <param name="kp">              0          0          0      </param>
         <param name="kd">              0          0          0      </param>
         <param name="ki">              0          0          0      </param>
         <param name="maxOutput">    2500       2500       2500      </param>
@@ -121,7 +121,7 @@
         <param name="stictionUp">      0          0          0      </param>
         <param name="stictionDown">    0          0          0      </param>
         <param name="kff">             1          1          1      </param>
-        <param name="kbemf">          -0.0004    -0.0004    -0.0002 </param>
+        <param name="kbemf">          -0.0001    -0.0003    -0.0003 </param>
         <param name="filterType">      0          0          0      </param>
         <param name="ktau">         -426.33    -209.96    -164.01   </param>
     </group>

--- a/iCubGenova04/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubGenova04/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -112,11 +112,11 @@
         <param name="outputType">          current                      </param>
         <param name="fbkControlUnits">     metric_units                 </param>
         <param name="outputControlUnits">  machine_units                </param>
-        <param name="kp">            -83.26     -41.01     -32.03   </param>
+        <param name="kp">           -150       -150       -150      </param>
         <param name="kd">              0          0          0      </param>
-        <param name="ki">              0          0          0      </param>
+        <param name="ki">            -50        -50        -50      </param>
         <param name="maxOutput">    2500       2500       2500      </param>
-        <param name="maxInt">        750        750        750      </param>
+        <param name="maxInt">        200        200        200      </param>
         <param name="ko">              0          0          0      </param>
         <param name="stictionUp">      0          0          0      </param>
         <param name="stictionDown">    0          0          0      </param>

--- a/iCubGenova04/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubGenova04/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -30,7 +30,7 @@
        <param name="positionControl">  POS_PID_DEFAULT           POS_PID_DEFAULT          POS_PID_DEFAULT          </param>
        <param name="velocityControl">  POS_PID_DEFAULT           POS_PID_DEFAULT          POS_PID_DEFAULT          </param>
        <param name="mixedControl">     POS_PID_DEFAULT           POS_PID_DEFAULT          POS_PID_DEFAULT          </param>
-       <param name="torqueControl">    TRQ_PID_OUTPUT_CURR       TRQ_PID_OUTPUT_CURR      TRQ_PID_OUTPUT_CURR      </param>
+       <param name="torqueControl">    TRQ_PID_CUSTOM            TRQ_PID_CUSTOM           TRQ_PID_CUSTOM           </param>
        <param name="currentPid">       2FOC_CUR_CONTROL          2FOC_CUR_CONTROL         2FOC_CUR_CONTROL         </param>
        <param name="speedPid">         2FOC_VEL_CONTROL          2FOC_VEL_CONTROL         2FOC_VEL_CONTROL         </param>
     </group>

--- a/iCubGenova04/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubGenova04/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -30,7 +30,7 @@
        <param name="positionControl">  POS_PID_DEFAULT           POS_PID_DEFAULT          POS_PID_DEFAULT          </param>
        <param name="velocityControl">  POS_PID_DEFAULT           POS_PID_DEFAULT          POS_PID_DEFAULT          </param>
        <param name="mixedControl">     POS_PID_DEFAULT           POS_PID_DEFAULT          POS_PID_DEFAULT          </param>
-       <param name="torqueControl">    TRQ_PID_CUSTOM            TRQ_PID_CUSTOM           TRQ_PID_CUSTOM           </param>
+       <param name="torqueControl">    TRQ_PID_OUTPUT_CURR       TRQ_PID_OUTPUT_CURR      TRQ_PID_OUTPUT_CURR      </param>
        <param name="currentPid">       2FOC_CUR_CONTROL          2FOC_CUR_CONTROL         2FOC_CUR_CONTROL         </param>
        <param name="speedPid">         2FOC_VEL_CONTROL          2FOC_VEL_CONTROL         2FOC_VEL_CONTROL         </param>
     </group>
@@ -105,6 +105,25 @@
         <param name="kbemf">           0          0          0   </param>
         <param name="filterType">      0          0          0   </param>
         <param name="ktau">         -0.63      -0.63      -0.63  </param>
+    </group>
+
+    <group name="TRQ_PID_OUTPUT_CURR">
+        <param name="controlLaw">          torque                       </param>
+        <param name="outputType">          current                      </param>
+        <param name="fbkControlUnits">     metric_units                 </param>
+        <param name="outputControlUnits">  machine_units                </param>
+        <param name="kp">          -0.31      -0.31      -0.31   </param>
+        <param name="kd">              0          0          0   </param>
+        <param name="ki">              0          0          0   </param>
+        <param name="maxOutput">    2500       2500       2500   </param>
+        <param name="maxInt">        750        750        750   </param>
+        <param name="ko">              0          0          0   </param>
+        <param name="stictionUp">      0          0          0   </param>
+        <param name="stictionDown">    0          0          0   </param>
+        <param name="kff">             1          1          1   </param>
+        <param name="kbemf">           0.29       0.18       0.18</param>
+        <param name="filterType">      0          0          0   </param>
+        <param name="ktau">         -426.33    -164.01    -164.01</param>
     </group>
 
     <group name="IMPEDANCE">

--- a/iCubGenova04/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubGenova04/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -112,18 +112,18 @@
         <param name="outputType">          current                      </param>
         <param name="fbkControlUnits">     metric_units                 </param>
         <param name="outputControlUnits">  machine_units                </param>
-        <param name="kp">          -0.31      -0.31      -0.31   </param>
-        <param name="kd">              0          0          0   </param>
-        <param name="ki">              0          0          0   </param>
-        <param name="maxOutput">    2500       2500       2500   </param>
-        <param name="maxInt">        750        750        750   </param>
-        <param name="ko">              0          0          0   </param>
-        <param name="stictionUp">      0          0          0   </param>
-        <param name="stictionDown">    0          0          0   </param>
-        <param name="kff">             1          1          1   </param>
-        <param name="kbemf">           0.29       0.18       0.18</param>
-        <param name="filterType">      0          0          0   </param>
-        <param name="ktau">         -426.33    -164.01    -164.01</param>
+        <param name="kp">          -0.31      -0.31      -0.31      </param>
+        <param name="kd">              0          0          0      </param>
+        <param name="ki">              0          0          0      </param>
+        <param name="maxOutput">    2500       2500       2500      </param>
+        <param name="maxInt">        750        750        750      </param>
+        <param name="ko">              0          0          0      </param>
+        <param name="stictionUp">      0          0          0      </param>
+        <param name="stictionDown">    0          0          0      </param>
+        <param name="kff">             1          1          1      </param>
+        <param name="kbemf">          -0.0004    -0.0004    -0.0002 </param>
+        <param name="filterType">      0          0          0      </param>
+        <param name="ktau">         -426.33    -209.96    -164.01   </param>
     </group>
 
     <group name="IMPEDANCE">

--- a/iCubGenova04/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubGenova04/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -112,7 +112,7 @@
         <param name="outputType">          current                      </param>
         <param name="fbkControlUnits">     metric_units                 </param>
         <param name="outputControlUnits">  machine_units                </param>
-        <param name="kp">              0          0          0      </param>
+        <param name="kp">            -83.26     -41.01     -32.03   </param>
         <param name="kd">              0          0          0      </param>
         <param name="ki">              0          0          0      </param>
         <param name="maxOutput">    2500       2500       2500      </param>


### PR DESCRIPTION
This PR implements https://github.com/dic-iit/element_torque-control-via-current/issues/77.

After the "flexible motor input" feature has been merged (refer to issue https://github.com/dic-iit/element_torque-control-via-current/issues/57), we apply to all robot parts (iCubGenova04) the configuration setting the EMS torque controller output to "current", using the JTCVC feed-forward parameters identified/computed in https://github.com/dic-iit/element_torque-control-via-current/issues/49.

The "kbemf" (mechanical friction) parameters were then manually tuned with the robot on the pole, for reaching the maximum mechanical friction compensation while keeping the controller stable (no extra energy injected by the controller to the joint while oscillating the joint with an external force).