### PR TITLE
Change acquisitionRate in head-imu-rfe

### DIFF
--- a/iCubGenova02/hardware/inertials/head-imu-rfe.xml
+++ b/iCubGenova02/hardware/inertials/head-imu-rfe.xml
@@ -43,7 +43,7 @@
             </group>
 
             <group name="SETTINGS">
-                <param name="acquisitionRate">      50      </param>
+                <param name="acquisitionRate">      10      </param>
                 <param name="enabledSensors">       rfeimu_acc  rfeimu_gyro  rfeimu_mag  rfeimu_status </param>
             </group>
 


### PR DESCRIPTION
I am not sure that this change is right.

`acquisitionRate` is it intended as rate in Hz or a period in milliseconds/seconds ?

See [here](https://github.com/robotology/icub-main/blob/master/src/libraries/icubmod/embObjIMU/eo_imu_privData.cpp#L316)