### PR TITLE
[WIP] iCubGenova04, iCubGenova02: Implement a static model with Stiction/Stribeck, Coulomb and Viscous components

### DIFF
--- a/iCubGenova02/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
+++ b/iCubGenova02/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
@@ -47,14 +47,14 @@
         <param name="outputType">           pwm                       </param>
         <param name="fbkControlUnits">      metric_units              </param>
         <param name="outputControlUnits">   machine_units             </param>
-        <param name="kp">            -1066.66     2066.66    -711.11    -1066.66    </param>
-        <param name="kd">               0.00        0.00       0.00       0.00      </param>
-        <param name="ki">          -10666.64    14222.18   -7111.09    -1066.64     </param>
-        <param name="maxOutput">        8000        8000       8000       8000      </param>
-        <param name="maxInt">           750        750        750       1000        </param>
-        <param name="stictionUp">          0           0          0          0      </param>
-        <param name="stictionDown">        0           0          0          0      </param>
-        <param name="kff">                 0           0          0          0      </param>
+         <param name="kp">            1066.66     2066.66     711.11     1066.66 </param>
+         <param name="kd">               0.00        0.00       0.00       0.00 </param>
+         <param name="ki">           10666.64    14222.18    7111.09     1066.64 </param>
+         <param name="maxOutput">        8000        8000       8000       8000 </param>
+         <param name="maxInt">           750        750        750       1000 </param>
+         <param name="stictionUp">          0           0          0          0 </param>
+         <param name="stictionDown">        0           0          0          0 </param>
+         <param name="kff">                 0           0          0          0 </param>
     </group>
     
     <!-- default position PID: end -->
@@ -67,19 +67,19 @@
         <param name="outputType">           pwm                 </param>
         <param name="fbkControlUnits">      metric_units        </param>
         <param name="outputControlUnits">   machine_units       </param>
-        <param name="kp">           -200        200          0       -200     </param>
-        <param name="kd">              0          0          0          0     </param>
-        <param name="ki">              0          0          0          0     </param>
-        <param name="maxOutput">    8000       8000       8000       8000     </param>
-        <param name="maxInt">        500        500        500        500     </param>
-        <param name="ko">              0          0          0          0     </param>
-        <param name="stictionUp">      0          0          0          0     </param>
-        <param name="stictionDown">    0          0          0          0     </param>
-        <param name="kff">             1          1          1          1     </param>
-        <param name="kbemf">           0          0          0          0     </param>
-        <param name="filterType">      0          0          0          0     </param>
-        <param name="ktau">            0          0          0          0     </param>
-    </group>
+        <param name="kp">           200        200          0        200     </param>
+        <param name="kd">             0          0          0          0     </param>
+        <param name="ki">             0          0          0          0     </param>
+        <param name="maxOutput">   8000       8000       8000       8000     </param>
+        <param name="maxInt">       500        500        500        500     </param>
+        <param name="ko">             0          0          0          0     </param>
+        <param name="stictionUp">     0          0          0          0     </param>
+        <param name="stictionDown">   0          0          0          0     </param>
+        <param name="kff">            1          1          1          1     </param>
+        <param name="kbemf">          0          0          0          0     </param>
+        <param name="filterType">     0          0          0          0     </param>
+        <param name="ktau">           0          0          0          0      </param>
+     </group>
 
     <group name="2FOC_CUR_CONTROL">
         <param name="controlLaw">           low_lev_current     </param>

--- a/iCubGenova02/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
+++ b/iCubGenova02/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
@@ -47,9 +47,9 @@
         <param name="outputType">           pwm                       </param>
         <param name="fbkControlUnits">      metric_units              </param>
         <param name="outputControlUnits">   machine_units             </param>
-        <param name="kp">                   -711.11   -1066.66    -711.11   -1066.66 </param>
-        <param name="kd">                   0.00       0.00       0.00       0.00 </param>
-        <param name="ki">                   -7111.09  -10666.64   -7111.09  -10666.64 </param>
+        <param name="kp">           711.11    1066.66     711.11    1066.66 </param>
+        <param name="kd">             0.00       0.00       0.00       0.00 </param>
+        <param name="ki">          7111.09   10666.64    7111.09   10666.64 </param>
         <param name="maxOutput">            8000       8000       8000       8000 </param>
         <param name="maxInt">               200        200        200       1000 </param>
         <param name="stictionUp">           0          0          0          0 </param>
@@ -67,7 +67,7 @@
         <param name="outputType">           pwm                          </param>
         <param name="fbkControlUnits">      metric_units                 </param>
         <param name="outputControlUnits">  machine_units                </param>
-        <param name="kp">             -200     -200       -250       -300   </param>
+        <param name="kp">              50       200        250        300   </param>
         <param name="kd">              0          0          0          0   </param>
         <param name="ki">              0          0          0          0   </param>
         <param name="maxOutput">    8000       8000       8000       8000   </param>

--- a/iCubGenova02/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
+++ b/iCubGenova02/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
@@ -47,9 +47,9 @@
         <param name="outputType">             pwm                       </param>
         <param name="fbkControlUnits">        metric_units              </param> 
         <param name="outputControlUnits">     machine_units             </param>
-        <param name="kp">           1066.66    -2066.66     711.11   1066.66    </param>
-        <param name="kd">           0.00        0.00       0.00       0.00      </param>
-        <param name="ki">           10666.64   -14222.18    7111.09   1066.64   </param>
+        <param name="kp">          1066.66     2066.66     711.11   1066.66 </param>
+        <param name="kd">             0.00        0.00       0.00       0.00 </param>
+        <param name="ki">         10666.64    14222.18    7111.09   1066.64 </param>
         <param name="maxOutput">    8000        8000       8000       8000      </param>
         <param name="maxInt">       750        750        750       1000        </param>
         <param name="stictionUp">   0           0          0          0         </param>
@@ -67,7 +67,7 @@
         <param name="outputType">          pwm                          </param>
         <param name="fbkControlUnits">     metric_units                 </param>
         <param name="outputControlUnits">  machine_units                </param>
-        <param name="kp">            200       -200          0        300       </param>
+       <param name="kp">           200        200          0        300     </param>
         <param name="kd">              0          0          0          0       </param>
         <param name="ki">              0          0          0          0       </param>
         <param name="maxOutput">     8000       8000       8000       8000      </param>

--- a/iCubGenova02/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
+++ b/iCubGenova02/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
@@ -47,9 +47,9 @@
         <param name="outputType">             pwm                       </param>
         <param name="fbkControlUnits">        metric_units              </param> 
         <param name="outputControlUnits">     machine_units             </param>
-        <param name="kp">           -2105.00     -2310.00           </param>
-        <param name="kd">               0.00         0.00           </param>
-        <param name="ki">            -0.09        -0.09             </param>
+        <param name="kp">            2105.00      2310.00       </param>
+        <param name="kd">             0.00         0.00         </param>
+        <param name="ki">             0.09         0.09         </param>
         <param name="maxOutput">     8000         8000              </param>
         <param name="maxInt">         750          750              </param>
         <param name="stictionUp">       0            0              </param>
@@ -67,7 +67,7 @@
         <param name="outputType">          pwm                      </param>
         <param name="fbkControlUnits">     metric_units             </param>
         <param name="outputControlUnits">  machine_units            </param>
-        <param name="kp">          -150        -150             </param>
+         <param name="kp">           150         150            </param>
         <param name="kd">              0          0             </param>
         <param name="ki">              0          0             </param>
         <param name="maxOutput">    8000        8000            </param>

--- a/iCubGenova02/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubGenova02/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -47,9 +47,9 @@
         <param name="outputType">             pwm                   </param>
         <param name="fbkControlUnits">        metric_units          </param>
         <param name="outputControlUnits">     machine_units         </param>
-        <param name="kp">           -711.11     -1066.66    -1066.66    </param>
-        <param name="kd">           0.00        0.00        0.00        </param>
-        <param name="ki">           -7111.09    -10666.64   -14222.18   </param>
+        <param name="kp">             711.11     1066.66     1066.66 </param>
+        <param name="kd">              0.00        0.00        0.00 </param>
+        <param name="ki">            7111.09    10666.64    14222.18 </param>
         <param name="maxOutput">    8000        8000        16000       </param>
         <param name="maxInt">       750         1000        1000        </param>
         <param name="stictionUp">   0           0           0           </param>
@@ -67,7 +67,7 @@
         <param name="outputType">          pwm                          </param>
         <param name="fbkControlUnits">     metric_units                 </param>
         <param name="outputControlUnits">  machine_units                </param>
-        <param name="kp">            -450       -400       -400 </param>
+        <param name="kp">             450        400        400 </param>
         <param name="kd">              0          0          0  </param>
         <param name="ki">              0          0          0  </param>
         <param name="maxOutput">    8000       8000       8000  </param>

--- a/iCubGenova04/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
+++ b/iCubGenova04/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
@@ -34,7 +34,7 @@
         <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
         <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
         <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
-        <param name="torqueControl">            TRQ_PID_CUSTOM      TRQ_PID_CUSTOM      TRQ_PID_CUSTOM      TRQ_PID_CUSTOM      </param>
+       <param name="torqueControl">    TRQ_PID_NO_FRICTION       TRQ_PID_NO_FRICTION      TRQ_PID_NO_FRICTION      TRQ_PID_NO_FRICTION      </param>
         <param name="currentPid">               2FOC_CUR_CONTROL    2FOC_CUR_CONTROL    2FOC_CUR_CONTROL    2FOC_CUR_CONTROL    </param>
         <param name="speedPid">                 2FOC_VEL_CONTROL    2FOC_VEL_CONTROL    2FOC_VEL_CONTROL    2FOC_VEL_CONTROL    </param>
     </group>
@@ -123,12 +123,12 @@
         <param name="maxOutput">      25         25         25         25     </param>
         <param name="maxInt">       1.56       1.56       1.56       1.56     </param>
         <param name="ko">              0          0          0          0     </param>
-        <param name="stictionUp">      0          0          0          0     </param>
-        <param name="stictionDown">    0          0          0          0     </param>
-        <param name="kff">             1          1          1          1     </param>
-        <param name="kbemf">         0.0030     0.0006     0.0007     0.00    </param>
-        <param name="filterType">      0          0          0          0     </param>
-        <param name="ktau">          0.56       1.45       1.45       1.40    </param>
+        <param name="stictionUp">      3          1.5        1.5        1.5    </param>
+        <param name="stictionDown">    3          1.5        1.5        1.5    </param>
+        <param name="kff">             1          1          1          1      </param>
+        <param name="kbemf">           0.1        0.08       0.08       0.08   </param>
+        <param name="filterType">      0          0          0          0      </param>
+        <param name="ktau">            0.56       1.45       1.45       1.40   </param>
     </group>
     
     <group name="TRQ_PID_NO_FRICTION">
@@ -136,7 +136,7 @@
         <param name="outputType">          pwm                          </param>
         <param name="fbkControlUnits">     metric_units                 </param>
         <param name="outputControlUnits">  dutycycle_percent            </param>
-        <param name="kp">             0.63       0.63       0.63       0.94   </param>
+        <param name="kp">              0.63       0.63       0.78       0.94   </param>
         <param name="kd">              0          0          0          0     </param>
         <param name="ki">              0          0          0          0     </param>
         <param name="maxOutput">      25         25         25         25     </param>

--- a/iCubGenova04/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
+++ b/iCubGenova04/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
@@ -34,7 +34,7 @@
         <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
         <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
         <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
-        <param name="torqueControl">            TRQ_PID_TUNED       TRQ_PID_TUNED       TRQ_PID_TUNED       TRQ_PID_TUNED       </param>
+       <param name="torqueControl">    TRQ_PID_OUTPUT_CURR       TRQ_PID_OUTPUT_CURR      TRQ_PID_OUTPUT_CURR      TRQ_PID_OUTPUT_CURR     </param>
         <param name="currentPid">               2FOC_CUR_CONTROL    2FOC_CUR_CONTROL    2FOC_CUR_CONTROL    2FOC_CUR_CONTROL    </param>
         <param name="speedPid">                 2FOC_VEL_CONTROL    2FOC_VEL_CONTROL    2FOC_VEL_CONTROL    2FOC_VEL_CONTROL    </param>
     </group>
@@ -47,9 +47,9 @@
         <param name="outputType">             pwm                       </param>
         <param name="fbkControlUnits">        metric_units              </param> 
         <param name="outputControlUnits">     machine_units             </param>
-        <param name="kp">            -1066.66     2066.66    -711.11    -9000.0  </param>
+        <param name="kp">             1066.66     2066.66     711.11     9000.0  </param>
         <param name="kd">                0.00        0.00       0.00       0.00  </param>
-        <param name="ki">           -10666.64    14222.18   -7111.09    -800.0   </param>
+        <param name="ki">            10666.64    14222.18    7111.09     800.0   </param>
         <param name="maxOutput">         8000        8000       8000       8000  </param>
         <param name="maxInt">            1500        1500        750       1000  </param>
         <param name="stictionUp">           0           0          0          0  </param>
@@ -67,7 +67,7 @@
         <param name="outputType">           pwm                 </param>
         <param name="fbkControlUnits">      metric_units        </param>
         <param name="outputControlUnits">   dutycycle_percent   </param>
-        <param name="kp">            -0.47       0.47       0.00      -0.47   </param>      
+        <param name="kp">             0.47       0.47       0.00       0.47   </param>
         <param name="kd">              0          0          0          0     </param>
         <param name="ki">              0          0          0          0     </param>
         <param name="maxOutput">      25         25         25         25     </param>
@@ -78,7 +78,7 @@
         <param name="kff">             1          1          1          1     </param>
         <param name="kbemf">           0          0          0          0     </param>
         <param name="filterType">      0          0          0          0     </param>
-        <param name="ktau">         -0.51       0.56      -0.62      -0.52    </param>
+        <param name="ktau">          0.51       0.56       0.62       0.52    </param>
     </group>
 
     <group name="2FOC_CUR_CONTROL">
@@ -117,41 +117,41 @@
         <param name="outputType">             pwm                       </param>
         <param name="fbkControlUnits">        metric_units              </param> 
         <param name="outputControlUnits">     machine_units             </param>
-        <param name="kp">            -2000.66     2000.66    -711.11    -2000.66 </param>
-        <param name="kd">             -100.00      100.00    -100.00     -100.00 </param>
-        <param name="ki">           -11000.00    14000.00   -7111.00    -1000.00 </param>
+        <param name="kp">             2000.66     2000.66     711.11     2000.66 </param>
+        <param name="kd">              100.00      100.00     100.00      100.00 </param>
+        <param name="ki">            11000.00    14000.00    7111.00     1000.00 </param>
         <param name="maxOutput">         8000        8000       8000       8000  </param>
         <param name="maxInt">            1500        1500        750       1000  </param>
         <param name="stictionUp">           0           0          0          0  </param>
         <param name="stictionDown">         0           0          0          0  </param>
         <param name="kff">                  0           0          0          0  </param>
-    </group>   
+    </group>
 
     <group name="TRQ_PID_TUNED">
         <param name="controlLaw">          torque                       </param>
         <param name="outputType">          pwm                          </param>
         <param name="fbkControlUnits">     metric_units                 </param>
         <param name="outputControlUnits">  dutycycle_percent            </param>
-        <param name="kp">            0.00       0.00       0.00      -0.47    </param>     
+        <param name="kp">              0          0          0          0.47  </param>
         <param name="kd">              0          0          0          0     </param>
         <param name="ki">              0          0          0          0     </param>
         <param name="maxOutput">      25         25         25         25     </param>
         <param name="maxInt">       1.56       1.56       1.56       1.56     </param>
         <param name="ko">              0          0          0          0     </param>
-        <param name="stictionUp">      0          0          0          0     </param>
-        <param name="stictionDown">    0          0          0          0     </param>
+        <param name="stictionUp">      3          3          3          3     </param>
+        <param name="stictionDown">    3.5        3.5        3.5        3.5   </param>
         <param name="kff">             1          1          1          1     </param>
-        <param name="kbemf">           0          0          0          0     </param>
+        <param name="kbemf">           0.2        0.2        0.2        0.2   </param>
         <param name="filterType">      0          0          0          0     </param>
-        <param name="ktau">        -0.44       0.56      -0.62      -0.63     </param>
+        <param name="ktau">         0.44       0.56       0.62       0.63     </param>
     </group>
-    
+
     <group name="TRQ_PID_NO_FRICTION">
-        <param name="controlLaw">           torque              </param>
-        <param name="outputType">           pwm                 </param>
-        <param name="fbkControlUnits">      metric_units        </param>
-        <param name="outputControlUnits">   dutycycle_percent   </param>
-        <param name="kp">              0          0          0          0     </param>
+        <param name="controlLaw">          torque                       </param>
+        <param name="outputType">          pwm                          </param>
+        <param name="fbkControlUnits">     metric_units                 </param>
+        <param name="outputControlUnits">  dutycycle_percent            </param>
+        <param name="kp">              0          0          0          0.47  </param>
         <param name="kd">              0          0          0          0     </param>
         <param name="ki">              0          0          0          0     </param>
         <param name="maxOutput">      25         25         25         25     </param>
@@ -162,7 +162,7 @@
         <param name="kff">             1          1          1          1     </param>
         <param name="kbemf">           0          0          0          0     </param>
         <param name="filterType">      0          0          0          0     </param>
-        <param name="ktau">         -0.44       0.56      -0.62      -0.63    </param>
+        <param name="ktau">          0.44       0.56       0.62       0.63    </param>
     </group>
 
     <group name="TRQ_PID_OUTPUT_CURR">
@@ -170,18 +170,18 @@
         <param name="outputType">          current                      </param>
         <param name="fbkControlUnits">     metric_units                 </param>
         <param name="outputControlUnits">  machine_units                </param>
-        <param name="kp">           -150.00     150.00    -200.00    -150.00  </param>
+        <param name="kp">              0          0          0          0     </param>
         <param name="kd">              0          0          0          0     </param>
-        <param name="ki">            -80         50        -80        -80.00  </param>
+        <param name="ki">              0          0          0          0     </param>
         <param name="maxOutput">    2500       2500       2500       2500     </param>
         <param name="maxInt">        200        200        200        200     </param>
         <param name="ko">              0          0          0          0     </param>
-        <param name="stictionUp">      0          0          0          0     </param>
-        <param name="stictionDown">    0          0          0          0     </param>
+        <param name="stictionUp">      1.5        1.5        1.5        1.5   </param>
+        <param name="stictionDown">    1.5        1.5        1.5        1.5   </param>
         <param name="kff">             1          1          1          1     </param>
-        <param name="kbemf">          -0.0003     0.0004    -0.0003    -0.0002</param>
+        <param name="kbemf">           0.0093    0.0036    0.0062    0.0038   </param>
         <param name="filterType">      0          0          0          0     </param>
-        <param name="ktau">         -175.56     177.83    -175.74    -230.10  </param>
+        <param name="ktau">          175.56     177.83     175.74     230.10  </param>
     </group>
 
     <!-- custom PIDs: end -->

--- a/iCubGenova04/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
+++ b/iCubGenova04/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
@@ -34,7 +34,7 @@
         <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
         <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
         <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
-        <param name="torqueControl">            TRQ_PID_TUNED       TRQ_PID_TUNED       </param>
+       <param name="torqueControl">             TRQ_PID_OUTPUT_CURR       TRQ_PID_OUTPUT_CURR       </param>
         <param name="currentPid">               2FOC_CUR_CONTROL    2FOC_CUR_CONTROL    </param>
         <param name="speedPid">                 2FOC_VEL_CONTROL    2FOC_VEL_CONTROL    </param>
     </group>
@@ -132,16 +132,16 @@
         <param name="outputType">          pwm                          </param>
         <param name="fbkControlUnits">     metric_units                 </param>
         <param name="outputControlUnits">  dutycycle_percent            </param>
-        <param name="kp">            0.31         0.31          </param>
+        <param name="kp">             0.31         0.31         </param>
         <param name="kd">             0            0            </param>
         <param name="ki">             0            0            </param>
         <param name="maxOutput">      25          25            </param>
         <param name="maxInt">       1.56          1.56          </param>
-        <param name="ko">              0           0            </param>
-        <param name="stictionUp">      0           0            </param>
-        <param name="stictionDown">    0           0            </param>
-        <param name="kff">             1           1            </param>
-        <param name="kbemf">           0           0            </param>
+        <param name="ko">              0          0           </param>
+        <param name="stictionUp">      3          3           </param>
+        <param name="stictionDown">    3.5        3.5         </param>
+        <param name="kff">             1          1           </param>
+        <param name="kbemf">           0.2        0.2         </param>
         <param name="filterType">      0           0            </param>
         <param name="ktau">         0.72        0.53            </param>
     </group>
@@ -151,7 +151,7 @@
         <param name="outputType">          pwm                          </param>
         <param name="fbkControlUnits">     metric_units                 </param>
         <param name="outputControlUnits">  dutycycle_percent            </param>
-        <param name="kp">              0            0              </param>
+        <param name="kp">              0.31         0.31           </param>
         <param name="kd">              0            0              </param>
         <param name="ki">              0            0              </param>
         <param name="maxOutput">      25           25              </param>
@@ -170,21 +170,48 @@
         <param name="outputType">          current                      </param>
         <param name="fbkControlUnits">     metric_units                 </param>
         <param name="outputControlUnits">  machine_units                </param>
-        <param name="kp">            36.21        26.77         </param>
+        <param name="kp">             0            0            </param>
         <param name="kd">             0            0            </param>
         <param name="ki">             0            0            </param>
         <param name="maxOutput">    2500        2500            </param>
         <param name="maxInt">        200         200            </param>
-        <param name="ko">              0           0            </param>
-        <param name="stictionUp">      0           0            </param>
-        <param name="stictionDown">    0           0            </param>
-        <param name="kff">             1           1            </param>
-        <param name="kbemf">           0.0003      0.0003       </param>
-        <param name="filterType">      0           0            </param>
-        <param name="ktau">          162.24      163.96         </param>
+        <param name="ko">              0          0             </param>
+        <param name="stictionUp">      1.5        1.5         </param>
+        <param name="stictionDown">    1.5        1.5         </param>
+        <param name="kff">             1          1           </param>
+        <param name="kbemf">           0.0102     0.0157      </param>
+        <param name="filterType">      0          0           </param>
+        <param name="ktau">          162.24     163.96        </param>
     </group>
 
-    <!-- custom PIDs: end -->
+    <group name="2FOC_CUR_CONTROL">
+        <param name="controlLaw">          low_lev_current      </param> 
+        <param name="fbkControlUnits">     machine_units        </param> 
+        <param name="outputControlUnits">  machine_units        </param>
+        <param name="kp">               8           8           </param>
+        <param name="kd">               0           0           </param>
+        <param name="ki">               2           2           </param>
+        <param name="shift">            10          10          </param>
+        <param name="maxOutput">        32000       32000       </param>
+        <param name="maxInt">           32000       32000       </param>
+        <param name="kff">              0            0          </param>
+    </group>
 
-</device>
+    <group name="2FOC_VEL_CONTROL">
+        <param name="controlLaw">          low_lev_speed        </param> 
+        <param name="fbkControlUnits">     machine_units        </param> 
+        <param name="outputControlUnits">  machine_units        </param>
+        <param name="kff">                     0         0      </param>
+        <param name="kp">                     12        12      </param>       
+        <param name="kd">                      0         0      </param>       
+        <param name="ki">                     16        16      </param>
+        <param name="shift">                  10        10      </param>
+        <param name="maxOutput">           32000     32000      </param>                 
+        <param name="maxInt">              32000     32000      </param>        
+    </group>
+
+    
+    <!-- custom PIDs: end -->
+    
+  </device>
 

--- a/iCubGenova04/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
+++ b/iCubGenova04/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
@@ -34,7 +34,7 @@
         <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
         <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
         <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
-        <param name="torqueControl">            TRQ_PID_CUSTOM      TRQ_PID_CUSTOM      TRQ_PID_CUSTOM      TRQ_PID_CUSTOM      </param>
+       <param name="torqueControl">    TRQ_PID_NO_FRICTION       TRQ_PID_NO_FRICTION      TRQ_PID_NO_FRICTION      TRQ_PID_NO_FRICTION      </param>
         <param name="currentPid">               2FOC_CUR_CONTROL    2FOC_CUR_CONTROL    2FOC_CUR_CONTROL    2FOC_CUR_CONTROL    </param>
         <param name="speedPid">                 2FOC_VEL_CONTROL    2FOC_VEL_CONTROL    2FOC_VEL_CONTROL    2FOC_VEL_CONTROL    </param>
     </group>
@@ -47,9 +47,9 @@
         <param name="outputType">           pwm                       </param>
         <param name="fbkControlUnits">      metric_units              </param>
         <param name="outputControlUnits">   machine_units             </param>
-        <param name="kp">                   -711.11   -1066.66    -711.11   -1066.66 </param>
-        <param name="kd">                   0.00       0.00       0.00       0.00 </param>
-        <param name="ki">                   -7111.09  -10666.64   -7111.09  -10666.64 </param>
+        <param name="kp">           711.11    1066.66     711.11    1066.66 </param>
+        <param name="kd">             0.00       0.00       0.00       0.00 </param>
+        <param name="ki">          7111.09   10666.64    7111.09   10666.64 </param>
         <param name="maxOutput">            8000       8000       8000       8000 </param>
         <param name="maxInt">               200        200        200       1000 </param>
         <param name="stictionUp">           0          0          0          0 </param>
@@ -67,7 +67,7 @@
         <param name="outputType">           pwm                          </param>
         <param name="fbkControlUnits">      metric_units                 </param>
         <param name="outputControlUnits">  dutycycle_percent            </param>
-        <param name="kp">            -0.16      -0.63      -0.78      -0.94   </param>
+        <param name="kp">             0.16       0.63       0.78       0.94   </param>
         <param name="kd">              0          0          0          0     </param>
         <param name="ki">              0          0          0          0     </param>
         <param name="maxOutput">      25         25         25         25     </param>
@@ -76,9 +76,9 @@
         <param name="stictionUp">      0          0          0          0     </param>
         <param name="stictionDown">    0          0          0          0     </param>
         <param name="kff">             1          1          1          1     </param>
-        <param name="kbemf">        -0.0030    -0.0006    -0.0007    -0.0007  </param>
+        <param name="kbemf">         0.0030     0.0006     0.0007     0.0007  </param>
         <param name="filterType">      0          0          0          0     </param>
-        <param name="ktau">         -0.56      -1.45      -1.45      -1.40    </param>
+        <param name="ktau">          0.56       1.45       1.45       1.40    </param>
     </group>
     
     <group name="2FOC_CUR_CONTROL">
@@ -117,37 +117,37 @@
         <param name="outputType">          pwm                          </param>
         <param name="fbkControlUnits">     metric_units                 </param>
         <param name="outputControlUnits">  dutycycle_percent            </param>
-        <param name="kp">            -0.16      -0.63      -0.78      -0.94   </param>
-        <param name="kd">              0          0          0          0     </param>
-        <param name="ki">              0          0          0          0     </param>
-        <param name="maxOutput">      25         25         25         25     </param>
-        <param name="maxInt">       1.56       1.56       1.56       1.56     </param>
-        <param name="ko">              0          0          0          0     </param>
-        <param name="stictionUp">      0          0          0          0     </param>
-        <param name="stictionDown">    0          0          0          0     </param>
-        <param name="kff">             1          1          1          1     </param>
-        <param name="kbemf">        -0.0030    -0.0006    -0.0007     0.00    </param>
-        <param name="filterType">      0          0          0          0     </param>
-        <param name="ktau">         -0.56      -1.45      -1.45      -1.40    </param>
+        <param name="kp">              0.63       0.63       0.78       0.94   </param>
+	<param name="kd">              0          0          0          0      </param>
+        <param name="ki">              0          0          0          0      </param>
+        <param name="maxOutput">      25         25         25         25      </param>
+        <param name="maxInt">          1.56       1.56       1.56       1.56   </param>
+        <param name="ko">              0          0          0          0      </param>
+        <param name="stictionUp">      3          1.5        1.5        1.5    </param>
+        <param name="stictionDown">    3          1.5        1.5        1.5    </param>
+        <param name="kff">             1          1          1          1      </param>
+        <param name="kbemf">           0.1        0.08       0.08       0.08   </param>
+        <param name="filterType">      0          0          0          0      </param>
+        <param name="ktau">            0.56       1.45       1.45       1.40   </param>
     </group>
-    
+
     <group name="TRQ_PID_NO_FRICTION">
         <param name="controlLaw">          torque                       </param>
         <param name="outputType">          pwm                          </param>
         <param name="fbkControlUnits">     metric_units                 </param>
         <param name="outputControlUnits">  dutycycle_percent            </param>
-        <param name="kp">            -0.63      -0.63      -0.63      -0.94   </param>
+        <param name="kp">              0.63       0.63       0.78       0.94  </param>
         <param name="kd">              0          0          0          0     </param>
         <param name="ki">              0          0          0          0     </param>
         <param name="maxOutput">      25         25         25         25     </param>
-        <param name="maxInt">       1.56       1.56       1.56       1.56     </param>
+        <param name="maxInt">          1.56       1.56       1.56       1.56  </param>
         <param name="ko">              0          0          0          0     </param>
         <param name="stictionUp">      0          0          0          0     </param>
         <param name="stictionDown">    0          0          0          0     </param>
         <param name="kff">             1          1          1          1     </param>
         <param name="kbemf">           0          0          0          0     </param>
         <param name="filterType">      0          0          0          0     </param>
-        <param name="ktau">         -0.56      -1.45      -1.45      -1.40    </param>
+        <param name="ktau">            0.56       1.45       1.45       1.40  </param>
     </group>
    
     <!-- custom PIDs: end -->

--- a/iCubGenova04/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
+++ b/iCubGenova04/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
@@ -181,7 +181,7 @@
         <param name="kff">             1          1          1          1     </param>
         <param name="kbemf">           0.0093    0.0036    0.0062    0.0038   </param>
         <param name="filterType">      0          0          0          0     </param>
-        <param name="ktau">          196.52     185.41     185.70     270.78  </param>
+        <param name="ktau">          196.52     185.41     185.70     230.10  </param>
     </group>
 
     <!-- custom PIDs: end -->

--- a/iCubGenova04/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
+++ b/iCubGenova04/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
@@ -34,7 +34,7 @@
       <param name="positionControl">            POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
       <param name="velocityControl">            POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
       <param name="mixedControl">               POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
-      <param name="torqueControl">              TRQ_PID_TUNED       TRQ_PID_TUNED       TRQ_PID_TUNED       TRQ_PID_TUNED       </param>
+       <param name="torqueControl">    TRQ_PID_OUTPUT_CURR       TRQ_PID_OUTPUT_CURR      TRQ_PID_OUTPUT_CURR      TRQ_PID_OUTPUT_CURR     </param>
       <param name="currentPid">                 2FOC_CUR_CONTROL    2FOC_CUR_CONTROL    2FOC_CUR_CONTROL    2FOC_CUR_CONTROL    </param>
       <param name="speedPid">                   2FOC_VEL_CONTROL    2FOC_VEL_CONTROL    2FOC_VEL_CONTROL    2FOC_VEL_CONTROL    </param>
     </group>
@@ -47,9 +47,9 @@
         <param name="outputType">             pwm                       </param>
         <param name="fbkControlUnits">        metric_units              </param> 
         <param name="outputControlUnits">     machine_units             </param>
-        <param name="kp">           1066.66    -2066.66     711.11   9000.0    </param>
+        <param name="kp">           1066.66     2066.66     711.11   9000.0    </param>
         <param name="kd">              0.00        0.00       0.00       0.00   </param>
-        <param name="ki">          10666.64   -14222.18    7111.09   800.0    </param>
+        <param name="ki">          10666.64    14222.18    7111.09   800.0    </param>
         <param name="maxOutput">       8000        8000       8000       8000   </param>
         <param name="maxInt">          1500        1500        750       1000   </param>
         <param name="stictionUp">         0           0          0          0   </param>
@@ -67,7 +67,7 @@
         <param name="outputType">          pwm                          </param>
         <param name="fbkControlUnits">     metric_units                 </param>
         <param name="outputControlUnits">  dutycycle_percent            </param>
-        <param name="kp">             0.47      -0.47       0.00       0.47   </param>      
+        <param name="kp">             0.47       0.47       0.00       0.47   </param>
         <param name="kd">              0          0          0          0     </param>
         <param name="ki">              0          0          0          0     </param>
         <param name="maxOutput">      25         25         25         25     </param>
@@ -78,7 +78,7 @@
         <param name="kff">             1          1          1          1     </param>
         <param name="kbemf">           0          0          0          0     </param>
         <param name="filterType">      0          0          0          0     </param>
-        <param name="ktau">          0.46      -0.56       0.68       0.88    </param>
+        <param name="ktau">          0.46       0.56       0.68       0.88    </param>
     </group>
 
     <group name="2FOC_CUR_CONTROL">
@@ -117,33 +117,33 @@
         <param name="outputType">             pwm                       </param>
         <param name="fbkControlUnits">        metric_units              </param> 
         <param name="outputControlUnits">     machine_units             </param>
-        <param name="kp">           2066.66    -2066.66     711.11   2066.66  </param>
-        <param name="kd">            100.00     -100.00     100.00    100.00  </param>
-        <param name="ki">          11000.00   -14000.00       0.00   1066.64  </param>
+        <param name="kp">           2066.66     2066.66     711.11   2066.66  </param>
+        <param name="kd">            100.00      100.00     100.00    100.00  </param>
+        <param name="ki">          11000.00    14000.00       0.00   1066.64  </param>
         <param name="maxOutput">       8000        8000       8000       8000 </param>
         <param name="maxInt">          1500        1500        750       1000 </param>
         <param name="stictionUp">         0           0          0          0 </param>
         <param name="stictionDown">       0           0          0          0 </param>
         <param name="kff">                0           0          0          0 </param>
     </group>
-    
+
     <group name="TRQ_PID_TUNED">
         <param name="controlLaw">          torque                       </param>
         <param name="outputType">          pwm                          </param>
         <param name="fbkControlUnits">     metric_units                 </param>
         <param name="outputControlUnits">  dutycycle_percent            </param>
-        <param name="kp">              0          0          0        0.47    </param>      
+        <param name="kp">              0          0          0          0.47  </param>
         <param name="kd">              0          0          0          0     </param>
         <param name="ki">              0          0          0          0     </param>
         <param name="maxOutput">      25         25         25         25     </param>
         <param name="maxInt">       1.56       1.56       1.56       1.56     </param>
         <param name="ko">              0          0          0          0     </param>
-        <param name="stictionUp">      0          0          0          0     </param>
-        <param name="stictionDown">    0          0          0          0     </param>
+        <param name="stictionUp">      3          3          3          3     </param>
+        <param name="stictionDown">    3.5        3.5        3.5        3.5   </param>
         <param name="kff">             1          1          1          1     </param>
-        <param name="kbemf">           0          0          0          0     </param>
+        <param name="kbemf">           0.2        0.2        0.2        0.2   </param>
         <param name="filterType">      0          0          0          0     </param>
-        <param name="ktau">          0.44      -0.56       0.68       0.63    </param>
+        <param name="ktau">          0.44       0.56       0.68       0.63    </param>
     </group>
 
     <group name="TRQ_PID_NO_FRICTION">
@@ -151,7 +151,7 @@
         <param name="outputType">          pwm                          </param>
         <param name="fbkControlUnits">     metric_units                 </param>
         <param name="outputControlUnits">  dutycycle_percent            </param>
-        <param name="kp">              0          0          0          0     </param>     
+        <param name="kp">              0          0          0          0.47  </param>
         <param name="kd">              0          0          0          0     </param>
         <param name="ki">              0          0          0          0     </param>
         <param name="maxOutput">      25         25         25         25     </param>
@@ -162,7 +162,7 @@
         <param name="kff">             1          1          1          1     </param>
         <param name="kbemf">           0          0          0          0     </param>
         <param name="filterType">      0          0          0          0     </param>
-        <param name="ktau">          0.44      -0.56       0.68       0.63    </param>
+        <param name="ktau">          0.44       0.56       0.68       0.63    </param>
     </group>
 
     <group name="TRQ_PID_OUTPUT_CURR">
@@ -170,18 +170,18 @@
         <param name="outputType">          current                      </param>
         <param name="fbkControlUnits">     metric_units                 </param>
         <param name="outputControlUnits">  machine_units                </param>
-        <param name="kp">            150.00    -150.00     200.00     150.00  </param>
-        <param name="kd">              0          0          0          0     </param>
-        <param name="ki">             80        -50         80         80.00  </param>
+        <param name="kp">              0           0         0          0     </param>
+        <param name="kd">              0           0         0          0     </param>
+        <param name="ki">              0           0         0          0     </param>
         <param name="maxOutput">    2500       2500       2500       2500     </param>
         <param name="maxInt">        200        200        200        200     </param>
         <param name="ko">              0          0          0          0     </param>
-        <param name="stictionUp">      0          0          0          0     </param>
-        <param name="stictionDown">    0          0          0          0     </param>
+        <param name="stictionUp">      1.5        1.5        1.5        1.5   </param>
+        <param name="stictionDown">    1.5        1.5        1.5        1.5   </param>
         <param name="kff">             1          1          1          1     </param>
-        <param name="kbemf">           0.0002    -0.0003     0.0003     0.0001</param>
+        <param name="kbemf">           0.0093    0.0036    0.0062    0.0038   </param>
         <param name="filterType">      0          0          0          0     </param>
-        <param name="ktau">          196.52    -185.41     185.70     270.78  </param>
+        <param name="ktau">          196.52     185.41     185.70     270.78  </param>
     </group>
 
     <!-- custom PIDs: end -->

--- a/iCubGenova04/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
+++ b/iCubGenova04/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
@@ -34,7 +34,7 @@
        <param name="positionControl">           POS_PID_DEFAULT         POS_PID_DEFAULT         </param>
        <param name="velocityControl">           POS_PID_DEFAULT         POS_PID_DEFAULT         </param>
        <param name="mixedControl">              POS_PID_DEFAULT         POS_PID_DEFAULT         </param>
-       <param name="torqueControl">             TRQ_PID_TUNED           TRQ_PID_TUNED           </param>
+       <param name="torqueControl">             TRQ_PID_OUTPUT_CURR       TRQ_PID_OUTPUT_CURR       </param>
        <param name="currentPid">                2FOC_CUR_CONTROL        2FOC_CUR_CONTROL        </param>
        <param name="speedPid">                  2FOC_VEL_CONTROL        2FOC_VEL_CONTROL        </param>
     </group>
@@ -47,9 +47,9 @@
         <param name="outputType">             pwm                       </param>
         <param name="fbkControlUnits">        metric_units              </param> 
         <param name="outputControlUnits">     machine_units             </param>
-        <param name="kp">           -4000.00     -2310.00         </param>
+        <param name="kp">            4000.00      2310.00         </param>
         <param name="kd">               0.00         0.00         </param>
-        <param name="ki">              -200.0        -0.09         </param>
+        <param name="ki">               200.0         0.09         </param>
         <param name="maxOutput">     8000         8000            </param>
         <param name="maxInt">         750          750            </param>
         <param name="stictionUp">       0            0            </param>
@@ -67,7 +67,7 @@
         <param name="outputType">          pwm                          </param>
         <param name="fbkControlUnits">     metric_units                 </param>
         <param name="outputControlUnits">  dutycycle_percent            </param>
-        <param name="kp">          -0.53        -0.53           </param>
+        <param name="kp">           0.53         0.53           </param>
         <param name="kd">              0          0             </param>
         <param name="ki">              0          0             </param>
         <param name="maxOutput">      25         25             </param>
@@ -78,7 +78,7 @@
         <param name="kff">             1          1             </param>
         <param name="kbemf">           0          0             </param>
         <param name="filterType">      0          0             </param>
-        <param name="ktau">          -0.72      -0.56           </param>
+        <param name="ktau">           0.72       0.56           </param>
     </group>
 
     <group name="2FOC_CUR_CONTROL">
@@ -117,9 +117,9 @@
         <param name="outputType">             pwm                       </param>
         <param name="fbkControlUnits">        metric_units              </param> 
         <param name="outputControlUnits">     machine_units             </param>
-        <param name="kp">           -3105.00     -2310.00         </param>
-        <param name="kd">            -100.00      -100.00         </param>
-        <param name="ki">              -0.09        -0.09         </param>
+        <param name="kp">            3105.00      2310.00         </param>
+        <param name="kd">             100.00       100.00         </param>
+        <param name="ki">               0.09         0.09         </param>
         <param name="maxOutput">     8000         8000            </param>
         <param name="maxInt">         750          750            </param>
         <param name="stictionUp">       0            0            </param>
@@ -132,18 +132,18 @@
         <param name="outputType">          pwm                          </param>
         <param name="fbkControlUnits">     metric_units                 </param>
         <param name="outputControlUnits">  dutycycle_percent            </param>
-        <param name="kp">           -0.31      -0.31           </param>
-        <param name="kd">             0          0             </param>
-        <param name="ki">             0          0             </param>
-        <param name="maxOutput">     25         25             </param>
-        <param name="maxInt">      1.56       1.56             </param>
-        <param name="ko">             0          0             </param>
-        <param name="stictionUp">     0          0             </param>
-        <param name="stictionDown">   0          0             </param>
-        <param name="kff">            1          1             </param>
-        <param name="kbemf">          0          0             </param>
-        <param name="filterType">     0          0             </param>
-        <param name="ktau">        -0.72      -0.53            </param>
+        <param name="kp">              0.31       0.31          </param>
+        <param name="kd">              0          0             </param>
+        <param name="ki">              0          0             </param>
+        <param name="maxOutput">      25         25             </param>
+        <param name="maxInt">       1.56       1.56             </param>
+        <param name="ko">              0          0           </param>
+        <param name="stictionUp">      3          3           </param>
+        <param name="stictionDown">    3.5        3.5         </param>
+        <param name="kff">             1          1           </param>
+        <param name="kbemf">           0.2        0.2         </param>
+        <param name="filterType">      0          0             </param>
+        <param name="ktau">         0.72       0.53            </param>
     </group>
 
     <group name="TRQ_PID_NO_FRICTION">
@@ -151,7 +151,7 @@
         <param name="outputType">          pwm                          </param>
         <param name="fbkControlUnits">     metric_units                 </param>
         <param name="outputControlUnits">  dutycycle_percent            </param>
-        <param name="kp">              0          0             </param>
+        <param name="kp">              0.31       0.31          </param>
         <param name="kd">              0          0             </param>
         <param name="ki">              0          0             </param>
         <param name="maxOutput">      25         25             </param>
@@ -162,7 +162,7 @@
         <param name="kff">             1          1             </param>
         <param name="kbemf">           0          0             </param>
         <param name="filterType">      0          0             </param>
-        <param name="ktau">          -0.72      -0.53           </param>
+        <param name="ktau">           0.72       0.53           </param>
     </group>
 
     <group name="TRQ_PID_OUTPUT_CURR">
@@ -170,18 +170,18 @@
         <param name="outputType">          current                      </param>
         <param name="fbkControlUnits">     metric_units                 </param>
         <param name="outputControlUnits">  machine_units                </param>
-        <param name="kp">            -40.44     -28.27    </param>
-        <param name="kd">              0          0       </param>
-        <param name="ki">              0          0       </param>
-        <param name="maxOutput">    2500       2500       </param>
-        <param name="maxInt">        200        200       </param>
-        <param name="ko">              0          0       </param>
-        <param name="stictionUp">      0          0       </param>
-        <param name="stictionDown">    0          0       </param>
-        <param name="kff">             1          1       </param>
-        <param name="kbemf">          -0.0003    -0.0004  </param>
-        <param name="filterType">      0          0       </param>
-        <param name="ktau">         -181.17    -230.00    </param>
+        <param name="kp">             0            0            </param>
+        <param name="kd">             0            0            </param>
+        <param name="ki">             0            0            </param>
+        <param name="maxOutput">    2500        2500            </param>
+        <param name="maxInt">        200         200            </param>
+        <param name="ko">              0          0           </param>
+        <param name="stictionUp">      1.5        1.5         </param>
+        <param name="stictionDown">    1.5        1.5         </param>
+        <param name="kff">             1          1           </param>
+        <param name="kbemf">           0.0102     0.0157      </param>
+        <param name="filterType">      0          0           </param>
+        <param name="ktau">          181.17     230.00        </param>
     </group>
 
     <!-- custom PIDs: end -->

--- a/iCubGenova04/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubGenova04/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -34,7 +34,7 @@
         <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
         <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
         <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
-        <param name="torqueControl">            TRQ_PID_CUSTOM      TRQ_PID_CUSTOM      TRQ_PID_CUSTOM      </param>
+       <param name="torqueControl">    TRQ_PID_OUTPUT_CURR       TRQ_PID_OUTPUT_CURR      TRQ_PID_OUTPUT_CURR      </param>
         <param name="currentPid">               2FOC_CUR_CONTROL    2FOC_CUR_CONTROL    2FOC_CUR_CONTROL    </param>
         <param name="speedPid">                 2FOC_VEL_CONTROL    2FOC_VEL_CONTROL    2FOC_VEL_CONTROL    </param>
     </group>
@@ -47,14 +47,14 @@
         <param name="outputType">             pwm                   </param>
         <param name="fbkControlUnits">        metric_units          </param>
         <param name="outputControlUnits">     machine_units         </param>
-        <param name="kp">           -711.11     -1066.66    -1066.66    </param>
-        <param name="kd">           0.00        0.00        0.00        </param>
-        <param name="ki">           -7111.09    -10666.64   -14222.18   </param>
-        <param name="maxOutput">    8000        8000        16000       </param>
-        <param name="maxInt">       750         1000        1000        </param>
-        <param name="stictionUp">   0           0           0           </param>
-        <param name="stictionDown"> 0           0           0           </param>
-        <param name="kff">          0           0           0           </param>
+        <param name="kp">             711.11     1066.66     1066.66 </param>
+        <param name="kd">              0.00        0.00        0.00  </param>
+        <param name="ki">            7111.09    10666.64    14222.18 </param>
+        <param name="maxOutput">       8000        8000       16000  </param>
+        <param name="maxInt">           750        1000        1000  </param>
+        <param name="stictionUp">         0           0           0  </param>
+        <param name="stictionDown">        0           0           0  </param>
+        <param name="kff">                0           0           0  </param>
     </group>
 
     <!-- default position PID: end -->
@@ -67,18 +67,18 @@
         <param name="outputType">          pwm                          </param>
         <param name="fbkControlUnits">     metric_units                 </param>
         <param name="outputControlUnits">  dutycycle_percent            </param>
-        <param name="kp">          -1.41      -1.25      -1.25  </param>
+        <param name="kp">           1.41       1.25       1.25  </param>
         <param name="kd">              0          0          0  </param>
         <param name="ki">              0          0          0  </param>
         <param name="maxOutput">      25         25         25  </param>
         <param name="maxInt">       1.56       1.56       1.56  </param>
         <param name="ko">              0          0          0  </param>
         <param name="stictionUp">      0          0          0  </param>
-        <param name="stictionDown">     0          0          0  </param>
+        <param name="stictionDown">    0          0          0  </param>
         <param name="kff">             1          1          1  </param>
-        <param name="kbemf">      -0.0016    -0.003     -0.003  </param>
+        <param name="kbemf">           0.0016     0.003      0.003 </param>
         <param name="filterType">      0          0          0  </param>
-        <param name="ktau">        -0.63      -0.63      -0.63  </param>
+        <param name="ktau">         0.63       0.63       0.63  </param>
     </group>
 
     <group name="2FOC_CUR_CONTROL">
@@ -112,23 +112,23 @@
  
     <!-- custom PIDs: begin -->
     
-    <group name="TRQ_PID_CUSTOM">
+    <group name="TRQ_PID_TUNED">
         <param name="controlLaw">          torque                       </param>
         <param name="outputType">          pwm                          </param>
         <param name="fbkControlUnits">     metric_units                 </param>
         <param name="outputControlUnits">  dutycycle_percent            </param>
-        <param name="kp">          -0.31      -0.31      -0.31   </param>
+        <param name="kp">              0.31       0.31       0.31</param>
         <param name="kd">              0          0          0   </param>
         <param name="ki">              0          0          0   </param>
         <param name="maxOutput">      25         25         25   </param>
         <param name="maxInt">       1.56       1.56       1.56   </param>
         <param name="ko">              0          0          0   </param>
-        <param name="stictionUp">      0          0          0   </param>
-        <param name="stictionDown">     0          0          0   </param>
-        <param name="kff">             1          1          1   </param>
-        <param name="kbemf">           0          0          0   </param>
-        <param name="filterType">      0          0          0   </param>
-        <param name="ktau">         -0.63      -0.63      -0.63  </param>
+        <param name="stictionUp">      3          3          3   </param>
+        <param name="stictionDown">    3.5        3.5        3.5 </param>
+        <param name="kff">             1          1          1      </param>
+        <param name="kbemf">           0.2        0.2        0.2    </param>
+        <param name="filterType">      0          0          0      </param>
+        <param name="ktau">            0.63       0.63       0.63   </param>
     </group>
 
     <group name="TRQ_PID_NO_FRICTION">
@@ -136,18 +136,18 @@
         <param name="outputType">          pwm                          </param>
         <param name="fbkControlUnits">     metric_units                 </param>
         <param name="outputControlUnits">  dutycycle_percent            </param>
-        <param name="kp">              0          0          0   </param>
+        <param name="kp">              0.31       0.31       0.31</param>
         <param name="kd">              0          0          0   </param>
         <param name="ki">              0          0          0   </param>
         <param name="maxOutput">      25         25         25   </param>
         <param name="maxInt">       1.56       1.56       1.56   </param>
         <param name="ko">              0          0          0   </param>
         <param name="stictionUp">      0          0          0   </param>
-        <param name="stictionDown">     0          0          0   </param>
+        <param name="stictionDown">    0          0          0   </param>
         <param name="kff">             1          1          1   </param>
         <param name="kbemf">           0          0          0   </param>
         <param name="filterType">      0          0          0   </param>
-        <param name="ktau">         -0.63      -0.63      -0.63  </param>
+        <param name="ktau">            0.63       0.63       0.63</param>
     </group>
 
     <group name="TRQ_PID_OUTPUT_CURR">
@@ -155,18 +155,18 @@
         <param name="outputType">          current                      </param>
         <param name="fbkControlUnits">     metric_units                 </param>
         <param name="outputControlUnits">  machine_units                </param>
-        <param name="kp">           -150       -150       -150      </param>
+        <param name="kp">              0          0          0      </param>
         <param name="kd">              0          0          0      </param>
-        <param name="ki">            -50        -50        -50      </param>
+        <param name="ki">              0          0          0      </param>
         <param name="maxOutput">    2500       2500       2500      </param>
         <param name="maxInt">        200        200        200      </param>
         <param name="ko">              0          0          0      </param>
-        <param name="stictionUp">      0          0          0      </param>
-        <param name="stictionDown">    0          0          0      </param>
+        <param name="stictionUp">      1.5        1.5        1.5    </param>
+        <param name="stictionDown">    1.5        1.5        1.5    </param>
         <param name="kff">             1          1          1      </param>
-        <param name="kbemf">          -0.0001    -0.0003    -0.0003 </param>
+        <param name="kbemf">           0.0017     0.003      0.003  </param>
         <param name="filterType">      0          0          0      </param>
-        <param name="ktau">         -426.33    -209.96    -164.01   </param>
+        <param name="ktau">          426.33     209.96     164.01   </param>
     </group>
 
     <!-- custom PIDs: end -->

--- a/iCubGenova04/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubGenova04/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -161,8 +161,8 @@
         <param name="maxOutput">    2500       2500       2500      </param>
         <param name="maxInt">        200        200        200      </param>
         <param name="ko">              0          0          0      </param>
-        <param name="stictionUp">      1.5        1.5        1.5    </param>
-        <param name="stictionDown">    1.5        1.5        1.5    </param>
+        <param name="stictionUp">      1          1          1    </param>
+        <param name="stictionDown">    1          1          1    </param>
         <param name="kff">             1          1          1      </param>
         <param name="kbemf">           0.0017     0.003      0.003  </param>
         <param name="filterType">      0          0          0      </param>


### PR DESCRIPTION
These changes are part of the implementation of https://github.com/dic-iit/element_torque-control-via-current/issues/81 and a dependency of https://github.com/robotology/icub-firmware/pull/101.

## The main impacts are...
- The implemented friction model includes Stiction, Coulomb and Viscous friction compensation as described in https://github.com/dic-iit/element_torque-control-via-current/issues/81.
- This requires the new input parameters, which already existed in the interface but were either never used in the EMS code, either always set to zero in the config files:
    - `stictionUp`, `stictionDown` ($\text{Nm}$): the static friction respectively for positive and negative joint velocities **[never used in the code]**.
(there are some configs we have to cleanup, that use these parameters though. I will push a new commit with the clwanup after I get the feedback from @marcoaccame and @valegagge and @ale-git on this).
    - `k0` ($\text{Nm}$): Coulomb friction Kc [always set to zero in every configuration].
- I have not changed the units of `Kbemf` (Still in $\text{Nm}/(deg \\, s^{-1})$), but now they represent $K_v$ With respect to the joint velocity instead of the motor velocity, such that the values set in the `yarpmotorgui` interface are larger and easier to tune (order of magnitude 1 instead of 0.0001).
- No change for `Ktau` units.
- !!! ALL THE VALUES ARE NOW POSITIVE !!!

## All positive values...
It is painful and error prone to carry around useless signs that depend on the orientation of the joint and the sign used for the gearbox ratio... even if we can distinguish a pattern in the signs across the `ktau` values for a given part, and we got used to them.
Removing the signs alows to have more portable parameters, considering that they don't change that much between two similar motor, and typically between  left and right legs. This also facilitates the portability of a given joint configuration between the robot and the single-motor testing setup I've been working on lately.

This does not impact the signs used on the gearbox ratios set in the `motorcontrol` configuration files. Actually, consider that the sign previously hard coded on the input `ktau`, is now set from the Gearbox ratio in the EMS controller when the parameters are parsed.

More details o the implementation will be given in https://github.com/robotology/icub-firmware/pull/101.