### PR TITLE
[iCubGenova04] fix icub_wbd_inertials right_leg_inertials

### DIFF
--- a/iCubGenova04/icub_wbd_inertials.xml
+++ b/iCubGenova04/icub_wbd_inertials.xml
@@ -77,17 +77,17 @@
     <xi:include href="wrappers/inertials/left_leg-inertials_wrapper.xml" />
 
     <!-- DEVICES FOR INERTIAL SENSORS ON MTB, EMS AND FT STRAIN BOARDS -->
-    <devices file="hardware/inertials/right_leg-eb8-IMU.xml" />
-    <devices file="hardware/inertials/right_leg-eb8-inertials.xml" />
-    <devices file="hardware/inertials/right_leg-eb9-IMU.xml" />
-    <devices file="hardware/inertials/right_leg-eb9-inertials.xml" />
-    <devices file="hardware/inertials/right_leg-eb11-inertials.xml" />
+    <xi:include href="hardware/inertials/right_leg-eb8-IMU.xml" />
+    <xi:include href="hardware/inertials/right_leg-eb8-inertials.xml" />
+    <xi:include href="hardware/inertials/right_leg-eb9-IMU.xml" />
+    <xi:include href="hardware/inertials/right_leg-eb9-inertials.xml" />
+    <xi:include href="hardware/inertials/right_leg-eb11-inertials.xml" />
 
     <!-- REMAPPERS FOR INERTIAL SENSORS ON MTB, EMS AND FT STRAIN BOARDS -->
-    <devices file="wrappers/inertials/right_leg-inertials_remapper.xml" />
+    <xi:include href="wrappers/inertials/right_leg-inertials_remapper.xml" />
 
     <!-- WRAPPERS FOR INERTIAL SENSORS ON MTB, EMS AND FT STRAIN BOARDS -->
-    <devices file="wrappers/inertials/right_leg-inertials_wrapper.xml" />
+    <xi:include href="wrappers/inertials/right_leg-inertials_wrapper.xml" />
 
     <!-- ANALOG SENSOR FT -->
     <xi:include href="wrappers/FT/left_arm-FT_wrapper.xml" />


### PR DESCRIPTION
This PR fixes the inclusion of the right leg inertial devices in the `icub_wbd_inertial.xml`

Without this fix, the `yarprobotinterface` silently skips the opening of these devices and a `multipleanalogsensorsserver`.

cc @S-Dafarra @nunoguedelha 