### PR TITLE
[iTeenGenova01] Fix robot name in iTeenGenova01/CMakeLists.txt

### DIFF
--- a/iTeenGenova01/CMakeLists.txt
+++ b/iTeenGenova01/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(appname iCubGenova04)
+set(appname iTeenGenova01)
 
 file(GLOB xml ${CMAKE_CURRENT_SOURCE_DIR}/*.xml)
 file(GLOB ini ${CMAKE_CURRENT_SOURCE_DIR}/*.ini)


### PR DESCRIPTION
This fixes the robot name in `robots-configuration/iTeenGenova01/CMakeLists.txt`