### PR TITLE
[devel_iCubGenova04] Update Feet FT IMU configurations in inertial wrapper and hardware

### DIFF
--- a/iCubGenova04/hardware/inertials/left_leg-eb7-IMU.xml
+++ b/iCubGenova04/hardware/inertials/left_leg-eb7-IMU.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">       l_lower_leg_ft_acc_3b13    l_lower_leg_ft_gyro_3b13    l_lower_leg_ft_eul_3b13    l_lower_leg_ft_mag_3b13    l_lower_leg_ft_stat_3b13
+                    <param name="id">       l_foot_ft_acc_3b13    l_foot_ft_gyro_3b13    l_foot_ft_eul_3b13    l_foot_ft_mag_3b13    l_foot_ft_stat_3b13
                     </param>
 
                     <param name="type">     eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status
@@ -47,7 +47,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">      50      </param>
-                <param name="enabledSensors">       l_lower_leg_ft_acc_3b13    l_lower_leg_ft_gyro_3b13    l_lower_leg_ft_eul_3b13    l_lower_leg_ft_mag_3b13    l_lower_leg_ft_stat_3b13
+                <param name="enabledSensors">       l_foot_ft_acc_3b13    l_foot_ft_gyro_3b13    l_foot_ft_eul_3b13    l_foot_ft_mag_3b13    l_foot_ft_stat_3b13
                 </param>
             </group>
 

--- a/iCubGenova04/hardware/inertials/right_leg-eb9-IMU.xml
+++ b/iCubGenova04/hardware/inertials/right_leg-eb9-IMU.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">       r_lower_leg_ft_acc_3b14    r_lower_leg_ft_gyro_3b14    r_lower_leg_ft_eul_3b14    r_lower_leg_ft_mag_3b14    r_lower_leg_ft_stat_3b14
+                    <param name="id">       r_foot_ft_acc_3b14    r_foot_ft_gyro_3b14    r_foot_ft_eul_3b14    r_foot_ft_mag_3b14    r_foot_ft_stat_3b14
                     </param>
 
                     <param name="type">     eoas_imu_acc  eoas_imu_gyr  eoas_imu_eul  eoas_imu_mag   eoas_imu_status
@@ -47,7 +47,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">      50      </param>
-                <param name="enabledSensors">   r_lower_leg_ft_acc_3b14    r_lower_leg_ft_gyro_3b14    r_lower_leg_ft_eul_3b14    r_lower_leg_ft_mag_3b14    r_lower_leg_ft_stat_3b14   </param>                
+                <param name="enabledSensors">   r_foot_ft_acc_3b14    r_foot_ft_gyro_3b14    r_foot_ft_eul_3b14    r_foot_ft_mag_3b14    r_foot_ft_stat_3b14   </param>                
             </group>
 
         </group>

--- a/iCubGenova04/wrappers/inertials/left_leg-inertials_remapper.xml
+++ b/iCubGenova04/wrappers/inertials/left_leg-inertials_remapper.xml
@@ -21,7 +21,12 @@
            l_foot_ft_acc_3b13
            l_foot_mtb_acc_10b12       l_foot_mtb_acc_10b13)
         </param>
-
+        <param name="OrientationSensorsNames">
+          (l_upper_leg_ft_eul_3b12 l_foot_ft_eul_3b13)
+        </param>
+        <param name="ThreeAxisMagnetometersNames">
+          (l_upper_leg_ft_mag_3b12 l_foot_ft_mag_3b13)
+        </param>        
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
                 <!-- The name of the element can be any string (we use SetOfInertials to better express its nature).

--- a/iCubGenova04/wrappers/inertials/left_leg-inertials_remapper.xml
+++ b/iCubGenova04/wrappers/inertials/left_leg-inertials_remapper.xml
@@ -11,14 +11,14 @@
            l_upper_leg_ems_gyro_eb6
            l_upper_leg_ems_gyro_eb10
            l_lower_leg_ems_gyro_eb7
-           l_lower_leg_ft_gyro_3b13)
+           l_foot_ft_gyro_3b13)
         </param>
         <param name="ThreeAxisLinearAccelerometersNames">
           (l_upper_leg_ft_acc_3b12
            l_upper_leg_mtb_acc_10b1   l_upper_leg_mtb_acc_10b2   l_upper_leg_mtb_acc_10b3   l_upper_leg_mtb_acc_10b4
            l_upper_leg_mtb_acc_10b5   l_upper_leg_mtb_acc_10b6   l_upper_leg_mtb_acc_10b7
            l_lower_leg_mtb_acc_10b8   l_lower_leg_mtb_acc_10b9   l_lower_leg_mtb_acc_10b10  l_lower_leg_mtb_acc_10b11
-           l_lower_leg_ft_acc_3b13
+           l_foot_ft_acc_3b13
            l_foot_mtb_acc_10b12       l_foot_mtb_acc_10b13)
         </param>
 

--- a/iCubGenova04/wrappers/inertials/right_leg-inertials_remapper.xml
+++ b/iCubGenova04/wrappers/inertials/right_leg-inertials_remapper.xml
@@ -21,6 +21,12 @@
            r_foot_ft_acc_3b14
            r_foot_mtb_acc_11b12       r_foot_mtb_acc_11b13)
         </param>
+        <param name="OrientationSensorsNames">
+          (r_upper_leg_ft_eul_3b11 r_foot_ft_eul_3b14)
+        </param>
+        <param name="ThreeAxisMagnetometersNames">
+          (r_upper_leg_ft_mag_3b11 r_foot_ft_mag_3b14)
+        </param>        
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
                 <!-- The name of the element can be any string (we use SetOfInertials to better express its nature).

--- a/iCubGenova04/wrappers/inertials/right_leg-inertials_remapper.xml
+++ b/iCubGenova04/wrappers/inertials/right_leg-inertials_remapper.xml
@@ -11,14 +11,14 @@
            r_upper_leg_ems_gyro_eb8
            r_upper_leg_ems_gyro_eb11
            r_lower_leg_ems_gyro_eb9
-           r_lower_leg_ft_gyro_3b14)
+           r_foot_ft_gyro_3b14)
         </param>
         <param name="ThreeAxisLinearAccelerometersNames">
           (r_upper_leg_ft_acc_3b11
            r_upper_leg_mtb_acc_11b1   r_upper_leg_mtb_acc_11b2   r_upper_leg_mtb_acc_11b3   r_upper_leg_mtb_acc_11b4
            r_upper_leg_mtb_acc_11b5   r_upper_leg_mtb_acc_11b6   r_upper_leg_mtb_acc_11b7
            r_lower_leg_mtb_acc_11b8   r_lower_leg_mtb_acc_11b9   r_lower_leg_mtb_acc_11b10  r_lower_leg_mtb_acc_11b11
-           r_lower_leg_ft_acc_3b14
+           r_foot_ft_acc_3b14
            r_foot_mtb_acc_11b12       r_foot_mtb_acc_11b13)
         </param>
         <action phase="startup" level="5" type="attach">


### PR DESCRIPTION
This PR changes the following,
- Updates the feet FT IMU names to be coherent with the sensor names generated in the URDF through the PR https://github.com/robotology/icub-model-generator/pull/122. Consequently fixes https://github.com/robotology/robots-configuration/issues/125
- Adds FT IMUs orientation sensors and magnetometer sensors to the right leg and left leg inertial MAS remapper

cc @S-Dafarra @nunoguedelha @traversaro 