### PR TITLE
[iCubSheffield01] migrated MC version 4 to 6

### DIFF
--- a/iCubSheffield01/hardware/mechanicals/left_arm-eb1-j0_3-mec.xml
+++ b/iCubSheffield01/hardware/mechanicals/left_arm-eb1-j0_3-mec.xml
@@ -3,7 +3,7 @@
 
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="iCubSheffield01" build="1">
     <group name="GENERAL">
-        <param name="MotioncontrolVersion">  4 </param>
+        <param name="MotioncontrolVersion"> 6 </param>
         <param name="Joints"> 4 </param> 
         <param name="AxisMap">               0           1             2             3      </param>
         <param name="AxisName"> "l_shoulder_pitch" "l_shoulder_roll" "l_shoulder_yaw" "l_elbow" </param>
@@ -20,10 +20,10 @@
     
     <group name="LIMITS">
         <!--                                     0                1              2              3            -->
-        <param name="hardwareJntPosMax">         8              160             80            106      </param>  
-        <param name="hardwareJntPosMin">       -95.5             9             -32             15      </param>
-        <param name="rotorPosMin">               0                0              0              0      </param> 
-        <param name="rotorPosMax">               0                0              0              0      </param>
+        <param name="hardwareJntPosMax">         8              160             80            106       </param>  
+        <param name="hardwareJntPosMin">       -95.5              9            -32             15       </param>
+        <param name="rotorPosMin">               0                0              0              0       </param> 
+        <param name="rotorPosMax">               0                0              0              0       </param>
     </group>
 
     <group name="2FOC">

--- a/iCubSheffield01/hardware/mechanicals/left_arm-eb2-j4_15-mec.xml
+++ b/iCubSheffield01/hardware/mechanicals/left_arm-eb2-j4_15-mec.xml
@@ -3,17 +3,19 @@
 
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="iCubSheffield01" build="1">
 <group name="GENERAL">
-        <param name="MotioncontrolVersion">  4 </param>
+        <param name="MotioncontrolVersion">  6 </param>
         <param name="Joints"> 12 </param>
         <param name="AxisMap">               0             1             2             3             4             5             6             7             8             9             10            11    </param>
         <param name="AxisName">      "l_wrist_prosup" "l_wrist_pitch" "l_wrist_yaw"  "l_hand_finger"    "l_thumb_oppose"     "l_thumb_proximal"     "l_thumb_distal"   "l_index_proximal"    "l_index_distal"    "l_middle_proximal"   "l_middle_distal"    "l_pinky"  </param>
         <param name="AxisType">       "revolute"    "revolute"    "revolute"    "revolute"   "revolute"       "revolute"     "revolute"    "revolute"    "revolute"    "revolute"   "revolute"    "revolute" </param>
+       
         <param name="Encoder">         182.044        182.044      182.044       182.044       182.044       182.044       182.044       182.044       182.044       182.044       182.044       182.044     </param>
         <param name="fullscalePWM">   1333         1333          1333           1333         1333          1333          1333          1333          1333          1333          1333         1333     </param>
         <param name="ampsToSensor">   1000.0       1000.0        1000.0         1000.0       1000.0        1000.0        1000.0        1000.0        1000.0        1000.0        1000.0       1000.0   </param>
         <param name="Gearbox_M2J">      1             1             1             1             1             1             1             1             1             1             1             1     </param>
         <param name="Gearbox_E2J">      1             1             1             1             1             1             1             1             1             1             1             1     </param>
         <param name="useMotorSpeedFbk"> 1             1             1             1             1             1             1             1             1             1             1             1     </param>
+  
         <param name="MotorType">         "DC_FH"         "DC_FH"        "DC_FH"      "DC_FH"       "DC_FH"        "DC_FH"       "DC_FH"       "DC_FH"     "DC_FH"        "DC_FH"       "DC_FH"       "DC_FH" </param>
        
         <param name="Verbose"> 0 </param> 

--- a/iCubSheffield01/hardware/mechanicals/right_arm-eb3-j0_3-mec.xml
+++ b/iCubSheffield01/hardware/mechanicals/right_arm-eb3-j0_3-mec.xml
@@ -3,7 +3,7 @@
 
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="iCubSheffield01" build="1">
 <group name="GENERAL">
-        <param name="MotioncontrolVersion">  4 </param>
+        <param name="MotioncontrolVersion">  6 </param>
         <param name="Joints"> 4 </param> 
         <param name="AxisMap">               0           1             2             3          </param>
         <param name="AxisName"> "r_shoulder_pitch" "r_shoulder_roll" "r_shoulder_yaw" "r_elbow" </param>
@@ -20,10 +20,10 @@
     </group>
 
     <group name="LIMITS">
-        <param name="hardwareJntPosMax">      8            160             80           106       </param>
-        <param name="hardwareJntPosMin">    -95.5           9             -32            15         </param>
-        <param name="rotorPosMin">              0            0              0             0       </param>
-        <param name="rotorPosMax">              0            0              0             0       </param>
+        <param name="hardwareJntPosMax">    8          160             80           106       </param>
+        <param name="hardwareJntPosMin">  -95.5            9            -32            15       </param>
+        <param name="rotorPosMin">          0            0              0             0       </param>
+        <param name="rotorPosMax">          0            0              0             0       </param>
     </group>
 
     <group name="2FOC">

--- a/iCubSheffield01/hardware/mechanicals/right_arm-eb4-j4_15-mec.xml
+++ b/iCubSheffield01/hardware/mechanicals/right_arm-eb4-j4_15-mec.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
-<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="iCubGenova02" build="1">
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="iCubSheffield01" build="1">
     <group name="GENERAL">
         <param name="MotioncontrolVersion">  6 </param>
         <param name="Joints"> 12 </param>

--- a/iCubSheffield01/hardware/mechanicals/right_arm-eb4-j4_15-mec.xml
+++ b/iCubSheffield01/hardware/mechanicals/right_arm-eb4-j4_15-mec.xml
@@ -1,16 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
-<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="iCubSheffield01" build="1">
-     <group name="GENERAL">
-        <param name="MotioncontrolVersion">  4 </param>
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="iCubGenova02" build="1">
+    <group name="GENERAL">
+        <param name="MotioncontrolVersion">  6 </param>
         <param name="Joints"> 12 </param>
         <param name="AxisMap"> 	             0             1             2             3             4             5             6             7            8             9            10            11     </param>
         <param name="AxisName">      "r_wrist_prosup" "r_wrist_pitch" "r_wrist_yaw"  "r_hand_finger"    "r_thumb_oppose"     "r_thumb_proximal"     "r_thumb_distal"   "r_index_proximal"    "r_index_distal"    "r_middle_proximal"   "r_middle_distal"    "r_pinky"  </param>
         <param name="AxisType">       "revolute"    "revolute"    "revolute"  "revolute"       "revolute"    "revolute"    "revolute"  "revolute"     "revolute"    "revolute"    "revolute"  "revolute"   </param>
+       
         <param name="Encoder">         182.044        182.044      182.044       182.044       182.044       182.044       182.044       182.044      182.044       182.044      182.044       182.044      </param>
         <param name="fullscalePWM">   1333         1333          1333           1333         1333          1333          1333          1333          1333          1333          1333         1333     </param>
-        <param name="ampsToSensor">   1000.0       1000.0        1000.0         1000.0       1000.0        1000.0        1000.0        1000.0        1000.0        1000.0        1000.0       1000.0   </param>
+        <param name="ampsToSensor">   1000.0       1000.0        1000.0         1000.0       1000.0        1000.0        1000.0        1000.0        1000.0        1000.0        1000.0       1000.0   </param>        
         <param name="Gearbox_M2J">      1             1             1             1             1             1             1             1             1             1             1             1     </param>
         <param name="Gearbox_E2J">      1             1             1             1             1             1             1             1             1             1             1             1     </param>
         <param name="useMotorSpeedFbk"> 1             1             1             1             1             1             1             1             1             1             1             1     </param>
@@ -27,5 +28,7 @@
         <param name="rotorPosMax">                 0             0             0             0             0             33             36             33           -38          33            38             77   </param>
     </group>
 
-</params>
 
+
+
+</params>

--- a/iCubSheffield01/hardware/mechanicals/torso-eb5-j0_2-mec.xml
+++ b/iCubSheffield01/hardware/mechanicals/torso-eb5-j0_2-mec.xml
@@ -3,7 +3,7 @@
 
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="iCubSheffield01" build="1">
     <group name="GENERAL">
-        <param name="MotioncontrolVersion">  4 </param>
+        <param name="MotioncontrolVersion">  6 </param>
         <param name="Joints"> 3 </param> 
         <param name="AxisMap">               2             0             1           </param>   
         <param name="AxisName">      "torso_yaw" "torso_roll" "torso_pitch"          </param>
@@ -19,10 +19,10 @@
     </group>
     
     <group name="LIMITS">
-        <param name="hardwareJntPosMax">      50            30            70           </param>
-        <param name="hardwareJntPosMin">     -50           -30           -20           </param>
-        <param name="rotorPosMin">             0             0             0           </param> 
-        <param name="rotorPosMax">             0             0             0           </param>
+        <param name="hardwareJntPosMax">    50            30            70        </param>
+        <param name="hardwareJntPosMin">   -50           -30           -20        </param>
+        <param name="rotorPosMin">           0             0             0        </param> 
+        <param name="rotorPosMax">           0             0             0        </param>
     </group>
 
     <group name="2FOC">

--- a/iCubSheffield01/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
+++ b/iCubSheffield01/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
@@ -1,94 +1,117 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
- <!-- Initialization file for EMS 1 - Left Upper Arm, 4 dof -->
 
 
-  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-eb1-j0_3-mc" type="embObjMotionControl">
-      <xi:include href="../../general.xml"/>
-      <xi:include href="../../hardware/electronics/left_arm-eb1-j0_3-eln.xml" />
-      <xi:include href="../../hardware/mechanicals/left_arm-eb1-j0_3-mec.xml" />
-      
-      <xi:include href="./left_arm-eb1-j0_3-mc_service.xml" />
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-eb1-j0_3-mc" type="embObjMotionControl">
 
+    <xi:include href="../../general.xml"/>
+    <xi:include href="../../hardware/electronics/left_arm-eb1-j0_3-eln.xml" />
+    <xi:include href="../../hardware/mechanicals/left_arm-eb1-j0_3-mec.xml" />
+    <xi:include href="./left_arm-eb1-j0_3-mc_service.xml" />
+    
+    <!-- joint number                           0                   1                   2                   3                   -->
+    <!-- joint name -->          
     <group name="LIMITS">
-        <!--                                    0               1               2             3 -->
-        <param name="jntPosMax">                8              160            80           106       </param>  
-        <param name="jntPosMin">                -95.5           9              -32           15        </param>
-        <param name="jntVelMax">                 1000            1000            1000          1000      </param>
-        <param name="motorNominalCurrents">    4000            4000            4000          4000       </param>
-        <param name="motorPeakCurrents">       5000            5000            5000          5000       </param>
-        <param name="motorOverloadCurrents">  15000           15000           15000         15000       </param>
-        <param name="motorPwmLimit">          10000           10000           10000         10000     </param>
+        <param name="jntPosMax">                8                   160                 80                  106                 </param>
+        <param name="jntPosMin">                -95.5               9                   -32                 15                  </param>
+        <param name="jntVelMax">                1000                1000                1000                1000                </param>
+        <param name="motorNominalCurrents">     4000                4000                4000                4000                </param>
+        <param name="motorPeakCurrents">        5000                5000                5000                5000                </param>
+        <param name="motorOverloadCurrents">    15000               15000               15000               15000               </param>
+        <param name="motorPwmLimit">            10000               10000               10000               10000               </param>
     </group>
 
     <group name="TIMEOUTS">
-        <param name="velocity">               100           100           100           100 </param>
+        <param name="velocity">                 100                 100                 100                 100                 </param>
     </group>
-
-    <group name="CONTROLS">
-       <param name="positionControl">  POS_PID_DEFAULT           POS_PID_DEFAULT          POS_PID_DEFAULT          POS_PID_DEFAULT          </param> 
-       <param name="velocityControl">  none                   none                  none                  none                  </param> 
-       <param name="torqueControl">    TRQ_PID_DEFAULT  TRQ_PID_DEFAULT TRQ_PID_DEFAULT TRQ_PID_DEFAULT </param>
-        <param name="currentPid">      2FOC_CUR_CONTROL          2FOC_CUR_CONTROL         2FOC_CUR_CONTROL         2FOC_CUR_CONTROL         </param> 
-    </group>
-
-
 
     <group name="IMPEDANCE">
-      <param name="stiffness"> 0.1     0.1   0.1    0.1    </param>
-      <param name="damping">  0.05   0.05  0.05   0.05    </param>
-    </group>
-
-
-    <group name="POS_PID_DEFAULT">
-        <param name="controlLaw">      Pid_inPos_outPwm </param>
-        <param name="controlUnits">    metric_units               </param>
-        <param name="pos_kp">           711.11    1066.66     711.11    1066.66 </param>       
-        <param name="pos_kd">             0.00       0.00       0.00       0.00 </param>       
-        <param name="pos_ki">          7111.09   10666.64    7111.09   10666.64 </param>         
-        <param name="pos_maxOutput">      8000       8000       8000       8000 </param>    
-        <param name="pos_maxInt">          200        200        200       1000 </param>       
-        <param name="pos_shift">             0          0          0          0 </param>       
-        <param name="pos_ko">                0          0          0          0 </param>       
-        <param name="pos_stictionUp">        0          0          0          0 </param>       
-        <param name="pos_stictionDwn">       0          0          0          0 </param>       
-        <param name="pos_kff">               0          0          0          0 </param>    
-    </group>
-
-    <group name="TRQ_PID_DEFAULT">
-        <param name="controlLaw">    Pid_inTrq_outPwm </param> 
-        <param name="controlUnits">  metric_units               </param> 
-        <param name="trq_kp">            200        200        250        300     </param>       
-        <param name="trq_kd">              0          0          0          0     </param>       
-        <param name="trq_ki">              0          0          0          0     </param>    
-        <param name="trq_maxOutput">    8000       8000       8000       8000     </param>       
-        <param name="trq_maxInt">        500        500        500        500     </param>       
-        <param name="trq_shift">           0          0          0          0     </param>       
-        <param name="trq_ko">              0          0          0          0     </param>       
-        <param name="trq_stictionUp">      0.5        0.5        1          1.7   </param>       
-        <param name="trq_stictionDwn">    -0.7       -0.7       -0.8       -1.2   </param>    
-        <param name="trq_kff">             1          1          1          1     </param>  
-        <param name="trq_kbemf">      0.0030     0.0006     0.0007     0.0007     </param>    
-        <param name="trq_filterType">      0          0          0          0     </param>    
-        <param name="trq_ktau">          180        464        463        449     </param>             
-    </group>
-
-    <group name="2FOC_CUR_CONTROL">
-        <param name="controlLaw">       limitscurrent          </param> 
-        <param name="controlUnits">     metric_units           </param> 
-        <param name="cur_kp">                8           8          8         8      </param>
-        <param name="cur_kd">                0           0          0         0      </param>
-        <param name="cur_ki">                2           2          2         2      </param>
-        <param name="cur_shift">             10          10         10        10     </param>
-        <param name="cur_maxOutput">         32000       32000      32000     32000  </param>
-        <param name="cur_maxInt">            32000       32000      32000     32000  </param>
-        <param name="cur_ko">               0            0          0            0  </param>       
-        <param name="cur_stictionUp">       0            0          0            0  </param>       
-        <param name="cur_stictionDwn">      0            0          0            0  </param>   
-        <param name="cur_kff">              0            0          0            0  </param>            
+        <param name="stiffness">                0.1                 0.1                 0.1                 0.1                 </param>
+        <param name="damping">                  0.05                0.05                0.05                0.05                </param>
     </group>
     
-  </device>
+    <group name="CONTROLS">
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="torqueControl">            TRQ_PID_DEFAULT     TRQ_PID_DEFAULT     TRQ_PID_DEFAULT     TRQ_PID_DEFAULT     </param>
+        <param name="currentPid">               2FOC_CUR_CONTROL    2FOC_CUR_CONTROL    2FOC_CUR_CONTROL    2FOC_CUR_CONTROL    </param>
+        <param name="speedPid">                 2FOC_VEL_CONTROL    2FOC_VEL_CONTROL    2FOC_VEL_CONTROL    2FOC_VEL_CONTROL    </param>
+    </group>
 
 
+    <!-- default position PID: begin -->
+    
+    <group name="POS_PID_DEFAULT">
+        <param name="controlLaw">           minjerk             </param>
+        <param name="outputType">           pwm                 </param>
+        <param name="fbkControlUnits">      metric_units        </param>
+        <param name="outputControlUnits">   machine_units       </param>
+        <param name="kp">                   711.11      1066.66     711.11      1066.66 </param>
+        <param name="kd">                   0.00        0.00        0.00        0.00    </param>
+        <param name="ki">                   7111.09     10666.64    7111.09     10666.64</param>
+        <param name="maxOutput">            8000        8000        8000        8000    </param>
+        <param name="maxInt">               200         200         200         1000    </param>
+        <param name="stictionUp">           0           0           0           0       </param>
+        <param name="stictionDown">         0           0           0           0       </param>
+        <param name="kff">                  0           0           0           0       </param>
+    </group>
+
+    <!-- default position PID: end -->
+
+
+    <!-- other default PIDs: begin -->  
+    
+    <group name="TRQ_PID_DEFAULT">
+        <param name="controlLaw">           torque              </param>
+        <param name="outputType">           pwm                 </param>
+        <param name="fbkControlUnits">      metric_units        </param>
+        <param name="outputControlUnits">   machine_units       </param>
+        <param name="kp">                   200         200         250         300     </param>
+        <param name="kd">                   0           0           0           0       </param>
+        <param name="ki">                   0           0           0           0       </param>
+        <param name="maxOutput">            8000        8000        8000        8000    </param>
+        <param name="maxInt">               500         500         500         500     </param>
+        <param name="ko">                   0           0           0           0       </param>
+        <param name="stictionUp">           0           0           0           0       </param>
+        <param name="stictionDown">         0           0           0           0       </param>
+        <param name="kff">                  1           1           1           1       </param>
+        <param name="kbemf">                0           0           0           0       </param>
+        <param name="filterType">           0           0           0           0       </param>
+        <param name="ktau">                 0           0           0           0       </param>
+    </group>
+    
+    <group name="2FOC_CUR_CONTROL">
+        <param name="controlLaw">           low_lev_current     </param>
+        <param name="fbkControlUnits">      machine_units       </param>
+        <param name="outputControlUnits">   machine_units       </param>
+        <param name="kp">                   8           8           8           8       </param>
+        <param name="kd">                   0           0           0           0       </param>
+        <param name="ki">                   2           2           2           2       </param>
+        <param name="shift">                10          10          10          10      </param>
+        <param name="maxOutput">            32000       32000       32000       32000   </param>
+        <param name="maxInt">               32000       32000       32000       32000   </param>
+        <param name="kff">                  0           0           0           0       </param>
+    </group>
+
+    <group name="2FOC_VEL_CONTROL">
+        <param name="controlLaw">           low_lev_speed       </param>
+        <param name="fbkControlUnits">      machine_units       </param>
+        <param name="outputControlUnits">   machine_units       </param>
+        <param name="kff">                  0           0           0           0       </param>
+        <param name="kp">                   12          12          12          12      </param>
+        <param name="kd">                   0           0           0           0       </param>
+        <param name="ki">                   16          16          16          16      </param>
+        <param name="shift">                10          10          10          10      </param>
+        <param name="maxOutput">            32000       32000       32000       32000   </param>
+        <param name="maxInt">               32000       32000       32000       32000   </param>
+    </group>
+
+    <!-- other default PIDs: end -->
+    
+    
+    <!-- custom PIDs: begin --> 
+    <!-- custom PIDs: end -->
+    
+</device>
 

--- a/iCubSheffield01/hardware/motorControl/left_arm-eb1-j0_3-mc_service.xml
+++ b/iCubSheffield01/hardware/motorControl/left_arm-eb1-j0_3-mc_service.xml
@@ -20,9 +20,9 @@
                     <param name="minor">            6           </param>     
                 </group>                    
                 <group name="FIRMWARE">
-                    <param name="major">            0           </param>    
-                    <param name="minor">            0           </param> 
-                    <param name="build">            0           </param>
+                    <param name="major">            3           </param>    
+                    <param name="minor">            3           </param> 
+                    <param name="build">            3           </param>
                 </group>
             </group>
             
@@ -39,7 +39,7 @@
                     <param name="port">             CONN:P6             CONN:P7             CONN:P8         CONN:P9     </param>
                     <param name="position">         eomc_pos_atjoint    atjoint             atjoint         atjoint     </param> 
                     <param name="resolution">       -4096               -4096               4096            -4096       </param>
-                    <param name="tolerance">        0.703                0.703              0.703            0.703        </param> 
+                    <param name="tolerance">        0.703               0.703               0.703           0.703       </param> 
                 </group>        
                 
                 <group name="ENCODER2">
@@ -47,7 +47,7 @@
                     <param name="port">             CAN1:1:0            CAN1:2:0            CAN1:3:0        CAN1:4:0    </param>
                     <param name="position">         atmotor             atmotor             atmotor         atmotor     </param>
                     <param name="resolution">       -14400              -14400              -14400          -14400      </param>
-                    <param name="tolerance">         0                   0                   0                  0        </param>  
+                    <param name="tolerance">        0                0                   0                  0        </param>  
                 </group>  
  
            </group>    

--- a/iCubSheffield01/hardware/motorControl/left_arm-eb2-j4_15-mc.xml
+++ b/iCubSheffield01/hardware/motorControl/left_arm-eb2-j4_15-mc.xml
@@ -1,79 +1,92 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
- <!-- Initialization file for EMS 2 - Left Lower Arm, 12 dof plus skin-->
 
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-eb2-j4_15-mc" type="embObjMotionControl">
+   
+    <xi:include href="../../general.xml" />
+    <xi:include href="../../hardware/electronics/left_arm-eb2-j4_15-eln.xml" />
+    <xi:include href="../../hardware/mechanicals/left_arm-eb2-j4_15-mec.xml" />
+    <xi:include href="./left_arm-eb2-j4_15-mc_service.xml" />
 
- <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-eb2-j4_15-mc" type="embObjMotionControl">
-      <xi:include href="../../general.xml" />
-      <xi:include href="../../hardware/electronics/left_arm-eb2-j4_15-eln.xml" />
-      <xi:include href="../../hardware/mechanicals/left_arm-eb2-j4_15-mec.xml" />
-
-      <xi:include href="./left_arm-eb2-j4_15-mc_service.xml" />
-      
+    <!-- joint number                           0           1             2             3             4             5             6             7             8             9             10            11          -->
+    <!-- joint name     --> 
     <group name="LIMITS">
-        <param name="jntPosMax">                      60            25            25            60            90            90            180           90            180           90            180           270       </param>
-        <param name="jntPosMin">                      -60           -80           -20           0             10            0             0             0             0             0             0             0         </param>
-        <param name="motorOverloadCurrents">    500           800           800           485           485           485           485           485           485           485           485           485       </param>
-        <param name="motorNominalCurrents">     0             0             0             0             0             0             0             0             0             0             0             0         </param>
-        <param name="motorPeakCurrents">        0             0             0             0             0             0             0             0             0             0             0             0         </param>
-        <param name="rotorPosMin">                 0             0             0             0             0             -10           16         -1.65          -16          -1.65          16               0   </param> 
-        <param name="rotorPosMax">                 0             0             0             0             0             33             -36            33           38             33         -38              -77     </param>
-        <param name="jntVelMax">                 1000          1000          1000          1000          1000          1000          1000          1000          1000          1000          1000          1000      </param>   
-        <param name="motorPwmLimit">            10000          10000         10000         10000        10000         10000         10000         10000         10000         10000         10000         10000     </param>    
+        <param name="jntPosMax">                60          25            25            60            90            90            180           90            180           90            180           270         </param>
+        <param name="jntPosMin">                -60         -80           -20           0             10            0             0             0             0             0             0             0           </param>
+        <param name="motorOverloadCurrents">    500         800           800           485           485           485           485           485           485           485           485           485         </param>
+        <param name="motorNominalCurrents">     0           0             0             0             0             0             0             0             0             0             0             0           </param>
+        <param name="motorPeakCurrents">        0           0             0             0             0             0             0             0             0             0             0             0           </param>
+        <param name="jntVelMax">                1000        1000          1000          1000          1000          1000          1000          1000          1000          1000          1000          1000        </param>
+        <param name="motorPwmLimit">            10000       10000         10000         10000        10000         10000         10000         10000         10000         10000         10000         10000        </param>
     </group>
-
+    
     <group name="TIMEOUTS">
         <param name="velocity">    100           100           100           100        100           100           100           100      100           100           100           100    </param>
     </group>
 
-
-     <group name="CONTROLS">
-       <param name="positionControl">  POS_PID_DEFAULT           POS_PID_DEFAULT          POS_PID_DEFAULT          POS_PID_DEFAULT          POS_PID_DEFAULT           POS_PID_DEFAULT          POS_PID_DEFAULT          POS_PID_DEFAULT POS_PID_DEFAULT           POS_PID_DEFAULT          POS_PID_DEFAULT          POS_PID_DEFAULT </param> 
-       <param name="velocityControl">  none                   none                  none                  none                  none                   none                  none                  none                  none                   none                  none                  none                  </param> 
-       <param name="torqueControl">    TRQ_PID_DEFAULT  none                  none                  none  none                   none                  none                  none   none                   none                  none                  none</param>
-        <param name="currentPid">none       none                  none                  none  none                   none                  none                  none   none                   none                  none                  none</param> 
-    </group>
-
-
-    <group name="POS_PID_DEFAULT">
-        <param name="controlLaw">    Pid_inPos_outPwm </param> 
-        <param name="controlUnits">  machine_units               </param> 
-        <param name="pos_kp">          -200          1000          -1000         -200    -500          -8000         -8000         -8000         8000          -8000         -8000         1200         </param>       
-        <param name="pos_kd">          -1000         10000         -10000        -200    -32000        -32000        -32000        -32000        32000         -32000        -32000        12500        </param>       
-        <param name="pos_ki">          -1            1             -1            -1      -1            -5            -5            -5            5             -5            -5            1            </param>       
-        <param name="pos_maxOutput">   1333          1333          1333          1333    1333          1333          1333          1333          1333          1333          1333          1333         </param>       
-        <param name="pos_maxInt">      1333          1333          1333          1333    1333          1333          1333          1333          1333          1333          1333          1333         </param>       
-        <param name="pos_shift">       6             7             7             4       6             8             8             8             8             8             8             6            </param>       
-        <param name="pos_ko">          0             0             0             0       0             0             0             0             0             0             0             0            </param>       
-        <param name="pos_stictionUp">  0             0             0             0       0             0             0             0             0             0             0             0            </param>       
-        <param name="pos_stictionDwn"> 0             0             0             0       0             0             0             0             0             0             0             0            </param>       
-        <param name="pos_kff">         0             0             0             0       0             0             0             0             0             0             0             0            </param>       
-    </group>
-   
-    <group name="TRQ_PID_DEFAULT">
-        <param name="controlLaw">    Pid_inTrq_outPwm </param> 
-        <param name="controlUnits">  machine_units               </param> 
-        <param name="trq_kp">            -80      0      0      0      0      0      0      0      0      0      0      0    </param>       
-        <param name="trq_kd">              0      0      0      0      0      0      0      0      0      0      0      0    </param>       
-        <param name="trq_ki">              0      0      0      0      0      0      0      0      0      0      0      0    </param>  
-        <param name="trq_maxOutput">       1333      0      0      0      0      0      0      0      0      0      0      0    </param>       
-        <param name="trq_maxInt">       1333      0      0      0      0      0      0      0      0      0      0      0    </param>       
-        <param name="trq_shift">          10      0      0      0      0      0      0      0      0      0      0      0    </param>       
-        <param name="trq_ko">              0      0      0      0      0      0      0      0      0      0      0      0    </param>       
-        <param name="trq_stictionUp">      0      0      0      0      0      0      0      0      0      0      0      0    </param>       
-        <param name="trq_stictionDwn">     0      0      0      0      0      0      0      0      0      0      0      0    </param>    
-        <param name="trq_kff">             0      0      0      0      0      0      0      0      0      0      0      0    </param> 
-        <param name="trq_kbemf">           0      0      0      0      0      0      0      0      0      0      0      0    </param>     
-        <param name="trq_filterType">      0      0      0      0      0      0      0      0      0      0      0      0    </param>   
-        <param name="trq_ktau">            1      1      1      1      1      1      1      1      1      1      1      1    </param>   
-    </group>
-    
     <group name="IMPEDANCE">
-        <param name="stiffness">       0      0      0      0      0      0      0      0      0      0      0      0    </param>    
-        <param name="damping">         0      0      0      0      0      0      0      0      0      0      0      0    </param>    
+        <param name="stiffness">    0      0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="damping">      0      0      0      0      0      0      0      0      0      0      0      0    </param>
     </group>
     
-  </device>
+    <group name="CONTROLS">
+        <param name="positionControl">  POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT      POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT </param>
+        <param name="velocityControl">  POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT      POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT </param>
+        <param name="mixedControl">     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT      POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT </param>
+        <param name="torqueControl">    TRQ_PID_DEFAULT     none                none                none                none                 none                none                none                none                none                none                none            </param>
+        <param name="currentPid">       none                none                none                none                none                 none                none                none                none                none                none                none            </param>
+        <param name="speedPid">         none                none                none                none                none                 none                none                none                none                none                none                none            </param>
+    </group>
 
-  
+
+    <!-- default position PID: begin -->
+    
+    <group name="POS_PID_DEFAULT">
+        <param name="controlLaw">           minjerk         </param>
+        <param name="outputType">           pwm             </param>
+        <param name="fbkControlUnits">      metric_units    </param>
+        <param name="outputControlUnits">   machine_units   </param>
+        <param name="kp">           -200        1000        -1000       -200        -500        -8000       -8000       -8000         8000          -8000         -8000         1200         </param>
+        <param name="kd">           -1000       10000       -10000      -200        -32000      -32000      -32000      -32000        32000         -32000        -32000        12500        </param>
+        <param name="ki">           -1          1           -1          -1          -1          -5          -5          -5            5             -5            -5            1            </param>
+        <param name="maxOutput">    1333        1333        1333        1333        1333        1333        1333        1333          1333          1333          1333          1333         </param>
+        <param name="maxInt">       1333        1333        1333        1333        1333        1333        1333        1333          1333          1333          1333          1333         </param>
+        <param name="stictionUp">   0           0           0           0           0           0           0           0             0             0             0             0            </param>
+        <param name="stictionDown"> 0           0           0           0           0           0           0           0             0             0             0             0            </param>
+        <param name="kff">          0           0           0           0           0           0           0           0             0             0             0             0            </param>
+    </group>
+
+    <!-- default position PID: end -->
+
+
+    <!-- other default PIDs: begin --> 
+
+    <group name="TRQ_PID_DEFAULT">
+        <param name="controlLaw">           torque              </param>
+        <param name="outputType">           pwm                 </param>
+        <param name="fbkControlUnits">      metric_units        </param>
+        <param name="outputControlUnits">   machine_units       </param>
+        <param name="kp">                   -80     0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="kd">                   0       0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="ki">                   0       0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="maxOutput">            1333    0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="maxInt">               1333    0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="ko">                   0       0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="stictionUp">           0       0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="stictionDown">         0       0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="kff">                  0       0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="kbemf">                0       0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="filterType">           0       0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="ktau">                 0       0      0      0      0      0      0      0      0      0      0      0    </param>
+    </group>
+
+    <!-- other default PIDs: end -->
+    
+    
+    <!-- custom PIDs: begin -->    
+    <!-- custom PIDs: end -->
+    
+</device>
+
+

--- a/iCubSheffield01/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
+++ b/iCubSheffield01/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
@@ -2,91 +2,116 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
 
-   <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-eb3-j0_3-mc" type="embObjMotionControl">
-      <xi:include href="../../general.xml" />
-      <xi:include href="../../hardware/electronics/right_arm-eb3-j0_3-eln.xml" />
-      <xi:include href="../../hardware/mechanicals/right_arm-eb3-j0_3-mec.xml" />
-      
-      <xi:include href="./right_arm-eb3-j0_3-mc_service.xml" />
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-eb3-j0_3-mc" type="embObjMotionControl">
 
+    <xi:include href="../../general.xml" />
+    <xi:include href="../../hardware/electronics/right_arm-eb3-j0_3-eln.xml" />
+    <xi:include href="../../hardware/mechanicals/right_arm-eb3-j0_3-mec.xml" />
+    <xi:include href="./right_arm-eb3-j0_3-mc_service.xml" />
+
+    <!-- joint number                           0                   1                   2                   3                   -->
+    <!-- joint name -->          
     <group name="LIMITS">
-        <!--                                    0             1               2            3      -->
-        <param name="jntPosMax">                8            160             80            106         </param>
-        <param name="jntPosMin">                -95.5         9             -32            15          </param>
-        <param name="motorNominalCurrents">    4000            4000            4000          4000       </param>
-        <param name="motorPeakCurrents">       5000            5000            5000          5000       </param>
-        <param name="motorOverloadCurrents">  15000           15000           15000         15000       </param>
-        <param name="jntVelMax">                1000           1000          1000          1000        </param>  
-        <param name="motorPwmLimit">           10000          10000         10000         10000       </param> 
-    </group>
-
-    <group name="IMPEDANCE">
-      <param name="stiffness">	 0.1   0.1   0.1  0.1   </param>
-      <param name="damping">	0.00  0.00  0.00 0.00   </param>
+        <param name="jntPosMax">                8                   160                 80                  106                 </param>
+        <param name="jntPosMin">                -95.5               9                   -32                 15                  </param>
+        <param name="jntVelMax">                1000                1000                1000                1000                </param>
+        <param name="motorNominalCurrents">     4000                4000                4000                4000                </param>
+        <param name="motorPeakCurrents">        5000                5000                5000                5000                </param>
+        <param name="motorOverloadCurrents">    15000               15000               15000               15000               </param>
+        <param name="motorPwmLimit">            10000               10000               10000               10000               </param>
     </group>
 
     <group name="TIMEOUTS">
-        <param name="velocity">       100           100           100           100   </param>
+        <param name="velocity">                 100                 100                 100                 100                 </param>
     </group>
 
-
-     <group name="CONTROLS">
-       <param name="positionControl">  POS_PID_DEFAULT           POS_PID_DEFAULT          POS_PID_DEFAULT          POS_PID_DEFAULT          </param> 
-       <param name="velocityControl">  none                   none                  none                  none                  </param> 
-       <param name="torqueControl">    TRQ_PID_DEFAULT  TRQ_PID_DEFAULT TRQ_PID_DEFAULT TRQ_PID_DEFAULT </param>
-        <param name="currentPid">      2FOC_CUR_CONTROL          2FOC_CUR_CONTROL         2FOC_CUR_CONTROL         2FOC_CUR_CONTROL         </param> 
-    </group>
-
-   
-    <group name="POS_PID_DEFAULT">
-        <param name="controlLaw">    Pid_inPos_outPwm </param> 
-        <param name="controlUnits">  metric_units               </param> 
-        <param name="pos_kp">          -711.11   -1066.66    -711.11   -1066.66 </param>       
-        <param name="pos_kd">             0.00       0.00       0.00       0.00 </param>       
-        <param name="pos_ki">         -7111.09  -10666.64   -7111.09  -10666.64 </param>          
-        <param name="pos_maxOutput">      8000       8000       8000       8000 </param>              
-        <param name="pos_maxInt">          200        200        200       1000 </param>       
-        <param name="pos_shift">             0          0          0          0 </param>       
-        <param name="pos_ko">                0          0          0          0 </param>       
-        <param name="pos_stictionUp">        0          0          0          0 </param>       
-        <param name="pos_stictionDwn">       0          0          0          0 </param>       
-        <param name="pos_kff">               0          0          0          0 </param>       
-    </group>
-
-    <group name="TRQ_PID_DEFAULT">
-        <param name="controlLaw">    Pid_inTrq_outPwm </param> 
-        <param name="controlUnits">  metric_units               </param> 
-        <param name="trq_kp">             -50      -200       -250       -300     </param>       
-        <param name="trq_kd">              0          0          0          0     </param>       
-        <param name="trq_ki">              0          0          0          0     </param> 
-        <param name="trq_maxOutput">    8000       8000       8000       8000     </param>       
-        <param name="trq_maxInt">        500        500        500        500     </param>       
-        <param name="trq_shift">           0          0          0          0     </param>       
-        <param name="trq_ko">              0          0          0          0     </param>       
-        <param name="trq_stictionUp">     -0.5       -0.2       -0.5       -2     </param>       
-        <param name="trq_stictionDwn">     1.4        1          0.6        2     </param>       
-        <param name="trq_kff">             1          1          1          1     </param>  
-        <param name="trq_kbemf">     -0.0032    -0.0007    -0.0007    -0.0007     </param>            
-        <param name="trq_filterType">      0          0          0          0     </param>     
-        <param name="trq_ktau">           -204     -481       -466       -500     </param>   
-    </group>
-
-    <group name="2FOC_CUR_CONTROL">
-        <param name="controlLaw">       limitscurrent          </param>
-        <param name="controlUnits">     metric_units           </param>
-        <param name="cur_kp">               8           8          8         8     </param>
-        <param name="cur_kd">               0           0          0         0     </param>
-        <param name="cur_ki">               2           2          2         2     </param>
-        <param name="cur_shift">            10          10         10        10    </param>
-        <param name="cur_maxOutput">        32000       32000      32000     32000 </param>
-        <param name="cur_maxInt">           32000       32000      32000     32000 </param>
-        <param name="cur_ko">               0            0          0            0  </param>
-        <param name="cur_stictionUp">       0            0          0            0  </param>
-        <param name="cur_stictionDwn">      0            0          0            0  </param>
-        <param name="cur_kff">              0            0          0            0  </param>
+    <group name="IMPEDANCE">
+        <param name="stiffness">                0.1                 0.1                 0.1                 0.1                 </param>
+        <param name="damping">                  0.00                0.00                0.00                0.00                </param>
     </group>
     
-  </device>
+    <group name="CONTROLS">
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="torqueControl">            TRQ_PID_DEFAULT     TRQ_PID_DEFAULT     TRQ_PID_DEFAULT     TRQ_PID_DEFAULT     </param>
+        <param name="currentPid">               2FOC_CUR_CONTROL    2FOC_CUR_CONTROL    2FOC_CUR_CONTROL    2FOC_CUR_CONTROL    </param>
+        <param name="speedPid">                 2FOC_VEL_CONTROL    2FOC_VEL_CONTROL    2FOC_VEL_CONTROL    2FOC_VEL_CONTROL    </param>
+    </group>
 
 
+    <!-- default position PID: begin -->
+    
+    <group name="POS_PID_DEFAULT">
+        <param name="controlLaw">           minjerk                   </param>
+        <param name="outputType">           pwm                       </param>
+        <param name="fbkControlUnits">      metric_units              </param>
+        <param name="outputControlUnits">   machine_units             </param>
+        <param name="kp">                   -711.11   -1066.66    -711.11   -1066.66 </param>
+        <param name="kd">                   0.00       0.00       0.00       0.00 </param>
+        <param name="ki">                   -7111.09  -10666.64   -7111.09  -10666.64 </param>
+        <param name="maxOutput">            8000       8000       8000       8000 </param>
+        <param name="maxInt">               200        200        200       1000 </param>
+        <param name="stictionUp">           0          0          0          0 </param>
+        <param name="stictionDown">         0          0          0          0 </param>
+        <param name="kff">                  0          0          0          0 </param>
+    </group>
+
+    <!-- default position PID: end -->
+    
+    
+    <!-- other default PIDs: begin -->
+    
+    <group name="TRQ_PID_DEFAULT">
+        <param name="controlLaw">           torque                       </param>
+        <param name="outputType">           pwm                          </param>
+        <param name="fbkControlUnits">      metric_units                 </param>
+        <param name="outputControlUnits">  machine_units                </param>
+        <param name="kp">             -50      -200       -250       -300   </param>
+        <param name="kd">              0          0          0          0   </param>
+        <param name="ki">              0          0          0          0   </param>
+        <param name="maxOutput">    8000       8000       8000       8000   </param>
+        <param name="maxInt">        500        500        500        500   </param>
+        <param name="ko">              0          0          0          0   </param>
+        <param name="stictionUp">      0          0          0          0   </param>
+        <param name="stictionDown">    0          0          0          0   </param>
+        <param name="kff">             1          1          1          1   </param>
+        <param name="kbemf">           0          0          0          0   </param>
+        <param name="filterType">      0          0          0          0   </param>
+        <param name="ktau">            0          0          0          0   </param>
+    </group>
+    
+    <group name="2FOC_CUR_CONTROL">
+        <param name="controlLaw">           low_lev_current     </param>
+        <param name="fbkControlUnits">      machine_units       </param>
+        <param name="outputControlUnits">   machine_units       </param>
+        <param name="kp">                   8           8           8           8       </param>
+        <param name="kd">                   0           0           0           0       </param>
+        <param name="ki">                   2           2           2           2       </param>
+        <param name="shift">                10          10          10          10      </param>
+        <param name="maxOutput">            32000       32000       32000       32000   </param>
+        <param name="maxInt">               32000       32000       32000       32000   </param>
+        <param name="kff">                  0           0           0           0       </param>
+    </group>
+
+    <group name="2FOC_VEL_CONTROL">
+        <param name="controlLaw">           low_lev_speed       </param>
+        <param name="fbkControlUnits">      machine_units       </param>
+        <param name="outputControlUnits">   machine_units       </param>
+        <param name="kff">                  0           0           0           0       </param>
+        <param name="kp">                   12          12          12          12      </param>
+        <param name="kd">                   0           0           0           0       </param>
+        <param name="ki">                   16          16          16          16      </param>
+        <param name="shift">                10          10          10          10      </param>
+        <param name="maxOutput">            32000       32000       32000       32000   </param>
+        <param name="maxInt">               32000       32000       32000       32000   </param>
+    </group>
+
+    <!-- other default PIDs: end -->
+    
+
+    <!-- custom PIDs: begin -->
+    <!-- custom PIDs: end -->
+   
+</device>
 

--- a/iCubSheffield01/hardware/motorControl/right_arm-eb3-j0_3-mc_service.xml
+++ b/iCubSheffield01/hardware/motorControl/right_arm-eb3-j0_3-mc_service.xml
@@ -20,9 +20,9 @@
                     <param name="minor">            6           </param>     
                 </group>                    
                 <group name="FIRMWARE">
-                    <param name="major">            0           </param>    
-                    <param name="minor">            0           </param> 
-                    <param name="build">            0           </param>
+                    <param name="major">            3           </param>    
+                    <param name="minor">            3           </param> 
+                    <param name="build">            3           </param>
                 </group>
             </group>
             
@@ -40,7 +40,7 @@
                     <param name="port">             CONN:P6             CONN:P7             CONN:P8         CONN:P9     </param>
                     <param name="position">         eomc_pos_atjoint    atjoint             atjoint         atjoint     </param>
                     <param name="resolution">       4096                4096                -4096           4096        </param>
-                    <param name="tolerance">        0.703                0.703               0.703          0.703        </param>  
+                    <param name="tolerance">        0.703               0.703               0.703           0.703        </param>  
                 </group>        
                 
                 <group name="ENCODER2">
@@ -48,7 +48,7 @@
                     <param name="port">             CAN1:1:0            CAN1:2:0            CAN1:3:0        CAN1:4:0    </param>
                     <param name="position">         atmotor             atmotor             atmotor         atmotor     </param>
                     <param name="resolution">       -14400              -14400              -14400          -14400      </param>
-                    <param name="tolerance">         0                0                   0                  0        </param>  
+                    <param name="tolerance">        0                0                   0                  0        </param>  
 
                 </group> 
  
@@ -60,4 +60,27 @@
     
   
 </params>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 

--- a/iCubSheffield01/hardware/motorControl/right_arm-eb4-j4_15-mc.xml
+++ b/iCubSheffield01/hardware/motorControl/right_arm-eb4-j4_15-mc.xml
@@ -1,77 +1,92 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
- <!-- Initialization file for EMS 4 - Right Lower Arm, 12 dof plus skin  -->
 
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-eb4-j4_15-mc" type="embObjMotionControl">
+    
+    <xi:include href="../../general.xml" />
+    <xi:include href="../../hardware/electronics/right_arm-eb4-j4_15-eln.xml" />
+    <xi:include href="../../hardware/mechanicals/right_arm-eb4-j4_15-mec.xml" />
+    <xi:include href="./right_arm-eb4-j4_15-mc_service.xml" />
 
-  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-eb4-j4_15-mc" type="embObjMotionControl">
-      <xi:include href="../../general.xml" />
-      <xi:include href="../../hardware/electronics/right_arm-eb4-j4_15-eln.xml" />
-      <xi:include href="../../hardware/mechanicals/right_arm-eb4-j4_15-mec.xml" />
-
-      <xi:include href="./right_arm-eb4-j4_15-mc_service.xml" />
-      
+    <!-- joint number                           0             1             2             3             4             5             6             7             8             9             10            11-->
+    <!-- joint name     --> 
     <group name="LIMITS">
-        <!--                                    0             1             2             3             4             5             6             7             8             9             10            11-->
         <param name="jntPosMax">                60            25            25            60            90            90            180           90            180           90            180           270       </param>
         <param name="jntPosMin">                -60           -80           -20           0             10            0             0             0             0             0             0             0         </param>
         <param name="motorOverloadCurrents">    500           800           800           485           485           485           485           485           485           485           485           485       </param>
         <param name="motorNominalCurrents">     0             0             0             0             0             0             0             0             0            0           0                0         </param>
         <param name="motorPeakCurrents">        0             0             0             0             0             0             0             0             0            0           0                0         </param>
-        <param name="jntVelMax">                 1000          1000          1000          1000          1000          1000          1000          1000          1000          1000          1000          1000      </param>   
+        <param name="jntVelMax">                1000          1000          1000          1000          1000          1000          1000          1000          1000          1000          1000          1000      </param>
         <param name="motorPwmLimit">            10000         10000         10000         10000         10000         10000         10000         10000         10000         10000         10000         10000     </param>
     </group>
 
-     <group name="TIMEOUTS">
-        <param name="velocity">    100           100           100           100        100           100           100           100      100           100           100           100    </param>
-    </group>
-
-
-     <group name="CONTROLS">
-       <param name="positionControl">  POS_PID_DEFAULT           POS_PID_DEFAULT          POS_PID_DEFAULT          POS_PID_DEFAULT          POS_PID_DEFAULT     POS_PID_DEFAULT      POS_PID_DEFAULT     POS_PID_DEFAULT    POS_PID_DEFAULT      POS_PID_DEFAULT    POS_PID_DEFAULT     POS_PID_DEFAULT </param>
-       <param name="velocityControl">  none                   none                  none                  none                  none             none              none             none            none              none            none             none         </param>
-       <param name="torqueControl">    TRQ_PID_DEFAULT  none                  none                  none                   none            none              none             none            none              none            none             none         </param>
-        <param name="currentPid">      none                   none                  none                  none                   none            none              none             none            none              none            none             none         </param>
-    </group>
-
-
-     <group name="POS_PID_DEFAULT">
-      <param name="controlLaw">     Pid_inPos_outPwm  </param>
-         <param name="controlUnits">     machine_units               </param>
-        <param name="pos_kp">           -200          1000          -1000         200   -500          -8000         8000          -8000         -8000         -8000         8000          -1200    </param>       
-        <param name="pos_kd">           -1000         10000         -10000        200   -32000        -32000        32000         -32000        -32000        -32000        32000         -12500   </param>       
-        <param name="pos_ki">           -1            1             -1            1     -1            -5            5             -5            -5            -5            5             -1       </param>       
-        <param name="pos_maxOutput">    1333          1333          1333          1333   1333          1333          1333          1333          1333          1333          1333          1333     </param>       
-        <param name="pos_maxInt">       1333          1333          1333          1333   1333          1333          1333          1333          1333          1333          1333          1333     </param>       
-        <param name="pos_shift">        6             7             7             4      6             8             8             8             8             8             8             6        </param>       
-        <param name="pos_ko">           0             0             0             0      0             0             0             0             0             0             0             0        </param>       
-        <param name="pos_stictionUp">   0             0             0             0      0             0             0             0             0             0             0             0        </param>       
-        <param name="pos_stictionDwn">  0             0             0             0      0             0             0             0             0             0             0             0        </param>      
-        <param name="pos_kff">          0             0             0             0      0             0             0             0             0             0             0             0        </param>              
-    </group>
-
-    <group name="TRQ_PID_DEFAULT">
-        <param name="controlLaw">         Pid_inTrq_outPwm  </param>
-        <param name="controlUnits">        machine_units               </param>
-        <param name="trq_kp">             80      0      0      0      0      0      0      0      0      0      0      0    </param>       
-        <param name="trq_kd">              0      0      0      0      0      0      0      0      0      0      0      0    </param>       
-        <param name="trq_ki">              0      0      0      0      0      0      0      0      0      0      0      0    </param>
-        <param name="trq_maxOutput">    1333      0      0      0      0      0      0      0      0      0      0      0    </param>       
-        <param name="trq_maxInt">       1333      0      0      0      0      0      0      0      0      0      0      0    </param>       
-        <param name="trq_shift">          10      0      0      0      0      0      0      0      0      0      0      0    </param>       
-        <param name="trq_ko">              0      0      0      0      0      0      0      0      0      0      0      0    </param>       
-        <param name="trq_stictionUp">      0      0      0      0      0      0      0      0      0      0      0      0    </param>       
-        <param name="trq_stictionDwn">     0      0      0      0      0      0      0      0      0      0      0      0    </param>       
-        <param name="trq_kff">             0      0      0      0      0      0      0      0      0      0      0      0    </param> 
-        <param name="trq_kbemf">           0      0      0      0      0      0      0      0      0      0      0      0    </param> 
-        <param name="trq_filterType">       0      0      0      0      0      0      0      0      0      0      0      0    </param> 
-        <param name="trq_ktau">            1      1      1      1      1      1      1      1      1      1      1      1    </param>   
+    <group name="TIMEOUTS">
+        <param name="velocity">     100           100           100           100        100           100           100           100      100           100           100           100    </param>
     </group>
 
     <group name="IMPEDANCE">
-        <param name="stiffness">       0      0      0      0      0      0      0      0      0      0      0      0    </param>    
-        <param name="damping">         0      0      0      0      0      0      0      0      0      0      0      0    </param>    
+        <param name="stiffness">    0      0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="damping">      0      0      0      0      0      0      0      0      0      0      0      0    </param>
     </group>
-	
-  </device>
+    
+    <group name="CONTROLS">
+        <param name="positionControl">  POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT      POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT </param>
+        <param name="velocityControl">  POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT      POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT </param>
+        <param name="mixedControl">     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT      POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT </param>
+        <param name="torqueControl">    TRQ_PID_DEFAULT     none                none                none                none                 none                none                none                none                none                none                none            </param>
+        <param name="currentPid">       none                none                none                none                none                 none                none                none                none                none                none                none            </param>
+        <param name="speedPid">         none                none                none                none                none                 none                none                none                none                none                none                none            </param>
+    </group>
+
+
+    <!-- default position PID: begin -->
+    
+    <group name="POS_PID_DEFAULT">
+        <param name="controlLaw">             minjerk                   </param>
+        <param name="outputType">             pwm                       </param>
+        <param name="fbkControlUnits">        metric_units              </param>
+        <param name="outputControlUnits">     machine_units             </param>
+        <param name="kp">          -200          1000          -1000         200   -500          -8000         8000          -8000         -8000         -8000         8000          -1200    </param>
+        <param name="kd">          -1000         10000         -10000        200   -32000        -32000        32000         -32000        -32000        -32000        32000         -12500   </param>
+        <param name="ki">          -1            1             -1            1     -1            -5            5             -5            -5            -5            5             -1       </param>
+        <param name="maxOutput">   1333          1333          1333          1333   1333          1333          1333          1333          1333          1333          1333          1333     </param>
+        <param name="maxInt">      1333          1333          1333          1333   1333          1333          1333          1333          1333          1333          1333          1333     </param>
+        <param name="stictionUp">   0             0             0             0      0             0             0             0             0             0             0             0        </param>
+        <param name="stictionDown"> 0             0             0             0      0             0             0             0             0             0             0             0        </param>
+        <param name="kff">          0             0             0             0      0             0             0             0             0             0             0             0        </param>
+    </group>
+
+    <!-- default position PID: end -->
+
+
+    <!-- other default PIDs: begin --> 
+
+    <group name="TRQ_PID_DEFAULT">
+        <param name="controlLaw">          torque                       </param>
+        <param name="outputType">          pwm                          </param>
+        <param name="fbkControlUnits">     metric_units                 </param>
+        <param name="outputControlUnits">  machine_units                </param>
+        <param name="kp">               80      0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="kd">                0      0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="ki">                0      0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="maxOutput">      1333      0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="maxInt">         1333      0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="ko">                0      0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="stictionUp">        0      0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="stictionDown">      0      0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="kff">               0      0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="kbemf">             0      0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="filterType">        0      0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="ktau">              0      0      0      0      0      0      0      0      0      0      0      0     </param>
+    </group>
+
+    <!-- other default PIDs: end -->
+    
+    
+    <!-- custom PIDs: begin -->    
+    <!-- custom PIDs: end -->
+    
+</device>
+
 

--- a/iCubSheffield01/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubSheffield01/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -1,91 +1,118 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
- <!-- Initialization file for EMS 5 - Torso, 3 dof -->
 
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="torso-eb5-j0_2-mc" type="embObjMotionControl">
 
-  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="torso-eb5-j0_2-mc" type="embObjMotionControl">
-      <xi:include href="../../general.xml" />
-      <xi:include href="../../hardware/electronics/torso-eb5-j0_2-eln.xml" />
-      <xi:include href="../../hardware/mechanicals/torso-eb5-j0_2-mec.xml" />
-      
-      <xi:include href="./torso-eb5-j0_2-mc_service.xml" />
-    
-        <group name="LIMITS">
-        <param name="jntPosMax">                  50            30            70        </param>
-        <param name="jntPosMin">                 -50           -30           -20        </param>
-        <param name="motorNominalCurrents">     4000          4000          4000        </param>
-        <param name="motorPeakCurrents">        5000          5000          5000        </param>
-        <param name="motorOverloadCurrents">   15000         15000         15000        </param>
-        <param name="jntVelMax">                1000          1000          1000        </param>
-        <param name="motorPwmLimit">           10000         10000         10000        </param>   
+    <xi:include href="../../general.xml" />
+    <xi:include href="../../hardware/electronics/torso-eb5-j0_2-eln.xml" />
+    <xi:include href="../../hardware/mechanicals/torso-eb5-j0_2-mec.xml" />
+    <xi:include href="./torso-eb5-j0_2-mc_service.xml" />
+
+    <!-- joint number                           0                   1                   2               -->
+    <!-- joint name -->          
+    <group name="LIMITS">
+        <param name="jntPosMax">                50                  30                  70                  </param>
+        <param name="jntPosMin">                -50                 -30                 -20                 </param>
+        <param name="jntVelMax">                1000                1000                1000                </param>
+        <param name="motorNominalCurrents">     4000                4000                4000                </param>
+        <param name="motorPeakCurrents">        5000                5000                5000                </param>
+        <param name="motorOverloadCurrents">    15000               15000               15000               </param>
+        <param name="motorPwmLimit">            10000               10000               10000               </param>
     </group>
 
-    
     <group name="TIMEOUTS">
-        <param name="velocity">                 100           100       100             </param>
-    </group>
-
-    <group name="CONTROLS">
-       <param name="positionControl">  POS_PID_DEFAULT           POS_PID_DEFAULT          POS_PID_DEFAULT           </param>
-       <param name="velocityControl">  none                   none                  none                   </param>
-       <param name="torqueControl">    TRQ_PID_DEFAULT  TRQ_PID_DEFAULT TRQ_PID_DEFAULT  </param>
-       <param name="currentPid">       2FOC_CUR_CONTROL          2FOC_CUR_CONTROL         2FOC_CUR_CONTROL          </param>
-    </group>
-
-    <group name="POS_PID_DEFAULT">
-        <param name="controlLaw">    Pid_inPos_outPwm                          </param>
-        <param name="controlUnits">  metric_units               </param> 
-        <param name="pos_kp">            711.11    -1066.66    -1066.66 </param>       
-        <param name="pos_kd">              0.00        0.00        0.00 </param>       
-        <param name="pos_ki">           7111.09   -10666.64   -14222.18 </param>            
-        <param name="pos_maxOutput">       8000        8000       16000 </param>  
-        <param name="pos_maxInt">           750        1000        2000 </param>       
-        <param name="pos_shift">              0           0           0 </param>       
-        <param name="pos_ko">                 0           0           0 </param>       
-        <param name="pos_stictionUp">         0           0           0 </param>       
-        <param name="pos_stictionDwn">        0           0           0 </param>       
-        <param name="pos_kff">                0           0           0 </param>     
-    </group>
-    
-    
-     <group name="TRQ_PID_DEFAULT">
-        <param name="controlLaw">    Pid_inTrq_outPwm           </param>
-        <param name="controlUnits">  metric_units               </param>  
-        <param name="trq_kp">            450       -400       -400  </param>       
-        <param name="trq_kd">              0          0          0  </param>       
-        <param name="trq_ki">              0          0          0  </param>    
-        <param name="trq_maxOutput">    8000       8000       8000  </param>       
-        <param name="trq_maxInt">        500        500        500  </param>       
-        <param name="trq_shift">           0          0          0  </param>       
-        <param name="trq_ko">              0          0          0  </param>       
-        <param name="trq_stictionUp">      2          2          2  </param>       
-        <param name="trq_stictionDwn">    -2         -2         -2  </param>       
-        <param name="trq_kff">             1          1          1  </param>   
-        <param name="trq_kbemf">          -0.0016    -0.003     -0.003  </param>    
-        <param name="trq_filterType">      0          0          0  </param>           
-        <param name="trq_ktau">          200       -200       -200  </param>  
+        <param name="velocity">                 100                 100                 100                 </param>
     </group>
 
     <group name="IMPEDANCE">
-        <param name="stiffness">       0      0      0     </param>    
-        <param name="damping">         0      0      0     </param>    
+        <param name="stiffness">                0                   0                   0                   </param>
+        <param name="damping">                  0                   0                   0                   </param>
+    </group>
+    
+    <group name="CONTROLS">
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="torqueControl">            TRQ_PID_DEFAULT     TRQ_PID_DEFAULT     TRQ_PID_DEFAULT     </param>
+        <param name="currentPid">               2FOC_CUR_CONTROL    2FOC_CUR_CONTROL    2FOC_CUR_CONTROL    </param>
+        <param name="speedPid">                 2FOC_VEL_CONTROL    2FOC_VEL_CONTROL    2FOC_VEL_CONTROL    </param>
+    </group>
+
+
+    <!-- default position PID: begin -->
+
+    <group name="POS_PID_DEFAULT">
+        <param name="controlLaw">             minjerk               </param>
+        <param name="outputType">             pwm                   </param>
+        <param name="fbkControlUnits">        metric_units          </param>
+        <param name="outputControlUnits">     machine_units         </param>
+        <param name="kp">           711.11      -1066.66    -1066.66    </param>
+        <param name="kd">           0.00        0.00        0.00        </param>
+        <param name="ki">           7111.09     -10666.64   -14222.18   </param>
+        <param name="maxOutput">    8000        8000        16000       </param>
+        <param name="maxInt">       750         1000        2000        </param>
+        <param name="stictionUp">   0           0           0           </param>
+        <param name="stictionDown"> 0           0           0           </param>
+        <param name="kff">          0           0           0           </param>
+    </group>
+
+    <!-- default position PID: end -->
+
+
+    <!-- other default PIDs: begin -->  
+    
+    <group name="TRQ_PID_DEFAULT">
+        <param name="controlLaw">          torque                       </param>
+        <param name="outputType">          pwm                          </param>
+        <param name="fbkControlUnits">     metric_units                 </param>
+        <param name="outputControlUnits">  machine_units                </param>
+        <param name="kp">             450       -400       -400 </param>
+        <param name="kd">              0          0          0  </param>
+        <param name="ki">              0          0          0  </param>
+        <param name="maxOutput">    8000       8000       8000  </param>
+        <param name="maxInt">        500        500        500  </param>
+        <param name="ko">              0          0          0  </param>
+        <param name="stictionUp">      0          0          0  </param>
+        <param name="stictionDown">    0          0          0  </param>
+        <param name="kff">             1          1          1  </param>
+        <param name="kbemf">           0          0          0  </param>
+        <param name="filterType">      0          0          0  </param>
+        <param name="ktau">            0          0          0  </param>
     </group>
 
     <group name="2FOC_CUR_CONTROL">
-        <param name="controlLaw">       limitscurrent          </param>
-        <param name="controlUnits">     metric_units           </param>
-        <param name="cur_kp">               8           8          8         </param>       
-        <param name="cur_kd">               0           0          0         </param>       
-        <param name="cur_ki">               2           2          2         </param>
-        <param name="cur_shift">            10          10         10        </param>
-        <param name="cur_maxOutput">        32000       32000      32000     </param>                 
-        <param name="cur_maxInt">           32000       32000      32000     </param> 
-        <param name="cur_ko">               0            0          0        </param>
-        <param name="cur_stictionUp">       0            0          0        </param>
-        <param name="cur_stictionDwn">      0            0          0        </param>
-        <param name="cur_kff">              0            0          0        </param>        
-   </group>
+        <param name="controlLaw">           low_lev_current     </param>
+        <param name="fbkControlUnits">      machine_units       </param>
+        <param name="outputControlUnits">   machine_units       </param>
+        <param name="kp">                   8           8           8       </param>
+        <param name="kd">                   0           0           0       </param>
+        <param name="ki">                   2           2           2       </param>
+        <param name="shift">                10          10          10      </param>
+        <param name="maxOutput">            32000       32000       32000   </param>
+        <param name="maxInt">               32000       32000       32000   </param>
+        <param name="kff">                  0            0          0       </param>
+    </group>
+
+    <group name="2FOC_VEL_CONTROL">
+        <param name="controlLaw">           low_lev_speed       </param>
+        <param name="fbkControlUnits">      machine_units       </param>
+        <param name="outputControlUnits">   machine_units       </param>
+        <param name="kff">                  0           0           0       </param>
+        <param name="kp">                   12          12          12      </param>
+        <param name="kd">                   0           0           0       </param>
+        <param name="ki">                   16          16          16      </param>
+        <param name="shift">                10          10          10      </param>
+        <param name="maxOutput">            32000       32000       32000   </param>
+        <param name="maxInt">               32000       32000       32000   </param>
+    </group>
+
+    <!-- other default PIDs: end -->
+ 
+ 
+    <!-- custom PIDs: begin -->
+    <!-- custom PIDs: end -->
     
-  </device>
+</device>
+
 

--- a/iCubSheffield01/hardware/motorControl/torso-eb5-j0_2-mc_service.xml
+++ b/iCubSheffield01/hardware/motorControl/torso-eb5-j0_2-mc_service.xml
@@ -20,9 +20,9 @@
                     <param name="minor">            6           </param>     
                 </group>                    
                 <group name="FIRMWARE">
-                    <param name="major">            0           </param>    
-                    <param name="minor">            0           </param> 
-                    <param name="build">            0           </param>
+                    <param name="major">            3           </param>    
+                    <param name="minor">            3           </param> 
+                    <param name="build">            3           </param>
                 </group>
             </group>
 
@@ -46,7 +46,7 @@
                     <param name="port">             CAN1:3:0            CAN1:4:0            CAN1:1:0    </param>
                     <param name="position">         atmotor             atmotor             atmotor     </param>
                     <param name="resolution">       -14400              -14400              -14400      </param>
-                    <param name="tolerance">         0                   0                   0           </param>
+                    <param name="tolerance">        0                   0                   0           </param>
                 </group>
  
             </group>


### PR DESCRIPTION
- started from iCubGenova02 because both robots have can-based arms.
- copied its -mec, -mc, -mc-service files into this robot, evaluated differences
- kept:
  - from iCubGenova02: the formatting, the new fields,
  - from iCubSheffield01: the values of the PIDs
- caveat: in TRQ_PID_DEFAULT i disabled (value = 0): stictionUp, stictionDown, kbemf, ktau.