### PR TITLE
Improve cameras quality for iCubGenova04

### DIFF
--- a/iCubGenova04/camera/dragonfly2_config_left.ini
+++ b/iCubGenova04/camera/dragonfly2_config_left.ini
@@ -1,7 +1,7 @@
 device dragonfly2
 width 640
 height 480
-video_type 1
+video_type 2
 white_balance 0.506 0.710
 gain 0.2
 shutter 0.913
@@ -13,7 +13,7 @@ sharpness 0.5
 hue 0.48
 gamma 0.4
 saturation 0.271
-framerate 30
+framerate 25
 #d 0
 guid 00b09d0100b79535 
 #<64bit global identifier, without the leading 0x> then remove the d option

--- a/iCubGenova04/camera/dragonfly2_config_right.ini
+++ b/iCubGenova04/camera/dragonfly2_config_right.ini
@@ -1,7 +1,7 @@
 device dragonfly2
 width 640
 height 480
-video_type 1
+video_type 2
 white_balance 0.506 0.710
 gain 0.2
 shutter 0.913
@@ -13,7 +13,7 @@ sharpness 0.5
 hue 0.48
 gamma 0.4
 saturation 0.271
-framerate 30
+framerate 25
 #d 1
 guid 00b09d0100b79534
 #<64bit global identifier, without the leading 0x> then remove the d option

--- a/iCubGenova04/icubEyes_640x480.ini
+++ b/iCubGenova04/icubEyes_640x480.ini
@@ -1,0 +1,61 @@
+[CAMERA_CALIBRATION_RIGHT]
+projection         pinhole
+drawCenterCross    0
+
+w 640
+h 480
+fx 446.30787465601099
+fy 448.44778322512855
+cx 313.73434091798771
+cy 224.4691342181579
+k1 -0.32616218659596552
+k2 0.086072743232755614
+p1 -0.001835706149853529
+p2 -0.001007764102799745
+
+[CAMERA_CALIBRATION_LEFT]
+projection         pinhole
+drawCenterCross    0
+
+w 640
+h 480
+fx 443.59549
+fy 444.751606
+cx 344.89962
+cy 207.652054
+k1 -0.32121817642921552
+k2 0.081499928514089562
+p1 -0.000925993397250783
+p2 2.6147302026114336e-05
+
+[CAMERA_CALIBRATION_CONFIGURATION_LEFT]
+
+numPatternImagesRequired    10
+numPatternInnerCornersX     8
+numPatternInnerCornersY     6
+patternSquareSideLength     25
+outputFilename              /tmp/results.ini
+outputGroupname             CAMERA_CALIBRATION_LEFT
+
+
+
+[CAMERA_CALIBRATION_CONFIGURATION_RIGHT]
+
+numPatternImagesRequired    10
+numPatternInnerCornersX     8
+numPatternInnerCornersY     6
+patternSquareSideLength     25
+outputFilename              /tmp/results.ini
+outputGroupname             CAMERA_CALIBRATION_RIGHT
+
+
+[STEREO_CALIBRATION_CONFIGURATION]
+boardWidth 8
+boardHeight 6
+boardSize 0.09241
+numberOfPairs 30
+
+[STEREO_DISPARITY]
+HN (0.997973 0.0396591 -0.0497703 -0.0686682 -0.0379375 0.998664 0.0350721 0.00192471 0.0510948 -0.0331128 0.998145 -0.0057142 0 0 0 1)
+QL ( 0.000000	 0.000000	 0.000000	 0.000767	 0.000153	 0.000767	-0.000652	-0.000135)
+QR ( 0.000000	 0.000000	 0.000000	 0.000767	 0.000153	 0.000767	-0.000652	-0.000135)


### PR DESCRIPTION
This PR:
- fixes the wrong `video_type` for iCubGenova04 cameras
- introduces `iCubGenova04/icubEyes_640x480.ini` configuration file

@pattacini @S-Dafarra @Nicogene 