### PR TITLE
iCubNottingham01 migration to MCV6

### DIFF
--- a/iCubNottingham01/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/iCubNottingham01/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -23,9 +23,9 @@
                         <param name="minor">            0                       </param>     
                     </group>                    
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
+                        <param name="major">            2                       </param>    
                         <param name="minor">            0                       </param> 
-                        <param name="build">            0                       </param>
+                        <param name="build">            4                       </param>
                     </group>
                 </group>
                 

--- a/iCubNottingham01/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/iCubNottingham01/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -23,9 +23,9 @@
                         <param name="minor">            0                       </param>     
                     </group>                    
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
+                        <param name="major">            2                       </param>    
                         <param name="minor">            0                       </param> 
-                        <param name="build">            0                       </param>
+                        <param name="build">            4                       </param>
                     </group>
                 </group>
                 

--- a/iCubNottingham01/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/iCubNottingham01/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -23,9 +23,9 @@
                         <param name="minor">            0                       </param>     
                     </group>                    
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
+                        <param name="major">            2                       </param>    
                         <param name="minor">            0                       </param> 
-                        <param name="build">            0                       </param>
+                        <param name="build">            4                       </param>
                     </group>
                 </group>
                 

--- a/iCubNottingham01/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/iCubNottingham01/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -23,9 +23,9 @@
                         <param name="minor">            0                       </param>     
                     </group>                    
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
+                        <param name="major">            2                       </param>    
                         <param name="minor">            0                       </param> 
-                        <param name="build">            0                       </param>
+                        <param name="build">            4                       </param>
                     </group>
                 </group>
                 

--- a/iCubNottingham01/hardware/mechanicals/left_arm-eb1-j0_3-mec.xml
+++ b/iCubNottingham01/hardware/mechanicals/left_arm-eb1-j0_3-mec.xml
@@ -3,7 +3,7 @@
 
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="iCubNottingham01" build="1">
     <group name="GENERAL">
-        <param name="MotioncontrolVersion">  4 </param>
+        <param name="MotioncontrolVersion">  5 </param>
         <param name="Joints"> 4 </param> 
         <param name="AxisMap">               0           1             2             3      </param>
         <param name="AxisName"> "l_shoulder_pitch" "l_shoulder_roll" "l_shoulder_yaw" "l_elbow" </param>

--- a/iCubNottingham01/hardware/mechanicals/left_arm-eb1-j0_3-mec.xml
+++ b/iCubNottingham01/hardware/mechanicals/left_arm-eb1-j0_3-mec.xml
@@ -3,7 +3,7 @@
 
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="iCubNottingham01" build="1">
     <group name="GENERAL">
-        <param name="MotioncontrolVersion">  5 </param>
+        <param name="MotioncontrolVersion">  6 </param>
         <param name="Joints"> 4 </param> 
         <param name="AxisMap">               0           1             2             3      </param>
         <param name="AxisName"> "l_shoulder_pitch" "l_shoulder_roll" "l_shoulder_yaw" "l_elbow" </param>

--- a/iCubNottingham01/hardware/mechanicals/left_arm-eb2-j4_15-mec.xml
+++ b/iCubNottingham01/hardware/mechanicals/left_arm-eb2-j4_15-mec.xml
@@ -3,7 +3,7 @@
 
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="iCubNottingham01" build="1">
     <group name="GENERAL">
-        <param name="MotioncontrolVersion">  4 </param>
+        <param name="MotioncontrolVersion">  5 </param>
         <param name="Joints"> 12 </param>
         <param name="AxisMap">               0             1             2             3             4             5             6             7             8             9             10            11    </param>
         <param name="AxisName">      "l_wrist_prosup" "l_wrist_pitch" "l_wrist_yaw"  "l_hand_finger"    "l_thumb_oppose"     "l_thumb_proximal"     "l_thumb_distal"   "l_index_proximal"    "l_index_distal"    "l_middle_proximal"   "l_middle_distal"    "l_pinky"  </param>

--- a/iCubNottingham01/hardware/mechanicals/left_arm-eb2-j4_15-mec.xml
+++ b/iCubNottingham01/hardware/mechanicals/left_arm-eb2-j4_15-mec.xml
@@ -3,7 +3,7 @@
 
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="iCubNottingham01" build="1">
     <group name="GENERAL">
-        <param name="MotioncontrolVersion">  5 </param>
+        <param name="MotioncontrolVersion">  6 </param>
         <param name="Joints"> 12 </param>
         <param name="AxisMap">               0             1             2             3             4             5             6             7             8             9             10            11    </param>
         <param name="AxisName">      "l_wrist_prosup" "l_wrist_pitch" "l_wrist_yaw"  "l_hand_finger"    "l_thumb_oppose"     "l_thumb_proximal"     "l_thumb_distal"   "l_index_proximal"    "l_index_distal"    "l_middle_proximal"   "l_middle_distal"    "l_pinky"  </param>

--- a/iCubNottingham01/hardware/mechanicals/left_leg-eb6-j0_3-mec.xml
+++ b/iCubNottingham01/hardware/mechanicals/left_leg-eb6-j0_3-mec.xml
@@ -3,7 +3,7 @@
 
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="iCubNottingham01" build="1">
     <group name="GENERAL">
-        <param name="MotioncontrolVersion">  5 </param>
+        <param name="MotioncontrolVersion">  6 </param>
         <param name="Joints"> 4 </param> 
         <param name="AxisMap">               0             1             2             3       </param>
         <param name="AxisName">     "l_hip_pitch"   "l_hip_roll"    "l_hip_yaw"   "l_knee"     </param>

--- a/iCubNottingham01/hardware/mechanicals/left_leg-eb6-j0_3-mec.xml
+++ b/iCubNottingham01/hardware/mechanicals/left_leg-eb6-j0_3-mec.xml
@@ -3,7 +3,7 @@
 
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="iCubNottingham01" build="1">
     <group name="GENERAL">
-        <param name="MotioncontrolVersion">  4 </param>
+        <param name="MotioncontrolVersion">  5 </param>
         <param name="Joints"> 4 </param> 
         <param name="AxisMap">               0             1             2             3       </param>
         <param name="AxisName">     "l_hip_pitch"   "l_hip_roll"    "l_hip_yaw"   "l_knee"     </param>

--- a/iCubNottingham01/hardware/mechanicals/left_leg-eb7-j4_5-mec.xml
+++ b/iCubNottingham01/hardware/mechanicals/left_leg-eb7-j4_5-mec.xml
@@ -3,7 +3,7 @@
 
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="iCubNottingham01" build="1">
     <group name="GENERAL">
-        <param name="MotioncontrolVersion">  4 </param>
+        <param name="MotioncontrolVersion">  5 </param>
         <param name="Joints">  2  </param>  
         <param name="AxisMap">               0             1         </param>
         <param name="AxisName">     "l_ankle_pitch"  "l_ankle_roll"  </param>

--- a/iCubNottingham01/hardware/mechanicals/left_leg-eb7-j4_5-mec.xml
+++ b/iCubNottingham01/hardware/mechanicals/left_leg-eb7-j4_5-mec.xml
@@ -3,7 +3,7 @@
 
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="iCubNottingham01" build="1">
     <group name="GENERAL">
-        <param name="MotioncontrolVersion">  5 </param>
+        <param name="MotioncontrolVersion">  6 </param>
         <param name="Joints">  2  </param>  
         <param name="AxisMap">               0             1         </param>
         <param name="AxisName">     "l_ankle_pitch"  "l_ankle_roll"  </param>

--- a/iCubNottingham01/hardware/mechanicals/right_arm-eb3-j0_3-mec.xml
+++ b/iCubNottingham01/hardware/mechanicals/right_arm-eb3-j0_3-mec.xml
@@ -3,7 +3,7 @@
 
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="iCubNottingham01" build="1">
     <group name="GENERAL">
-        <param name="MotioncontrolVersion">  5 </param>
+        <param name="MotioncontrolVersion">  6 </param>
         <param name="Joints"> 4 </param> 
         <param name="AxisMap">               0           1             2             3          </param>
         <param name="AxisName"> "r_shoulder_pitch" "r_shoulder_roll" "r_shoulder_yaw" "r_elbow" </param>

--- a/iCubNottingham01/hardware/mechanicals/right_arm-eb3-j0_3-mec.xml
+++ b/iCubNottingham01/hardware/mechanicals/right_arm-eb3-j0_3-mec.xml
@@ -3,7 +3,7 @@
 
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="iCubNottingham01" build="1">
     <group name="GENERAL">
-        <param name="MotioncontrolVersion">  4 </param>
+        <param name="MotioncontrolVersion">  5 </param>
         <param name="Joints"> 4 </param> 
         <param name="AxisMap">               0           1             2             3          </param>
         <param name="AxisName"> "r_shoulder_pitch" "r_shoulder_roll" "r_shoulder_yaw" "r_elbow" </param>

--- a/iCubNottingham01/hardware/mechanicals/right_arm-eb4-j4_15-mec.xml
+++ b/iCubNottingham01/hardware/mechanicals/right_arm-eb4-j4_15-mec.xml
@@ -3,7 +3,7 @@
 
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="iCubNottingham01" build="1">
     <group name="GENERAL">
-        <param name="MotioncontrolVersion">  4 </param>
+        <param name="MotioncontrolVersion">  5 </param>
         <param name="Joints"> 12 </param>
         <param name="AxisMap"> 	             0             1             2             3             4             5             6             7            8             9            10            11     </param>
         <param name="AxisName">      "r_wrist_prosup" "r_wrist_pitch" "r_wrist_yaw"  "r_hand_finger"    "r_thumb_oppose"     "r_thumb_proximal"     "r_thumb_distal"   "r_index_proximal"    "r_index_distal"    "r_middle_proximal"   "r_middle_distal"    "r_pinky"  </param>

--- a/iCubNottingham01/hardware/mechanicals/right_arm-eb4-j4_15-mec.xml
+++ b/iCubNottingham01/hardware/mechanicals/right_arm-eb4-j4_15-mec.xml
@@ -3,7 +3,7 @@
 
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="iCubNottingham01" build="1">
     <group name="GENERAL">
-        <param name="MotioncontrolVersion">  5 </param>
+        <param name="MotioncontrolVersion">  6 </param>
         <param name="Joints"> 12 </param>
         <param name="AxisMap"> 	             0             1             2             3             4             5             6             7            8             9            10            11     </param>
         <param name="AxisName">      "r_wrist_prosup" "r_wrist_pitch" "r_wrist_yaw"  "r_hand_finger"    "r_thumb_oppose"     "r_thumb_proximal"     "r_thumb_distal"   "r_index_proximal"    "r_index_distal"    "r_middle_proximal"   "r_middle_distal"    "r_pinky"  </param>

--- a/iCubNottingham01/hardware/mechanicals/right_leg-eb8-j0_3-mec.xml
+++ b/iCubNottingham01/hardware/mechanicals/right_leg-eb8-j0_3-mec.xml
@@ -3,7 +3,7 @@
 
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="iCubNottingham01" build="1">
      <group name="GENERAL">
-        <param name="MotioncontrolVersion">  5 </param>
+        <param name="MotioncontrolVersion">  6 </param>
         <param name="Joints"> 4 </param> 
 
         <param name="AxisMap">               0             1             2             3   </param>

--- a/iCubNottingham01/hardware/mechanicals/right_leg-eb8-j0_3-mec.xml
+++ b/iCubNottingham01/hardware/mechanicals/right_leg-eb8-j0_3-mec.xml
@@ -3,7 +3,7 @@
 
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="iCubNottingham01" build="1">
      <group name="GENERAL">
-        <param name="MotioncontrolVersion">  4 </param>
+        <param name="MotioncontrolVersion">  5 </param>
         <param name="Joints"> 4 </param> 
 
         <param name="AxisMap">               0             1             2             3   </param>

--- a/iCubNottingham01/hardware/mechanicals/right_leg-eb9-j4_5-mec.xml
+++ b/iCubNottingham01/hardware/mechanicals/right_leg-eb9-j4_5-mec.xml
@@ -3,7 +3,7 @@
 
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="iCubNottingham01" build="1">
         <group name="GENERAL">
-        <param name="MotioncontrolVersion">  5 </param>
+        <param name="MotioncontrolVersion">  6 </param>
         <param name="Joints">  2  </param>  
         <param name="AxisMap">               0             1       </param>
         <param name="AxisName">   "r_ankle_pitch"  "r_ankle_roll"  </param>

--- a/iCubNottingham01/hardware/mechanicals/right_leg-eb9-j4_5-mec.xml
+++ b/iCubNottingham01/hardware/mechanicals/right_leg-eb9-j4_5-mec.xml
@@ -3,7 +3,7 @@
 
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="iCubNottingham01" build="1">
         <group name="GENERAL">
-        <param name="MotioncontrolVersion">  4 </param>
+        <param name="MotioncontrolVersion">  5 </param>
         <param name="Joints">  2  </param>  
         <param name="AxisMap">               0             1       </param>
         <param name="AxisName">   "r_ankle_pitch"  "r_ankle_roll"  </param>

--- a/iCubNottingham01/hardware/mechanicals/torso-eb5-j0_2-mec.xml
+++ b/iCubNottingham01/hardware/mechanicals/torso-eb5-j0_2-mec.xml
@@ -3,7 +3,7 @@
 
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="iCubNottingham01" build="1">
    <group name="GENERAL">
-        <param name="MotioncontrolVersion">  5 </param>
+        <param name="MotioncontrolVersion">  6 </param>
         <param name="Joints"> 3 </param> 
         <param name="AxisMap">               2             0             1           </param>   
         <param name="AxisName">      "torso_yaw" "torso_roll" "torso_pitch"          </param>

--- a/iCubNottingham01/hardware/mechanicals/torso-eb5-j0_2-mec.xml
+++ b/iCubNottingham01/hardware/mechanicals/torso-eb5-j0_2-mec.xml
@@ -3,7 +3,7 @@
 
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="iCubNottingham01" build="1">
    <group name="GENERAL">
-        <param name="MotioncontrolVersion">  4 </param>
+        <param name="MotioncontrolVersion">  5 </param>
         <param name="Joints"> 3 </param> 
         <param name="AxisMap">               2             0             1           </param>   
         <param name="AxisName">      "torso_yaw" "torso_roll" "torso_pitch"          </param>

--- a/iCubNottingham01/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
+++ b/iCubNottingham01/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
@@ -43,7 +43,8 @@
 
   <group name="POS_PID_DEFAULT">
         <param name="controlLaw">      Pid_inPos_outPwm </param>
-        <param name="controlUnits">    metric_units               </param>
+        <param name="fbkControlUnits">  metric_units   </param>
+        <param name="outputControlUnits">  machine_units      </param>
         <param name="pos_kp">           711.11    1066.66     711.11    1066.66 </param>       
         <param name="pos_kd">             0.00       0.00       0.00       0.00 </param>       
         <param name="pos_ki">          7111.09   10666.64    7111.09   10666.64 </param>         
@@ -58,7 +59,8 @@
 
     <group name="TRQ_PID_DEFAULT">
         <param name="controlLaw">    Pid_inTrq_outPwm </param> 
-        <param name="controlUnits">  metric_units               </param> 
+        <param name="fbkControlUnits">  metric_units   </param>
+        <param name="outputControlUnits">  machine_units      </param> 
         <param name="trq_kp">            200        200        250        300     </param>       
         <param name="trq_kd">              0          0          0          0     </param>       
         <param name="trq_ki">              0          0          0          0     </param>    
@@ -66,17 +68,18 @@
         <param name="trq_maxInt">        500        500        500        500     </param>       
         <param name="trq_shift">           0          0          0          0     </param>       
         <param name="trq_ko">              0          0          0          0     </param>       
-        <param name="trq_stictionUp">      0.5        0.5        1          1.7   </param>       
-        <param name="trq_stictionDwn">    -0.7       -0.7       -0.8       -1.2   </param>    
+        <param name="stictionUp">0 0 0 0</param>       
+        <param name="stictionDwn">0 0 0 0</param>    
         <param name="trq_kff">             1          1          1          1     </param>  
-        <param name="trq_kbemf">      0.0030     0.0006     0.0007     0.0007     </param>    
+        <param name="kbemf">0 0 0 0</param>    
         <param name="trq_filterType">      0          0          0          0     </param>    
-        <param name="trq_ktau">          180        464        463        449     </param>             
+        <param name="ktau">0 0 0 0</param>             
     </group>
     
     <group name="2FOC_CUR_CONTROL">
         <param name="controlLaw">       limitscurrent          </param> 
-        <param name="controlUnits">     metric_units           </param> 
+        <param name="fbkControlUnits">  metric_units   </param>
+        <param name="outputControlUnits">  machine_units      </param> 
         <param name="cur_kp">                8           8          8         8      </param>
         <param name="cur_kd">                0           0          0         0      </param>
         <param name="cur_ki">                2           2          2         2      </param>

--- a/iCubNottingham01/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
+++ b/iCubNottingham01/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
@@ -28,7 +28,8 @@
 
     <group name="CONTROLS">
        <param name="positionControl">  POS_PID_DEFAULT           POS_PID_DEFAULT          POS_PID_DEFAULT          POS_PID_DEFAULT          </param> 
-       <param name="velocityControl">  none                   none                  none                  none                  </param> 
+       <param name="velocityControl"> POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT</param>
+           <param name="mixedControl"> POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT</param> 
        <param name="torqueControl">    TRQ_PID_DEFAULT  TRQ_PID_DEFAULT TRQ_PID_DEFAULT TRQ_PID_DEFAULT </param>
         <param name="currentPid">      2FOC_CUR_CONTROL          2FOC_CUR_CONTROL         2FOC_CUR_CONTROL         2FOC_CUR_CONTROL         </param> 
     </group>
@@ -45,53 +46,66 @@
         <param name="controlLaw">      Pid_inPos_outPwm </param>
         <param name="fbkControlUnits">  metric_units   </param>
         <param name="outputControlUnits">  machine_units      </param>
-        <param name="pos_kp">           711.11    1066.66     711.11    1066.66 </param>       
-        <param name="pos_kd">             0.00       0.00       0.00       0.00 </param>       
-        <param name="pos_ki">          7111.09   10666.64    7111.09   10666.64 </param>         
-        <param name="pos_maxOutput">      8000       8000       8000       8000 </param>    
-        <param name="pos_maxInt">          200        200        200       1000 </param>       
-        <param name="pos_shift">             0          0          0          0 </param>       
-        <param name="pos_ko">                0          0          0          0 </param>       
-        <param name="pos_stictionUp">        0          0          0          0 </param>       
-        <param name="pos_stictionDwn">       0          0          0          0 </param>       
-        <param name="pos_kff">               0          0          0          0 </param>    
+        <param name="kp">           711.11    1066.66     711.11    1066.66 </param>       
+        <param name="kd">             0.00       0.00       0.00       0.00 </param>       
+        <param name="ki">          7111.09   10666.64    7111.09   10666.64 </param>         
+        <param name="maxOutput">      8000       8000       8000       8000 </param>    
+        <param name="maxInt">          200        200        200       1000 </param>       
+        <param name="shift">             0          0          0          0 </param>       
+        <param name="ko">                0          0          0          0 </param>       
+        <param name="stictionUp">        0          0          0          0 </param>       
+        <param name="stictionDown">       0          0          0          0 </param>       
+        <param name="kff">               0          0          0          0 </param>    
     </group>
 
     <group name="TRQ_PID_DEFAULT">
         <param name="controlLaw">    Pid_inTrq_outPwm </param> 
         <param name="fbkControlUnits">  metric_units   </param>
         <param name="outputControlUnits">  machine_units      </param> 
-        <param name="trq_kp">            200        200        250        300     </param>       
-        <param name="trq_kd">              0          0          0          0     </param>       
-        <param name="trq_ki">              0          0          0          0     </param>    
-        <param name="trq_maxOutput">    8000       8000       8000       8000     </param>       
-        <param name="trq_maxInt">        500        500        500        500     </param>       
-        <param name="trq_shift">           0          0          0          0     </param>       
-        <param name="trq_ko">              0          0          0          0     </param>       
+        <param name="kp">            200        200        250        300     </param>       
+        <param name="kd">              0          0          0          0     </param>       
+        <param name="ki">              0          0          0          0     </param>    
+        <param name="maxOutput">    8000       8000       8000       8000     </param>       
+        <param name="maxInt">        500        500        500        500     </param>       
+        <param name="shift">           0          0          0          0     </param>       
+        <param name="ko">              0          0          0          0     </param>       
         <param name="stictionUp">0 0 0 0</param>       
         <param name="stictionDwn">0 0 0 0</param>    
-        <param name="trq_kff">             1          1          1          1     </param>  
+        <param name="kff">             1          1          1          1     </param>  
         <param name="kbemf">0 0 0 0</param>    
-        <param name="trq_filterType">      0          0          0          0     </param>    
+        <param name="filterType">      0          0          0          0     </param>    
         <param name="ktau">0 0 0 0</param>             
     </group>
     
     <group name="2FOC_CUR_CONTROL">
         <param name="controlLaw">       limitscurrent          </param> 
-        <param name="fbkControlUnits">  metric_units   </param>
+        <param name="fbkControlUnits">  machine_units   </param>
         <param name="outputControlUnits">  machine_units      </param> 
-        <param name="cur_kp">                8           8          8         8      </param>
-        <param name="cur_kd">                0           0          0         0      </param>
-        <param name="cur_ki">                2           2          2         2      </param>
-        <param name="cur_shift">             10          10         10        10     </param>
-        <param name="cur_maxOutput">         32000       32000      32000     32000  </param>
-        <param name="cur_maxInt">            32000       32000      32000     32000  </param>
-        <param name="cur_ko">               0            0          0            0  </param>       
-        <param name="cur_stictionUp">       0            0          0            0  </param>       
-        <param name="cur_stictionDwn">      0            0          0            0  </param>   
-        <param name="cur_kff">              0            0          0            0  </param>            
+        <param name="kp">                8           8          8         8      </param>
+        <param name="kd">                0           0          0         0      </param>
+        <param name="ki">                2           2          2         2      </param>
+        <param name="shift">             10          10         10        10     </param>
+        <param name="maxOutput">         32000       32000      32000     32000  </param>
+        <param name="maxInt">            32000       32000      32000     32000  </param>
+        <param name="ko">               0            0          0            0  </param>       
+        <param name="stictionUp">       0            0          0            0  </param>       
+        <param name="stictionDown">      0            0          0            0  </param>   
+        <param name="kff">              0            0          0            0  </param>            
     </group>
     
+	
+	<group name="2FOC_VEL_CONTROL">
+        <param name="controlLaw">           low_lev_speed       </param>
+        <param name="fbkControlUnits">      machine_units       </param>
+        <param name="outputControlUnits">   machine_units       </param>
+        <param name="kff">                  0           0           0           0       </param>
+        <param name="kp">                   12          12          12          12      </param>
+        <param name="kd">                   0           0           0           0       </param>
+        <param name="ki">                   16          16          16          16      </param>
+        <param name="shift">                10          10          10          10      </param>
+        <param name="maxOutput">            32000       32000       32000       32000   </param>
+        <param name="maxInt">               32000       32000       32000       32000   </param>
+    </group>
   </device>
 
 

--- a/iCubNottingham01/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
+++ b/iCubNottingham01/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
- <!-- Initialization file for EMS 1 - Left Upper Arm, 4 dof -->
 
 
-  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-eb1-j0_3-mc" type="embObjMotionControl">
-      <xi:include href="../../general.xml"/>
-      <xi:include href="../../hardware/electronics/left_arm-eb1-j0_3-eln.xml" />
-      <xi:include href="../../hardware/mechanicals/left_arm-eb1-j0_3-mec.xml" />
-      
-      <xi:include href="./left_arm-eb1-j0_3-mc_service.xml" />
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-eb1-j0_3-mc" type="embObjMotionControl">
 
-
+    <xi:include href="../../general.xml"/>
+    <xi:include href="../../hardware/electronics/left_arm-eb1-j0_3-eln.xml" />
+    <xi:include href="../../hardware/mechanicals/left_arm-eb1-j0_3-mec.xml" />
+    <xi:include href="./left_arm-eb1-j0_3-mc_service.xml" />
+    
+    <!-- joint number                           0                   1                   2                   3                   -->
+    <!-- joint name -->          
     <group name="LIMITS">
         <!--                                     0                1              2              3            -->
         <param name="jntPosMax">                 8              160             80            106       </param>  
@@ -23,78 +23,79 @@
     </group>
 
     <group name="TIMEOUTS">
-        <param name="velocity">               100           100           100           100 </param>
+        <param name="velocity">                 100                 100                 100                 100                 </param>
     </group>
-
-    <group name="CONTROLS">
-       <param name="positionControl">  POS_PID_DEFAULT           POS_PID_DEFAULT          POS_PID_DEFAULT          POS_PID_DEFAULT          </param> 
-       <param name="velocityControl"> POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT</param>
-           <param name="mixedControl"> POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT</param> 
-       <param name="torqueControl">    TRQ_PID_DEFAULT  TRQ_PID_DEFAULT TRQ_PID_DEFAULT TRQ_PID_DEFAULT </param>
-        <param name="currentPid">      2FOC_CUR_CONTROL          2FOC_CUR_CONTROL         2FOC_CUR_CONTROL         2FOC_CUR_CONTROL         </param> 
-    </group>
-
-
 
     <group name="IMPEDANCE">
-      <param name="stiffness"> 0.1     0.1   0.1    0.1    </param>
-      <param name="damping">  0.05   0.05  0.05   0.05    </param>
+        <param name="stiffness">                0.1                 0.1                 0.1                 0.1                 </param>
+        <param name="damping">                  0.05                0.05                0.05                0.05                </param>
+    </group>
+    
+    <group name="CONTROLS">
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="torqueControl">            TRQ_PID_DEFAULT     TRQ_PID_DEFAULT     TRQ_PID_DEFAULT     TRQ_PID_DEFAULT     </param>
+        <param name="currentPid">               2FOC_CUR_CONTROL    2FOC_CUR_CONTROL    2FOC_CUR_CONTROL    2FOC_CUR_CONTROL    </param>
+        <param name="speedPid">                 2FOC_VEL_CONTROL    2FOC_VEL_CONTROL    2FOC_VEL_CONTROL    2FOC_VEL_CONTROL    </param>
     </group>
 
 
-  <group name="POS_PID_DEFAULT">
-        <param name="controlLaw">      Pid_inPos_outPwm </param>
-        <param name="fbkControlUnits">  metric_units   </param>
-        <param name="outputControlUnits">  machine_units      </param>
-        <param name="kp">           711.11    1066.66     711.11    1066.66 </param>       
-        <param name="kd">             0.00       0.00       0.00       0.00 </param>       
-        <param name="ki">          7111.09   10666.64    7111.09   10666.64 </param>         
-        <param name="maxOutput">      8000       8000       8000       8000 </param>    
-        <param name="maxInt">          200        200        200       1000 </param>       
-        <param name="shift">             0          0          0          0 </param>       
-        <param name="ko">                0          0          0          0 </param>       
-        <param name="stictionUp">        0          0          0          0 </param>       
-        <param name="stictionDown">       0          0          0          0 </param>       
-        <param name="kff">               0          0          0          0 </param>    
+    <!-- default position PID: begin -->
+    
+    <group name="POS_PID_DEFAULT">
+        <param name="controlLaw">           minjerk             </param>
+        <param name="outputType">           pwm                 </param>
+        <param name="fbkControlUnits">      metric_units        </param>
+        <param name="outputControlUnits">   machine_units       </param>
+        <param name="kp">                   711.11      1066.66     711.11      1066.66 </param>
+        <param name="kd">                   0.00        0.00        0.00        0.00    </param>
+        <param name="ki">                   7111.09     10666.64    7111.09     10666.64</param>
+        <param name="maxOutput">            8000        8000        8000        8000    </param>
+        <param name="maxInt">               200         200         200         1000    </param>
+        <param name="stictionUp">           0           0           0           0       </param>
+        <param name="stictionDown">         0           0           0           0       </param>
+        <param name="kff">                  0           0           0           0       </param>
     </group>
 
+    <!-- default position PID: end -->
+
+
+    <!-- other default PIDs: begin -->  
+    
     <group name="TRQ_PID_DEFAULT">
-        <param name="controlLaw">    Pid_inTrq_outPwm </param> 
-        <param name="fbkControlUnits">  metric_units   </param>
-        <param name="outputControlUnits">  machine_units      </param> 
-        <param name="kp">            200        200        250        300     </param>       
-        <param name="kd">              0          0          0          0     </param>       
-        <param name="ki">              0          0          0          0     </param>    
-        <param name="maxOutput">    8000       8000       8000       8000     </param>       
-        <param name="maxInt">        500        500        500        500     </param>       
-        <param name="shift">           0          0          0          0     </param>       
-        <param name="ko">              0          0          0          0     </param>       
-        <param name="stictionUp">0 0 0 0</param>       
-        <param name="stictionDwn">0 0 0 0</param>    
-        <param name="kff">             1          1          1          1     </param>  
-        <param name="kbemf">0 0 0 0</param>    
-        <param name="filterType">      0          0          0          0     </param>    
-        <param name="ktau">0 0 0 0</param>             
+        <param name="controlLaw">           torque              </param>
+        <param name="outputType">           pwm                 </param>
+        <param name="fbkControlUnits">      metric_units        </param>
+        <param name="outputControlUnits">   machine_units       </param>
+        <param name="kp">                   200         200         250         300     </param>
+        <param name="kd">                   0           0           0           0       </param>
+        <param name="ki">                   0           0           0           0       </param>
+        <param name="maxOutput">            8000        8000        8000        8000    </param>
+        <param name="maxInt">               500         500         500         500     </param>
+        <param name="ko">                   0           0           0           0       </param>
+        <param name="stictionUp">           0           0           0           0       </param>
+        <param name="stictionDown">         0           0           0           0       </param>
+        <param name="kff">                  1           1           1           1       </param>
+        <param name="kbemf">                0           0           0           0       </param>
+        <param name="filterType">           0           0           0           0       </param>
+        <param name="ktau">                 0           0           0           0       </param>
     </group>
     
     <group name="2FOC_CUR_CONTROL">
-        <param name="controlLaw">       limitscurrent          </param> 
-        <param name="fbkControlUnits">  machine_units   </param>
-        <param name="outputControlUnits">  machine_units      </param> 
-        <param name="kp">                8           8          8         8      </param>
-        <param name="kd">                0           0          0         0      </param>
-        <param name="ki">                2           2          2         2      </param>
-        <param name="shift">             10          10         10        10     </param>
-        <param name="maxOutput">         32000       32000      32000     32000  </param>
-        <param name="maxInt">            32000       32000      32000     32000  </param>
-        <param name="ko">               0            0          0            0  </param>       
-        <param name="stictionUp">       0            0          0            0  </param>       
-        <param name="stictionDown">      0            0          0            0  </param>   
-        <param name="kff">              0            0          0            0  </param>            
+        <param name="controlLaw">           low_lev_current     </param>
+        <param name="fbkControlUnits">      machine_units       </param>
+        <param name="outputControlUnits">   machine_units       </param>
+        <param name="kp">                   8           8           8           8       </param>
+        <param name="kd">                   0           0           0           0       </param>
+        <param name="ki">                   2           2           2           2       </param>
+        <param name="shift">                10          10          10          10      </param>
+        <param name="maxOutput">            32000       32000       32000       32000   </param>
+        <param name="maxInt">               32000       32000       32000       32000   </param>
+        <param name="kff">                  0           0           0           0       </param>
     </group>
-    
-	
-	<group name="2FOC_VEL_CONTROL">
+
+    <group name="2FOC_VEL_CONTROL">
         <param name="controlLaw">           low_lev_speed       </param>
         <param name="fbkControlUnits">      machine_units       </param>
         <param name="outputControlUnits">   machine_units       </param>
@@ -106,7 +107,12 @@
         <param name="maxOutput">            32000       32000       32000       32000   </param>
         <param name="maxInt">               32000       32000       32000       32000   </param>
     </group>
-  </device>
 
-
+    <!-- other default PIDs: end -->
+    
+    
+    <!-- custom PIDs: begin -->    
+    <!-- custom PIDs: end -->
+    
+</device>
 

--- a/iCubNottingham01/hardware/motorControl/left_arm-eb1-j0_3-mc_service.xml
+++ b/iCubNottingham01/hardware/motorControl/left_arm-eb1-j0_3-mc_service.xml
@@ -20,9 +20,9 @@
                     <param name="minor">            6           </param>     
                 </group>                    
                 <group name="FIRMWARE">
-                    <param name="major">            0           </param>    
-                    <param name="minor">            0           </param> 
-                    <param name="build">            0           </param>
+                    <param name="major">            3                       </param>    
+                    <param name="minor">            3                       </param> 
+                    <param name="build">            3                       </param>
                 </group>
             </group>
             

--- a/iCubNottingham01/hardware/motorControl/left_arm-eb1-j0_3-mc_service.xml
+++ b/iCubNottingham01/hardware/motorControl/left_arm-eb1-j0_3-mc_service.xml
@@ -20,9 +20,9 @@
                     <param name="minor">            6           </param>     
                 </group>                    
                 <group name="FIRMWARE">
-                    <param name="major">            0                       </param>    
-                    <param name="minor">            0                       </param> 
-                    <param name="build">            0                       </param>
+                    <param name="major">            3                       </param>    
+                    <param name="minor">            3                       </param> 
+                    <param name="build">            3                       </param>
                 </group>
             </group>
             

--- a/iCubNottingham01/hardware/motorControl/left_arm-eb1-j0_3-mc_service.xml
+++ b/iCubNottingham01/hardware/motorControl/left_arm-eb1-j0_3-mc_service.xml
@@ -20,9 +20,9 @@
                     <param name="minor">            6           </param>     
                 </group>                    
                 <group name="FIRMWARE">
-                    <param name="major">            3                       </param>    
-                    <param name="minor">            3                       </param> 
-                    <param name="build">            3                       </param>
+                    <param name="major">            0                       </param>    
+                    <param name="minor">            0                       </param> 
+                    <param name="build">            0                       </param>
                 </group>
             </group>
             

--- a/iCubNottingham01/hardware/motorControl/left_arm-eb2-j4_15-mc.xml
+++ b/iCubNottingham01/hardware/motorControl/left_arm-eb2-j4_15-mc.xml
@@ -37,34 +37,34 @@
     <group name="POS_PID_DEFAULT">
         <param name="controlLaw">    Pid_inPos_outPwm </param> 
         <param name="controlUnits">  machine_units               </param> 
-        <param name="pos_kp">          -200          1000          -1000         -200    -500          -8000         -8000         -8000         8000          -8000         -8000         1200         </param>       
-        <param name="pos_kd">          -1000         10000         -10000        -200    -32000        -32000        -32000        -32000        32000         -32000        -32000        12500        </param>       
-        <param name="pos_ki">          -1            1             -1            -1      -1            -5            -5            -5            5             -5            -5            1            </param>       
-        <param name="pos_maxOutput">   1333          1333          1333          1333    1333          1333          1333          1333          1333          1333          1333          1333         </param>       
-        <param name="pos_maxInt">      1333          1333          1333          1333    1333          1333          1333          1333          1333          1333          1333          1333         </param>       
-        <param name="pos_shift">       6             7             7             4       6             8             8             8             8             8             8             6            </param>       
-        <param name="pos_ko">          0             0             0             0       0             0             0             0             0             0             0             0            </param>       
-        <param name="pos_stictionUp">  0             0             0             0       0             0             0             0             0             0             0             0            </param>       
-        <param name="pos_stictionDwn"> 0             0             0             0       0             0             0             0             0             0             0             0            </param>       
-        <param name="pos_kff">         0             0             0             0       0             0             0             0             0             0             0             0            </param>       
+        <param name="kp">          -200          1000          -1000         -200    -500          -8000         -8000         -8000         8000          -8000         -8000         1200         </param>       
+        <param name="kd">          -1000         10000         -10000        -200    -32000        -32000        -32000        -32000        32000         -32000        -32000        12500        </param>       
+        <param name="ki">          -1            1             -1            -1      -1            -5            -5            -5            5             -5            -5            1            </param>       
+        <param name="maxOutput">   1333          1333          1333          1333    1333          1333          1333          1333          1333          1333          1333          1333         </param>       
+        <param name="maxInt">      1333          1333          1333          1333    1333          1333          1333          1333          1333          1333          1333          1333         </param>       
+        <param name="shift">       6             7             7             4       6             8             8             8             8             8             8             6            </param>       
+        <param name="ko">          0             0             0             0       0             0             0             0             0             0             0             0            </param>       
+        <param name="stictionUp">  0             0             0             0       0             0             0             0             0             0             0             0            </param>       
+        <param name="stictionDown"> 0             0             0             0       0             0             0             0             0             0             0             0            </param>       
+        <param name="kff">         0             0             0             0       0             0             0             0             0             0             0             0            </param>       
     </group>
    
     <group name="TRQ_PID_DEFAULT">
         <param name="controlLaw">    Pid_inTrq_outPwm </param> 
         <param name="controlUnits">  machine_units               </param> 
-        <param name="trq_kp">            -80      0      0      0      0      0      0      0      0      0      0      0    </param>       
-        <param name="trq_kd">              0      0      0      0      0      0      0      0      0      0      0      0    </param>       
-        <param name="trq_ki">              0      0      0      0      0      0      0      0      0      0      0      0    </param>  
-        <param name="trq_maxOutput">       1333      0      0      0      0      0      0      0      0      0      0      0    </param>       
-        <param name="trq_maxInt">       1333      0      0      0      0      0      0      0      0      0      0      0    </param>       
-        <param name="trq_shift">          10      0      0      0      0      0      0      0      0      0      0      0    </param>       
-        <param name="trq_ko">              0      0      0      0      0      0      0      0      0      0      0      0    </param>       
-        <param name="trq_stictionUp">      0      0      0      0      0      0      0      0      0      0      0      0    </param>       
-        <param name="trq_stictionDwn">     0      0      0      0      0      0      0      0      0      0      0      0    </param>    
-        <param name="trq_kff">             0      0      0      0      0      0      0      0      0      0      0      0    </param> 
-        <param name="trq_kbemf">           0      0      0      0      0      0      0      0      0      0      0      0    </param>     
-        <param name="trq_filterType">      0      0      0      0      0      0      0      0      0      0      0      0    </param>   
-        <param name="trq_ktau">            1      1      1      1      1      1      1      1      1      1      1      1    </param>   
+        <param name="kp">            -80      0      0      0      0      0      0      0      0      0      0      0    </param>       
+        <param name="kd">              0      0      0      0      0      0      0      0      0      0      0      0    </param>       
+        <param name="ki">              0      0      0      0      0      0      0      0      0      0      0      0    </param>  
+        <param name="maxOutput">       1333      0      0      0      0      0      0      0      0      0      0      0    </param>       
+        <param name="maxInt">       1333      0      0      0      0      0      0      0      0      0      0      0    </param>       
+        <param name="shift">          10      0      0      0      0      0      0      0      0      0      0      0    </param>       
+        <param name="ko">              0      0      0      0      0      0      0      0      0      0      0      0    </param>       
+        <param name="stictionUp">      0      0      0      0      0      0      0      0      0      0      0      0    </param>       
+        <param name="stictionDown">     0      0      0      0      0      0      0      0      0      0      0      0    </param>    
+        <param name="kff">             0      0      0      0      0      0      0      0      0      0      0      0    </param> 
+        <param name="kbemf">           0      0      0      0      0      0      0      0      0      0      0      0    </param>     
+        <param name="filterType">      0      0      0      0      0      0      0      0      0      0      0      0    </param>   
+        <param name="ktau">            1      1      1      1      1      1      1      1      1      1      1      1    </param>   
     </group>
     
     <group name="IMPEDANCE">

--- a/iCubNottingham01/hardware/motorControl/left_arm-eb2-j4_15-mc.xml
+++ b/iCubNottingham01/hardware/motorControl/left_arm-eb2-j4_15-mc.xml
@@ -2,76 +2,91 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
 
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-eb2-j4_15-mc" type="embObjMotionControl">
+   
+    <xi:include href="../../general.xml" />
+    <xi:include href="../../hardware/electronics/left_arm-eb2-j4_15-eln.xml" />
+    <xi:include href="../../hardware/mechanicals/left_arm-eb2-j4_15-mec.xml" />
+    <xi:include href="./left_arm-eb2-j4_15-mc_service.xml" />
 
-  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-eb2-j4_15-mc" type="embObjMotionControl">
-      <xi:include href="../../general.xml" />
-      <xi:include href="../../hardware/electronics/left_arm-eb2-j4_15-eln.xml" />
-      <xi:include href="../../hardware/mechanicals/left_arm-eb2-j4_15-mec.xml" />
-
-      <xi:include href="./left_arm-eb2-j4_15-mc_service.xml" />
-
+    <!-- joint number                           0           1             2             3             4             5             6             7             8             9             10            11          -->
+    <!-- joint name     --> 
     <group name="LIMITS">
-        <param name="jntPosMax">               60            25            25            60            90            90            180           90            180           90            180           270       </param>
-        <param name="jntPosMin">               -60           -80           -20           0             10            0             0             0             0             0             0             0         </param>
-        <param name="motorOverloadCurrents">    500           800           800           485           485           485           485           485           485           485           485           485       </param>
-        <param name="motorNominalCurrents">     0             0             0             0             0             0             0             0             0             0             0             0         </param>
-        <param name="motorPeakCurrents">        0             0             0             0             0             0             0             0             0             0             0             0         </param>
-        <param name="jntVelMax">                 1000          1000          1000          1000          1000          1000          1000          1000          1000          1000          1000          1000      </param>   
-        <param name="motorPwmLimit">            10000          10000         10000         10000        10000         10000         10000         10000         10000         10000         10000         10000     </param>    
+        <param name="jntPosMax">                60          25            25            60            90            90            180           90            180           90            180           270         </param>
+        <param name="jntPosMin">                -60         -80           -20           0             10            0             0             0             0             0             0             0           </param>
+        <param name="motorOverloadCurrents">    500         800           800           485           485           485           485           485           485           485           485           485         </param>
+        <param name="motorNominalCurrents">     0           0             0             0             0             0             0             0             0             0             0             0           </param>
+        <param name="motorPeakCurrents">        0           0             0             0             0             0             0             0             0             0             0             0           </param>
+        <param name="jntVelMax">                1000        1000          1000          1000          1000          1000          1000          1000          1000          1000          1000          1000        </param>
+        <param name="motorPwmLimit">            10000       10000         10000         10000        10000         10000         10000         10000         10000         10000         10000         10000        </param>
     </group>
-
-
+    
     <group name="TIMEOUTS">
         <param name="velocity">    100           100           100           100        100           100           100           100      100           100           100           100    </param>
     </group>
 
-
-     <group name="CONTROLS">
-       <param name="positionControl">  POS_PID_DEFAULT           POS_PID_DEFAULT          POS_PID_DEFAULT          POS_PID_DEFAULT          POS_PID_DEFAULT           POS_PID_DEFAULT          POS_PID_DEFAULT          POS_PID_DEFAULT POS_PID_DEFAULT           POS_PID_DEFAULT          POS_PID_DEFAULT          POS_PID_DEFAULT </param> 
-       <param name="velocityControl">  none                   none                  none                  none                  none                   none                  none                  none                  none                   none                  none                  none                  </param> 
-       <param name="torqueControl">    TRQ_PID_DEFAULT  none                  none                  none  none                   none                  none                  none   none                   none                  none                  none</param>
-        <param name="currentPid">none       none                  none                  none  none                   none                  none                  none   none                   none                  none                  none</param> 
-    </group>
-
-
-    <group name="POS_PID_DEFAULT">
-        <param name="controlLaw">    Pid_inPos_outPwm </param> 
-        <param name="controlUnits">  machine_units               </param> 
-        <param name="kp">          -200          1000          -1000         -200    -500          -8000         -8000         -8000         8000          -8000         -8000         1200         </param>       
-        <param name="kd">          -1000         10000         -10000        -200    -32000        -32000        -32000        -32000        32000         -32000        -32000        12500        </param>       
-        <param name="ki">          -1            1             -1            -1      -1            -5            -5            -5            5             -5            -5            1            </param>       
-        <param name="maxOutput">   1333          1333          1333          1333    1333          1333          1333          1333          1333          1333          1333          1333         </param>       
-        <param name="maxInt">      1333          1333          1333          1333    1333          1333          1333          1333          1333          1333          1333          1333         </param>       
-        <param name="shift">       6             7             7             4       6             8             8             8             8             8             8             6            </param>       
-        <param name="ko">          0             0             0             0       0             0             0             0             0             0             0             0            </param>       
-        <param name="stictionUp">  0             0             0             0       0             0             0             0             0             0             0             0            </param>       
-        <param name="stictionDown"> 0             0             0             0       0             0             0             0             0             0             0             0            </param>       
-        <param name="kff">         0             0             0             0       0             0             0             0             0             0             0             0            </param>       
-    </group>
-   
-    <group name="TRQ_PID_DEFAULT">
-        <param name="controlLaw">    Pid_inTrq_outPwm </param> 
-        <param name="controlUnits">  machine_units               </param> 
-        <param name="kp">            -80      0      0      0      0      0      0      0      0      0      0      0    </param>       
-        <param name="kd">              0      0      0      0      0      0      0      0      0      0      0      0    </param>       
-        <param name="ki">              0      0      0      0      0      0      0      0      0      0      0      0    </param>  
-        <param name="maxOutput">       1333      0      0      0      0      0      0      0      0      0      0      0    </param>       
-        <param name="maxInt">       1333      0      0      0      0      0      0      0      0      0      0      0    </param>       
-        <param name="shift">          10      0      0      0      0      0      0      0      0      0      0      0    </param>       
-        <param name="ko">              0      0      0      0      0      0      0      0      0      0      0      0    </param>       
-        <param name="stictionUp">      0      0      0      0      0      0      0      0      0      0      0      0    </param>       
-        <param name="stictionDown">     0      0      0      0      0      0      0      0      0      0      0      0    </param>    
-        <param name="kff">             0      0      0      0      0      0      0      0      0      0      0      0    </param> 
-        <param name="kbemf">           0      0      0      0      0      0      0      0      0      0      0      0    </param>     
-        <param name="filterType">      0      0      0      0      0      0      0      0      0      0      0      0    </param>   
-        <param name="ktau">            1      1      1      1      1      1      1      1      1      1      1      1    </param>   
-    </group>
-    
     <group name="IMPEDANCE">
-        <param name="stiffness">       0      0      0      0      0      0      0      0      0      0      0      0    </param>    
-        <param name="damping">         0      0      0      0      0      0      0      0      0      0      0      0    </param>    
+        <param name="stiffness">    0      0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="damping">      0      0      0      0      0      0      0      0      0      0      0      0    </param>
     </group>
     
-  </device>
+    <group name="CONTROLS">
+        <param name="positionControl">  POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT      POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT </param>
+        <param name="velocityControl">  POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT      POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT </param>
+        <param name="mixedControl">     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT      POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT </param>
+        <param name="torqueControl">    TRQ_PID_DEFAULT     none                none                none                none                 none                none                none                none                none                none                none            </param>
+        <param name="currentPid">       none                none                none                none                none                 none                none                none                none                none                none                none            </param>
+        <param name="speedPid">         none                none                none                none                none                 none                none                none                none                none                none                none            </param>
+    </group>
 
-  
+
+    <!-- default position PID: begin -->
+    
+    <group name="POS_PID_DEFAULT">
+        <param name="controlLaw">           minjerk         </param>
+        <param name="outputType">           pwm             </param>
+        <param name="fbkControlUnits">      metric_units    </param>
+        <param name="outputControlUnits">   machine_units   </param>
+        <param name="kp">           -200        1000        -1000       -200        -500        -8000       -8000       -8000         8000          -8000         -8000         1200         </param>
+        <param name="kd">           -1000       10000       -10000      -200        -32000      -32000      -32000      -32000        32000         -32000        -32000        12500        </param>
+        <param name="ki">           -1          1           -1          -1          -1          -5          -5          -5            5             -5            -5            1            </param>
+        <param name="maxOutput">    1333        1333        1333        1333        1333        1333        1333        1333          1333          1333          1333          1333         </param>
+        <param name="maxInt">       1333        1333        1333        1333        1333        1333        1333        1333          1333          1333          1333          1333         </param>
+        <param name="stictionUp">   0           0           0           0           0           0           0           0             0             0             0             0            </param>
+        <param name="stictionDown"> 0           0           0           0           0           0           0           0             0             0             0             0            </param>
+        <param name="kff">          0           0           0           0           0           0           0           0             0             0             0             0            </param>
+    </group>
+
+    <!-- default position PID: end -->
+
+
+    <!-- other default PIDs: begin --> 
+
+    <group name="TRQ_PID_DEFAULT">
+        <param name="controlLaw">           torque              </param>
+        <param name="outputType">           pwm                 </param>
+        <param name="fbkControlUnits">      metric_units        </param>
+        <param name="outputControlUnits">   machine_units       </param>
+        <param name="kp">                   -80     0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="kd">                   0       0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="ki">                   0       0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="maxOutput">            1333    0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="maxInt">               1333    0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="ko">                   0       0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="stictionUp">           0       0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="stictionDown">         0       0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="kff">                  0       0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="kbemf">                0       0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="filterType">           0       0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="ktau">                 0       0      0      0      0      0      0      0      0      0      0      0    </param>
+    </group>
+
+    <!-- other default PIDs: end -->
+    
+    
+    <!-- custom PIDs: begin -->    
+    <!-- custom PIDs: end -->
+    
+</device>
+
+

--- a/iCubNottingham01/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
+++ b/iCubNottingham01/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
@@ -27,7 +27,8 @@
 
     <group name="CONTROLS">
        <param name="positionControl">  POS_PID_DEFAULT           POS_PID_DEFAULT          POS_PID_DEFAULT          POS_PID_DEFAULT          </param> 
-       <param name="velocityControl">  none                   none                  none                  none                  </param> 
+       <param name="velocityControl"> POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT</param>
+           <param name="mixedControl"> POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT</param> 
        <param name="torqueControl">    TRQ_PID_DEFAULT  TRQ_PID_DEFAULT TRQ_PID_DEFAULT TRQ_PID_DEFAULT </param>
         <param name="currentPid">      2FOC_CUR_CONTROL          2FOC_CUR_CONTROL         2FOC_CUR_CONTROL         2FOC_CUR_CONTROL         </param> 
     </group>
@@ -37,16 +38,16 @@
         <param name="controlLaw">    Pid_inPos_outPwm </param>
         <param name="fbkControlUnits">  metric_units   </param>
         <param name="outputControlUnits">  machine_units      </param> 
-        <param name="pos_kp">           -1066.66     2066.66    -711.11    1066.66 </param>       
-        <param name="pos_kd">               0.00        0.00       0.00       0.00 </param>       
-        <param name="pos_ki">          -10666.64    14222.18   -7111.09    1066.64 </param>            
-        <param name="pos_maxOutput">        8000        8000       8000       8000 </param>       
-        <param name="pos_maxInt">           1500        750        750       1000 </param>       
-        <param name="pos_shift">               0           0          0          0 </param>       
-        <param name="pos_ko">                  0           0          0          0 </param>       
-        <param name="pos_stictionUp">          0           0          0          0 </param>       
-        <param name="pos_stictionDwn">         0           0          0          0 </param>       
-        <param name="pos_kff">                 0           0          0          0 </param>  
+        <param name="kp">           -1066.66     2066.66    -711.11    1066.66 </param>       
+        <param name="kd">               0.00        0.00       0.00       0.00 </param>       
+        <param name="ki">          -10666.64    14222.18   -7111.09    1066.64 </param>            
+        <param name="maxOutput">        8000        8000       8000       8000 </param>       
+        <param name="maxInt">           1500        750        750       1000 </param>       
+        <param name="shift">               0           0          0          0 </param>       
+        <param name="ko">                  0           0          0          0 </param>       
+        <param name="stictionUp">          0           0          0          0 </param>       
+        <param name="stictionDown">         0           0          0          0 </param>       
+        <param name="kff">                 0           0          0          0 </param>  
     </group>
     
      <group name="IMPEDANCE">
@@ -58,35 +59,49 @@
         <param name="controlLaw">    Pid_inTrq_outPwm </param> 
         <param name="fbkControlUnits">  metric_units   </param>
         <param name="outputControlUnits">  machine_units      </param>   
-        <param name="trq_kp">           -200        200          0          0     </param>       <!--        -200        200       -200        200      --> 
-        <param name="trq_kd">              0          0          0          0     </param>       
-        <param name="trq_ki">              0          0          0          0     </param>     
-        <param name="trq_maxOutput">    8000       8000       8000       8000     </param>       
-        <param name="trq_maxInt">        500        500        500        500     </param>       
-        <param name="trq_shift">           0          0          0          0     </param>       
-        <param name="trq_ko">              0          0          0          0     </param>       
+        <param name="kp">           -200        200          0          0     </param>       <!--        -200        200       -200        200      --> 
+        <param name="kd">              0          0          0          0     </param>       
+        <param name="ki">              0          0          0          0     </param>     
+        <param name="maxOutput">    8000       8000       8000       8000     </param>       
+        <param name="maxInt">        500        500        500        500     </param>       
+        <param name="shift">           0          0          0          0     </param>       
+        <param name="ko">              0          0          0          0     </param>       
         <param name="stictionUp">0 0 0 0</param>       
         <param name="stictionDwn">0 0 0 0</param>       
-        <param name="trq_kff">             1          1          1          1     </param>      
+        <param name="kff">             1          1          1          1     </param>      
         <param name="kbemf">0 0 0 0</param>     
-        <param name="trq_filterType">      0          0          0          0     </param>              
+        <param name="filterType">      0          0          0          0     </param>              
         <param name="ktau">0 0 0 0</param>      
     </group>
 
     <group name="2FOC_CUR_CONTROL">
         <param name="controlLaw">       limitscurrent          </param> 
-        <param name="fbkControlUnits">  metric_units   </param>
+        <param name="fbkControlUnits">  machine_units   </param>
         <param name="outputControlUnits">  machine_units      </param> 
-        <param name="cur_kp">                8           8          8         8      </param>
-        <param name="cur_kd">                0           0          0         0      </param>
-        <param name="cur_ki">                2           2          2         2      </param>
-        <param name="cur_shift">             10          10         10        10     </param>
-        <param name="cur_maxOutput">         32000       32000      32000     32000  </param>
-        <param name="cur_maxInt">            32000       32000      32000     32000  </param>
-        <param name="cur_ko">               0            0          0            0  </param>       
-        <param name="cur_stictionUp">       0            0          0            0  </param>       
-        <param name="cur_stictionDwn">      0            0          0            0  </param>   
-        <param name="cur_kff">              0            0          0            0  </param>            
+        <param name="kp">                8           8          8         8      </param>
+        <param name="kd">                0           0          0         0      </param>
+        <param name="ki">                2           2          2         2      </param>
+        <param name="shift">             10          10         10        10     </param>
+        <param name="maxOutput">         32000       32000      32000     32000  </param>
+        <param name="maxInt">            32000       32000      32000     32000  </param>
+        <param name="ko">               0            0          0            0  </param>       
+        <param name="stictionUp">       0            0          0            0  </param>       
+        <param name="stictionDown">      0            0          0            0  </param>   
+        <param name="kff">              0            0          0            0  </param>            
+    </group>
+	
+	
+	<group name="2FOC_VEL_CONTROL">
+        <param name="controlLaw">           low_lev_speed       </param>
+        <param name="fbkControlUnits">      machine_units       </param>
+        <param name="outputControlUnits">   machine_units       </param>
+        <param name="kff">                  0           0           0           0       </param>
+        <param name="kp">                   12          12          12          12      </param>
+        <param name="kd">                   0           0           0           0       </param>
+        <param name="ki">                   16          16          16          16      </param>
+        <param name="shift">                10          10          10          10      </param>
+        <param name="maxOutput">            32000       32000       32000       32000   </param>
+        <param name="maxInt">               32000       32000       32000       32000   </param>
     </group>
     
   </device>

--- a/iCubNottingham01/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
+++ b/iCubNottingham01/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
@@ -35,7 +35,8 @@
 
     <group name="POS_PID_DEFAULT">
         <param name="controlLaw">    Pid_inPos_outPwm </param>
-        <param name="controlUnits">  metric_units                              </param> 
+        <param name="fbkControlUnits">  metric_units   </param>
+        <param name="outputControlUnits">  machine_units      </param> 
         <param name="pos_kp">           -1066.66     2066.66    -711.11    1066.66 </param>       
         <param name="pos_kd">               0.00        0.00       0.00       0.00 </param>       
         <param name="pos_ki">          -10666.64    14222.18   -7111.09    1066.64 </param>            
@@ -55,7 +56,8 @@
     
     <group name="TRQ_PID_DEFAULT">
         <param name="controlLaw">    Pid_inTrq_outPwm </param> 
-        <param name="controlUnits">  metric_units                             </param>   
+        <param name="fbkControlUnits">  metric_units   </param>
+        <param name="outputControlUnits">  machine_units      </param>   
         <param name="trq_kp">           -200        200          0          0     </param>       <!--        -200        200       -200        200      --> 
         <param name="trq_kd">              0          0          0          0     </param>       
         <param name="trq_ki">              0          0          0          0     </param>     
@@ -63,17 +65,18 @@
         <param name="trq_maxInt">        500        500        500        500     </param>       
         <param name="trq_shift">           0          0          0          0     </param>       
         <param name="trq_ko">              0          0          0          0     </param>       
-        <param name="trq_stictionUp">     -2.0        2.0       -1.0       -1.0   </param>       
-        <param name="trq_stictionDwn">     1.4       -2.0        1.3        0.2   </param>       
+        <param name="stictionUp">0 0 0 0</param>       
+        <param name="stictionDwn">0 0 0 0</param>       
         <param name="trq_kff">             1          1          1          1     </param>      
-        <param name="trq_kbemf">           0          0          0          0     </param>     
+        <param name="kbemf">0 0 0 0</param>     
         <param name="trq_filterType">      0          0          0          0     </param>              
-        <param name="trq_ktau">         -162        178       -197        167     </param>      
+        <param name="ktau">0 0 0 0</param>      
     </group>
 
     <group name="2FOC_CUR_CONTROL">
         <param name="controlLaw">       limitscurrent          </param> 
-        <param name="controlUnits">     metric_units           </param> 
+        <param name="fbkControlUnits">  metric_units   </param>
+        <param name="outputControlUnits">  machine_units      </param> 
         <param name="cur_kp">                8           8          8         8      </param>
         <param name="cur_kd">                0           0          0         0      </param>
         <param name="cur_ki">                2           2          2         2      </param>

--- a/iCubNottingham01/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
+++ b/iCubNottingham01/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
- <!-- Initialization file for EMS 6 - Left Upper Leg, 4 dof -->
 
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb6-j0_3-mc" type="embObjMotionControl">
+ 
+    <xi:include href="../../general.xml" />
+    <xi:include href="../../hardware/electronics/left_leg-eb6-j0_3-eln.xml" />
+    <xi:include href="../../hardware/mechanicals/left_leg-eb6-j0_3-mec.xml" />
+    <xi:include href="./left_leg-eb6-j0_3-mc_service.xml" />
 
-  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb6-j0_3-mc" type="embObjMotionControl">
-      <xi:include href="../../general.xml" />
-      <xi:include href="../../hardware/electronics/left_leg-eb6-j0_3-eln.xml" />
-      <xi:include href="../../hardware/mechanicals/left_leg-eb6-j0_3-mec.xml" />
-      
-      <xi:include href="./left_leg-eb6-j0_3-mc_service.xml" />
-
+    <!-- joint number                           0                   1                   2                   3                   -->
+    <!-- joint name --> 
     <group name="LIMITS">
         <param name="jntPosMax">                      85            85            70            0     </param>
         <param name="jntPosMin">                     -30             0           -70         -100     </param>
@@ -20,78 +20,81 @@
         <param name="motorOverloadCurrents">       15000         15000         15000        15000     </param>
         <param name="motorPwmLimit">               10000         10000         10000        10000     </param>    
     </group>
-
-<group name="TIMEOUTS">
-        <param name="velocity">        100                    100                   100                   100                   </param>
+   
+    <group name="TIMEOUTS">
+        <param name="velocity">                 100                 100                 100                 100                 </param>
     </group>
 
+    <group name="IMPEDANCE">
+        <param name="stiffness">                0.0                 0.0                 0.0                 0.0                 </param>
+        <param name="damping">                  0.0                 0.0                 0.0                 0.0                 </param>
+    </group>
+    
     <group name="CONTROLS">
-       <param name="positionControl">  POS_PID_DEFAULT           POS_PID_DEFAULT          POS_PID_DEFAULT          POS_PID_DEFAULT          </param> 
-       <param name="velocityControl"> POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT</param>
-           <param name="mixedControl"> POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT</param> 
-       <param name="torqueControl">    TRQ_PID_DEFAULT  TRQ_PID_DEFAULT TRQ_PID_DEFAULT TRQ_PID_DEFAULT </param>
-        <param name="currentPid">      2FOC_CUR_CONTROL          2FOC_CUR_CONTROL         2FOC_CUR_CONTROL         2FOC_CUR_CONTROL         </param> 
+      <param name="positionControl">            POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+      <param name="velocityControl">            POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+      <param name="mixedControl">               POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+      <param name="torqueControl">              TRQ_PID_DEFAULT     TRQ_PID_DEFAULT     TRQ_PID_DEFAULT     TRQ_PID_DEFAULT     </param>
+      <param name="currentPid">                 2FOC_CUR_CONTROL    2FOC_CUR_CONTROL    2FOC_CUR_CONTROL    2FOC_CUR_CONTROL    </param>
+      <param name="speedPid">                   2FOC_VEL_CONTROL    2FOC_VEL_CONTROL    2FOC_VEL_CONTROL    2FOC_VEL_CONTROL    </param>
     </group>
 
+
+    <!-- default position PID: begin -->
 
     <group name="POS_PID_DEFAULT">
-        <param name="controlLaw">    Pid_inPos_outPwm </param>
-        <param name="fbkControlUnits">  metric_units   </param>
-        <param name="outputControlUnits">  machine_units      </param> 
-        <param name="kp">           -1066.66     2066.66    -711.11    1066.66 </param>       
-        <param name="kd">               0.00        0.00       0.00       0.00 </param>       
-        <param name="ki">          -10666.64    14222.18   -7111.09    1066.64 </param>            
-        <param name="maxOutput">        8000        8000       8000       8000 </param>       
-        <param name="maxInt">           1500        750        750       1000 </param>       
-        <param name="shift">               0           0          0          0 </param>       
-        <param name="ko">                  0           0          0          0 </param>       
-        <param name="stictionUp">          0           0          0          0 </param>       
-        <param name="stictionDown">         0           0          0          0 </param>       
-        <param name="kff">                 0           0          0          0 </param>  
+        <param name="controlLaw">           minjerk                   </param>
+        <param name="outputType">           pwm                       </param>
+        <param name="fbkControlUnits">      metric_units              </param>
+        <param name="outputControlUnits">   machine_units             </param>
+        <param name="kp">            -1066.66     2066.66    -711.11    -1066.66    </param>
+        <param name="kd">               0.00        0.00       0.00       0.00      </param>
+        <param name="ki">          -10666.64    14222.18   -7111.09    -1066.64     </param>
+        <param name="maxOutput">        8000        8000       8000       8000      </param>
+        <param name="maxInt">           750        750        750       1000        </param>
+        <param name="stictionUp">          0           0          0          0      </param>
+        <param name="stictionDown">        0           0          0          0      </param>
+        <param name="kff">                 0           0          0          0      </param>
     </group>
     
-     <group name="IMPEDANCE">
-        <param name="stiffness">       0      0      0      0     </param>    
-        <param name="damping">         0      0      0      0     </param>    
-    </group>
+    <!-- default position PID: end -->
+
+
+    <!-- other default PIDs: begin -->  
     
     <group name="TRQ_PID_DEFAULT">
-        <param name="controlLaw">    Pid_inTrq_outPwm </param> 
-        <param name="fbkControlUnits">  metric_units   </param>
-        <param name="outputControlUnits">  machine_units      </param>   
-        <param name="kp">           -200        200          0          0     </param>       <!--        -200        200       -200        200      --> 
-        <param name="kd">              0          0          0          0     </param>       
-        <param name="ki">              0          0          0          0     </param>     
-        <param name="maxOutput">    8000       8000       8000       8000     </param>       
-        <param name="maxInt">        500        500        500        500     </param>       
-        <param name="shift">           0          0          0          0     </param>       
-        <param name="ko">              0          0          0          0     </param>       
-        <param name="stictionUp">0 0 0 0</param>       
-        <param name="stictionDwn">0 0 0 0</param>       
-        <param name="kff">             1          1          1          1     </param>      
-        <param name="kbemf">0 0 0 0</param>     
-        <param name="filterType">      0          0          0          0     </param>              
-        <param name="ktau">0 0 0 0</param>      
+        <param name="controlLaw">           torque              </param>
+        <param name="outputType">           pwm                 </param>
+        <param name="fbkControlUnits">      metric_units        </param>
+        <param name="outputControlUnits">   machine_units       </param>
+        <param name="kp">           -200        200          0          0     </param>
+        <param name="kd">              0          0          0          0     </param>
+        <param name="ki">              0          0          0          0     </param>
+        <param name="maxOutput">    8000       8000       8000       8000     </param>
+        <param name="maxInt">        500        500        500        500     </param>
+        <param name="ko">              0          0          0          0     </param>
+        <param name="stictionUp">      0          0          0          0     </param>
+        <param name="stictionDown">    0          0          0          0     </param>
+        <param name="kff">             1          1          1          1     </param>
+        <param name="kbemf">           0          0          0          0     </param>
+        <param name="filterType">      0          0          0          0     </param>
+        <param name="ktau">            0          0          0          0     </param>
     </group>
 
     <group name="2FOC_CUR_CONTROL">
-        <param name="controlLaw">       limitscurrent          </param> 
-        <param name="fbkControlUnits">  machine_units   </param>
-        <param name="outputControlUnits">  machine_units      </param> 
-        <param name="kp">                8           8          8         8      </param>
-        <param name="kd">                0           0          0         0      </param>
-        <param name="ki">                2           2          2         2      </param>
-        <param name="shift">             10          10         10        10     </param>
-        <param name="maxOutput">         32000       32000      32000     32000  </param>
-        <param name="maxInt">            32000       32000      32000     32000  </param>
-        <param name="ko">               0            0          0            0  </param>       
-        <param name="stictionUp">       0            0          0            0  </param>       
-        <param name="stictionDown">      0            0          0            0  </param>   
-        <param name="kff">              0            0          0            0  </param>            
+        <param name="controlLaw">           low_lev_current     </param>
+        <param name="fbkControlUnits">      machine_units       </param>
+        <param name="outputControlUnits">   machine_units       </param>
+        <param name="kp">                   8           8           8           8       </param>
+        <param name="kd">                   0           0           0           0       </param>
+        <param name="ki">                   2           2           2           2       </param>
+        <param name="shift">                10          10          10          10      </param>
+        <param name="maxOutput">            32000       32000       32000       32000   </param>
+        <param name="maxInt">               32000       32000       32000       32000   </param>
+        <param name="kff">                  0           0           0           0       </param>
     </group>
-	
-	
-	<group name="2FOC_VEL_CONTROL">
+
+    <group name="2FOC_VEL_CONTROL">
         <param name="controlLaw">           low_lev_speed       </param>
         <param name="fbkControlUnits">      machine_units       </param>
         <param name="outputControlUnits">   machine_units       </param>
@@ -104,8 +107,11 @@
         <param name="maxInt">               32000       32000       32000       32000   </param>
     </group>
     
-  </device>
+    <!-- other default PIDs: end -->
 
 
-
+    <!-- custom PIDs: begin -->  
+    <!-- custom PIDs: end -->
+    
+</device>
 

--- a/iCubNottingham01/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
+++ b/iCubNottingham01/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
@@ -47,11 +47,11 @@
         <param name="outputType">           pwm                       </param>
         <param name="fbkControlUnits">      metric_units              </param>
         <param name="outputControlUnits">   machine_units             </param>
-        <param name="kp">            -1066.66     2066.66    -711.11    -1066.66    </param>
+        <param name="kp">            -1066.66     2066.66    -711.11     1066.66    </param>
         <param name="kd">               0.00        0.00       0.00       0.00      </param>
-        <param name="ki">          -10666.64    14222.18   -7111.09    -1066.64     </param>
+        <param name="ki">          -10666.64    14222.18   -7111.09     1066.64     </param>
         <param name="maxOutput">        8000        8000       8000       8000      </param>
-        <param name="maxInt">           750        750        750       1000        </param>
+        <param name="maxInt">           1500        750        750       1000        </param>
         <param name="stictionUp">          0           0          0          0      </param>
         <param name="stictionDown">        0           0          0          0      </param>
         <param name="kff">                 0           0          0          0      </param>

--- a/iCubNottingham01/hardware/motorControl/left_leg-eb6-j0_3-mc_service.xml
+++ b/iCubNottingham01/hardware/motorControl/left_leg-eb6-j0_3-mc_service.xml
@@ -20,9 +20,9 @@
                     <param name="minor">            6           </param>     
                 </group>                    
                 <group name="FIRMWARE">
-                    <param name="major">            0           </param>    
-                    <param name="minor">            0           </param> 
-                    <param name="build">            0           </param>
+                    <param name="major">            3                       </param>    
+                    <param name="minor">            3                       </param> 
+                    <param name="build">            3                       </param>
                 </group>
             </group>
             

--- a/iCubNottingham01/hardware/motorControl/left_leg-eb6-j0_3-mc_service.xml
+++ b/iCubNottingham01/hardware/motorControl/left_leg-eb6-j0_3-mc_service.xml
@@ -20,9 +20,9 @@
                     <param name="minor">            6           </param>     
                 </group>                    
                 <group name="FIRMWARE">
-                    <param name="major">            0                       </param>    
-                    <param name="minor">            0                       </param> 
-                    <param name="build">            0                       </param>
+                    <param name="major">            3                       </param>    
+                    <param name="minor">            3                       </param> 
+                    <param name="build">            3                       </param>
                 </group>
             </group>
             

--- a/iCubNottingham01/hardware/motorControl/left_leg-eb6-j0_3-mc_service.xml
+++ b/iCubNottingham01/hardware/motorControl/left_leg-eb6-j0_3-mc_service.xml
@@ -20,9 +20,9 @@
                     <param name="minor">            6           </param>     
                 </group>                    
                 <group name="FIRMWARE">
-                    <param name="major">            3                       </param>    
-                    <param name="minor">            3                       </param> 
-                    <param name="build">            3                       </param>
+                    <param name="major">            0                       </param>    
+                    <param name="minor">            0                       </param> 
+                    <param name="build">            0                       </param>
                 </group>
             </group>
             

--- a/iCubNottingham01/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
+++ b/iCubNottingham01/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
@@ -32,7 +32,8 @@
 
     <group name="POS_PID_DEFAULT">
         <param name="controlLaw">    Pid_inPos_outPwm </param>
-        <param name="controlUnits">  metric_units              </param> 
+        <param name="fbkControlUnits">  metric_units   </param>
+        <param name="outputControlUnits">  machine_units      </param> 
         <param name="pos_kp">          2200.00     2200.00         </param>       
         <param name="pos_kd">            0.00         0.00         </param>       
         <param name="pos_ki">            0.09         0.09         </param>           
@@ -52,7 +53,8 @@
 
      <group name="TRQ_PID_DEFAULT">
         <param name="controlLaw">    Pid_inTrq_outPwm </param> 
-        <param name="controlUnits">  metric_units               </param> 
+        <param name="fbkControlUnits">  metric_units   </param>
+        <param name="outputControlUnits">  machine_units      </param> 
         <param name="trq_kp">         200          200              </param>       
         <param name="trq_kd">           0            0              </param>       
         <param name="trq_ki">           0            0              </param>    
@@ -60,17 +62,18 @@
         <param name="trq_maxInt">     500          500              </param>       
         <param name="trq_shift">        0            0              </param>       
         <param name="trq_ko">           0            0              </param>       
-        <param name="trq_stictionUp">   1.7          0.8            </param>       
-        <param name="trq_stictionDwn"> -1.7         -1.8            </param>   
+        <param name="stictionUp">0 0</param>       
+        <param name="stictionDwn">0 0</param>   
         <param name="trq_kff">          1            1              </param>         
-        <param name="trq_kbemf">        0            0              </param>      
+        <param name="kbemf">0 0</param>      
         <param name="trq_filterType">   0            0              </param>                 
-        <param name="trq_ktau">       209          160              </param>          
+        <param name="ktau">0 0</param>          
     </group>
 
     <group name="2FOC_CUR_CONTROL">
         <param name="controlLaw">       limitscurrent            </param>
-        <param name="controlUnits">     metric_units             </param>
+        <param name="fbkControlUnits">  metric_units   </param>
+        <param name="outputControlUnits">  machine_units      </param>
         <param name="cur_kp">                 8           8      </param>
         <param name="cur_kd">                 0           0      </param>
         <param name="cur_ki">                 2           2      </param>

--- a/iCubNottingham01/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
+++ b/iCubNottingham01/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
@@ -25,7 +25,8 @@
 
     <group name="CONTROLS">
        <param name="positionControl">  POS_PID_DEFAULT           POS_PID_DEFAULT         </param> 
-       <param name="velocityControl">  none                   none                  </param> 
+       <param name="velocityControl"> POS_PID_DEFAULT POS_PID_DEFAULT</param>
+       <param name="mixedControl"> POS_PID_DEFAULT POS_PID_DEFAULT</param> 
        <param name="torqueControl">    TRQ_PID_DEFAULT  TRQ_PID_DEFAULT  </param>
         <param name="currentPid">      2FOC_CUR_CONTROL          2FOC_CUR_CONTROL         </param> 
     </group>
@@ -34,16 +35,16 @@
         <param name="controlLaw">    Pid_inPos_outPwm </param>
         <param name="fbkControlUnits">  metric_units   </param>
         <param name="outputControlUnits">  machine_units      </param> 
-        <param name="pos_kp">          2200.00     2200.00         </param>       
-        <param name="pos_kd">            0.00         0.00         </param>       
-        <param name="pos_ki">            0.09         0.09         </param>           
-        <param name="pos_maxOutput">     8000         8000         </param>       
-        <param name="pos_maxInt">         750          750         </param>       
-        <param name="pos_shift">            0            0         </param>       
-        <param name="pos_ko">               0            0         </param>       
-        <param name="pos_stictionUp">       0            0         </param>       
-        <param name="pos_stictionDwn">      0            0         </param>      
-        <param name="pos_kff">              0            0         </param>          
+        <param name="kp">          2200.00     2200.00         </param>       
+        <param name="kd">            0.00         0.00         </param>       
+        <param name="ki">            0.09         0.09         </param>           
+        <param name="maxOutput">     8000         8000         </param>       
+        <param name="maxInt">         750          750         </param>       
+        <param name="shift">            0            0         </param>       
+        <param name="ko">               0            0         </param>       
+        <param name="stictionUp">       0            0         </param>       
+        <param name="stictionDown">      0            0         </param>      
+        <param name="kff">              0            0         </param>          
         </group>
 
     <group name="IMPEDANCE">
@@ -55,35 +56,48 @@
         <param name="controlLaw">    Pid_inTrq_outPwm </param> 
         <param name="fbkControlUnits">  metric_units   </param>
         <param name="outputControlUnits">  machine_units      </param> 
-        <param name="trq_kp">         200          200              </param>       
-        <param name="trq_kd">           0            0              </param>       
-        <param name="trq_ki">           0            0              </param>    
-        <param name="trq_maxOutput"> 8000         8000              </param>       
-        <param name="trq_maxInt">     500          500              </param>       
-        <param name="trq_shift">        0            0              </param>       
-        <param name="trq_ko">           0            0              </param>       
+        <param name="kp">         200          200              </param>       
+        <param name="kd">           0            0              </param>       
+        <param name="ki">           0            0              </param>    
+        <param name="maxOutput"> 8000         8000              </param>       
+        <param name="maxInt">     500          500              </param>       
+        <param name="shift">        0            0              </param>       
+        <param name="ko">           0            0              </param>       
         <param name="stictionUp">0 0</param>       
         <param name="stictionDwn">0 0</param>   
-        <param name="trq_kff">          1            1              </param>         
+        <param name="kff">          1            1              </param>         
         <param name="kbemf">0 0</param>      
-        <param name="trq_filterType">   0            0              </param>                 
+        <param name="filterType">   0            0              </param>                 
         <param name="ktau">0 0</param>          
     </group>
 
     <group name="2FOC_CUR_CONTROL">
         <param name="controlLaw">       limitscurrent            </param>
-        <param name="fbkControlUnits">  metric_units   </param>
+        <param name="fbkControlUnits">  machine_units   </param>
         <param name="outputControlUnits">  machine_units      </param>
-        <param name="cur_kp">                 8           8      </param>
-        <param name="cur_kd">                 0           0      </param>
-        <param name="cur_ki">                 2           2      </param>
-        <param name="cur_shift">             10          10      </param>
-        <param name="cur_maxOutput">      32000       32000      </param>
-        <param name="cur_maxInt">         32000       32000      </param>
-        <param name="cur_ko">                 0           0      </param>
-        <param name="cur_stictionUp">         0           0      </param>
-        <param name="cur_stictionDwn">        0           0      </param>
-        <param name="cur_kff">                0           0      </param>
+        <param name="kp">                 8           8      </param>
+        <param name="kd">                 0           0      </param>
+        <param name="ki">                 2           2      </param>
+        <param name="shift">             10          10      </param>
+        <param name="maxOutput">      32000       32000      </param>
+        <param name="maxInt">         32000       32000      </param>
+        <param name="ko">                 0           0      </param>
+        <param name="stictionUp">         0           0      </param>
+        <param name="stictionDown">        0           0      </param>
+        <param name="kff">                0           0      </param>
+    </group>
+	
+	<group name="2FOC_VEL_CONTROL">
+        <param name="controlLaw">           low_lev_speed       </param>
+        <param name="fbkControlUnits">      machine_units       </param>
+        <param name="outputControlUnits">   machine_units       </param>
+        <param name="kff">                  0           0           0           0       </param>
+        <param name="kp">                   12          12          12          12      </param>
+        <param name="kd">                   0           0           0           0       </param>
+        <param name="ki">                   16          16          16          16      </param>
+        <param name="shift">                10          10          10          10      </param>
+        <param name="maxOutput">            32000       32000       32000       32000   </param>
+        <param name="maxInt">               32000       32000       32000       32000   </param>
     </group>
     
   </device>

--- a/iCubNottingham01/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
+++ b/iCubNottingham01/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
@@ -2,92 +2,100 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
 
- <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb7-j4_5-mc" type="embObjMotionControl">
-      <xi:include href="../../general.xml" />
-      <xi:include href="../../hardware/electronics/left_leg-eb7-j4_5-eln.xml" />
-      <xi:include href="../../hardware/mechanicals/left_leg-eb7-j4_5-mec.xml" />
-      
-      <xi:include href="./left_leg-eb7-j4_5-mc_service.xml" />
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb7-j4_5-mc" type="embObjMotionControl">
+    
+    <xi:include href="../../general.xml" />
+    <xi:include href="../../hardware/electronics/left_leg-eb7-j4_5-eln.xml" />
+    <xi:include href="../../hardware/mechanicals/left_leg-eb7-j4_5-mec.xml" />
+    <xi:include href="./left_leg-eb7-j4_5-mc_service.xml" />
 
+    <!-- joint number                           0                   1                   -->
+    <!-- joint name -->          
     <group name="LIMITS">
-        <param name="jntPosMax">               30.00         20.00      </param>
-        <param name="jntPosMin">              -30.00        -20.00      </param>
-        <param name="motorNominalCurrents">      5000         5000      </param>
-        <param name="motorPeakCurrents">        10000        10000      </param>
-        <param name="motorOverloadCurrents">    15000        15000      </param>
-        <param name="jntVelMax">                 1000         1000      </param>
-        <param name="motorPwmLimit">            10000        10000      </param>    
+        <param name="jntPosMax">                30                  20                  </param>
+        <param name="jntPosMin">                -30                 -20                 </param>
+        <param name="motorNominalCurrents">     5000                5000                </param>
+        <param name="motorPeakCurrents">        10000               10000               </param>
+        <param name="motorOverloadCurrents">    15000               15000               </param>
+        <param name="jntVelMax">                1000                1000                </param>
+        <param name="motorPwmLimit">            10000               10000               </param>
     </group>
 
     <group name="TIMEOUTS">
-        <param name="velocity">            100           100           </param>
+        <param name="velocity">                 100                 100                 </param>
     </group>
-
-    <group name="CONTROLS">
-       <param name="positionControl">  POS_PID_DEFAULT           POS_PID_DEFAULT         </param> 
-       <param name="velocityControl"> POS_PID_DEFAULT POS_PID_DEFAULT</param>
-       <param name="mixedControl"> POS_PID_DEFAULT POS_PID_DEFAULT</param> 
-       <param name="torqueControl">    TRQ_PID_DEFAULT  TRQ_PID_DEFAULT  </param>
-        <param name="currentPid">      2FOC_CUR_CONTROL          2FOC_CUR_CONTROL         </param> 
-    </group>
-
-    <group name="POS_PID_DEFAULT">
-        <param name="controlLaw">    Pid_inPos_outPwm </param>
-        <param name="fbkControlUnits">  metric_units   </param>
-        <param name="outputControlUnits">  machine_units      </param> 
-        <param name="kp">          2200.00     2200.00         </param>       
-        <param name="kd">            0.00         0.00         </param>       
-        <param name="ki">            0.09         0.09         </param>           
-        <param name="maxOutput">     8000         8000         </param>       
-        <param name="maxInt">         750          750         </param>       
-        <param name="shift">            0            0         </param>       
-        <param name="ko">               0            0         </param>       
-        <param name="stictionUp">       0            0         </param>       
-        <param name="stictionDown">      0            0         </param>      
-        <param name="kff">              0            0         </param>          
-        </group>
 
     <group name="IMPEDANCE">
-      <param name="stiffness">  0.0   0.0 </param>
-      <param name="damping">    0.0   0.0 </param>
+      <param name="stiffness">                  0.0                 0.0                 </param>
+      <param name="damping">                    0.0                 0.0                 </param>
+    </group>
+    
+    <group name="CONTROLS">
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="torqueControl">            TRQ_PID_DEFAULT     TRQ_PID_DEFAULT     </param>
+        <param name="currentPid">               2FOC_CUR_CONTROL    2FOC_CUR_CONTROL    </param>
+        <param name="speedPid">                 2FOC_VEL_CONTROL    2FOC_VEL_CONTROL    </param>
     </group>
 
-     <group name="TRQ_PID_DEFAULT">
-        <param name="controlLaw">    Pid_inTrq_outPwm </param> 
-        <param name="fbkControlUnits">  metric_units   </param>
-        <param name="outputControlUnits">  machine_units      </param> 
-        <param name="kp">         200          200              </param>       
-        <param name="kd">           0            0              </param>       
-        <param name="ki">           0            0              </param>    
-        <param name="maxOutput"> 8000         8000              </param>       
-        <param name="maxInt">     500          500              </param>       
-        <param name="shift">        0            0              </param>       
-        <param name="ko">           0            0              </param>       
-        <param name="stictionUp">0 0</param>       
-        <param name="stictionDwn">0 0</param>   
-        <param name="kff">          1            1              </param>         
-        <param name="kbemf">0 0</param>      
-        <param name="filterType">   0            0              </param>                 
-        <param name="ktau">0 0</param>          
+
+    <!-- default position PID: begin -->
+    
+    <group name="POS_PID_DEFAULT">
+        <param name="controlLaw">             minjerk                   </param>
+        <param name="outputType">             pwm                       </param>
+        <param name="fbkControlUnits">        metric_units              </param> 
+        <param name="outputControlUnits">     machine_units             </param>
+        <param name="kp">           2200.00     2200.00     </param>
+        <param name="kd">            0.00         0.00      </param>
+        <param name="ki">            0.09        0.09       </param>
+        <param name="maxOutput">     8000         8000      </param>
+        <param name="maxInt">         750          750      </param>
+        <param name="stictionUp">       0            0      </param>
+        <param name="stictionDown">     0            0      </param>
+        <param name="kff">              0            0      </param>
     </group>
 
+    <!-- default position PID: end -->
+
+
+    <!-- other default PIDs: begin -->     
+    
+    <group name="TRQ_PID_DEFAULT">
+        <param name="controlLaw">          torque           </param>
+        <param name="outputType">          pwm              </param>
+        <param name="fbkControlUnits">     metric_units     </param>
+        <param name="outputControlUnits">  machine_units    </param>
+        <param name="kp">         200          200          </param>
+        <param name="kp">           0           0           </param>
+        <param name="kd">           0           0           </param>
+        <param name="ki">           0           0           </param>
+        <param name="maxOutput">   8000         8000        </param>
+        <param name="maxInt">       500         500         </param>
+        <param name="ko">           0           0           </param>
+        <param name="stictionUp">   0           0           </param>
+        <param name="stictionDown"> 0           0           </param>
+        <param name="kff">          1           1           </param>
+        <param name="kbemf">        0           0           </param>
+        <param name="filterType">   0           0           </param>
+        <param name="ktau">         0           0           </param>
+    </group>
+            
     <group name="2FOC_CUR_CONTROL">
-        <param name="controlLaw">       limitscurrent            </param>
-        <param name="fbkControlUnits">  machine_units   </param>
-        <param name="outputControlUnits">  machine_units      </param>
-        <param name="kp">                 8           8      </param>
-        <param name="kd">                 0           0      </param>
-        <param name="ki">                 2           2      </param>
-        <param name="shift">             10          10      </param>
-        <param name="maxOutput">      32000       32000      </param>
-        <param name="maxInt">         32000       32000      </param>
-        <param name="ko">                 0           0      </param>
-        <param name="stictionUp">         0           0      </param>
-        <param name="stictionDown">        0           0      </param>
-        <param name="kff">                0           0      </param>
+        <param name="controlLaw">           low_lev_current     </param>
+        <param name="fbkControlUnits">      machine_units       </param>
+        <param name="outputControlUnits">   machine_units       </param>
+        <param name="kp">                   8           8       </param>
+        <param name="kd">                   0           0       </param>
+        <param name="ki">                   2           2       </param>
+        <param name="shift">                10          10      </param>
+        <param name="maxOutput">            32000       32000   </param>
+        <param name="maxInt">               32000       32000   </param>
+        <param name="kff">                  0           0       </param>
     </group>
-	
-	<group name="2FOC_VEL_CONTROL">
+
+    <group name="2FOC_VEL_CONTROL">
         <param name="controlLaw">           low_lev_speed       </param>
         <param name="fbkControlUnits">      machine_units       </param>
         <param name="outputControlUnits">   machine_units       </param>
@@ -99,6 +107,12 @@
         <param name="maxOutput">            32000       32000       32000       32000   </param>
         <param name="maxInt">               32000       32000       32000       32000   </param>
     </group>
+
+    <!-- other default PIDs: end -->
     
-  </device>
+    
+    <!-- custom PIDs: begin -->    
+    <!-- custom PIDs: end -->
+    
+</device>
 

--- a/iCubNottingham01/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
+++ b/iCubNottingham01/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
@@ -99,13 +99,13 @@
         <param name="controlLaw">           low_lev_speed       </param>
         <param name="fbkControlUnits">      machine_units       </param>
         <param name="outputControlUnits">   machine_units       </param>
-        <param name="kff">                  0           0           0           0       </param>
-        <param name="kp">                   12          12          12          12      </param>
-        <param name="kd">                   0           0           0           0       </param>
-        <param name="ki">                   16          16          16          16      </param>
-        <param name="shift">                10          10          10          10      </param>
-        <param name="maxOutput">            32000       32000       32000       32000   </param>
-        <param name="maxInt">               32000       32000       32000       32000   </param>
+        <param name="kff">                  0           0       </param>
+        <param name="kp">                   12          12      </param>
+        <param name="kd">                   0           0       </param>
+        <param name="ki">                   16          16      </param>
+        <param name="shift">                10          10      </param>
+        <param name="maxOutput">            32000       32000   </param>
+        <param name="maxInt">               32000       32000   </param>
     </group>
 
     <!-- other default PIDs: end -->

--- a/iCubNottingham01/hardware/motorControl/left_leg-eb7-j4_5-mc_service.xml
+++ b/iCubNottingham01/hardware/motorControl/left_leg-eb7-j4_5-mc_service.xml
@@ -20,9 +20,9 @@
                     <param name="minor">            6           </param>     
                 </group>                    
                 <group name="FIRMWARE">
-                    <param name="major">            0           </param>    
-                    <param name="minor">            0           </param> 
-                    <param name="build">            0           </param>
+                    <param name="major">            3                       </param>    
+                    <param name="minor">            3                       </param> 
+                    <param name="build">            3                       </param>
                 </group>
             </group>
             

--- a/iCubNottingham01/hardware/motorControl/left_leg-eb7-j4_5-mc_service.xml
+++ b/iCubNottingham01/hardware/motorControl/left_leg-eb7-j4_5-mc_service.xml
@@ -20,9 +20,9 @@
                     <param name="minor">            6           </param>     
                 </group>                    
                 <group name="FIRMWARE">
-                    <param name="major">            0                       </param>    
-                    <param name="minor">            0                       </param> 
-                    <param name="build">            0                       </param>
+                    <param name="major">            3                       </param>    
+                    <param name="minor">            3                       </param> 
+                    <param name="build">            3                       </param>
                 </group>
             </group>
             

--- a/iCubNottingham01/hardware/motorControl/left_leg-eb7-j4_5-mc_service.xml
+++ b/iCubNottingham01/hardware/motorControl/left_leg-eb7-j4_5-mc_service.xml
@@ -20,9 +20,9 @@
                     <param name="minor">            6           </param>     
                 </group>                    
                 <group name="FIRMWARE">
-                    <param name="major">            3                       </param>    
-                    <param name="minor">            3                       </param> 
-                    <param name="build">            3                       </param>
+                    <param name="major">            0                       </param>    
+                    <param name="minor">            0                       </param> 
+                    <param name="build">            0                       </param>
                 </group>
             </group>
             

--- a/iCubNottingham01/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
+++ b/iCubNottingham01/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
@@ -40,7 +40,8 @@
    
     <group name="POS_PID_DEFAULT">
         <param name="controlLaw">    Pid_inPos_outPwm </param> 
-        <param name="controlUnits">  metric_units               </param> 
+        <param name="fbkControlUnits">  metric_units   </param>
+        <param name="outputControlUnits">  machine_units      </param> 
         <param name="pos_kp">          -711.11   -1066.66    -711.11   -1066.66 </param>       
         <param name="pos_kd">             0.00       0.00       0.00       0.00 </param>       
         <param name="pos_ki">         -7111.09  -10666.64   -7111.09  -10666.64 </param>          
@@ -55,7 +56,8 @@
 
     <group name="TRQ_PID_DEFAULT">
         <param name="controlLaw">    Pid_inTrq_outPwm </param> 
-        <param name="controlUnits">  metric_units               </param> 
+        <param name="fbkControlUnits">  metric_units   </param>
+        <param name="outputControlUnits">  machine_units      </param> 
         <param name="trq_kp">             -50      -200       -250       -300     </param>       
         <param name="trq_kd">              0          0          0          0     </param>       
         <param name="trq_ki">              0          0          0          0     </param> 
@@ -63,17 +65,18 @@
         <param name="trq_maxInt">        500        500        500        500     </param>       
         <param name="trq_shift">           0          0          0          0     </param>       
         <param name="trq_ko">              0          0          0          0     </param>       
-        <param name="trq_stictionUp">     -0.5       -0.2       -0.5       -2     </param>       
-        <param name="trq_stictionDwn">     1.4        1          0.6        2     </param>       
+        <param name="stictionUp">0 0 0 0</param>       
+        <param name="stictionDwn">0 0 0 0</param>       
         <param name="trq_kff">             1          1          1          1     </param>  
-        <param name="trq_kbemf">     -0.0032    -0.0007    -0.0007    -0.0007     </param>            
+        <param name="kbemf">0 0 0 0</param>            
         <param name="trq_filterType">      0          0          0          0     </param>     
-        <param name="trq_ktau">           -204     -481       -466       -500     </param>   
+        <param name="ktau">0 0 0 0</param>   
     </group>
     
     <group name="2FOC_CUR_CONTROL">
         <param name="controlLaw">       limitscurrent          </param>
-        <param name="controlUnits">     metric_units           </param>
+        <param name="fbkControlUnits">  metric_units   </param>
+        <param name="outputControlUnits">  machine_units      </param>
         <param name="cur_kp">               8           8          8         8     </param>
         <param name="cur_kd">               0           0          0         0     </param>
         <param name="cur_ki">               2           2          2         2     </param>

--- a/iCubNottingham01/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
+++ b/iCubNottingham01/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
@@ -32,7 +32,8 @@
 
      <group name="CONTROLS">
        <param name="positionControl">  POS_PID_DEFAULT           POS_PID_DEFAULT          POS_PID_DEFAULT          POS_PID_DEFAULT          </param> 
-       <param name="velocityControl">  none                   none                  none                  none                  </param> 
+       <param name="velocityControl"> POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT</param>
+           <param name="mixedControl"> POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT</param> 
        <param name="torqueControl">    TRQ_PID_DEFAULT  TRQ_PID_DEFAULT TRQ_PID_DEFAULT TRQ_PID_DEFAULT </param>
         <param name="currentPid">      2FOC_CUR_CONTROL          2FOC_CUR_CONTROL         2FOC_CUR_CONTROL         2FOC_CUR_CONTROL         </param> 
     </group>
@@ -42,51 +43,65 @@
         <param name="controlLaw">    Pid_inPos_outPwm </param> 
         <param name="fbkControlUnits">  metric_units   </param>
         <param name="outputControlUnits">  machine_units      </param> 
-        <param name="pos_kp">          -711.11   -1066.66    -711.11   -1066.66 </param>       
-        <param name="pos_kd">             0.00       0.00       0.00       0.00 </param>       
-        <param name="pos_ki">         -7111.09  -10666.64   -7111.09  -10666.64 </param>          
-        <param name="pos_maxOutput">      8000       8000       8000       8000 </param>              
-        <param name="pos_maxInt">          200        200        200       1000 </param>       
-        <param name="pos_shift">             0          0          0          0 </param>       
-        <param name="pos_ko">                0          0          0          0 </param>       
-        <param name="pos_stictionUp">        0          0          0          0 </param>       
-        <param name="pos_stictionDwn">       0          0          0          0 </param>       
-        <param name="pos_kff">               0          0          0          0 </param>       
+        <param name="kp">          -711.11   -1066.66    -711.11   -1066.66 </param>       
+        <param name="kd">             0.00       0.00       0.00       0.00 </param>       
+        <param name="ki">         -7111.09  -10666.64   -7111.09  -10666.64 </param>          
+        <param name="maxOutput">      8000       8000       8000       8000 </param>              
+        <param name="maxInt">          200        200        200       1000 </param>       
+        <param name="shift">             0          0          0          0 </param>       
+        <param name="ko">                0          0          0          0 </param>       
+        <param name="stictionUp">        0          0          0          0 </param>       
+        <param name="stictionDown">       0          0          0          0 </param>       
+        <param name="kff">               0          0          0          0 </param>       
     </group>
 
     <group name="TRQ_PID_DEFAULT">
         <param name="controlLaw">    Pid_inTrq_outPwm </param> 
         <param name="fbkControlUnits">  metric_units   </param>
         <param name="outputControlUnits">  machine_units      </param> 
-        <param name="trq_kp">             -50      -200       -250       -300     </param>       
-        <param name="trq_kd">              0          0          0          0     </param>       
-        <param name="trq_ki">              0          0          0          0     </param> 
-        <param name="trq_maxOutput">    8000       8000       8000       8000     </param>       
-        <param name="trq_maxInt">        500        500        500        500     </param>       
-        <param name="trq_shift">           0          0          0          0     </param>       
-        <param name="trq_ko">              0          0          0          0     </param>       
+        <param name="kp">             -50      -200       -250       -300     </param>       
+        <param name="kd">              0          0          0          0     </param>       
+        <param name="ki">              0          0          0          0     </param> 
+        <param name="maxOutput">    8000       8000       8000       8000     </param>       
+        <param name="maxInt">        500        500        500        500     </param>       
+        <param name="shift">           0          0          0          0     </param>       
+        <param name="ko">              0          0          0          0     </param>       
         <param name="stictionUp">0 0 0 0</param>       
         <param name="stictionDwn">0 0 0 0</param>       
-        <param name="trq_kff">             1          1          1          1     </param>  
+        <param name="kff">             1          1          1          1     </param>  
         <param name="kbemf">0 0 0 0</param>            
-        <param name="trq_filterType">      0          0          0          0     </param>     
+        <param name="filterType">      0          0          0          0     </param>     
         <param name="ktau">0 0 0 0</param>   
     </group>
     
     <group name="2FOC_CUR_CONTROL">
         <param name="controlLaw">       limitscurrent          </param>
-        <param name="fbkControlUnits">  metric_units   </param>
+        <param name="fbkControlUnits">  machine_units   </param>
         <param name="outputControlUnits">  machine_units      </param>
-        <param name="cur_kp">               8           8          8         8     </param>
-        <param name="cur_kd">               0           0          0         0     </param>
-        <param name="cur_ki">               2           2          2         2     </param>
-        <param name="cur_shift">            10          10         10        10    </param>
-        <param name="cur_maxOutput">        32000       32000      32000     32000 </param>
-        <param name="cur_maxInt">           32000       32000      32000     32000 </param>
-        <param name="cur_ko">               0            0          0            0  </param>
-        <param name="cur_stictionUp">       0            0          0            0  </param>
-        <param name="cur_stictionDwn">      0            0          0            0  </param>
-        <param name="cur_kff">              0            0          0            0  </param>
+        <param name="kp">               8           8          8         8     </param>
+        <param name="kd">               0           0          0         0     </param>
+        <param name="ki">               2           2          2         2     </param>
+        <param name="shift">            10          10         10        10    </param>
+        <param name="maxOutput">        32000       32000      32000     32000 </param>
+        <param name="maxInt">           32000       32000      32000     32000 </param>
+        <param name="ko">               0            0          0            0  </param>
+        <param name="stictionUp">       0            0          0            0  </param>
+        <param name="stictionDown">      0            0          0            0  </param>
+        <param name="kff">              0            0          0            0  </param>
+    </group>
+	
+	
+	<group name="2FOC_VEL_CONTROL">
+        <param name="controlLaw">           low_lev_speed       </param>
+        <param name="fbkControlUnits">      machine_units       </param>
+        <param name="outputControlUnits">   machine_units       </param>
+        <param name="kff">                  0           0           0           0       </param>
+        <param name="kp">                   12          12          12          12      </param>
+        <param name="kd">                   0           0           0           0       </param>
+        <param name="ki">                   16          16          16          16      </param>
+        <param name="shift">                10          10          10          10      </param>
+        <param name="maxOutput">            32000       32000       32000       32000   </param>
+        <param name="maxInt">               32000       32000       32000       32000   </param>
     </group>
     
   </device>

--- a/iCubNottingham01/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
+++ b/iCubNottingham01/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
@@ -2,96 +2,99 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
 
-  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-eb3-j0_3-mc" type="embObjMotionControl">
-      <xi:include href="../../general.xml" />
-      <xi:include href="../../hardware/electronics/right_arm-eb3-j0_3-eln.xml" />
-      <xi:include href="../../hardware/mechanicals/right_arm-eb3-j0_3-mec.xml" />
-      
-      <xi:include href="./right_arm-eb3-j0_3-mc_service.xml" />
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-eb3-j0_3-mc" type="embObjMotionControl">
 
+    <xi:include href="../../general.xml" />
+    <xi:include href="../../hardware/electronics/right_arm-eb3-j0_3-eln.xml" />
+    <xi:include href="../../hardware/mechanicals/right_arm-eb3-j0_3-mec.xml" />
+    <xi:include href="./right_arm-eb3-j0_3-mc_service.xml" />
+
+    <!-- joint number                           0                   1                   2                   3                   -->
+    <!-- joint name -->          
     <group name="LIMITS">
-        <!--                                    0             1               2            3      -->
-        <param name="jntPosMax">                8            160             80           106     </param>
-        <param name="jntPosMin">              -95.5           12            -32            15     </param>
-        <param name="motorNominalCurrents">    4000         4000           4000          4000     </param>
-        <param name="motorPeakCurrents">       5000         5000           5000          5000     </param>
-        <param name="motorOverloadCurrents">  15000        15000          15000         15000     </param>
-        <param name="jntVelMax">               1000         1000           1000          1000     </param>  
-        <param name="motorPwmLimit">          10000        10000          10000         10000     </param> 
-    </group>
-
-    <group name="IMPEDANCE">
-      <param name="stiffness">	 0.1   0.1   0.1  0.1   </param>
-      <param name="damping">	0.00  0.00  0.00 0.00   </param>
+        <param name="jntPosMax">                8                   160                 80                  106                 </param>
+        <param name="jntPosMin">                -95.5               12                  -32                 15                  </param>
+        <param name="jntVelMax">                1000                1000                1000                1000                </param>
+        <param name="motorNominalCurrents">     4000                4000                4000                4000                </param>
+        <param name="motorPeakCurrents">        5000                5000                5000                5000                </param>
+        <param name="motorOverloadCurrents">    15000               15000               15000               15000               </param>
+        <param name="motorPwmLimit">            10000               10000               10000               10000               </param>
     </group>
 
     <group name="TIMEOUTS">
-        <param name="velocity">       100           100           100           100   </param>
+        <param name="velocity">                 100                 100                 100                 100                 </param>
+    </group>
+
+    <group name="IMPEDANCE">
+        <param name="stiffness">                0.1                 0.1                 0.1                 0.1                 </param>
+        <param name="damping">                  0.00                0.00                0.00                0.00                </param>
+    </group>
+    
+    <group name="CONTROLS">
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="torqueControl">            TRQ_PID_DEFAULT     TRQ_PID_DEFAULT     TRQ_PID_DEFAULT     TRQ_PID_DEFAULT     </param>
+        <param name="currentPid">               2FOC_CUR_CONTROL    2FOC_CUR_CONTROL    2FOC_CUR_CONTROL    2FOC_CUR_CONTROL    </param>
+        <param name="speedPid">                 2FOC_VEL_CONTROL    2FOC_VEL_CONTROL    2FOC_VEL_CONTROL    2FOC_VEL_CONTROL    </param>
     </group>
 
 
-     <group name="CONTROLS">
-       <param name="positionControl">  POS_PID_DEFAULT           POS_PID_DEFAULT          POS_PID_DEFAULT          POS_PID_DEFAULT          </param> 
-       <param name="velocityControl"> POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT</param>
-           <param name="mixedControl"> POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT</param> 
-       <param name="torqueControl">    TRQ_PID_DEFAULT  TRQ_PID_DEFAULT TRQ_PID_DEFAULT TRQ_PID_DEFAULT </param>
-        <param name="currentPid">      2FOC_CUR_CONTROL          2FOC_CUR_CONTROL         2FOC_CUR_CONTROL         2FOC_CUR_CONTROL         </param> 
-    </group>
-
-   
+    <!-- default position PID: begin -->
+    
     <group name="POS_PID_DEFAULT">
-        <param name="controlLaw">    Pid_inPos_outPwm </param> 
-        <param name="fbkControlUnits">  metric_units   </param>
-        <param name="outputControlUnits">  machine_units      </param> 
-        <param name="kp">          -711.11   -1066.66    -711.11   -1066.66 </param>       
-        <param name="kd">             0.00       0.00       0.00       0.00 </param>       
-        <param name="ki">         -7111.09  -10666.64   -7111.09  -10666.64 </param>          
-        <param name="maxOutput">      8000       8000       8000       8000 </param>              
-        <param name="maxInt">          200        200        200       1000 </param>       
-        <param name="shift">             0          0          0          0 </param>       
-        <param name="ko">                0          0          0          0 </param>       
-        <param name="stictionUp">        0          0          0          0 </param>       
-        <param name="stictionDown">       0          0          0          0 </param>       
-        <param name="kff">               0          0          0          0 </param>       
+        <param name="controlLaw">           minjerk                   </param>
+        <param name="outputType">           pwm                       </param>
+        <param name="fbkControlUnits">      metric_units              </param>
+        <param name="outputControlUnits">   machine_units             </param>
+        <param name="kp">                   -711.11   -1066.66    -711.11   -1066.66 </param>
+        <param name="kd">                   0.00       0.00       0.00       0.00 </param>
+        <param name="ki">                   -7111.09  -10666.64   -7111.09  -10666.64 </param>
+        <param name="maxOutput">            8000       8000       8000       8000 </param>
+        <param name="maxInt">               200        200        200       1000 </param>
+        <param name="stictionUp">           0          0          0          0 </param>
+        <param name="stictionDown">         0          0          0          0 </param>
+        <param name="kff">                  0          0          0          0 </param>
     </group>
 
+    <!-- default position PID: end -->
+    
+    
+    <!-- other default PIDs: begin -->
+    
     <group name="TRQ_PID_DEFAULT">
-        <param name="controlLaw">    Pid_inTrq_outPwm </param> 
-        <param name="fbkControlUnits">  metric_units   </param>
-        <param name="outputControlUnits">  machine_units      </param> 
-        <param name="kp">             -50      -200       -250       -300     </param>       
-        <param name="kd">              0          0          0          0     </param>       
-        <param name="ki">              0          0          0          0     </param> 
-        <param name="maxOutput">    8000       8000       8000       8000     </param>       
-        <param name="maxInt">        500        500        500        500     </param>       
-        <param name="shift">           0          0          0          0     </param>       
-        <param name="ko">              0          0          0          0     </param>       
-        <param name="stictionUp">0 0 0 0</param>       
-        <param name="stictionDwn">0 0 0 0</param>       
-        <param name="kff">             1          1          1          1     </param>  
-        <param name="kbemf">0 0 0 0</param>            
-        <param name="filterType">      0          0          0          0     </param>     
-        <param name="ktau">0 0 0 0</param>   
+        <param name="controlLaw">           torque                       </param>
+        <param name="outputType">           pwm                          </param>
+        <param name="fbkControlUnits">      metric_units                 </param>
+        <param name="outputControlUnits">  machine_units                </param>
+        <param name="kp">             -50      -200       -250       -300   </param>
+        <param name="kd">              0          0          0          0   </param>
+        <param name="ki">              0          0          0          0   </param>
+        <param name="maxOutput">    8000       8000       8000       8000   </param>
+        <param name="maxInt">        500        500        500        500   </param>
+        <param name="ko">              0          0          0          0   </param>
+        <param name="stictionUp">      0          0          0          0   </param>
+        <param name="stictionDown">    0          0          0          0   </param>
+        <param name="kff">             1          1          1          1   </param>
+        <param name="kbemf">           0          0          0          0   </param>
+        <param name="filterType">      0          0          0          0   </param>
+        <param name="ktau">            0          0          0          0   </param>
     </group>
     
     <group name="2FOC_CUR_CONTROL">
-        <param name="controlLaw">       limitscurrent          </param>
-        <param name="fbkControlUnits">  machine_units   </param>
-        <param name="outputControlUnits">  machine_units      </param>
-        <param name="kp">               8           8          8         8     </param>
-        <param name="kd">               0           0          0         0     </param>
-        <param name="ki">               2           2          2         2     </param>
-        <param name="shift">            10          10         10        10    </param>
-        <param name="maxOutput">        32000       32000      32000     32000 </param>
-        <param name="maxInt">           32000       32000      32000     32000 </param>
-        <param name="ko">               0            0          0            0  </param>
-        <param name="stictionUp">       0            0          0            0  </param>
-        <param name="stictionDown">      0            0          0            0  </param>
-        <param name="kff">              0            0          0            0  </param>
+        <param name="controlLaw">           low_lev_current     </param>
+        <param name="fbkControlUnits">      machine_units       </param>
+        <param name="outputControlUnits">   machine_units       </param>
+        <param name="kp">                   8           8           8           8       </param>
+        <param name="kd">                   0           0           0           0       </param>
+        <param name="ki">                   2           2           2           2       </param>
+        <param name="shift">                10          10          10          10      </param>
+        <param name="maxOutput">            32000       32000       32000       32000   </param>
+        <param name="maxInt">               32000       32000       32000       32000   </param>
+        <param name="kff">                  0           0           0           0       </param>
     </group>
-	
-	
-	<group name="2FOC_VEL_CONTROL">
+
+    <group name="2FOC_VEL_CONTROL">
         <param name="controlLaw">           low_lev_speed       </param>
         <param name="fbkControlUnits">      machine_units       </param>
         <param name="outputControlUnits">   machine_units       </param>
@@ -103,8 +106,12 @@
         <param name="maxOutput">            32000       32000       32000       32000   </param>
         <param name="maxInt">               32000       32000       32000       32000   </param>
     </group>
+
+    <!-- other default PIDs: end -->
     
-  </device>
 
-
+    <!-- custom PIDs: begin -->
+    <!-- custom PIDs: end -->
+   
+</device>
 

--- a/iCubNottingham01/hardware/motorControl/right_arm-eb3-j0_3-mc_service.xml
+++ b/iCubNottingham01/hardware/motorControl/right_arm-eb3-j0_3-mc_service.xml
@@ -20,9 +20,9 @@
                     <param name="minor">            6           </param>     
                 </group>                    
                 <group name="FIRMWARE">
-                    <param name="major">            0           </param>    
-                    <param name="minor">            0           </param> 
-                    <param name="build">            0           </param>
+                    <param name="major">            3                       </param>    
+                    <param name="minor">            3                       </param> 
+                    <param name="build">            3                       </param>
                 </group>
             </group>
             

--- a/iCubNottingham01/hardware/motorControl/right_arm-eb3-j0_3-mc_service.xml
+++ b/iCubNottingham01/hardware/motorControl/right_arm-eb3-j0_3-mc_service.xml
@@ -20,9 +20,9 @@
                     <param name="minor">            6           </param>     
                 </group>                    
                 <group name="FIRMWARE">
-                    <param name="major">            3                       </param>    
-                    <param name="minor">            3                       </param> 
-                    <param name="build">            3                       </param>
+                    <param name="major">            0                       </param>    
+                    <param name="minor">            0                       </param> 
+                    <param name="build">            0                      </param>
                 </group>
             </group>
             

--- a/iCubNottingham01/hardware/motorControl/right_arm-eb3-j0_3-mc_service.xml
+++ b/iCubNottingham01/hardware/motorControl/right_arm-eb3-j0_3-mc_service.xml
@@ -20,9 +20,9 @@
                     <param name="minor">            6           </param>     
                 </group>                    
                 <group name="FIRMWARE">
-                    <param name="major">            0                       </param>    
-                    <param name="minor">            0                       </param> 
-                    <param name="build">            0                      </param>
+                    <param name="major">            3                       </param>    
+                    <param name="minor">            3                       </param> 
+                    <param name="build">            3                      </param>
                 </group>
             </group>
             

--- a/iCubNottingham01/hardware/motorControl/right_arm-eb4-j4_15-mc.xml
+++ b/iCubNottingham01/hardware/motorControl/right_arm-eb4-j4_15-mc.xml
@@ -38,34 +38,34 @@
      <group name="POS_PID_DEFAULT">
       <param name="controlLaw">     Pid_inPos_outPwm  </param>
          <param name="controlUnits">     machine_units               </param>
-         <param name="pos_kp">          -200          1000          -1000         200   -500          -8000         8000          -8000         -8000         -8000         8000          -1200    </param>
-         <param name="pos_kd">          -1000         10000         -10000        200   -32000        -32000        32000         -32000        -32000        -32000        32000         -12500   </param>
-         <param name="pos_ki">          -1            1             -1            1     -1            -5            5             -5            -5            -5            5             -1       </param>
-         <param name="pos_maxOutput">   1333          1333          1333          1333   1333          1333          1333          1333          1333          1333          1333          1333     </param>
-         <param name="pos_maxInt">      1333          1333          1333          1333   1333          1333          1333          1333          1333          1333          1333          1333     </param>
-         <param name="pos_shift">       6             7             7             4      6             8             8             8             8             8             8             6        </param>
-         <param name="pos_ko">          0             0             0             0      0             0             0             0             0             0             0             0        </param>
-         <param name="pos_stictionUp">  0             0             0             0      0             0             0             0             0             0             0             0        </param>
-         <param name="pos_stictionDwn"> 0             0             0             0      0             0             0             0             0             0             0             0        </param>
-         <param name="pos_kff">         0             0             0             0      0             0             0             0             0             0             0             0        </param>
+         <param name="kp">          -200          1000          -1000         200   -500          -8000         8000          -8000         -8000         -8000         8000          -1200    </param>
+         <param name="kd">          -1000         10000         -10000        200   -32000        -32000        32000         -32000        -32000        -32000        32000         -12500   </param>
+         <param name="ki">          -1            1             -1            1     -1            -5            5             -5            -5            -5            5             -1       </param>
+         <param name="maxOutput">   1333          1333          1333          1333   1333          1333          1333          1333          1333          1333          1333          1333     </param>
+         <param name="maxInt">      1333          1333          1333          1333   1333          1333          1333          1333          1333          1333          1333          1333     </param>
+         <param name="shift">       6             7             7             4      6             8             8             8             8             8             8             6        </param>
+         <param name="ko">          0             0             0             0      0             0             0             0             0             0             0             0        </param>
+         <param name="stictionUp">  0             0             0             0      0             0             0             0             0             0             0             0        </param>
+         <param name="stictionDown"> 0             0             0             0      0             0             0             0             0             0             0             0        </param>
+         <param name="kff">         0             0             0             0      0             0             0             0             0             0             0             0        </param>
      </group>
     
     <group name="TRQ_PID_DEFAULT">
         <param name="controlLaw">         Pid_inTrq_outPwm  </param>
         <param name="controlUnits">        machine_units               </param>
-        <param name="trq_kp">               80      0      0      0      0      0      0      0      0      0      0      0    </param>
-        <param name="trq_kd">                0      0      0      0      0      0      0      0      0      0      0      0    </param>
-        <param name="trq_ki">                0      0      0      0      0      0      0      0      0      0      0      0    </param>
-        <param name="trq_maxOutput">      1333      0      0      0      0      0      0      0      0      0      0      0    </param>
-        <param name="trq_maxInt">         1333      0      0      0      0      0      0      0      0      0      0      0    </param>
-        <param name="trq_shift">            10      0      0      0      0      0      0      0      0      0      0      0    </param>
-        <param name="trq_ko">                0      0      0      0      0      0      0      0      0      0      0      0    </param>
-        <param name="trq_stictionUp">        0      0      0      0      0      0      0      0      0      0      0      0    </param>
-        <param name="trq_stictionDwn">       0      0      0      0      0      0      0      0      0      0      0      0    </param>
-        <param name="trq_kff">               0      0      0      0      0      0      0      0      0      0      0      0    </param>
-        <param name="trq_kbemf">             0      0      0      0      0      0      0      0      0      0      0      0    </param>
-        <param name="trq_filterType">         0      0      0      0      0      0      0      0      0      0      0      0    </param>
-        <param name="trq_ktau">              1      1      1      1      1      1      1      1      1      1      1      1    </param>
+        <param name="kp">               80      0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="kd">                0      0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="ki">                0      0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="maxOutput">      1333      0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="maxInt">         1333      0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="shift">            10      0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="ko">                0      0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="stictionUp">        0      0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="stictionDown">       0      0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="kff">               0      0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="kbemf">             0      0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="filterType">         0      0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="ktau">              1      1      1      1      1      1      1      1      1      1      1      1    </param>
     </group>
 
     <group name="IMPEDANCE">

--- a/iCubNottingham01/hardware/motorControl/right_arm-eb4-j4_15-mc.xml
+++ b/iCubNottingham01/hardware/motorControl/right_arm-eb4-j4_15-mc.xml
@@ -2,76 +2,91 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
 
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-eb4-j4_15-mc" type="embObjMotionControl">
+    
+    <xi:include href="../../general.xml" />
+    <xi:include href="../../hardware/electronics/right_arm-eb4-j4_15-eln.xml" />
+    <xi:include href="../../hardware/mechanicals/right_arm-eb4-j4_15-mec.xml" />
+    <xi:include href="./right_arm-eb4-j4_15-mc_service.xml" />
 
-  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-eb4-j4_15-mc" type="embObjMotionControl">
-      <xi:include href="../../general.xml" />
-      <xi:include href="../../hardware/electronics/right_arm-eb4-j4_15-eln.xml" />
-      <xi:include href="../../hardware/mechanicals/right_arm-eb4-j4_15-mec.xml" />
-
-      <xi:include href="./right_arm-eb4-j4_15-mc_service.xml" />
-
+    <!-- joint number                           0             1             2             3             4             5             6             7             8             9             10            11-->
+    <!-- joint name     --> 
     <group name="LIMITS">
-        <!--                                    0             1             2             3             4             5             6             7             8             9             10            11-->
         <param name="jntPosMax">                60            25            25            60            90            90            180           90            180           90            180           270       </param>
         <param name="jntPosMin">                -60           -80           -20           0             10            0             0             0             0             0             0             0         </param>
         <param name="motorOverloadCurrents">    500           800           800           485           485           485           485           485           485           485           485           485       </param>
         <param name="motorNominalCurrents">     0             0             0             0             0             0             0             0             0            0           0                0         </param>
         <param name="motorPeakCurrents">        0             0             0             0             0             0             0             0             0            0           0                0         </param>
-        <param name="jntVelMax">                 1000          1000          1000          1000          1000          1000          1000          1000          1000          1000          1000          1000      </param>   
+        <param name="jntVelMax">                1000          1000          1000          1000          1000          1000          1000          1000          1000          1000          1000          1000      </param>
         <param name="motorPwmLimit">            10000         10000         10000         10000         10000         10000         10000         10000         10000         10000         10000         10000     </param>
     </group>
 
-
-     <group name="TIMEOUTS">
-        <param name="velocity">    100           100           100           100        100           100           100           100      100           100           100           100    </param>
+    <group name="TIMEOUTS">
+        <param name="velocity">     100           100           100           100        100           100           100           100      100           100           100           100    </param>
     </group>
 
-
-     <group name="CONTROLS">
-       <param name="positionControl">  POS_PID_DEFAULT           POS_PID_DEFAULT          POS_PID_DEFAULT          POS_PID_DEFAULT          POS_PID_DEFAULT           POS_PID_DEFAULT          POS_PID_DEFAULT          POS_PID_DEFAULT POS_PID_DEFAULT           POS_PID_DEFAULT          POS_PID_DEFAULT          POS_PID_DEFAULT </param>
-       <param name="velocityControl">  none                   none                  none                  none                  none                   none                  none                  none                  none                   none                  none                  none                  </param>
-       <param name="torqueControl">    TRQ_PID_DEFAULT  none                  none                  none  none                   none                  none                  none   none                   none                  none                  none</param>
-        <param name="currentPid">none       none                  none                  none  none                   none                  none                  none   none                   none                  none                  none</param>
+    <group name="IMPEDANCE">
+        <param name="stiffness">    0      0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="damping">      0      0      0      0      0      0      0      0      0      0      0      0    </param>
     </group>
-
-
-     <group name="POS_PID_DEFAULT">
-      <param name="controlLaw">     Pid_inPos_outPwm  </param>
-         <param name="controlUnits">     machine_units               </param>
-         <param name="kp">          -200          1000          -1000         200   -500          -8000         8000          -8000         -8000         -8000         8000          -1200    </param>
-         <param name="kd">          -1000         10000         -10000        200   -32000        -32000        32000         -32000        -32000        -32000        32000         -12500   </param>
-         <param name="ki">          -1            1             -1            1     -1            -5            5             -5            -5            -5            5             -1       </param>
-         <param name="maxOutput">   1333          1333          1333          1333   1333          1333          1333          1333          1333          1333          1333          1333     </param>
-         <param name="maxInt">      1333          1333          1333          1333   1333          1333          1333          1333          1333          1333          1333          1333     </param>
-         <param name="shift">       6             7             7             4      6             8             8             8             8             8             8             6        </param>
-         <param name="ko">          0             0             0             0      0             0             0             0             0             0             0             0        </param>
-         <param name="stictionUp">  0             0             0             0      0             0             0             0             0             0             0             0        </param>
-         <param name="stictionDown"> 0             0             0             0      0             0             0             0             0             0             0             0        </param>
-         <param name="kff">         0             0             0             0      0             0             0             0             0             0             0             0        </param>
-     </group>
     
+    <group name="CONTROLS">
+        <param name="positionControl">  POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT      POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT </param>
+        <param name="velocityControl">  POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT      POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT </param>
+        <param name="mixedControl">     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT      POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT </param>
+        <param name="torqueControl">    TRQ_PID_DEFAULT     none                none                none                none                 none                none                none                none                none                none                none            </param>
+        <param name="currentPid">       none                none                none                none                none                 none                none                none                none                none                none                none            </param>
+        <param name="speedPid">         none                none                none                none                none                 none                none                none                none                none                none                none            </param>
+    </group>
+
+
+    <!-- default position PID: begin -->
+    
+    <group name="POS_PID_DEFAULT">
+        <param name="controlLaw">             minjerk                   </param>
+        <param name="outputType">             pwm                       </param>
+        <param name="fbkControlUnits">        metric_units              </param>
+        <param name="outputControlUnits">     machine_units             </param>
+        <param name="kp">          -200          1000          -1000         200   -500          -8000         8000          -8000         -8000         -8000         8000          -1200    </param>
+        <param name="kd">          -1000         10000         -10000        200   -32000        -32000        32000         -32000        -32000        -32000        32000         -12500   </param>
+        <param name="ki">          -1            1             -1            1     -1            -5            5             -5            -5            -5            5             -1       </param>
+        <param name="maxOutput">   1333          1333          1333          1333   1333          1333          1333          1333          1333          1333          1333          1333     </param>
+        <param name="maxInt">      1333          1333          1333          1333   1333          1333          1333          1333          1333          1333          1333          1333     </param>
+        <param name="stictionUp">   0             0             0             0      0             0             0             0             0             0             0             0        </param>
+        <param name="stictionDown"> 0             0             0             0      0             0             0             0             0             0             0             0        </param>
+        <param name="kff">          0             0             0             0      0             0             0             0             0             0             0             0        </param>
+    </group>
+
+    <!-- default position PID: end -->
+
+
+    <!-- other default PIDs: begin --> 
+
     <group name="TRQ_PID_DEFAULT">
-        <param name="controlLaw">         Pid_inTrq_outPwm  </param>
-        <param name="controlUnits">        machine_units               </param>
+        <param name="controlLaw">          torque                       </param>
+        <param name="outputType">          pwm                          </param>
+        <param name="fbkControlUnits">     metric_units                 </param>
+        <param name="outputControlUnits">  machine_units                </param>
         <param name="kp">               80      0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="kd">                0      0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="ki">                0      0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="maxOutput">      1333      0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="maxInt">         1333      0      0      0      0      0      0      0      0      0      0      0    </param>
-        <param name="shift">            10      0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="ko">                0      0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="stictionUp">        0      0      0      0      0      0      0      0      0      0      0      0    </param>
-        <param name="stictionDown">       0      0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="stictionDown">      0      0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="kff">               0      0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="kbemf">             0      0      0      0      0      0      0      0      0      0      0      0    </param>
-        <param name="filterType">         0      0      0      0      0      0      0      0      0      0      0      0    </param>
-        <param name="ktau">              1      1      1      1      1      1      1      1      1      1      1      1    </param>
+        <param name="filterType">        0      0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="ktau">              0      0      0      0      0      0      0      0      0      0      0      0     </param>
     </group>
 
-    <group name="IMPEDANCE">
-        <param name="stiffness">       0      0      0      0      0      0      0      0      0      0      0      0    </param>    
-        <param name="damping">         0      0      0      0      0      0      0      0      0      0      0      0    </param>    
-    </group>
+    <!-- other default PIDs: end -->
+    
+    
+    <!-- custom PIDs: begin -->    
+    <!-- custom PIDs: end -->
+    
+</device>
 
-  </device>
 

--- a/iCubNottingham01/hardware/motorControl/right_arm-eb4-j4_15-mc_service.xml
+++ b/iCubNottingham01/hardware/motorControl/right_arm-eb4-j4_15-mc_service.xml
@@ -57,7 +57,7 @@
                     <param name="port">             CONN:none    CONN:none     CONN:none   CONN:none      CONN:none    MAIS:thumbproximal  MAIS:thumbdistal MAIS:indexproximal   MAIS:indexdistal    MAIS:mediumproximal MAIS:mediumdistal   MAIS:littlefingers    </param>
                     <param name="position">         atjoint      atjoint       atjoint     atjoint        atjoint      atjoint             atjoint          atjoint           atjoint    atjoint       atjoint       atjoint      </param>
                     <param name="resolution">       -254440     4096         -4096         65535         65535          65535          65535          65535          65535         65535         65535          65535      </param>
-                    <param name="tolerance">          0         0.703             0.703           0              0                0            0           0           0          0             0             0        </param>
+                    <param name="tolerance">        0           0.703        0.703           0              0                0            0           0           0          0             0             0        </param>
                 </group>
 
                 <group name="ENCODER2">
@@ -65,7 +65,7 @@
                     <param name="port">             CONN:none  CONN:none   CONN:none  CONN:none  CONN:none  CONN:none  CONN:none  CONN:non  CONN:nonee  CONN:none  CONN:none  CONN:none </param>
                     <param name="position">         none       none        none       none       none       none       none       none      none        none       none       none      </param>
                     <param name="resolution">       1             1           1          1          1          1          1          1         1           1          1          1      </param>
-                    <param name="tolerance">        0             0           0          0          0          0          0          0         0           0          0          0       </param>
+                    <param name="tolerance">   0             0           0          0          0          0          0          0         0           0          0          0       </param>
                 </group>
 
            </group>

--- a/iCubNottingham01/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
+++ b/iCubNottingham01/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
@@ -27,7 +27,8 @@
 
      <group name="CONTROLS">
        <param name="positionControl">  POS_PID_DEFAULT           POS_PID_DEFAULT          POS_PID_DEFAULT          POS_PID_DEFAULT          </param>
-       <param name="velocityControl">  none                   none                  none                  none                  </param>
+       <param name="velocityControl"> POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT</param>
+           <param name="mixedControl"> POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT</param>
        <param name="torqueControl">    TRQ_PID_DEFAULT  TRQ_PID_DEFAULT TRQ_PID_DEFAULT TRQ_PID_DEFAULT </param>
        <param name="currentPid">       2FOC_CUR_CONTROL          2FOC_CUR_CONTROL         2FOC_CUR_CONTROL         2FOC_CUR_CONTROL         </param>
     </group>
@@ -36,16 +37,16 @@
         <param name="controlLaw">    Pid_inPos_outPwm                          </param>
         <param name="fbkControlUnits">  metric_units   </param>
         <param name="outputControlUnits">  machine_units      </param>
-        <param name="pos_kp">            1066.66    -2066.66     711.11   -1066.66 </param>       
-        <param name="pos_kd">               0.00        0.00       0.00       0.00 </param>       
-        <param name="pos_ki">           10666.64   -14222.18    7111.09   -1066.64 </param>         
-        <param name="pos_maxOutput">        8000        8000       8000       8000 </param>          
-        <param name="pos_maxInt">           1500        750        750       1000 </param>       
-        <param name="pos_shift">               0           0          0          0 </param>       
-        <param name="pos_ko">                  0           0          0          0 </param>       
-        <param name="pos_stictionUp">          0           0          0          0 </param>       
-        <param name="pos_stictionDwn">         0           0          0          0 </param>     
-        <param name="pos_kff">                 0           0          0          0 </param>   
+        <param name="kp">            1066.66    -2066.66     711.11   -1066.66 </param>       
+        <param name="kd">               0.00        0.00       0.00       0.00 </param>       
+        <param name="ki">           10666.64   -14222.18    7111.09   -1066.64 </param>         
+        <param name="maxOutput">        8000        8000       8000       8000 </param>          
+        <param name="maxInt">           1500        750        750       1000 </param>       
+        <param name="shift">               0           0          0          0 </param>       
+        <param name="ko">                  0           0          0          0 </param>       
+        <param name="stictionUp">          0           0          0          0 </param>       
+        <param name="stictionDown">         0           0          0          0 </param>     
+        <param name="kff">                 0           0          0          0 </param>   
     </group>
 
     <group name="IMPEDANCE">
@@ -57,35 +58,48 @@
         <param name="controlLaw">    Pid_inTrq_outPwm                         </param>
         <param name="fbkControlUnits">  metric_units   </param>
         <param name="outputControlUnits">  machine_units      </param>     
-        <param name="trq_kp">            200       -200          0       -300     </param>    
-        <param name="trq_kd">              0          0          0          0     </param>       
-        <param name="trq_ki">              0          0          0          0     </param>     
-        <param name="trq_maxOutput">    8000       8000       8000       8000     </param>       
-        <param name="trq_maxInt">        500        500        500        500     </param>       
-        <param name="trq_shift">           0          0          0          0     </param>       
-        <param name="trq_ko">              0          0          0          0     </param>       
+        <param name="kp">            200       -200          0       -300     </param>    
+        <param name="kd">              0          0          0          0     </param>       
+        <param name="ki">              0          0          0          0     </param>     
+        <param name="maxOutput">    8000       8000       8000       8000     </param>       
+        <param name="maxInt">        500        500        500        500     </param>       
+        <param name="shift">           0          0          0          0     </param>       
+        <param name="ko">              0          0          0          0     </param>       
         <param name="stictionUp">0 0 0 0</param>       
         <param name="stictionDwn">0 0 0 0</param>       
-        <param name="trq_kff">             1          1          1          1     </param>  
+        <param name="kff">             1          1          1          1     </param>  
         <param name="kbemf">0 0 0 0</param>            
-        <param name="trq_filterType">      0          0          0          0     </param>     
+        <param name="filterType">      0          0          0          0     </param>     
         <param name="ktau">0 0 0 0</param>          
     </group>
 
      <group name="2FOC_CUR_CONTROL">
         <param name="controlLaw">       limitscurrent          </param>
-        <param name="fbkControlUnits">  metric_units   </param>
+        <param name="fbkControlUnits">  machine_units   </param>
         <param name="outputControlUnits">  machine_units      </param>
-        <param name="cur_kp">               8           8          8         8      </param>
-        <param name="cur_kd">               0           0          0         0      </param>
-        <param name="cur_ki">               2           2          2         2      </param>
-        <param name="cur_shift">            10          10         10        10     </param>
-        <param name="cur_maxOutput">        32000       32000      32000     32000  </param>
-        <param name="cur_maxInt">           32000       32000      32000     32000  </param>
-        <param name="cur_ko">               0            0          0            0  </param>
-        <param name="cur_stictionUp">       0            0          0            0  </param>
-        <param name="cur_stictionDwn">      0            0          0            0  </param>
-        <param name="cur_kff">              0            0          0            0  </param>
+        <param name="kp">               8           8          8         8      </param>
+        <param name="kd">               0           0          0         0      </param>
+        <param name="ki">               2           2          2         2      </param>
+        <param name="shift">            10          10         10        10     </param>
+        <param name="maxOutput">        32000       32000      32000     32000  </param>
+        <param name="maxInt">           32000       32000      32000     32000  </param>
+        <param name="ko">               0            0          0            0  </param>
+        <param name="stictionUp">       0            0          0            0  </param>
+        <param name="stictionDown">      0            0          0            0  </param>
+        <param name="kff">              0            0          0            0  </param>
+    </group>
+	
+	<group name="2FOC_VEL_CONTROL">
+        <param name="controlLaw">           low_lev_speed       </param>
+        <param name="fbkControlUnits">      machine_units       </param>
+        <param name="outputControlUnits">   machine_units       </param>
+        <param name="kff">                  0           0           0           0       </param>
+        <param name="kp">                   12          12          12          12      </param>
+        <param name="kd">                   0           0           0           0       </param>
+        <param name="ki">                   16          16          16          16      </param>
+        <param name="shift">                10          10          10          10      </param>
+        <param name="maxOutput">            32000       32000       32000       32000   </param>
+        <param name="maxInt">               32000       32000       32000       32000   </param>
     </group>
     
   </device>

--- a/iCubNottingham01/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
+++ b/iCubNottingham01/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
@@ -34,7 +34,8 @@
 
     <group name="POS_PID_DEFAULT">
         <param name="controlLaw">    Pid_inPos_outPwm                          </param>
-        <param name="controlUnits">  metric_units                              </param>
+        <param name="fbkControlUnits">  metric_units   </param>
+        <param name="outputControlUnits">  machine_units      </param>
         <param name="pos_kp">            1066.66    -2066.66     711.11   -1066.66 </param>       
         <param name="pos_kd">               0.00        0.00       0.00       0.00 </param>       
         <param name="pos_ki">           10666.64   -14222.18    7111.09   -1066.64 </param>         
@@ -54,7 +55,8 @@
 
     <group name="TRQ_PID_DEFAULT">
         <param name="controlLaw">    Pid_inTrq_outPwm                         </param>
-        <param name="controlUnits">  metric_units                             </param>     
+        <param name="fbkControlUnits">  metric_units   </param>
+        <param name="outputControlUnits">  machine_units      </param>     
         <param name="trq_kp">            200       -200          0       -300     </param>    
         <param name="trq_kd">              0          0          0          0     </param>       
         <param name="trq_ki">              0          0          0          0     </param>     
@@ -62,17 +64,18 @@
         <param name="trq_maxInt">        500        500        500        500     </param>       
         <param name="trq_shift">           0          0          0          0     </param>       
         <param name="trq_ko">              0          0          0          0     </param>       
-        <param name="trq_stictionUp">      2.3       -1.79       1.8        1.2   </param>       
-        <param name="trq_stictionDwn">    -3.3        1.76      -1.4       -1.7   </param>       
+        <param name="stictionUp">0 0 0 0</param>       
+        <param name="stictionDwn">0 0 0 0</param>       
         <param name="trq_kff">             1          1          1          1     </param>  
-        <param name="trq_kbemf">           0          0          0          0     </param>            
+        <param name="kbemf">0 0 0 0</param>            
         <param name="trq_filterType">      0          0          0          0     </param>     
-        <param name="trq_ktau">          147       -180        217       -282     </param>          
+        <param name="ktau">0 0 0 0</param>          
     </group>
 
      <group name="2FOC_CUR_CONTROL">
         <param name="controlLaw">       limitscurrent          </param>
-        <param name="controlUnits">     metric_units           </param>
+        <param name="fbkControlUnits">  metric_units   </param>
+        <param name="outputControlUnits">  machine_units      </param>
         <param name="cur_kp">               8           8          8         8      </param>
         <param name="cur_kd">               0           0          0         0      </param>
         <param name="cur_ki">               2           2          2         2      </param>

--- a/iCubNottingham01/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
+++ b/iCubNottingham01/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
@@ -13,7 +13,7 @@
     <!-- joint name --> 
     <group name="LIMITS">
         <param name="jntPosMax">                85                  85                  70                  0                   </param>
-        <param name="jntPosMin">                -30                 -12                 -70                 -100                </param>
+        <param name="jntPosMin">                -30                 0                  -70                 -100                </param>
         <param name="jntVelMax">                1000                1000                1000                1000                </param>
         <param name="motorNominalCurrents">     4000                4000                4000                4000                </param>
         <param name="motorPeakCurrents">        6000                 10000               6000                10000               </param>
@@ -47,9 +47,9 @@
         <param name="outputType">             pwm                       </param>
         <param name="fbkControlUnits">        metric_units              </param> 
         <param name="outputControlUnits">     machine_units             </param>
-        <param name="kp">           1066.66    -2066.66     711.11   1066.66    </param>
+        <param name="kp">           1066.66    -2066.66     711.11   -1066.66    </param>
         <param name="kd">           0.00        0.00       0.00       0.00      </param>
-        <param name="ki">           10666.64   -14222.18    7111.09   1066.64   </param>
+        <param name="ki">           10666.64   -14222.18    7111.09   -1066.64   </param>
         <param name="maxOutput">    8000        8000       8000       8000      </param>
         <param name="maxInt">       1500        750        750       1000        </param>
         <param name="stictionUp">   0           0          0          0         </param>

--- a/iCubNottingham01/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
+++ b/iCubNottingham01/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
@@ -1,110 +1,118 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
- <!-- Initialization file for EMS 8 - Right Upper Leg, 4 dof -->
 
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb8-j0_3-mc" type="embObjMotionControl">
+    
+    <xi:include href="../../general.xml" />
+    <xi:include href="../../hardware/electronics/right_leg-eb8-j0_3-eln.xml" />
+    <xi:include href="../../hardware/mechanicals/right_leg-eb8-j0_3-mec.xml" />
+    <xi:include href="./right_leg-eb8-j0_3-mc_service.xml" />
 
-  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb8-j0_3-mc" type="embObjMotionControl">
-      <xi:include href="../../general.xml" />
-      <xi:include href="../../hardware/electronics/right_leg-eb8-j0_3-eln.xml" />
-      <xi:include href="../../hardware/mechanicals/right_leg-eb8-j0_3-mec.xml" />
-      
-      <xi:include href="./right_leg-eb8-j0_3-mc_service.xml" />
+    <!-- joint number                           0                   1                   2                   3                   -->
+    <!-- joint name --> 
     <group name="LIMITS">
-        <!--                                    0             	1            2          3         -->
-        <param name="jntPosMax">               85              85           70          0    </param>
-        <param name="jntPosMin">              -30               0          -70       -100    </param>
-        <param name="motorNominalCurrents">     4000         4000         4000       4000    </param>
-        <param name="motorPeakCurrents">        6000        10000         6000      10000    </param>
-        <param name="motorOverloadCurrents">   15000        15000        15000      15000    </param>
-        <param name="jntVelMax">                1000         1000         1000       1000    </param>   
-        <param name="motorPwmLimit">           10000        10000        10000      10000    </param>    
+        <param name="jntPosMax">                85                  85                  70                  0                   </param>
+        <param name="jntPosMin">                -30                 -12                 -70                 -100                </param>
+        <param name="jntVelMax">                1000                1000                1000                1000                </param>
+        <param name="motorNominalCurrents">     4000                4000                4000                4000                </param>
+        <param name="motorPeakCurrents">        6000                 10000               6000                10000               </param>
+        <param name="motorOverloadCurrents">    15000               15000               15000               15000               </param>
+        <param name="motorPwmLimit">            10000               10000               10000               10000               </param>
     </group>
-
-     <group name="TIMEOUTS">
-        <param name="velocity">                 100           100           100           100   </param>
-    </group>
-
-     <group name="CONTROLS">
-       <param name="positionControl">  POS_PID_DEFAULT           POS_PID_DEFAULT          POS_PID_DEFAULT          POS_PID_DEFAULT          </param>
-       <param name="velocityControl"> POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT</param>
-           <param name="mixedControl"> POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT</param>
-       <param name="torqueControl">    TRQ_PID_DEFAULT  TRQ_PID_DEFAULT TRQ_PID_DEFAULT TRQ_PID_DEFAULT </param>
-       <param name="currentPid">       2FOC_CUR_CONTROL          2FOC_CUR_CONTROL         2FOC_CUR_CONTROL         2FOC_CUR_CONTROL         </param>
-    </group>
-
-    <group name="POS_PID_DEFAULT">
-        <param name="controlLaw">    Pid_inPos_outPwm                          </param>
-        <param name="fbkControlUnits">  metric_units   </param>
-        <param name="outputControlUnits">  machine_units      </param>
-        <param name="kp">            1066.66    -2066.66     711.11   -1066.66 </param>       
-        <param name="kd">               0.00        0.00       0.00       0.00 </param>       
-        <param name="ki">           10666.64   -14222.18    7111.09   -1066.64 </param>         
-        <param name="maxOutput">        8000        8000       8000       8000 </param>          
-        <param name="maxInt">           1500        750        750       1000 </param>       
-        <param name="shift">               0           0          0          0 </param>       
-        <param name="ko">                  0           0          0          0 </param>       
-        <param name="stictionUp">          0           0          0          0 </param>       
-        <param name="stictionDown">         0           0          0          0 </param>     
-        <param name="kff">                 0           0          0          0 </param>   
+   
+    <group name="TIMEOUTS">
+        <param name="velocity">                 100                 100                 100                 100                 </param>
     </group>
 
     <group name="IMPEDANCE">
-        <param name="stiffness">       0      0      0      0     </param>    
-        <param name="damping">         0      0      0      0     </param>    
+        <param name="stiffness">                0.0                 0.0                 0.0                 0.0                 </param>
+        <param name="damping">                  0.0                 0.0                 0.0                 0.0                 </param>
     </group>
+    
+    <group name="CONTROLS">
+      <param name="positionControl">            POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+      <param name="velocityControl">            POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+      <param name="mixedControl">               POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+      <param name="torqueControl">              TRQ_PID_DEFAULT     TRQ_PID_DEFAULT     TRQ_PID_DEFAULT     TRQ_PID_DEFAULT     </param>
+      <param name="currentPid">                 2FOC_CUR_CONTROL    2FOC_CUR_CONTROL    2FOC_CUR_CONTROL    2FOC_CUR_CONTROL    </param>
+      <param name="speedPid">                   2FOC_VEL_CONTROL    2FOC_VEL_CONTROL    2FOC_VEL_CONTROL    2FOC_VEL_CONTROL    </param>
+    </group>
+       
 
+    <!-- default position PID: begin -->
+
+    <group name="POS_PID_DEFAULT">
+        <param name="controlLaw">             minjerk                   </param>
+        <param name="outputType">             pwm                       </param>
+        <param name="fbkControlUnits">        metric_units              </param> 
+        <param name="outputControlUnits">     machine_units             </param>
+        <param name="kp">           1066.66    -2066.66     711.11   1066.66    </param>
+        <param name="kd">           0.00        0.00       0.00       0.00      </param>
+        <param name="ki">           10666.64   -14222.18    7111.09   1066.64   </param>
+        <param name="maxOutput">    8000        8000       8000       8000      </param>
+        <param name="maxInt">       1500        750        750       1000        </param>
+        <param name="stictionUp">   0           0          0          0         </param>
+        <param name="stictionDown"> 0           0          0          0         </param>
+        <param name="kff">          0           0          0          0         </param>
+    </group>
+    
+    <!-- default position PID: end -->
+
+
+    <!-- other default PIDs: begin -->  
+        
     <group name="TRQ_PID_DEFAULT">
-        <param name="controlLaw">    Pid_inTrq_outPwm                         </param>
-        <param name="fbkControlUnits">  metric_units   </param>
-        <param name="outputControlUnits">  machine_units      </param>     
-        <param name="kp">            200       -200          0       -300     </param>    
-        <param name="kd">              0          0          0          0     </param>       
-        <param name="ki">              0          0          0          0     </param>     
-        <param name="maxOutput">    8000       8000       8000       8000     </param>       
-        <param name="maxInt">        500        500        500        500     </param>       
-        <param name="shift">           0          0          0          0     </param>       
-        <param name="ko">              0          0          0          0     </param>       
-        <param name="stictionUp">0 0 0 0</param>       
-        <param name="stictionDwn">0 0 0 0</param>       
-        <param name="kff">             1          1          1          1     </param>  
-        <param name="kbemf">0 0 0 0</param>            
-        <param name="filterType">      0          0          0          0     </param>     
-        <param name="ktau">0 0 0 0</param>          
+        <param name="controlLaw">          torque                       </param>
+        <param name="outputType">          pwm                          </param>
+        <param name="fbkControlUnits">     metric_units                 </param>
+        <param name="outputControlUnits">  machine_units                </param>
+        <param name="kp">            200       -200          0       -300       </param>
+        <param name="kd">              0          0          0          0       </param>
+        <param name="ki">              0          0          0          0       </param>
+        <param name="maxOutput">     8000       8000       8000       8000      </param>
+        <param name="maxInt">        500        500        500        500       </param>
+        <param name="ko">              0          0          0          0       </param>
+        <param name="stictionUp">      0          0          0          0       </param>
+        <param name="stictionDown">    0          0          0          0       </param>
+        <param name="kff">             1          1          1          1       </param>
+        <param name="kbemf">           0          0          0          0       </param>
+        <param name="filterType">      0          0          0          0       </param>
+       <param name="ktau">             0          0          0          0       </param>
     </group>
 
-     <group name="2FOC_CUR_CONTROL">
-        <param name="controlLaw">       limitscurrent          </param>
-        <param name="fbkControlUnits">  machine_units   </param>
-        <param name="outputControlUnits">  machine_units      </param>
-        <param name="kp">               8           8          8         8      </param>
-        <param name="kd">               0           0          0         0      </param>
-        <param name="ki">               2           2          2         2      </param>
-        <param name="shift">            10          10         10        10     </param>
-        <param name="maxOutput">        32000       32000      32000     32000  </param>
-        <param name="maxInt">           32000       32000      32000     32000  </param>
-        <param name="ko">               0            0          0            0  </param>
-        <param name="stictionUp">       0            0          0            0  </param>
-        <param name="stictionDown">      0            0          0            0  </param>
-        <param name="kff">              0            0          0            0  </param>
+    <group name="2FOC_CUR_CONTROL">
+        <param name="controlLaw">           low_lev_current     </param>
+        <param name="fbkControlUnits">      machine_units       </param>
+        <param name="outputControlUnits">   machine_units       </param>
+        <param name="kp">                   8           8          8         8      </param>
+        <param name="kd">                   0           0          0         0      </param>
+        <param name="ki">                   2           2          2         2      </param>
+        <param name="shift">                10          10         10        10     </param>
+        <param name="maxOutput">            32000       32000      32000     32000  </param>
+        <param name="maxInt">               32000       32000      32000     32000  </param>
+        <param name="kff">                  0            0          0            0  </param>
     </group>
-	
-	<group name="2FOC_VEL_CONTROL">
+
+    <group name="2FOC_VEL_CONTROL">
         <param name="controlLaw">           low_lev_speed       </param>
         <param name="fbkControlUnits">      machine_units       </param>
         <param name="outputControlUnits">   machine_units       </param>
-        <param name="kff">                  0           0           0           0       </param>
-        <param name="kp">                   12          12          12          12      </param>
-        <param name="kd">                   0           0           0           0       </param>
-        <param name="ki">                   16          16          16          16      </param>
-        <param name="shift">                10          10          10          10      </param>
-        <param name="maxOutput">            32000       32000       32000       32000   </param>
-        <param name="maxInt">               32000       32000       32000       32000   </param>
+        <param name="kff">                  0           0       0         0       </param>
+        <param name="kp">                   12          12      12        12      </param>
+        <param name="kd">                   0           0       0         0       </param>
+        <param name="ki">                   16          16      16        16      </param>
+        <param name="shift">                10          10      10        10      </param>
+        <param name="maxOutput">            32000       32000   32000     32000   </param>
+        <param name="maxInt">               32000       32000   32000     32000   </param>
     </group>
     
-  </device>
+    <!-- other default PIDs: end -->
 
 
+    <!-- custom PIDs: begin -->  
+    <!-- custom PIDs: end -->
 
+</device>
 
 

--- a/iCubNottingham01/hardware/motorControl/right_leg-eb8-j0_3-mc_service.xml
+++ b/iCubNottingham01/hardware/motorControl/right_leg-eb8-j0_3-mc_service.xml
@@ -20,9 +20,9 @@
                     <param name="minor">            6           </param>     
                 </group>                    
                 <group name="FIRMWARE">
-                    <param name="major">            0           </param>    
-                    <param name="minor">            0           </param> 
-                    <param name="build">            0           </param>
+                    <param name="major">            3                       </param>    
+                    <param name="minor">            3                       </param> 
+                    <param name="build">            3                       </param>
                 </group>
             </group>
             

--- a/iCubNottingham01/hardware/motorControl/right_leg-eb8-j0_3-mc_service.xml
+++ b/iCubNottingham01/hardware/motorControl/right_leg-eb8-j0_3-mc_service.xml
@@ -20,9 +20,9 @@
                     <param name="minor">            6           </param>     
                 </group>                    
                 <group name="FIRMWARE">
-                    <param name="major">            0                       </param>    
-                    <param name="minor">            0                       </param> 
-                    <param name="build">            0                       </param>
+                    <param name="major">            3                       </param>    
+                    <param name="minor">            3                       </param> 
+                    <param name="build">            3                       </param>
                 </group>
             </group>
             

--- a/iCubNottingham01/hardware/motorControl/right_leg-eb8-j0_3-mc_service.xml
+++ b/iCubNottingham01/hardware/motorControl/right_leg-eb8-j0_3-mc_service.xml
@@ -20,9 +20,9 @@
                     <param name="minor">            6           </param>     
                 </group>                    
                 <group name="FIRMWARE">
-                    <param name="major">            3                       </param>    
-                    <param name="minor">            3                       </param> 
-                    <param name="build">            3                       </param>
+                    <param name="major">            0                       </param>    
+                    <param name="minor">            0                       </param> 
+                    <param name="build">            0                       </param>
                 </group>
             </group>
             

--- a/iCubNottingham01/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
+++ b/iCubNottingham01/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
@@ -34,7 +34,8 @@
     
     <group name="POS_PID_DEFAULT">
         <param name="controlLaw">    Pid_inPos_outPwm </param>
-        <param name="controlUnits">  metric_units                     </param>
+        <param name="fbkControlUnits">  metric_units   </param>
+        <param name="outputControlUnits">  machine_units      </param>
         <param name="pos_kp">        -2105.00     -2310.00         </param>       
         <param name="pos_kd">            0.00         0.00         </param>       
         <param name="pos_ki">           -0.09        -0.09         </param>          
@@ -54,7 +55,8 @@
     
     <group name="TRQ_PID_DEFAULT">
         <param name="controlLaw">    Pid_inTrq_outPwm           </param>
-        <param name="controlUnits">  metric_units               </param>
+        <param name="fbkControlUnits">  metric_units   </param>
+        <param name="outputControlUnits">  machine_units      </param>
         <param name="trq_kp">         -200        -200              </param>       
         <param name="trq_kd">            0           0              </param>       
         <param name="trq_ki">            0           0              </param>     
@@ -63,16 +65,17 @@
         <param name="trq_shift">         0           0              </param>       
         <param name="trq_ko">            0           0              </param>       
         <param name="trq_stictionUp">   -1.4        -1.5	        </param>       
-        <param name="trq_stictionDwn">   2.4         1.6            </param>       
+        <param name="stictionDwn">0 0</param>       
         <param name="trq_kff">           1           1              </param>      
-        <param name="trq_kbemf">         0           0              </param>  
+        <param name="kbemf">0 0</param>  
         <param name="trq_filterType">    0           0              </param>  
-        <param name="trq_ktau">       -231        -180              </param>        
+        <param name="ktau">0 0</param>        
     </group>
 	
     <group name="2FOC_CUR_CONTROL">
         <param name="controlLaw">       limitscurrent           </param>
-        <param name="controlUnits">     metric_units            </param>
+        <param name="fbkControlUnits">  metric_units   </param>
+        <param name="outputControlUnits">  machine_units      </param>
         <param name="cur_kp">               8           8           </param>
         <param name="cur_kd">               0           0           </param>
         <param name="cur_ki">               2           2           </param>

--- a/iCubNottingham01/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
+++ b/iCubNottingham01/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
@@ -27,7 +27,8 @@
 
     <group name="CONTROLS">
        <param name="positionControl">           POS_PID_DEFAULT           POS_PID_DEFAULT           </param>
-       <param name="velocityControl">           none                   none                   </param>
+       <param name="velocityControl"> POS_PID_DEFAULT POS_PID_DEFAULT</param>
+       <param name="mixedControl"> POS_PID_DEFAULT POS_PID_DEFAULT</param>
        <param name="torqueControl">             TRQ_PID_DEFAULT  TRQ_PID_DEFAULT  </param>
        <param name="currentPid">                2FOC_CUR_CONTROL          2FOC_CUR_CONTROL          </param>
     </group>
@@ -36,16 +37,16 @@
         <param name="controlLaw">    Pid_inPos_outPwm </param>
         <param name="fbkControlUnits">  metric_units   </param>
         <param name="outputControlUnits">  machine_units      </param>
-        <param name="pos_kp">        -2105.00     -2310.00         </param>       
-        <param name="pos_kd">            0.00         0.00         </param>       
-        <param name="pos_ki">           -0.09        -0.09         </param>          
-        <param name="pos_maxOutput">     8000         8000         </param>      
-        <param name="pos_maxInt">         750          750         </param>       
-        <param name="pos_shift">            0            0         </param>       
-        <param name="pos_ko">               0            0         </param>       
-        <param name="pos_stictionUp">       0            0         </param>       
-        <param name="pos_stictionDwn">      0            0         </param>       
-        <param name="pos_kff">              0            0         </param>     
+        <param name="kp">        -2105.00     -2310.00         </param>       
+        <param name="kd">            0.00         0.00         </param>       
+        <param name="ki">           -0.09        -0.09         </param>          
+        <param name="maxOutput">     8000         8000         </param>      
+        <param name="maxInt">         750          750         </param>       
+        <param name="shift">            0            0         </param>       
+        <param name="ko">               0            0         </param>       
+        <param name="stictionUp">       0            0         </param>       
+        <param name="stictionDown">      0            0         </param>       
+        <param name="kff">              0            0         </param>     
     </group>
 
     <group name="IMPEDANCE">
@@ -57,35 +58,48 @@
         <param name="controlLaw">    Pid_inTrq_outPwm           </param>
         <param name="fbkControlUnits">  metric_units   </param>
         <param name="outputControlUnits">  machine_units      </param>
-        <param name="trq_kp">         -200        -200              </param>       
-        <param name="trq_kd">            0           0              </param>       
-        <param name="trq_ki">            0           0              </param>     
-        <param name="trq_maxOutput">  8000        8000              </param>       
-        <param name="trq_maxInt">      500         500              </param>       
-        <param name="trq_shift">         0           0              </param>       
-        <param name="trq_ko">            0           0              </param>       
-        <param name="trq_stictionUp">   -1.4        -1.5	        </param>       
+        <param name="kp">         -200        -200              </param>       
+        <param name="kd">            0           0              </param>       
+        <param name="ki">            0           0              </param>     
+        <param name="maxOutput">  8000        8000              </param>       
+        <param name="maxInt">      500         500              </param>       
+        <param name="shift">         0           0              </param>       
+        <param name="ko">            0           0              </param>       
+        <param name="stictionUp">   -1.4        -1.5	        </param>       
         <param name="stictionDwn">0 0</param>       
-        <param name="trq_kff">           1           1              </param>      
+        <param name="kff">           1           1              </param>      
         <param name="kbemf">0 0</param>  
-        <param name="trq_filterType">    0           0              </param>  
+        <param name="filterType">    0           0              </param>  
         <param name="ktau">0 0</param>        
     </group>
 	
     <group name="2FOC_CUR_CONTROL">
         <param name="controlLaw">       limitscurrent           </param>
-        <param name="fbkControlUnits">  metric_units   </param>
+        <param name="fbkControlUnits">  machine_units   </param>
         <param name="outputControlUnits">  machine_units      </param>
-        <param name="cur_kp">               8           8           </param>
-        <param name="cur_kd">               0           0           </param>
-        <param name="cur_ki">               2           2           </param>
-        <param name="cur_shift">            10          10          </param>
-        <param name="cur_maxOutput">        32000       32000       </param>
-        <param name="cur_maxInt">           32000       32000       </param>
-        <param name="cur_ko">               0            0          </param>
-        <param name="cur_stictionUp">       0            0          </param>
-        <param name="cur_stictionDwn">      0            0          </param>
-        <param name="cur_kff">              0            0          </param>
+        <param name="kp">               8           8           </param>
+        <param name="kd">               0           0           </param>
+        <param name="ki">               2           2           </param>
+        <param name="shift">            10          10          </param>
+        <param name="maxOutput">        32000       32000       </param>
+        <param name="maxInt">           32000       32000       </param>
+        <param name="ko">               0            0          </param>
+        <param name="stictionUp">       0            0          </param>
+        <param name="stictionDown">      0            0          </param>
+        <param name="kff">              0            0          </param>
+    </group>
+	
+	<group name="2FOC_VEL_CONTROL">
+        <param name="controlLaw">           low_lev_speed       </param>
+        <param name="fbkControlUnits">      machine_units       </param>
+        <param name="outputControlUnits">   machine_units       </param>
+        <param name="kff">                  0           0           0           0       </param>
+        <param name="kp">                   12          12          12          12      </param>
+        <param name="kd">                   0           0           0           0       </param>
+        <param name="ki">                   16          16          16          16      </param>
+        <param name="shift">                10          10          10          10      </param>
+        <param name="maxOutput">            32000       32000       32000       32000   </param>
+        <param name="maxInt">               32000       32000       32000       32000   </param>
     </group>
     
     

--- a/iCubNottingham01/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
+++ b/iCubNottingham01/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
@@ -67,7 +67,7 @@
         <param name="outputType">          pwm                      </param>
         <param name="fbkControlUnits">     metric_units             </param>
         <param name="outputControlUnits">  machine_units            </param>
-        <param name="kp">          -150        -150             </param>
+        <param name="kp">          -200        -200             </param>
         <param name="kd">              0          0             </param>
         <param name="ki">              0          0             </param>
         <param name="maxOutput">    8000        8000            </param>
@@ -98,13 +98,13 @@
         <param name="controlLaw">           low_lev_speed       </param>
         <param name="fbkControlUnits">      machine_units       </param>
         <param name="outputControlUnits">   machine_units       </param>
-        <param name="kff">                  0           0           0           0       </param>
-        <param name="kp">                   12          12          12          12      </param>
-        <param name="kd">                   0           0           0           0       </param>
-        <param name="ki">                   16          16          16          16      </param>
-        <param name="shift">                10          10          10          10      </param>
-        <param name="maxOutput">            32000       32000       32000       32000   </param>
-        <param name="maxInt">               32000       32000       32000       32000   </param>
+        <param name="kff">                  0           0       </param>
+        <param name="kp">                   12          12      </param>
+        <param name="kd">                   0           0       </param>
+        <param name="ki">                   16          16      </param>
+        <param name="shift">                10          10      </param>
+        <param name="maxOutput">            32000       32000   </param>
+        <param name="maxInt">               32000       32000   </param>
     </group>
 
     <!-- other default PIDs: end -->

--- a/iCubNottingham01/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
+++ b/iCubNottingham01/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
@@ -1,95 +1,100 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
- <!-- Initialization file for EMS 9 - Right Lower Leg, 2 dof -->
 
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb9-j4_5-mc" type="embObjMotionControl">
+      
+    <xi:include href="../../general.xml" />
+    <xi:include href="../../hardware/electronics/right_leg-eb9-j4_5-eln.xml" />
+    <xi:include href="../../hardware/mechanicals/right_leg-eb9-j4_5-mec.xml" />
+    <xi:include href="./right_leg-eb9-j4_5-mc_service.xml" />
 
-  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb9-j4_5-mc" type="embObjMotionControl">
-      <xi:include href="../../general.xml" />
-      <xi:include href="../../hardware/electronics/right_leg-eb9-j4_5-eln.xml" />
-      <xi:include href="../../hardware/mechanicals/right_leg-eb9-j4_5-mec.xml" />
-      <xi:include href="./right_leg-eb9-j4_5-mc_service.xml" />
-    
+    <!-- joint number                           0               1           -->
+    <!-- joint name -->          
     <group name="LIMITS">
-        <param name="jntPosMax">                      30            20     </param>
-        <param name="jntPosMin">                     -30           -20     </param>
-        <param name="motorNominalCurrents">         5000          5000     </param>
-        <param name="motorPeakCurrents">           10000         10000     </param>
-        <param name="motorOverloadCurrents">       15000         15000     </param>
-        <param name="jntVelMax">                    1000          1000     </param>
-        <param name="motorPwmLimit">               10000         10000     </param>    
+        <param name="jntPosMax">                30              20          </param>
+        <param name="jntPosMin">                -30             -20         </param>
+        <param name="motorNominalCurrents">     5000            5000        </param>
+        <param name="motorPeakCurrents">        10000           10000       </param>
+        <param name="motorOverloadCurrents">    15000           15000       </param>
+        <param name="jntVelMax">                1000            1000        </param>
+        <param name="motorPwmLimit">            10000           10000       </param>
     </group>
-    
+
     <group name="TIMEOUTS">
-        <param name="velocity">                 100           100        </param>
-    </group>
-
-
-    <group name="CONTROLS">
-       <param name="positionControl">           POS_PID_DEFAULT           POS_PID_DEFAULT           </param>
-       <param name="velocityControl"> POS_PID_DEFAULT POS_PID_DEFAULT</param>
-       <param name="mixedControl"> POS_PID_DEFAULT POS_PID_DEFAULT</param>
-       <param name="torqueControl">             TRQ_PID_DEFAULT  TRQ_PID_DEFAULT  </param>
-       <param name="currentPid">                2FOC_CUR_CONTROL          2FOC_CUR_CONTROL          </param>
-    </group>
-    
-    <group name="POS_PID_DEFAULT">
-        <param name="controlLaw">    Pid_inPos_outPwm </param>
-        <param name="fbkControlUnits">  metric_units   </param>
-        <param name="outputControlUnits">  machine_units      </param>
-        <param name="kp">        -2105.00     -2310.00         </param>       
-        <param name="kd">            0.00         0.00         </param>       
-        <param name="ki">           -0.09        -0.09         </param>          
-        <param name="maxOutput">     8000         8000         </param>      
-        <param name="maxInt">         750          750         </param>       
-        <param name="shift">            0            0         </param>       
-        <param name="ko">               0            0         </param>       
-        <param name="stictionUp">       0            0         </param>       
-        <param name="stictionDown">      0            0         </param>       
-        <param name="kff">              0            0         </param>     
+        <param name="velocity">                 100             100         </param>
     </group>
 
     <group name="IMPEDANCE">
-        <param name="stiffness">       0      0     </param>    
-        <param name="damping">         0      0     </param>    
+        <param name="stiffness">                0               0           </param>
+        <param name="damping">                  0               0           </param>
     </group>
     
+    <group name="CONTROLS">
+       <param name="positionControl">           POS_PID_DEFAULT         POS_PID_DEFAULT         </param>
+       <param name="velocityControl">           POS_PID_DEFAULT         POS_PID_DEFAULT         </param>
+       <param name="mixedControl">              POS_PID_DEFAULT         POS_PID_DEFAULT         </param>
+       <param name="torqueControl">             TRQ_PID_DEFAULT         TRQ_PID_DEFAULT         </param>
+       <param name="currentPid">                2FOC_CUR_CONTROL        2FOC_CUR_CONTROL        </param>
+       <param name="speedPid">                  2FOC_VEL_CONTROL        2FOC_VEL_CONTROL        </param>
+    </group>
+
+
+    <!-- default position PID: begin -->
+
+    <group name="POS_PID_DEFAULT">
+        <param name="controlLaw">             minjerk                   </param>
+        <param name="outputType">             pwm                       </param>
+        <param name="fbkControlUnits">        metric_units              </param> 
+        <param name="outputControlUnits">     machine_units             </param>
+        <param name="kp">           -2105.00     -2310.00           </param>
+        <param name="kd">               0.00         0.00           </param>
+        <param name="ki">            -0.09        -0.09             </param>
+        <param name="maxOutput">     8000         8000              </param>
+        <param name="maxInt">         750          750              </param>
+        <param name="stictionUp">       0            0              </param>
+        <param name="stictionDown">     0            0              </param>
+        <param name="kff">              0            0              </param>
+    </group>
+
+    <!-- default position PID: end -->
+
+
+    <!-- other default PIDs: begin -->     
+    
     <group name="TRQ_PID_DEFAULT">
-        <param name="controlLaw">    Pid_inTrq_outPwm           </param>
-        <param name="fbkControlUnits">  metric_units   </param>
-        <param name="outputControlUnits">  machine_units      </param>
-        <param name="kp">         -200        -200              </param>       
-        <param name="kd">            0           0              </param>       
-        <param name="ki">            0           0              </param>     
-        <param name="maxOutput">  8000        8000              </param>       
-        <param name="maxInt">      500         500              </param>       
-        <param name="shift">         0           0              </param>       
-        <param name="ko">            0           0              </param>       
-        <param name="stictionUp">   -1.4        -1.5	        </param>       
-        <param name="stictionDwn">0 0</param>       
-        <param name="kff">           1           1              </param>      
-        <param name="kbemf">0 0</param>  
-        <param name="filterType">    0           0              </param>  
-        <param name="ktau">0 0</param>        
+        <param name="controlLaw">          torque                   </param>
+        <param name="outputType">          pwm                      </param>
+        <param name="fbkControlUnits">     metric_units             </param>
+        <param name="outputControlUnits">  machine_units            </param>
+        <param name="kp">          -150        -150             </param>
+        <param name="kd">              0          0             </param>
+        <param name="ki">              0          0             </param>
+        <param name="maxOutput">    8000        8000            </param>
+        <param name="maxInt">       500         500             </param>
+        <param name="ko">              0          0             </param>
+        <param name="stictionUp">      0          0             </param>
+        <param name="stictionDown">    0          0             </param>
+        <param name="kff">             1          1             </param>
+        <param name="kbemf">           0          0             </param>
+        <param name="filterType">      0          0             </param>
+        <param name="ktau">         0           0               </param>
     </group>
-	
+
     <group name="2FOC_CUR_CONTROL">
-        <param name="controlLaw">       limitscurrent           </param>
-        <param name="fbkControlUnits">  machine_units   </param>
-        <param name="outputControlUnits">  machine_units      </param>
-        <param name="kp">               8           8           </param>
-        <param name="kd">               0           0           </param>
-        <param name="ki">               2           2           </param>
-        <param name="shift">            10          10          </param>
-        <param name="maxOutput">        32000       32000       </param>
-        <param name="maxInt">           32000       32000       </param>
-        <param name="ko">               0            0          </param>
-        <param name="stictionUp">       0            0          </param>
-        <param name="stictionDown">      0            0          </param>
-        <param name="kff">              0            0          </param>
+        <param name="controlLaw">           low_lev_current     </param>
+        <param name="fbkControlUnits">      machine_units       </param>
+        <param name="outputControlUnits">   machine_units       </param>
+        <param name="kp">                   8           8       </param>
+        <param name="kd">                   0           0       </param>
+        <param name="ki">                   2           2       </param>
+        <param name="shift">                10          10      </param>
+        <param name="maxOutput">            32000       32000   </param>
+        <param name="maxInt">               32000       32000   </param>
+        <param name="kff">                  0           0       </param>
     </group>
-	
-	<group name="2FOC_VEL_CONTROL">
+
+    <group name="2FOC_VEL_CONTROL">
         <param name="controlLaw">           low_lev_speed       </param>
         <param name="fbkControlUnits">      machine_units       </param>
         <param name="outputControlUnits">   machine_units       </param>
@@ -101,7 +106,13 @@
         <param name="maxOutput">            32000       32000       32000       32000   </param>
         <param name="maxInt">               32000       32000       32000       32000   </param>
     </group>
+
+    <!-- other default PIDs: end -->
+
+
+    <!-- custom PIDs: begin -->  
+    <!-- custom PIDs: end -->
     
-    
-  </device>
+</device>
+
 

--- a/iCubNottingham01/hardware/motorControl/right_leg-eb9-j4_5-mc_service.xml
+++ b/iCubNottingham01/hardware/motorControl/right_leg-eb9-j4_5-mc_service.xml
@@ -20,9 +20,9 @@
                     <param name="minor">            6           </param>     
                 </group>                    
                 <group name="FIRMWARE">
-                    <param name="major">            0           </param>    
-                    <param name="minor">            0           </param> 
-                    <param name="build">            0           </param>
+                    <param name="major">            3                       </param>    
+                    <param name="minor">            3                       </param> 
+                    <param name="build">            3                       </param>
                 </group>
             </group>
 

--- a/iCubNottingham01/hardware/motorControl/right_leg-eb9-j4_5-mc_service.xml
+++ b/iCubNottingham01/hardware/motorControl/right_leg-eb9-j4_5-mc_service.xml
@@ -20,9 +20,9 @@
                     <param name="minor">            6           </param>     
                 </group>                    
                 <group name="FIRMWARE">
-                    <param name="major">            3                       </param>    
-                    <param name="minor">            3                       </param> 
-                    <param name="build">            3                       </param>
+                    <param name="major">            0                       </param>    
+                    <param name="minor">            0                       </param> 
+                    <param name="build">            0                       </param>
                 </group>
             </group>
 

--- a/iCubNottingham01/hardware/motorControl/right_leg-eb9-j4_5-mc_service.xml
+++ b/iCubNottingham01/hardware/motorControl/right_leg-eb9-j4_5-mc_service.xml
@@ -20,9 +20,9 @@
                     <param name="minor">            6           </param>     
                 </group>                    
                 <group name="FIRMWARE">
-                    <param name="major">            0                       </param>    
-                    <param name="minor">            0                       </param> 
-                    <param name="build">            0                       </param>
+                    <param name="major">            3                       </param>    
+                    <param name="minor">            3                       </param> 
+                    <param name="build">            3                       </param>
                 </group>
             </group>
 

--- a/iCubNottingham01/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubNottingham01/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -34,7 +34,8 @@
 
     <group name="POS_PID_DEFAULT">
         <param name="controlLaw">    Pid_inPos_outPwm                          </param>
-        <param name="controlUnits">  metric_units               </param> 
+        <param name="fbkControlUnits">  metric_units   </param>
+        <param name="outputControlUnits">  machine_units      </param> 
         <param name="pos_kp">            711.11    -1066.66    -1066.66 </param>       
         <param name="pos_kd">              0.00        0.00        0.00 </param>       
         <param name="pos_ki">           7111.09   -10666.64   -10666.64 </param>            
@@ -49,7 +50,8 @@
     
      <group name="TRQ_PID_DEFAULT">
         <param name="controlLaw">    Pid_inTrq_outPwm           </param>
-        <param name="controlUnits">  metric_units               </param>  
+        <param name="fbkControlUnits">  metric_units   </param>
+        <param name="outputControlUnits">  machine_units      </param>  
         <param name="trq_kp">            450       -400       -400  </param>       
         <param name="trq_kd">              0          0          0  </param>       
         <param name="trq_ki">              0          0          0  </param>    
@@ -57,12 +59,12 @@
         <param name="trq_maxInt">        500        500        500  </param>       
         <param name="trq_shift">           0          0          0  </param>       
         <param name="trq_ko">              0          0          0  </param>       
-        <param name="trq_stictionUp">      2          2          2  </param>       
-        <param name="trq_stictionDwn">    -2         -2         -2  </param>       
+        <param name="stictionUp">0 0 0</param>       
+        <param name="stictionDwn">0 0 0</param>       
         <param name="trq_kff">             1          1          1  </param>   
-        <param name="trq_kbemf">          -0.0016    -0.003     -0.003  </param>    
+        <param name="kbemf">0 0 0</param>    
         <param name="trq_filterType">      0          0          0  </param>           
-        <param name="trq_ktau">          200       -200       -200  </param>  
+        <param name="ktau">0 0 0</param>  
     </group>    
     
     <group name="IMPEDANCE">
@@ -72,7 +74,8 @@
     
     <group name="2FOC_CUR_CONTROL">
         <param name="controlLaw">       limitscurrent          </param>
-        <param name="controlUnits">     metric_units           </param>
+        <param name="fbkControlUnits">  metric_units   </param>
+        <param name="outputControlUnits">  machine_units      </param>
         <param name="cur_kp">               8           8          8         </param>       
         <param name="cur_kd">               0           0          0         </param>       
         <param name="cur_ki">               2           2          2         </param>

--- a/iCubNottingham01/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubNottingham01/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -27,7 +27,8 @@
 
     <group name="CONTROLS">
        <param name="positionControl">  POS_PID_DEFAULT           POS_PID_DEFAULT          POS_PID_DEFAULT           </param>
-       <param name="velocityControl">  none                   none                  none                   </param>
+       <param name="velocityControl"> POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT</param>
+       <param name="mixedControl"> POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT</param>
        <param name="torqueControl">    TRQ_PID_DEFAULT  TRQ_PID_DEFAULT TRQ_PID_DEFAULT  </param>
        <param name="currentPid">       2FOC_CUR_CONTROL          2FOC_CUR_CONTROL         2FOC_CUR_CONTROL          </param>
     </group>
@@ -36,34 +37,34 @@
         <param name="controlLaw">    Pid_inPos_outPwm                          </param>
         <param name="fbkControlUnits">  metric_units   </param>
         <param name="outputControlUnits">  machine_units      </param> 
-        <param name="pos_kp">            711.11    -1066.66    -1066.66 </param>       
-        <param name="pos_kd">              0.00        0.00        0.00 </param>       
-        <param name="pos_ki">           7111.09   -10666.64   -10666.64 </param>            
-        <param name="pos_maxOutput">       8000        8000       16000 </param>  
-        <param name="pos_maxInt">           750        1000        1000 </param>       
-        <param name="pos_shift">              0           0           0 </param>       
-        <param name="pos_ko">                 0           0           0 </param>       
-        <param name="pos_stictionUp">         0           0           0 </param>       
-        <param name="pos_stictionDwn">        0           0           0 </param>       
-        <param name="pos_kff">                0           0           0 </param>     
+        <param name="kp">            711.11    -1066.66    -1066.66 </param>       
+        <param name="kd">              0.00        0.00        0.00 </param>       
+        <param name="ki">           7111.09   -10666.64   -10666.64 </param>            
+        <param name="maxOutput">       8000        8000       16000 </param>  
+        <param name="maxInt">           750        1000        1000 </param>       
+        <param name="shift">              0           0           0 </param>       
+        <param name="ko">                 0           0           0 </param>       
+        <param name="stictionUp">         0           0           0 </param>       
+        <param name="stictionDown">        0           0           0 </param>       
+        <param name="kff">                0           0           0 </param>     
     </group>
     
      <group name="TRQ_PID_DEFAULT">
         <param name="controlLaw">    Pid_inTrq_outPwm           </param>
         <param name="fbkControlUnits">  metric_units   </param>
         <param name="outputControlUnits">  machine_units      </param>  
-        <param name="trq_kp">            450       -400       -400  </param>       
-        <param name="trq_kd">              0          0          0  </param>       
-        <param name="trq_ki">              0          0          0  </param>    
-        <param name="trq_maxOutput">    8000       8000       8000  </param>       
-        <param name="trq_maxInt">        500        500        500  </param>       
-        <param name="trq_shift">           0          0          0  </param>       
-        <param name="trq_ko">              0          0          0  </param>       
+        <param name="kp">            450       -400       -400  </param>       
+        <param name="kd">              0          0          0  </param>       
+        <param name="ki">              0          0          0  </param>    
+        <param name="maxOutput">    8000       8000       8000  </param>       
+        <param name="maxInt">        500        500        500  </param>       
+        <param name="shift">           0          0          0  </param>       
+        <param name="ko">              0          0          0  </param>       
         <param name="stictionUp">0 0 0</param>       
         <param name="stictionDwn">0 0 0</param>       
-        <param name="trq_kff">             1          1          1  </param>   
+        <param name="kff">             1          1          1  </param>   
         <param name="kbemf">0 0 0</param>    
-        <param name="trq_filterType">      0          0          0  </param>           
+        <param name="filterType">      0          0          0  </param>           
         <param name="ktau">0 0 0</param>  
     </group>    
     
@@ -74,19 +75,32 @@
     
     <group name="2FOC_CUR_CONTROL">
         <param name="controlLaw">       limitscurrent          </param>
-        <param name="fbkControlUnits">  metric_units   </param>
+        <param name="fbkControlUnits">  machine_units   </param>
         <param name="outputControlUnits">  machine_units      </param>
-        <param name="cur_kp">               8           8          8         </param>       
-        <param name="cur_kd">               0           0          0         </param>       
-        <param name="cur_ki">               2           2          2         </param>
-        <param name="cur_shift">            10          10         10        </param>
-        <param name="cur_maxOutput">        32000       32000      32000     </param>                 
-        <param name="cur_maxInt">           32000       32000      32000     </param> 
-        <param name="cur_ko">               0            0          0        </param>
-        <param name="cur_stictionUp">       0            0          0        </param>
-        <param name="cur_stictionDwn">      0            0          0        </param>
-        <param name="cur_kff">              0            0          0        </param>        
+        <param name="kp">               8           8          8         </param>       
+        <param name="kd">               0           0          0         </param>       
+        <param name="ki">               2           2          2         </param>
+        <param name="shift">            10          10         10        </param>
+        <param name="maxOutput">        32000       32000      32000     </param>                 
+        <param name="maxInt">           32000       32000      32000     </param> 
+        <param name="ko">               0            0          0        </param>
+        <param name="stictionUp">       0            0          0        </param>
+        <param name="stictionDown">      0            0          0        </param>
+        <param name="kff">              0            0          0        </param>        
    </group>
+   
+   <group name="2FOC_VEL_CONTROL">
+        <param name="controlLaw">           low_lev_speed       </param>
+        <param name="fbkControlUnits">      machine_units       </param>
+        <param name="outputControlUnits">   machine_units       </param>
+        <param name="kff">                  0           0           0           </param>
+        <param name="kp">                   12          12          12          </param>
+        <param name="kd">                   0           0           0           </param>
+        <param name="ki">                   16          16          16          </param>
+        <param name="shift">                10          10          10          </param>
+        <param name="maxOutput">            32000       32000       32000       </param>
+        <param name="maxInt">               32000       32000       32000       </param>
+    </group>
     
   </device>
 

--- a/iCubNottingham01/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubNottingham01/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -1,106 +1,118 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
- <!-- Initialization file for EMS 5 - Torso, 3 dof -->
 
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="torso-eb5-j0_2-mc" type="embObjMotionControl">
 
-  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="torso-eb5-j0_2-mc" type="embObjMotionControl">
-      <xi:include href="../../general.xml" />
-      <xi:include href="../../hardware/electronics/torso-eb5-j0_2-eln.xml" />
-      <xi:include href="../../hardware/mechanicals/torso-eb5-j0_2-mec.xml" />
-      
-      <xi:include href="./torso-eb5-j0_2-mc_service.xml" />
-    
+    <xi:include href="../../general.xml" />
+    <xi:include href="../../hardware/electronics/torso-eb5-j0_2-eln.xml" />
+    <xi:include href="../../hardware/mechanicals/torso-eb5-j0_2-mec.xml" />
+    <xi:include href="./torso-eb5-j0_2-mc_service.xml" />
+
+    <!-- joint number                           0                   1                   2               -->
+    <!-- joint name -->          
     <group name="LIMITS">
-        <param name="jntPosMax">                      50            30            70        </param>
-        <param name="jntPosMin">                     -50           -30           -20        </param>
-        <param name="motorNominalCurrents">         4000          4000          4000        </param>
-        <param name="motorPeakCurrents">            5000          5000          5000        </param>
-        <param name="motorOverloadCurrents">       15000         15000         15000        </param>
-        <param name="jntVelMax">                    1000          1000          1000        </param>
-        <param name="motorPwmLimit">               10000         10000         10000        </param>   
+        <param name="jntPosMax">                50                  30                  70                  </param>
+        <param name="jntPosMin">                -50                 -30                 -20                 </param>
+        <param name="jntVelMax">                1000                1000                1000                </param>
+        <param name="motorNominalCurrents">     4000                4000                4000                </param>
+        <param name="motorPeakCurrents">        5000                5000                5000                </param>
+        <param name="motorOverloadCurrents">    15000               15000               15000               </param>
+        <param name="motorPwmLimit">            10000               10000               10000               </param>
     </group>
 
     <group name="TIMEOUTS">
-        <param name="velocity">                 100           100       100 </param>
+        <param name="velocity">                 100                 100                 100                 </param>
     </group>
 
-    <group name="CONTROLS">
-       <param name="positionControl">  POS_PID_DEFAULT           POS_PID_DEFAULT          POS_PID_DEFAULT           </param>
-       <param name="velocityControl"> POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT</param>
-       <param name="mixedControl"> POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT</param>
-       <param name="torqueControl">    TRQ_PID_DEFAULT  TRQ_PID_DEFAULT TRQ_PID_DEFAULT  </param>
-       <param name="currentPid">       2FOC_CUR_CONTROL          2FOC_CUR_CONTROL         2FOC_CUR_CONTROL          </param>
+    <group name="IMPEDANCE">
+        <param name="stiffness">                0                   0                   0                   </param>
+        <param name="damping">                  0                   0                   0                   </param>
     </group>
+    
+    <group name="CONTROLS">
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="torqueControl">            TRQ_PID_DEFAULT     TRQ_PID_DEFAULT     TRQ_PID_DEFAULT     </param>
+        <param name="currentPid">               2FOC_CUR_CONTROL    2FOC_CUR_CONTROL    2FOC_CUR_CONTROL    </param>
+        <param name="speedPid">                 2FOC_VEL_CONTROL    2FOC_VEL_CONTROL    2FOC_VEL_CONTROL    </param>
+    </group>
+
+
+    <!-- default position PID: begin -->
 
     <group name="POS_PID_DEFAULT">
-        <param name="controlLaw">    Pid_inPos_outPwm                          </param>
-        <param name="fbkControlUnits">  metric_units   </param>
-        <param name="outputControlUnits">  machine_units      </param> 
-        <param name="kp">            711.11    -1066.66    -1066.66 </param>       
-        <param name="kd">              0.00        0.00        0.00 </param>       
-        <param name="ki">           7111.09   -10666.64   -10666.64 </param>            
-        <param name="maxOutput">       8000        8000       16000 </param>  
-        <param name="maxInt">           750        1000        1000 </param>       
-        <param name="shift">              0           0           0 </param>       
-        <param name="ko">                 0           0           0 </param>       
-        <param name="stictionUp">         0           0           0 </param>       
-        <param name="stictionDown">        0           0           0 </param>       
-        <param name="kff">                0           0           0 </param>     
+        <param name="controlLaw">             minjerk               </param>
+        <param name="outputType">             pwm                   </param>
+        <param name="fbkControlUnits">        metric_units          </param>
+        <param name="outputControlUnits">     machine_units         </param>
+        <param name="kp">           711.11     -1066.66    -1066.66    </param>
+        <param name="kd">           0.00        0.00        0.00        </param>
+        <param name="ki">           -7111.09    -10666.64   -10666.64   </param>
+        <param name="maxOutput">    8000        8000        16000       </param>
+        <param name="maxInt">       750         1000        1000        </param>
+        <param name="stictionUp">   0           0           0           </param>
+        <param name="stictionDown"> 0           0           0           </param>
+        <param name="kff">          0           0           0           </param>
     </group>
+
+    <!-- default position PID: end -->
+
+
+    <!-- other default PIDs: begin -->  
     
-     <group name="TRQ_PID_DEFAULT">
-        <param name="controlLaw">    Pid_inTrq_outPwm           </param>
-        <param name="fbkControlUnits">  metric_units   </param>
-        <param name="outputControlUnits">  machine_units      </param>  
-        <param name="kp">            450       -400       -400  </param>       
-        <param name="kd">              0          0          0  </param>       
-        <param name="ki">              0          0          0  </param>    
-        <param name="maxOutput">    8000       8000       8000  </param>       
-        <param name="maxInt">        500        500        500  </param>       
-        <param name="shift">           0          0          0  </param>       
-        <param name="ko">              0          0          0  </param>       
-        <param name="stictionUp">0 0 0</param>       
-        <param name="stictionDwn">0 0 0</param>       
-        <param name="kff">             1          1          1  </param>   
-        <param name="kbemf">0 0 0</param>    
-        <param name="filterType">      0          0          0  </param>           
-        <param name="ktau">0 0 0</param>  
-    </group>    
-    
-    <group name="IMPEDANCE">
-        <param name="stiffness">       0      0      0     </param>    
-        <param name="damping">         0      0      0     </param>    
-    </group>    
-    
+    <group name="TRQ_PID_DEFAULT">
+        <param name="controlLaw">          torque                       </param>
+        <param name="outputType">          pwm                          </param>
+        <param name="fbkControlUnits">     metric_units                 </param>
+        <param name="outputControlUnits">  machine_units                </param>
+        <param name="kp">            -450       -400       -400 </param>
+        <param name="kd">              0          0          0  </param>
+        <param name="ki">              0          0          0  </param>
+        <param name="maxOutput">    8000       8000       8000  </param>
+        <param name="maxInt">        500        500        500  </param>
+        <param name="ko">              0          0          0  </param>
+        <param name="stictionUp">      0          0          0  </param>
+        <param name="stictionDown">    0          0          0  </param>
+        <param name="kff">             1          1          1  </param>
+        <param name="kbemf">           0          0          0  </param>
+        <param name="filterType">      0          0          0  </param>
+        <param name="ktau">            0          0          0  </param>
+    </group>
+
     <group name="2FOC_CUR_CONTROL">
-        <param name="controlLaw">       limitscurrent          </param>
-        <param name="fbkControlUnits">  machine_units   </param>
-        <param name="outputControlUnits">  machine_units      </param>
-        <param name="kp">               8           8          8         </param>       
-        <param name="kd">               0           0          0         </param>       
-        <param name="ki">               2           2          2         </param>
-        <param name="shift">            10          10         10        </param>
-        <param name="maxOutput">        32000       32000      32000     </param>                 
-        <param name="maxInt">           32000       32000      32000     </param> 
-        <param name="ko">               0            0          0        </param>
-        <param name="stictionUp">       0            0          0        </param>
-        <param name="stictionDown">      0            0          0        </param>
-        <param name="kff">              0            0          0        </param>        
-   </group>
-   
-   <group name="2FOC_VEL_CONTROL">
+        <param name="controlLaw">           low_lev_current     </param>
+        <param name="fbkControlUnits">      machine_units       </param>
+        <param name="outputControlUnits">   machine_units       </param>
+        <param name="kp">                   8           8           8       </param>
+        <param name="kd">                   0           0           0       </param>
+        <param name="ki">                   2           2           2       </param>
+        <param name="shift">                10          10          10      </param>
+        <param name="maxOutput">            32000       32000       32000   </param>
+        <param name="maxInt">               32000       32000       32000   </param>
+        <param name="kff">                  0            0          0       </param>
+    </group>
+
+    <group name="2FOC_VEL_CONTROL">
         <param name="controlLaw">           low_lev_speed       </param>
         <param name="fbkControlUnits">      machine_units       </param>
         <param name="outputControlUnits">   machine_units       </param>
-        <param name="kff">                  0           0           0           </param>
-        <param name="kp">                   12          12          12          </param>
-        <param name="kd">                   0           0           0           </param>
-        <param name="ki">                   16          16          16          </param>
-        <param name="shift">                10          10          10          </param>
-        <param name="maxOutput">            32000       32000       32000       </param>
-        <param name="maxInt">               32000       32000       32000       </param>
+        <param name="kff">                  0           0           0       </param>
+        <param name="kp">                   12          12          12      </param>
+        <param name="kd">                   0           0           0       </param>
+        <param name="ki">                   16          16          16      </param>
+        <param name="shift">                10          10          10      </param>
+        <param name="maxOutput">            32000       32000       32000   </param>
+        <param name="maxInt">               32000       32000       32000   </param>
     </group>
+
+    <!-- other default PIDs: end -->
+ 
+ 
+    <!-- custom PIDs: begin -->
+    <!-- custom PIDs: end -->
     
-  </device>
+</device>
+
 

--- a/iCubNottingham01/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubNottingham01/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -49,7 +49,7 @@
         <param name="outputControlUnits">     machine_units         </param>
         <param name="kp">           711.11     -1066.66    -1066.66    </param>
         <param name="kd">           0.00        0.00        0.00        </param>
-        <param name="ki">           -7111.09    -10666.64   -10666.64   </param>
+        <param name="ki">           7111.09    -10666.64   -10666.64   </param>
         <param name="maxOutput">    8000        8000        16000       </param>
         <param name="maxInt">       750         1000        1000        </param>
         <param name="stictionUp">   0           0           0           </param>
@@ -67,7 +67,7 @@
         <param name="outputType">          pwm                          </param>
         <param name="fbkControlUnits">     metric_units                 </param>
         <param name="outputControlUnits">  machine_units                </param>
-        <param name="kp">            -450       -400       -400 </param>
+        <param name="kp">            450       -400       -400  </param>
         <param name="kd">              0          0          0  </param>
         <param name="ki">              0          0          0  </param>
         <param name="maxOutput">    8000       8000       8000  </param>

--- a/iCubNottingham01/hardware/motorControl/torso-eb5-j0_2-mc_service.xml
+++ b/iCubNottingham01/hardware/motorControl/torso-eb5-j0_2-mc_service.xml
@@ -20,9 +20,9 @@
                     <param name="minor">            6           </param>     
                 </group>                    
                 <group name="FIRMWARE">
-                    <param name="major">            0           </param>    
-                    <param name="minor">            0           </param> 
-                    <param name="build">            0           </param>
+                    <param name="major">            3                       </param>    
+                    <param name="minor">            3                       </param> 
+                    <param name="build">            3                       </param>
                 </group>
             </group>
 

--- a/iCubNottingham01/hardware/motorControl/torso-eb5-j0_2-mc_service.xml
+++ b/iCubNottingham01/hardware/motorControl/torso-eb5-j0_2-mc_service.xml
@@ -20,9 +20,9 @@
                     <param name="minor">            6           </param>     
                 </group>                    
                 <group name="FIRMWARE">
-                    <param name="major">            3                       </param>    
-                    <param name="minor">            3                       </param> 
-                    <param name="build">            3                       </param>
+                    <param name="major">            0                       </param>    
+                    <param name="minor">            0                       </param> 
+                    <param name="build">            0                       </param>
                 </group>
             </group>
 

--- a/iCubNottingham01/hardware/motorControl/torso-eb5-j0_2-mc_service.xml
+++ b/iCubNottingham01/hardware/motorControl/torso-eb5-j0_2-mc_service.xml
@@ -20,9 +20,9 @@
                     <param name="minor">            6           </param>     
                 </group>                    
                 <group name="FIRMWARE">
-                    <param name="major">            0                       </param>    
-                    <param name="minor">            0                       </param> 
-                    <param name="build">            0                       </param>
+                    <param name="major">            3                       </param>    
+                    <param name="minor">            3                       </param> 
+                    <param name="build">            3                       </param>
                 </group>
             </group>
 


### PR DESCRIPTION
PR for Nottignham01 robots
- propagated to MotorControlVersion 6 (was MCV 4)
- fixed a few mistakes

ready for PR