### PR TITLE
Streamline CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,13 +5,7 @@ on:
     branches:
     - 'master'
     - 'devel'
-    - 'feat/**'
-    - 'fix/**'
   pull_request:
-  schedule:
-  # * is a special character in YAML so you have to quote this string
-  # Execute a "nightly" build at 2 AM UTC 
-  - cron:  '0 2 * * *'
     
 jobs:
   build:
@@ -20,90 +14,26 @@ jobs:
     strategy:
       matrix:
         build_type: [Release]
-        os: [windows-latest, ubuntu-latest, macOS-latest]
+        os: [ubuntu-latest]
 
     steps:
     - uses: actions/checkout@master
         
-    - name: Set up environment variables [Windows]
-      if: matrix.os == 'windows-latest'
-      shell: bash
-      run: |
-        # the following fix the problem described in https://github.community/t5/GitHub-Actions/Windows-tests-worked-yesterday-broken-today/m-p/43839#M5530
-        echo "::add-path::C:\Program Files\Git\bin"
-        echo "::set-env name=VCPKG_ROBOTOLOGY_ROOT::D:/vcpkg-robotology"
-        echo "::set-env name=VCPKG_ROBOTOLOGY_BIN_PORTS_ROOT::D:/vcpkg-robotology-binary-ports"
-        
-    - name: Display environment variables
-      shell: bash
-      run: env
-
     # Remove apt repos that are known to break from time to time
     # See https://github.com/actions/virtual-environments/issues/323
-    - name: Remove broken apt repos [Ubuntu]
-      if: matrix.os == 'ubuntu-latest'
+    - name: Remove broken apt repos
       run: |
         for apt_file in `grep -lr microsoft /etc/apt/sources.list.d/`; do sudo rm $apt_file; done
 
     # ============
     # DEPENDENCIES
     # ============
-    - name: Dependencies [Windows]
-      if: matrix.os == 'windows-latest'
-      shell: bash
-      run: |
-        # To avoid spending a huge time compiling vcpkg dependencies, we download a root that comes precompiled with all the ports that we need
-        choco install -y wget unzip
-        # To avoid problems with non-relocatable packages, we unzip the archive exactly in the same C:/vcpkg-robotology
-        # that has been used to create the pre-compiled archive
-        cd D:/
-        wget https://github.com/robotology-playground/robotology-superbuild-dependencies/releases/download/v0.0.2/vcpkg-robotology.zip
-        unzip vcpkg-robotology.zip
-
-    - name: Dependencies [Ubuntu]
-      if: matrix.os == 'ubuntu-latest'
+    - name: Dependencies
       run: |
         sudo apt update
-        sudo apt install git build-essential pkg-config zip unzip zlib1g-dev cmake libace-dev coinor-libipopt-dev libeigen3-dev \
-                         libtinyxml-dev libgsl-dev wget curl autoconf \
-                         autogen automake libtool mlocate
+        sudo apt install git build-essential pkg-config zip unzip zlib1g-dev cmake libace-dev libeigen3-dev libtinyxml-dev libgsl-dev
 
-    - name: Dependencies [macOS]
-      if: matrix.os == 'macOS-latest'
-      run: |
-        brew update
-        brew upgrade
-        brew install ace cmake eigen gsl ipopt pkg-config
-    - name: Source-based Dependencies [Windows] 
-      if: matrix.os == 'windows-latest'
-      shell: bash
-      run: |
-        # ycm
-        cd ${GITHUB_WORKSPACE}/..
-        git clone https://github.com/robotology/ycm.git --depth 1 --branch master
-        cd ycm && mkdir -p build && cd build
-        cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROBOTOLOGY_ROOT}/scripts/buildsystems/vcpkg.cmake \
-                     -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
-        cmake --build . --config ${{ matrix.build_type }} --target INSTALL 
-        # yarp
-        cd ${GITHUB_WORKSPACE}/..
-        git clone https://github.com/robotology/yarp.git --depth 1 --branch master
-        cd yarp && mkdir -p build && cd build
-        cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROBOTOLOGY_ROOT}/scripts/buildsystems/vcpkg.cmake \
-                     -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install \
-                     -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DYARP_COMPILE_DEVICE_PLUGINS:BOOL=OFF -DYARP_COMPILE_EXECUTABLES:BOOL=OFF \
-                     -DYARP_COMPILE_CARRIER_PLUGINS:BOOL=OFF ..
-        cmake --build . --config ${{ matrix.build_type }} --target INSTALL
-        # icub-contrib-common
-        cd ${GITHUB_WORKSPACE}/..
-        git clone https://github.com/robotology/icub-contrib-common.git --depth 1
-        cd icub-contrib-common && mkdir -p build && cd build
-        cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROBOTOLOGY_ROOT}/scripts/buildsystems/vcpkg.cmake \
-                     -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..        
-        cmake --build . --config ${{ matrix.build_type }} --target INSTALL
-        
-    - name: Source-based Dependencies [Ubuntu/macOS]
-      if: matrix.os == 'ubuntu-latest' || matrix.os == 'macOS-latest'
+    - name: Source-based Dependencies
       shell: bash
       run: |
         # ycm
@@ -129,34 +59,18 @@ jobs:
     # ===================
     # CMAKE-BASED PROJECT
     # ===================
-    - name: Configure [Windows]
-      if: matrix.os == 'windows-latest'
+    - name: Configure
       shell: bash
       run: |
         mkdir -p build
         cd build
-        cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROBOTOLOGY_ROOT}/scripts/buildsystems/vcpkg.cmake \
-                     -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install \
-                     -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DINSTALL_ALL_ROBOTS:BOOL=ON ..
-
-    - name: Configure [Ubuntu/macOS]
-      if: matrix.os == 'ubuntu-latest' || matrix.os == 'macOS-latest'
-      shell: bash
-      run: |
-        mkdir -p build
-        cd build
-        ls -la ..
         cmake -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
               -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DINSTALL_ALL_ROBOTS:BOOL=ON ..
 
-      
     - name: Build
       shell: bash
       run: |
         cd build
-        # Fix for using YARP idl generators (that link ACE) in Windows 
-        # See https://github.com/robotology/idyntree/issues/569 for more details
-        export PATH=$PATH:${GITHUB_WORKSPACE}/install/bin:${VCPKG_ROBOTOLOGY_ROOT}/installed/x64-windows/bin
         cmake --build . --config ${{ matrix.build_type }}
         
     - name: Install


### PR DESCRIPTION
We don't really need the complication of handling different platforms as we only aim to test that the installation of all robots goes smoothly without any mistakes in the single `CMakeLists.txt` files located in the robots' folders.

For the same reason, we don't really care about doing CI over night 🌙 