### PR TITLE
update wholebodydynamics configuration files after #116

### DIFF
--- a/experimentalSetups/iCubGenova02-VelCtrl/estimators/wholebodydynamics.xml
+++ b/experimentalSetups/iCubGenova02-VelCtrl/estimators/wholebodydynamics.xml
@@ -55,7 +55,7 @@
                 <elem name="head-j0">head-eb20-j0_1-mc</elem>
                 <elem name="head-j2">head-eb21-j2_5-mc</elem>
                 <!-- imu -->
-                <elem name="imu">inertial</elem>
+                <elem name="imu">head-inertial</elem>
                 <!-- ft -->
                 <elem name="l_arm_ft_sensor">left_arm-eb1-j0_3-strain</elem>
                 <elem name="r_arm_ft_sensor">right_arm-eb3-j0_3-strain</elem>

--- a/iCubChemnitz01/estimators/wholebodydynamics.xml
+++ b/iCubChemnitz01/estimators/wholebodydynamics.xml
@@ -87,7 +87,7 @@
                 <elem name="head-j0">head-eb20-j0_1-mc</elem>
                 <elem name="head-j2">head-eb21-j2_5-mc</elem>
                 <!-- imu -->
-                <elem name="imu">inertial</elem>
+                <elem name="imu">head-inertial</elem>
                 <!-- imu_waist -->
 <!--            <elem name="imu">xsens_inertial</elem> -->
                 <!-- ft -->

--- a/iCubChemnitz01/estimators/wholebodydynamics_standup.xml
+++ b/iCubChemnitz01/estimators/wholebodydynamics_standup.xml
@@ -85,7 +85,7 @@
                 <elem name="head-j0">head-eb20-j0_1-mc</elem>
                 <elem name="head-j2">head-eb21-j2_5-mc</elem>
                 <!-- imu -->
-                <elem name="imu">inertial</elem>
+                <elem name="imu">head-inertial</elem>
                 <!-- ft -->
                 <elem name="l_arm_ft_sensor">left_arm-eb1-j0_3-strain</elem>
                 <elem name="r_arm_ft_sensor">right_arm-eb3-j0_3-strain</elem>

--- a/iCubGenova02/estimators/wholebodydynamics.xml
+++ b/iCubGenova02/estimators/wholebodydynamics.xml
@@ -55,7 +55,7 @@
                 <elem name="head-j0">head-eb20-j0_1-mc</elem>
                 <elem name="head-j2">head-eb21-j2_5-mc</elem>
                 <!-- imu -->
-                <elem name="imu">inertial</elem>
+                <elem name="imu">head-inertial</elem>
                 <!-- ft -->
                 <elem name="l_arm_ft_sensor">left_arm-eb1-j0_3-strain</elem>
                 <elem name="r_arm_ft_sensor">right_arm-eb3-j0_3-strain</elem>

--- a/iCubGenova04/estimators/wholebodydynamics.xml
+++ b/iCubGenova04/estimators/wholebodydynamics.xml
@@ -87,7 +87,7 @@
                 <elem name="head-j0">head-eb20-j0_1-mc</elem>
                 <elem name="head-j2">head-eb21-j2_5-mc</elem>
                 <!-- imu -->
-                <elem name="imu">inertial</elem>
+                <elem name="imu">head-inertial</elem>
                 <!-- imu_waist -->
 <!--            <elem name="imu">xsens_inertial</elem> -->
                 <!-- ft -->

--- a/iCubGenova04/estimators/wholebodydynamics_standup.xml
+++ b/iCubGenova04/estimators/wholebodydynamics_standup.xml
@@ -85,7 +85,7 @@
                 <elem name="head-j0">head-eb20-j0_1-mc</elem>
                 <elem name="head-j2">head-eb21-j2_5-mc</elem>
                 <!-- imu -->
-                <elem name="imu">inertial</elem>
+                <elem name="imu">head-inertial</elem>
                 <!-- ft -->
                 <elem name="l_arm_ft_sensor">left_arm-eb1-j0_3-strain</elem>
                 <elem name="r_arm_ft_sensor">right_arm-eb3-j0_3-strain</elem>

--- a/iCubGenova07/estimators/wholebodydynamics.xml
+++ b/iCubGenova07/estimators/wholebodydynamics.xml
@@ -84,7 +84,7 @@
                 <elem name="head-j0">head-eb20-j0_1-mc</elem>
                 <elem name="head-j2">head-eb21-j2_5-mc</elem>
                 <!-- imu -->
-                <elem name="imu">inertial</elem>
+                <elem name="imu">head-inertial</elem>
                 <!-- ft -->
                 <elem name="l_arm_ft_sensor">left_arm-eb1-j0_3-strain</elem>
                 <elem name="r_arm_ft_sensor">right_arm-eb3-j0_3-strain</elem>

--- a/iCubGenova07/estimators/wholebodydynamics_standup.xml
+++ b/iCubGenova07/estimators/wholebodydynamics_standup.xml
@@ -72,7 +72,7 @@
                 <elem name="head-j0">head-eb20-j0_1-mc</elem>
                 <elem name="head-j2">head-eb21-j2_5-mc</elem>
                 <!-- imu -->
-                <elem name="imu">inertial</elem>
+                <elem name="imu">head-inertial</elem>
                 <!-- ft -->
                 <elem name="l_arm_ft_sensor">left_arm-eb1-j0_3-strain</elem>
                 <elem name="r_arm_ft_sensor">right_arm-eb3-j0_3-strain</elem>

--- a/iCubMoscow01/estimators/wholebodydynamics.xml
+++ b/iCubMoscow01/estimators/wholebodydynamics.xml
@@ -84,7 +84,7 @@
                 <elem name="head-j0">head-eb20-j0_1-mc</elem>
                 <elem name="head-j2">head-eb21-j2_5-mc</elem>
                 <!-- imu -->
-                <elem name="imu">inertial</elem>
+                <elem name="imu">head-inertial</elem>
                 <!-- ft -->
                 <elem name="l_arm_ft_sensor">left_arm-eb1-j0_3-strain</elem>
                 <elem name="r_arm_ft_sensor">right_arm-eb3-j0_3-strain</elem>

--- a/iCubMoscow01/estimators/wholebodydynamics_standup.xml
+++ b/iCubMoscow01/estimators/wholebodydynamics_standup.xml
@@ -72,7 +72,7 @@
                 <elem name="head-j0">head-eb20-j0_1-mc</elem>
                 <elem name="head-j2">head-eb21-j2_5-mc</elem>
                 <!-- imu -->
-                <elem name="imu">inertial</elem>
+                <elem name="imu">head-inertial</elem>
                 <!-- ft -->
                 <elem name="l_arm_ft_sensor">left_arm-eb1-j0_3-strain</elem>
                 <elem name="r_arm_ft_sensor">right_arm-eb3-j0_3-strain</elem>

--- a/iCubNancy01/estimators/wholebodydynamics.xml
+++ b/iCubNancy01/estimators/wholebodydynamics.xml
@@ -53,7 +53,7 @@
                 <elem name="left_upper_arm">left_arm-eb1-j0_3-mc</elem>
                 <elem name="head">head-cfw2_can0-mc</elem>
                 <!-- imu -->
-                <elem name="imu">inertial</elem>
+                <elem name="imu">head-inertial</elem>
                 <!-- ft -->
                 <elem name="l_arm_ft_sensor">left_arm-eb1-j0_3-strain</elem>
                 <elem name="r_arm_ft_sensor">right_arm-eb3-j0_3-strain</elem>

--- a/iCubNancy01/estimators/wholebodydynamics_BALANCING_IIT.xml
+++ b/iCubNancy01/estimators/wholebodydynamics_BALANCING_IIT.xml
@@ -53,7 +53,7 @@
                 <elem name="left_upper_arm">left_arm-eb1-j0_3-mc</elem>
                 <elem name="head">head-cfw2_can0-mc</elem>
                 <!-- imu -->
-                <elem name="imu">inertial</elem>
+                <elem name="imu">head-inertial</elem>
                 <!-- ft -->
                 <elem name="l_arm_ft_sensor">left_arm-eb1-j0_3-strain</elem>
                 <elem name="r_arm_ft_sensor">right_arm-eb3-j0_3-strain</elem>

--- a/iCubNancy01/estimators/wholebodydynamics_BALANCING_NANCY.xml
+++ b/iCubNancy01/estimators/wholebodydynamics_BALANCING_NANCY.xml
@@ -55,7 +55,7 @@
                 <elem name="left_upper_arm">left_arm-eb1-j0_3-mc</elem>
                 <elem name="head">head-cfw2_can0-mc</elem>
                 <!-- imu -->
-                <elem name="imu">inertial</elem>
+                <elem name="imu">head-inertial</elem>
                 <!-- ft -->
                 <elem name="l_arm_ft_sensor">left_arm-eb1-j0_3-strain</elem>
                 <elem name="r_arm_ft_sensor">right_arm-eb3-j0_3-strain</elem>

--- a/iCubNancy01/estimators/wholebodydynamics_STANDUP.xml
+++ b/iCubNancy01/estimators/wholebodydynamics_STANDUP.xml
@@ -59,7 +59,7 @@
                 <elem name="left_upper_arm">left_arm-eb1-j0_3-mc</elem>
                 <elem name="head">head-cfw2_can0-mc</elem>
                 <!-- imu -->
-                <elem name="imu">inertial</elem>
+                <elem name="imu">head-inertial</elem>
                 <!-- ft -->
                 <elem name="l_arm_ft_sensor">left_arm-eb1-j0_3-strain</elem>
                 <elem name="r_arm_ft_sensor">right_arm-eb3-j0_3-strain</elem>

--- a/iCubShenzhen/estimators/wholebodydynamics.xml
+++ b/iCubShenzhen/estimators/wholebodydynamics.xml
@@ -84,7 +84,7 @@
                 <elem name="head-j0">head-eb20-j0_1-mc</elem>
                 <elem name="head-j2">head-eb21-j2_5-mc</elem>
                 <!-- imu -->
-                <elem name="imu">inertial</elem>
+                <elem name="imu">head-inertial</elem>
                 <!-- ft -->
                 <elem name="l_arm_ft_sensor">left_arm-eb1-j0_3-strain</elem>
                 <elem name="r_arm_ft_sensor">right_arm-eb3-j0_3-strain</elem>

--- a/iCubShenzhen/estimators/wholebodydynamics_standup.xml
+++ b/iCubShenzhen/estimators/wholebodydynamics_standup.xml
@@ -72,7 +72,7 @@
                 <elem name="head-j0">head-eb20-j0_1-mc</elem>
                 <elem name="head-j2">head-eb21-j2_5-mc</elem>
                 <!-- imu -->
-                <elem name="imu">inertial</elem>
+                <elem name="imu">head-inertial</elem>
                 <!-- ft -->
                 <elem name="l_arm_ft_sensor">left_arm-eb1-j0_3-strain</elem>
                 <elem name="r_arm_ft_sensor">right_arm-eb3-j0_3-strain</elem>

--- a/iCubShenzhen01/estimators/wholebodydynamics.xml
+++ b/iCubShenzhen01/estimators/wholebodydynamics.xml
@@ -84,7 +84,7 @@
                 <elem name="head-j0">head-eb20-j0_1-mc</elem>
                 <elem name="head-j2">head-eb21-j2_5-mc</elem>
                 <!-- imu -->
-                <elem name="imu">inertial</elem>
+                <elem name="imu">head-inertial</elem>
                 <!-- ft -->
                 <elem name="l_arm_ft_sensor">left_arm-eb1-j0_3-strain</elem>
                 <elem name="r_arm_ft_sensor">right_arm-eb3-j0_3-strain</elem>

--- a/iCubShenzhen01/estimators/wholebodydynamics_standup.xml
+++ b/iCubShenzhen01/estimators/wholebodydynamics_standup.xml
@@ -72,7 +72,7 @@
                 <elem name="head-j0">head-eb20-j0_1-mc</elem>
                 <elem name="head-j2">head-eb21-j2_5-mc</elem>
                 <!-- imu -->
-                <elem name="imu">inertial</elem>
+                <elem name="imu">head-inertial</elem>
                 <!-- ft -->
                 <elem name="l_arm_ft_sensor">left_arm-eb1-j0_3-strain</elem>
                 <elem name="r_arm_ft_sensor">right_arm-eb3-j0_3-strain</elem>


### PR DESCRIPTION
The name of the `imu` device changed with #116 and the `wholebodydynamics` configuration files where not updated accordingly.

cc @GiulioRomualdi @julijenv @isorrentino @nunoguedelha 