### PR TITLE
Update iCubGenova02 torque control gains

### DIFF
--- a/iCubGenova02/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
+++ b/iCubGenova02/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
@@ -66,19 +66,19 @@
         <param name="controlLaw">           torque              </param>
         <param name="outputType">           pwm                 </param>
         <param name="fbkControlUnits">      metric_units        </param>
-        <param name="outputControlUnits">   machine_units       </param>
-        <param name="kp">                   200         200         250         300     </param>
+        <param name="outputControlUnits">   dutycycle_percent   </param>
+        <param name="kp">                   0.3         0.3         0.4         0.5     </param>
         <param name="kd">                   0           0           0           0       </param>
         <param name="ki">                   0           0           0           0       </param>
-        <param name="maxOutput">            8000        8000        8000        8000    </param>
-        <param name="maxInt">               500         500         500         500     </param>
+        <param name="maxOutput">            25          25          25          25      </param>
+        <param name="maxInt">               1.56        1.56        1.56        1.56    </param>
         <param name="ko">                   0           0           0           0       </param>
         <param name="stictionUp">           0           0           0           0       </param>
         <param name="stictionDown">         0           0           0           0       </param>
         <param name="kff">                  1           1           1           1       </param>
-        <param name="kbemf">                0           0           0           0       </param>
+        <param name="kbemf">                0.0030      0.0006      0.0007      0.0007  </param>
         <param name="filterType">           0           0           0           0       </param>
-        <param name="ktau">                 0           0           0           0       </param>
+        <param name="ktau">                 0.56        1.45        1.45        1.40    </param>
     </group>
     
     <group name="2FOC_CUR_CONTROL">

--- a/iCubGenova02/hardware/motorControl/left_arm-eb2-j4_15-mc.xml
+++ b/iCubGenova02/hardware/motorControl/left_arm-eb2-j4_15-mc.xml
@@ -66,19 +66,19 @@
         <param name="controlLaw">           torque              </param>
         <param name="outputType">           pwm                 </param>
         <param name="fbkControlUnits">      metric_units        </param>
-        <param name="outputControlUnits">   machine_units       </param>
-        <param name="kp">                   -80     0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="outputControlUnits">   dutycycle_percent   </param>
+        <param name="kp">                   0       0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="kd">                   0       0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="ki">                   0       0      0      0      0      0      0      0      0      0      0      0    </param>
-        <param name="maxOutput">            1333    0      0      0      0      0      0      0      0      0      0      0    </param>
-        <param name="maxInt">               1333    0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="maxOutput">          100       0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="maxInt">             14.88     0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="ko">                   0       0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="stictionUp">           0       0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="stictionDown">         0       0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="kff">                  0       0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="kbemf">                0       0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="filterType">           0       0      0      0      0      0      0      0      0      0      0      0    </param>
-        <param name="ktau">                 0       0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="ktau">                0.03     0      0      0      0      0      0      0      0      0      0      0    </param>
     </group>
 
     <!-- other default PIDs: end -->

--- a/iCubGenova02/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
+++ b/iCubGenova02/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
@@ -66,19 +66,19 @@
         <param name="controlLaw">           torque              </param>
         <param name="outputType">           pwm                 </param>
         <param name="fbkControlUnits">      metric_units        </param>
-        <param name="outputControlUnits">   machine_units       </param>
-        <param name="kp">           -200        200          0       -200     </param>
+        <param name="outputControlUnits">   dutycycle_percent   </param>
+        <param name="kp">            -0.2        0.2       -0.2       -0.2    </param>      
         <param name="kd">              0          0          0          0     </param>
         <param name="ki">              0          0          0          0     </param>
-        <param name="maxOutput">    8000       8000       8000       8000     </param>
-        <param name="maxInt">        500        500        500        500     </param>
+        <param name="maxOutput">      25         25         25         25     </param>
+        <param name="maxInt">       1.56       1.56       1.56       1.56     </param>
         <param name="ko">              0          0          0          0     </param>
         <param name="stictionUp">      0          0          0          0     </param>
         <param name="stictionDown">    0          0          0          0     </param>
         <param name="kff">             1          1          1          1     </param>
-        <param name="kbemf">           0          0          0          0     </param>
+        <param name="kbemf">        -0.003      0.003        0       -0.003   </param>
         <param name="filterType">      0          0          0          0     </param>
-        <param name="ktau">            0          0          0          0     </param>
+        <param name="ktau">         -0.51       0.56      -0.62      -0.52    </param>
     </group>
 
     <group name="2FOC_CUR_CONTROL">

--- a/iCubGenova02/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
+++ b/iCubGenova02/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
@@ -63,23 +63,22 @@
     <!-- other default PIDs: begin -->     
     
     <group name="TRQ_PID_DEFAULT">
-        <param name="controlLaw">          torque           </param>
-        <param name="outputType">          pwm              </param>
-        <param name="fbkControlUnits">     metric_units     </param>
-        <param name="outputControlUnits">  machine_units    </param>
-        <param name="kp">         150          150          </param>
-        <param name="kp">           0           0           </param>
-        <param name="kd">           0           0           </param>
-        <param name="ki">           0           0           </param>
-        <param name="maxOutput">   8000         8000        </param>
-        <param name="maxInt">       500         500         </param>
-        <param name="ko">           0           0           </param>
-        <param name="stictionUp">   0           0           </param>
-        <param name="stictionDown"> 0           0           </param>
-        <param name="kff">          1           1           </param>
-        <param name="kbemf">        0           0           </param>
-        <param name="filterType">   0           0           </param>
-        <param name="ktau">         0           0           </param>
+        <param name="controlLaw">          torque                       </param>
+        <param name="outputType">          pwm                          </param>
+        <param name="fbkControlUnits">     metric_units                 </param>
+        <param name="outputControlUnits">  dutycycle_percent            </param>
+        <param name="kp">             0         0            </param>
+        <param name="kd">             0         0              </param>
+        <param name="ki">             0         0              </param>
+        <param name="maxOutput">     25         25             </param>
+        <param name="maxInt">      1.56       1.56             </param>
+        <param name="ko">             0          0             </param>
+        <param name="stictionUp">     0          0             </param>
+        <param name="stictionDown">   0          0             </param>
+        <param name="kff">            1          1             </param>
+        <param name="kbemf">          0          0             </param>
+        <param name="filterType">     0          0             </param>
+        <param name="ktau">          0.65       0.50           </param>
     </group>
             
     <group name="2FOC_CUR_CONTROL">

--- a/iCubGenova02/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
+++ b/iCubGenova02/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
@@ -66,19 +66,19 @@
         <param name="controlLaw">           torque                       </param>
         <param name="outputType">           pwm                          </param>
         <param name="fbkControlUnits">      metric_units                 </param>
-        <param name="outputControlUnits">  machine_units                </param>
-        <param name="kp">             -200     -200       -250       -300   </param>
-        <param name="kd">              0          0          0          0   </param>
-        <param name="ki">              0          0          0          0   </param>
-        <param name="maxOutput">    8000       8000       8000       8000   </param>
-        <param name="maxInt">        500        500        500        500   </param>
-        <param name="ko">              0          0          0          0   </param>
-        <param name="stictionUp">      0          0          0          0   </param>
-        <param name="stictionDown">    0          0          0          0   </param>
-        <param name="kff">             1          1          1          1   </param>
-        <param name="kbemf">           0          0          0          0   </param>
-        <param name="filterType">      0          0          0          0   </param>
-        <param name="ktau">            0          0          0          0   </param>
+        <param name="outputControlUnits">  dutycycle_percent            </param>
+        <param name="kp">            -0.3       -0.3       -0.4       -0.5     </param>
+        <param name="kd">              0          0          0          0     </param>
+        <param name="ki">              0          0          0          0     </param>
+        <param name="maxOutput">      25         25         25         25     </param>
+        <param name="maxInt">       1.56       1.56       1.56       1.56     </param>
+        <param name="ko">              0          0          0          0     </param>
+        <param name="stictionUp">      0          0          0          0     </param>
+        <param name="stictionDown">    0          0          0          0     </param>
+        <param name="kff">             1          1          1          1     </param>
+        <param name="kbemf">        -0.0030    -0.0006    -0.0007    -0.0007  </param>
+        <param name="filterType">      0          0          0          0     </param>
+        <param name="ktau">         -0.56      -1.45      -1.45      -1.40    </param>
     </group>
     
     <group name="2FOC_CUR_CONTROL">

--- a/iCubGenova02/hardware/motorControl/right_arm-eb4-j4_15-mc.xml
+++ b/iCubGenova02/hardware/motorControl/right_arm-eb4-j4_15-mc.xml
@@ -66,19 +66,19 @@
         <param name="controlLaw">          torque                       </param>
         <param name="outputType">          pwm                          </param>
         <param name="fbkControlUnits">     metric_units                 </param>
-        <param name="outputControlUnits">  machine_units                </param>
-        <param name="kp">               80      0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="outputControlUnits">  dutycycle_percent            </param>
+        <param name="kp">              29.76    0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="kd">                0      0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="ki">                0      0      0      0      0      0      0      0      0      0      0      0    </param>
-        <param name="maxOutput">      1333      0      0      0      0      0      0      0      0      0      0      0    </param>
-        <param name="maxInt">         1333      0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="maxOutput">       100      0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="maxInt">          14.88    0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="ko">                0      0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="stictionUp">        0      0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="stictionDown">      0      0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="kff">               0      0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="kbemf">             0      0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="filterType">        0      0      0      0      0      0      0      0      0      0      0      0    </param>
-        <param name="ktau">              0      0      0      0      0      0      0      0      0      0      0      0     </param>
+        <param name="ktau">             0.03    0      0      0      0      0      0      0      0      0      0      0     </param>
     </group>
 
     <!-- other default PIDs: end -->

--- a/iCubGenova02/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
+++ b/iCubGenova02/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
@@ -66,19 +66,19 @@
         <param name="controlLaw">          torque                       </param>
         <param name="outputType">          pwm                          </param>
         <param name="fbkControlUnits">     metric_units                 </param>
-        <param name="outputControlUnits">  machine_units                </param>
-        <param name="kp">            200       -200          0        300       </param>
-        <param name="kd">              0          0          0          0       </param>
-        <param name="ki">              0          0          0          0       </param>
-        <param name="maxOutput">     8000       8000       8000       8000      </param>
-        <param name="maxInt">        500        500        500        500       </param>
-        <param name="ko">              0          0          0          0       </param>
-        <param name="stictionUp">      0          0          0          0       </param>
-        <param name="stictionDown">    0          0          0          0       </param>
-        <param name="kff">             1          1          1          1       </param>
-        <param name="kbemf">           0          0          0          0       </param>
-        <param name="filterType">      0          0          0          0       </param>
-       <param name="ktau">             0          0          0          0       </param>
+        <param name="outputControlUnits">  dutycycle_percent            </param>
+        <param name="kp">             0.2       -0.2        0.2        0.2  </param>      
+        <param name="kd">              0          0          0          0     </param>
+        <param name="ki">              0          0          0          0     </param>
+        <param name="maxOutput">      25         25         25         25     </param>
+        <param name="maxInt">       1.56       1.56       1.56       1.56     </param>
+        <param name="ko">              0          0          0          0     </param>
+        <param name="stictionUp">      0          0          0          0     </param>
+        <param name="stictionDown">    0          0          0          0     </param>
+        <param name="kff">             1          1          1          1     </param>
+        <param name="kbemf">         0.003     -0.0025       0        0.0035  </param>
+        <param name="filterType">      0          0          0          0     </param>
+        <param name="ktau">          0.46      -0.63       0.68       0.52    </param>
     </group>
 
     <group name="2FOC_CUR_CONTROL">

--- a/iCubGenova02/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
+++ b/iCubGenova02/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
@@ -63,22 +63,22 @@
     <!-- other default PIDs: begin -->     
     
     <group name="TRQ_PID_DEFAULT">
-        <param name="controlLaw">          torque                   </param>
-        <param name="outputType">          pwm                      </param>
-        <param name="fbkControlUnits">     metric_units             </param>
-        <param name="outputControlUnits">  machine_units            </param>
-        <param name="kp">          -150        -150             </param>
+        <param name="controlLaw">          torque                       </param>
+        <param name="outputType">          pwm                          </param>
+        <param name="fbkControlUnits">     metric_units                 </param>
+        <param name="outputControlUnits">  dutycycle_percent            </param>
+        <param name="kp">              0          0             </param>
         <param name="kd">              0          0             </param>
         <param name="ki">              0          0             </param>
-        <param name="maxOutput">    8000        8000            </param>
-        <param name="maxInt">       500         500             </param>
+        <param name="maxOutput">      25         25             </param>
+        <param name="maxInt">       1.56       1.56             </param>
         <param name="ko">              0          0             </param>
         <param name="stictionUp">      0          0             </param>
         <param name="stictionDown">    0          0             </param>
         <param name="kff">             1          1             </param>
         <param name="kbemf">           0          0             </param>
         <param name="filterType">      0          0             </param>
-        <param name="ktau">         0           0               </param>
+        <param name="ktau">          -0.72      -0.56           </param>
     </group>
 
     <group name="2FOC_CUR_CONTROL">

--- a/iCubGenova02/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubGenova02/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -66,19 +66,19 @@
         <param name="controlLaw">          torque                       </param>
         <param name="outputType">          pwm                          </param>
         <param name="fbkControlUnits">     metric_units                 </param>
-        <param name="outputControlUnits">  machine_units                </param>
-        <param name="kp">            -450       -400       -400 </param>
+        <param name="outputControlUnits">  dutycycle_percent            </param>
+        <param name="kp">              0          0          0  </param>
         <param name="kd">              0          0          0  </param>
         <param name="ki">              0          0          0  </param>
-        <param name="maxOutput">    8000       8000       8000  </param>
-        <param name="maxInt">        500        500        500  </param>
+        <param name="maxOutput">      25         25         25  </param>
+        <param name="maxInt">       1.56       1.56       1.56  </param>
         <param name="ko">              0          0          0  </param>
         <param name="stictionUp">      0          0          0  </param>
-        <param name="stictionDown">    0          0          0  </param>
+        <param name="stictionDown">     0          0          0  </param>
         <param name="kff">             1          1          1  </param>
-        <param name="kbemf">           0          0          0  </param>
+        <param name="kbemf">      -0.0016    -0.003     -0.003  </param>
         <param name="filterType">      0          0          0  </param>
-        <param name="ktau">            0          0          0  </param>
+        <param name="ktau">        -0.63      -0.63      -0.63  </param>
     </group>
 
     <group name="2FOC_CUR_CONTROL">


### PR DESCRIPTION
Trying to use torque control on `iCubGenova02`, we found out that with the current gains configuration the performances were bad, and in particular switching to torque control mode for the torso was cause of unstable behaviour (soon starting oscillating).

Given that the current values look like some "standard" values rather than tuned gains, and all the feedforward parameters were missing, I have performed a tuning of the gains starting from the values of `iCubGenova04` robot. In this way we observed better performances, e.g. in performing gravity compensation. 

I know improvement of torque control, also at the firmware level, are in process. However, for the time being I think we can merge those gains that, even if not yet perfectly tune is reached, allows to use torque control and run some demos on `iCubGenova02`.

CC @DanielePucci @S-Dafarra @nunoguedelha 