### PR TITLE
iCubGenova[02,04,07] + [iCubMoscow01] + [iCubShenzhen]: updated the required application version of strain2

### DIFF
--- a/experimentalSetups/singleETHboard/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/experimentalSetups/singleETHboard/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -23,9 +23,9 @@
                         <param name="minor">            0                       </param>     
                     </group>                    
                     <group name="FIRMWARE">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            3                       </param> 
-                        <param name="build">            5                       </param>
+                        <param name="major">            2                       </param>    
+                        <param name="minor">            0                       </param> 
+                        <param name="build">            7                       </param>
                     </group>
                 </group>
                 

--- a/iCubGenova02/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/iCubGenova02/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -16,7 +16,7 @@
             <group name="PROPERTIES">
   
                 <group name="CANBOARDS">
-                    <param name="type">                 eobrd_strain2            </param>
+                    <param name="type">                 strain2                 </param>
 
                     <group name="PROTOCOL">
                         <param name="major">            2                       </param>    
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                       </param>    
                         <param name="minor">            0                       </param> 
-                        <param name="build">            4                       </param>
+                        <param name="build">            7                       </param>
                     </group>
                 </group>
                 

--- a/iCubGenova02/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/iCubGenova02/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -16,7 +16,7 @@
             <group name="PROPERTIES">
   
                 <group name="CANBOARDS">
-                    <param name="type">                 eobrd_strain2            </param>
+                    <param name="type">                 strain2                 </param>
 
                     <group name="PROTOCOL">
                         <param name="major">            2                       </param>    
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                       </param>    
                         <param name="minor">            0                       </param> 
-                        <param name="build">            4                       </param>
+                        <param name="build">            7                       </param>
                     </group>
                 </group>
                 

--- a/iCubGenova02/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/iCubGenova02/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -16,7 +16,7 @@
             <group name="PROPERTIES">
   
                 <group name="CANBOARDS">
-                    <param name="type">                 eobrd_strain2            </param>
+                    <param name="type">                 strain2                 </param>
 
                     <group name="PROTOCOL">
                         <param name="major">            2                       </param>    
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                       </param>    
                         <param name="minor">            0                       </param> 
-                        <param name="build">            4                       </param>
+                        <param name="build">            7                       </param>
                     </group>
                 </group>
                 

--- a/iCubGenova02/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/iCubGenova02/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -16,7 +16,7 @@
             <group name="PROPERTIES">
   
                 <group name="CANBOARDS">
-                    <param name="type">                 eobrd_strain2            </param>
+                    <param name="type">                 strain2                 </param>
 
                     <group name="PROTOCOL">
                         <param name="major">            2                       </param>    
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                       </param>    
                         <param name="minor">            0                       </param> 
-                        <param name="build">            4                       </param>
+                        <param name="build">            7                       </param>
                     </group>
                 </group>
                 

--- a/iCubGenova04/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/iCubGenova04/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                       </param>    
                         <param name="minor">            0                       </param> 
-                        <param name="build">            4                       </param>
+                        <param name="build">            7                       </param>
                     </group>
                 </group>
                 

--- a/iCubGenova04/hardware/FT/left_leg-eb6-j0_3-strain2.xml
+++ b/iCubGenova04/hardware/FT/left_leg-eb6-j0_3-strain2.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                       </param>    
                         <param name="minor">            0                       </param> 
-                        <param name="build">            4                       </param>
+                        <param name="build">            7                       </param>
                     </group>
                 </group>
                 

--- a/iCubGenova04/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/iCubGenova04/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                       </param>    
                         <param name="minor">            0                       </param> 
-                        <param name="build">            4                       </param>
+                        <param name="build">            7                       </param>
                     </group>
                 </group>
                 

--- a/iCubGenova04/hardware/FT/left_leg-eb7-j4_5-strain2.xml
+++ b/iCubGenova04/hardware/FT/left_leg-eb7-j4_5-strain2.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                       </param>    
                         <param name="minor">            0                       </param> 
-                        <param name="build">            4                       </param>
+                        <param name="build">            7                       </param>
                     </group>
                 </group>
                 

--- a/iCubGenova04/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/iCubGenova04/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                       </param>    
                         <param name="minor">            0                       </param> 
-                        <param name="build">            4                       </param>
+                        <param name="build">            7                       </param>
                     </group>
                 </group>
                 

--- a/iCubGenova04/hardware/FT/right_leg-eb8-j0_3-strain2.xml
+++ b/iCubGenova04/hardware/FT/right_leg-eb8-j0_3-strain2.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                       </param>    
                         <param name="minor">            0                       </param> 
-                        <param name="build">            4                       </param>
+                        <param name="build">            7                       </param>
                     </group>
                 </group>
                 

--- a/iCubGenova04/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/iCubGenova04/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                       </param>    
                         <param name="minor">            0                       </param> 
-                        <param name="build">            4                       </param>
+                        <param name="build">            7                       </param>
                     </group>
                 </group>
                 

--- a/iCubGenova04/hardware/FT/right_leg-eb9-j4_5-strain2.xml
+++ b/iCubGenova04/hardware/FT/right_leg-eb9-j4_5-strain2.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                       </param>    
                         <param name="minor">            0                       </param> 
-                        <param name="build">            4                       </param>
+                        <param name="build">            7                       </param>
                     </group>
                 </group>
                 

--- a/iCubGenova04/hardware/inertials/left_leg-eb6-IMU.xml
+++ b/iCubGenova04/hardware/inertials/left_leg-eb6-IMU.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                   </param>
                         <param name="minor">            0                   </param>
-                        <param name="build">            4                   </param>
+                        <param name="build">            7                   </param>
                     </group>
                 </group>
 

--- a/iCubGenova04/hardware/inertials/left_leg-eb7-IMU.xml
+++ b/iCubGenova04/hardware/inertials/left_leg-eb7-IMU.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                   </param>
                         <param name="minor">            0                   </param>
-                        <param name="build">            4                   </param>
+                        <param name="build">            7                   </param>
                     </group>
                 </group>
 

--- a/iCubGenova04/hardware/inertials/left_leg-imu-example.xml
+++ b/iCubGenova04/hardware/inertials/left_leg-imu-example.xml
@@ -16,16 +16,16 @@
             <group name="PROPERTIES">
             
                 <group name="CANBOARDS">
-                    <param name="type">              eobrd_strain2       </param>
+                    <param name="type">                 strain2             </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">           2                   </param>    
-                        <param name="minor">           0                   </param>     
+                        <param name="major">            2                   </param>    
+                        <param name="minor">            0                   </param>     
                     </group>                    
                     <group name="FIRMWARE">
-                        <param name="major">           2                   </param>    
-                        <param name="minor">           0                   </param> 
-                        <param name="build">           4                   </param>
+                        <param name="major">            2                   </param>    
+                        <param name="minor">            0                   </param> 
+                        <param name="build">            7                   </param>
                     </group>
                 </group>
 

--- a/iCubGenova04/hardware/inertials/right_leg-eb8-IMU.xml
+++ b/iCubGenova04/hardware/inertials/right_leg-eb8-IMU.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                   </param>
                         <param name="minor">            0                   </param>
-                        <param name="build">            4                   </param>
+                        <param name="build">            7                   </param>
                     </group>
                 </group>
 

--- a/iCubGenova04/hardware/inertials/right_leg-eb9-IMU.xml
+++ b/iCubGenova04/hardware/inertials/right_leg-eb9-IMU.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                   </param>
                         <param name="minor">            0                   </param>
-                        <param name="build">            4                   </param>
+                        <param name="build">            7                   </param>
                     </group>
                 </group>
 

--- a/iCubGenova07/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/iCubGenova07/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                       </param>    
                         <param name="minor">            0                       </param> 
-                        <param name="build">            4                       </param>
+                        <param name="build">            7                       </param>
                     </group>
                 </group>
                 

--- a/iCubGenova07/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/iCubGenova07/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                       </param>    
                         <param name="minor">            0                       </param> 
-                        <param name="build">            4                       </param>
+                        <param name="build">            7                       </param>
                     </group>
                 </group>
                 

--- a/iCubGenova07/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/iCubGenova07/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                       </param>    
                         <param name="minor">            0                       </param> 
-                        <param name="build">            4                       </param>
+                        <param name="build">            7                       </param>
                     </group>
                 </group>
                 

--- a/iCubGenova07/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/iCubGenova07/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                       </param>    
                         <param name="minor">            0                       </param> 
-                        <param name="build">            4                       </param>
+                        <param name="build">            7                       </param>
                     </group>
                 </group>
                 

--- a/iCubGenova07/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/iCubGenova07/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                       </param>    
                         <param name="minor">            0                       </param> 
-                        <param name="build">            4                       </param>
+                        <param name="build">            7                       </param>
                     </group>
                 </group>
                 

--- a/iCubGenova07/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/iCubGenova07/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                       </param>    
                         <param name="minor">            0                       </param> 
-                        <param name="build">            4                       </param>
+                        <param name="build">            7                       </param>
                     </group>
                 </group>
                 

--- a/iCubGenova07/hardware/inertials/left_leg-eb6-IMU.xml
+++ b/iCubGenova07/hardware/inertials/left_leg-eb6-IMU.xml
@@ -23,9 +23,9 @@
                         <param name="minor">            0                   </param>
                     </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                   </param>
+                        <param name="major">            2                   </param>
                         <param name="minor">            0                   </param>
-                        <param name="build">            0                   </param>
+                        <param name="build">            7                   </param>
                     </group>
                 </group>
 

--- a/iCubGenova07/hardware/inertials/left_leg-eb7-IMU.xml
+++ b/iCubGenova07/hardware/inertials/left_leg-eb7-IMU.xml
@@ -23,9 +23,9 @@
                         <param name="minor">            0                   </param>
                     </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                   </param>
+                        <param name="major">            2                   </param>
                         <param name="minor">            0                   </param>
-                        <param name="build">            0                   </param>
+                        <param name="build">            7                   </param>
                     </group>
                 </group>
 

--- a/iCubGenova07/hardware/inertials/right_leg-eb8-IMU.xml
+++ b/iCubGenova07/hardware/inertials/right_leg-eb8-IMU.xml
@@ -23,9 +23,9 @@
                         <param name="minor">            0                   </param>
                     </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                   </param>
+                        <param name="major">            2                   </param>
                         <param name="minor">            0                   </param>
-                        <param name="build">            0                   </param>
+                        <param name="build">            7                   </param>
                     </group>
                 </group>
 

--- a/iCubGenova07/hardware/inertials/right_leg-eb9-IMU.xml
+++ b/iCubGenova07/hardware/inertials/right_leg-eb9-IMU.xml
@@ -23,9 +23,9 @@
                         <param name="minor">            0                   </param>
                     </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                   </param>
+                        <param name="major">            2                   </param>
                         <param name="minor">            0                   </param>
-                        <param name="build">            0                   </param>
+                        <param name="build">            7                   </param>
                     </group>
                 </group>
 

--- a/iCubMoscow01/hardware/inertials/left_leg-eb6-IMU.xml
+++ b/iCubMoscow01/hardware/inertials/left_leg-eb6-IMU.xml
@@ -23,9 +23,9 @@
                         <param name="minor">            0                   </param>
                     </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                   </param>
+                        <param name="major">            2                   </param>
                         <param name="minor">            0                   </param>
-                        <param name="build">            0                   </param>
+                        <param name="build">            7                   </param>
                     </group>
                 </group>
 

--- a/iCubMoscow01/hardware/inertials/left_leg-eb7-IMU.xml
+++ b/iCubMoscow01/hardware/inertials/left_leg-eb7-IMU.xml
@@ -23,9 +23,9 @@
                         <param name="minor">            0                   </param>
                     </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                   </param>
+                        <param name="major">            2                   </param>
                         <param name="minor">            0                   </param>
-                        <param name="build">            0                   </param>
+                        <param name="build">            7                   </param>
                     </group>
                 </group>
 

--- a/iCubMoscow01/hardware/inertials/right_leg-eb8-IMU.xml
+++ b/iCubMoscow01/hardware/inertials/right_leg-eb8-IMU.xml
@@ -23,9 +23,9 @@
                         <param name="minor">            0                   </param>
                     </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                   </param>
+                        <param name="major">            2                   </param>
                         <param name="minor">            0                   </param>
-                        <param name="build">            0                   </param>
+                        <param name="build">            7                   </param>
                     </group>
                 </group>
 

--- a/iCubMoscow01/hardware/inertials/right_leg-eb9-IMU.xml
+++ b/iCubMoscow01/hardware/inertials/right_leg-eb9-IMU.xml
@@ -23,9 +23,9 @@
                         <param name="minor">            0                   </param>
                     </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                   </param>
+                        <param name="major">            2                   </param>
                         <param name="minor">            0                   </param>
-                        <param name="build">            0                   </param>
+                        <param name="build">            7                   </param>
                     </group>
                 </group>
 

--- a/iCubShenzhen/hardware/inertials/left_leg-eb6-IMU.xml
+++ b/iCubShenzhen/hardware/inertials/left_leg-eb6-IMU.xml
@@ -23,9 +23,9 @@
                         <param name="minor">            0                   </param>
                     </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                   </param>
+                        <param name="major">            2                   </param>
                         <param name="minor">            0                   </param>
-                        <param name="build">            0                   </param>
+                        <param name="build">            7                   </param>
                     </group>
                 </group>
 

--- a/iCubShenzhen/hardware/inertials/left_leg-eb7-IMU.xml
+++ b/iCubShenzhen/hardware/inertials/left_leg-eb7-IMU.xml
@@ -23,9 +23,9 @@
                         <param name="minor">            0                   </param>
                     </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                   </param>
+                        <param name="major">            2                   </param>
                         <param name="minor">            0                   </param>
-                        <param name="build">            0                   </param>
+                        <param name="build">            7                   </param>
                     </group>
                 </group>
 

--- a/iCubShenzhen/hardware/inertials/right_leg-eb8-IMU.xml
+++ b/iCubShenzhen/hardware/inertials/right_leg-eb8-IMU.xml
@@ -23,9 +23,9 @@
                         <param name="minor">            0                   </param>
                     </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                   </param>
+                        <param name="major">            2                   </param>
                         <param name="minor">            0                   </param>
-                        <param name="build">            0                   </param>
+                        <param name="build">            7                   </param>
                     </group>
                 </group>
 

--- a/iCubShenzhen/hardware/inertials/right_leg-eb9-IMU.xml
+++ b/iCubShenzhen/hardware/inertials/right_leg-eb9-IMU.xml
@@ -23,9 +23,9 @@
                         <param name="minor">            0                   </param>
                     </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                   </param>
+                        <param name="major">            2                   </param>
                         <param name="minor">            0                   </param>
-                        <param name="build">            0                   </param>
+                        <param name="build">            7                   </param>
                     </group>
                 </group>
 

--- a/iCubShenzhen01/hardware/inertials/left_leg-eb6-IMU.xml
+++ b/iCubShenzhen01/hardware/inertials/left_leg-eb6-IMU.xml
@@ -23,9 +23,9 @@
                         <param name="minor">            0                   </param>
                     </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                   </param>
+                        <param name="major">            2                   </param>
                         <param name="minor">            0                   </param>
-                        <param name="build">            0                   </param>
+                        <param name="build">            7                   </param>
                     </group>
                 </group>
 

--- a/iCubShenzhen01/hardware/inertials/left_leg-eb7-IMU.xml
+++ b/iCubShenzhen01/hardware/inertials/left_leg-eb7-IMU.xml
@@ -23,9 +23,9 @@
                         <param name="minor">            0                   </param>
                     </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                   </param>
+                        <param name="major">            2                   </param>
                         <param name="minor">            0                   </param>
-                        <param name="build">            0                   </param>
+                        <param name="build">            7                   </param>
                     </group>
                 </group>
 

--- a/iCubShenzhen01/hardware/inertials/right_leg-eb8-IMU.xml
+++ b/iCubShenzhen01/hardware/inertials/right_leg-eb8-IMU.xml
@@ -23,9 +23,9 @@
                         <param name="minor">            0                   </param>
                     </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                   </param>
+                        <param name="major">            2                   </param>
                         <param name="minor">            0                   </param>
-                        <param name="build">            0                   </param>
+                        <param name="build">            7                   </param>
                     </group>
                 </group>
 

--- a/iCubShenzhen01/hardware/inertials/right_leg-eb9-IMU.xml
+++ b/iCubShenzhen01/hardware/inertials/right_leg-eb9-IMU.xml
@@ -23,9 +23,9 @@
                         <param name="minor">            0                   </param>
                     </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                   </param>
+                        <param name="major">            2                   </param>
                         <param name="minor">            0                   </param>
-                        <param name="build">            0                   </param>
+                        <param name="build">            7                   </param>
                     </group>
                 </group>
 


### PR DESCRIPTION
this PR is required to force robots with strain2 boards on them to use the latest version
which was committed in icub-firmware-build with log: https://github.com/robotology/icub-firmware-build/commit/946ee97b69ce82c1ed6a129aec587fe67eaf2c50

this version allows to:
- stream FT data @ 1 Khz. for details of the firmware, pls see https://github.com/robotology/icub-firmware/pull/113

