### PR TITLE
[iCubShenzen][iCubShenzen01][iCubGenova02,04,07][iCubChemnitz01][iCubMoscow01][iCubNancy01][experimentalSetups/iCubGenova02-VelCtrl] Update the configuration parameters in estimators/wholebodydynamics to be compatible to a bug fix in robotology/whole-body-estimators

### DIFF
--- a/experimentalSetups/iCubGenova02-VelCtrl/estimators/wholebodydynamics.xml
+++ b/experimentalSetups/iCubGenova02-VelCtrl/estimators/wholebodydynamics.xml
@@ -10,6 +10,12 @@
         <param name="defaultContactFrames">(l_hand,r_hand,root_link,l_sole,r_sole,r_lower_leg,l_lower_leg,l_elbow_1,r_elbow_1)</param>
         <param name="imuFrameName">imu_frame</param>
         <param name="publishOnROS">true</param>
+        <param name="useJointVelocity">true</param>
+        <param name="useJointAcceleration">true</param>
+        <param name="imuFilterCutoffInHz">3.0</param>
+        <param name="forceTorqueFilterCutoffInHz">3.0</param>
+        <param name="jointVelFilterCutoffInHz">3.0</param> <!-- used if useJointVelocity is set to true -->
+        <param name="jointAccFilterCutoffInHz">3.0</param> <!-- used if useJointAcceleration is set to true -->
 
         <!-- map between iDynTree links (identified by a name)
              and skinDynLib links (identified by their frame name, a BodyPart enum

--- a/iCubChemnitz01/estimators/wholebodydynamics.xml
+++ b/iCubChemnitz01/estimators/wholebodydynamics.xml
@@ -13,6 +13,10 @@
         <param name="useJointVelocity">true</param>
         <param name="useJointAcceleration">false</param>
 	<param name="streamFilteredFT">true</param>
+	    <param name="imuFilterCutoffInHz">3.0</param>
+        <param name="forceTorqueFilterCutoffInHz">3.0</param>
+        <param name="jointVelFilterCutoffInHz">3.0</param> <!-- used if useJointVelocity is set to true -->
+        <param name="jointAccFilterCutoffInHz">3.0</param> <!-- used if useJointAcceleration is set to true -->
 
         <!-- map between iDynTree links (identified by a name)
              and skinDynLib links (identified by their frame name, a BodyPart enum

--- a/iCubChemnitz01/estimators/wholebodydynamics_standup.xml
+++ b/iCubChemnitz01/estimators/wholebodydynamics_standup.xml
@@ -12,6 +12,10 @@
 	<param name="forceTorqueEstimateConfidence">2</param>
         <param name="useJointVelocity">true</param>
         <param name="useJointAcceleration">false</param>
+        <param name="imuFilterCutoffInHz">3.0</param>
+        <param name="forceTorqueFilterCutoffInHz">3.0</param>
+        <param name="jointVelFilterCutoffInHz">3.0</param> <!-- used if useJointVelocity is set to true -->
+        <param name="jointAccFilterCutoffInHz">3.0</param> <!-- used if useJointAcceleration is set to true -->
 
         <!-- map between iDynTree links (identified by a name)
              and skinDynLib links (identified by their frame name, a BodyPart enum

--- a/iCubGenova02/estimators/wholebodydynamics.xml
+++ b/iCubGenova02/estimators/wholebodydynamics.xml
@@ -10,6 +10,12 @@
         <param name="defaultContactFrames">(l_hand,r_hand,root_link,l_sole,r_sole,r_lower_leg,l_lower_leg,l_elbow_1,r_elbow_1)</param>
         <param name="imuFrameName">imu_frame</param>
         <param name="publishOnROS">true</param>
+        <param name="useJointVelocity">true</param>
+        <param name="useJointAcceleration">true</param>
+        <param name="imuFilterCutoffInHz">3.0</param>
+        <param name="forceTorqueFilterCutoffInHz">3.0</param>
+        <param name="jointVelFilterCutoffInHz">3.0</param> <!-- used if useJointVelocity is set to true -->
+        <param name="jointAccFilterCutoffInHz">3.0</param> <!-- used if useJointAcceleration is set to true -->
 
         <!-- map between iDynTree links (identified by a name)
              and skinDynLib links (identified by their frame name, a BodyPart enum

--- a/iCubGenova04/estimators/wholebodydynamics.xml
+++ b/iCubGenova04/estimators/wholebodydynamics.xml
@@ -13,6 +13,10 @@
         <param name="useJointVelocity">true</param>
         <param name="useJointAcceleration">false</param>
 	<param name="streamFilteredFT">true</param>
+        <param name="imuFilterCutoffInHz">3.0</param>
+        <param name="forceTorqueFilterCutoffInHz">3.0</param>
+        <param name="jointVelFilterCutoffInHz">3.0</param> <!-- used if useJointVelocity is set to true -->
+        <param name="jointAccFilterCutoffInHz">3.0</param> <!-- used if useJointAcceleration is set to true -->
 
         <!-- map between iDynTree links (identified by a name)
              and skinDynLib links (identified by their frame name, a BodyPart enum

--- a/iCubGenova04/estimators/wholebodydynamics_iRonCub.xml
+++ b/iCubGenova04/estimators/wholebodydynamics_iRonCub.xml
@@ -12,7 +12,11 @@
 	<param name="forceTorqueEstimateConfidence">2</param>
         <param name="useJointVelocity">true</param>
         <param name="useJointAcceleration">false</param>
-	<param name="streamFilteredFT">true</param>
+	<param name="streamFilteredFT">true</param>	    
+        <param name="imuFilterCutoffInHz">3.0</param>
+        <param name="forceTorqueFilterCutoffInHz">3.0</param>
+        <param name="jointVelFilterCutoffInHz">3.0</param> <!-- used if useJointVelocity is set to true -->
+        <param name="jointAccFilterCutoffInHz">3.0</param> <!-- used if useJointAcceleration is set to true -->
 
         <!-- map between iDynTree links (identified by a name)
              and skinDynLib links (identified by their frame name, a BodyPart enum

--- a/iCubGenova04/estimators/wholebodydynamics_standup.xml
+++ b/iCubGenova04/estimators/wholebodydynamics_standup.xml
@@ -12,6 +12,10 @@
 	<param name="forceTorqueEstimateConfidence">2</param>
         <param name="useJointVelocity">true</param>
         <param name="useJointAcceleration">false</param>
+        <param name="imuFilterCutoffInHz">3.0</param>
+        <param name="forceTorqueFilterCutoffInHz">3.0</param>
+        <param name="jointVelFilterCutoffInHz">3.0</param> <!-- used if useJointVelocity is set to true -->
+        <param name="jointAccFilterCutoffInHz">3.0</param> <!-- used if useJointAcceleration is set to true -->
 
         <!-- map between iDynTree links (identified by a name)
              and skinDynLib links (identified by their frame name, a BodyPart enum

--- a/iCubGenova07/estimators/wholebodydynamics.xml
+++ b/iCubGenova07/estimators/wholebodydynamics.xml
@@ -12,6 +12,10 @@
 	<param name="forceTorqueEstimateConfidence">2</param>
         <param name="useJointVelocity">true</param>
         <param name="useJointAcceleration">false</param>
+        <param name="imuFilterCutoffInHz">3.0</param>
+        <param name="forceTorqueFilterCutoffInHz">3.0</param>
+        <param name="jointVelFilterCutoffInHz">3.0</param> <!-- used if useJointVelocity is set to true -->
+        <param name="jointAccFilterCutoffInHz">3.0</param> <!-- used if useJointAcceleration is set to true -->
 
         <!-- map between iDynTree links (identified by a name)
              and skinDynLib links (identified by their frame name, a BodyPart enum

--- a/iCubGenova07/estimators/wholebodydynamics_standup.xml
+++ b/iCubGenova07/estimators/wholebodydynamics_standup.xml
@@ -9,6 +9,12 @@
         <param name="defaultContactFrames">(l_hand,r_hand,root_link,l_sole,r_sole,r_upper_leg,l_upper_leg,l_elbow_1,r_elbow_1)</param>
         <param name="imuFrameName">imu_frame</param>
         <param name="publishOnROS">true</param>
+        <param name="useJointVelocity">true</param>
+        <param name="useJointAcceleration">true</param>
+        <param name="imuFilterCutoffInHz">3.0</param>
+        <param name="forceTorqueFilterCutoffInHz">3.0</param>
+        <param name="jointVelFilterCutoffInHz">3.0</param> <!-- used if useJointVelocity is set to true -->
+        <param name="jointAccFilterCutoffInHz">3.0</param> <!-- used if useJointAcceleration is set to true -->
 
         <!-- map between iDynTree links (identified by a name)
              and skinDynLib links (identified by their frame name, a BodyPart enum

--- a/iCubMoscow01/estimators/wholebodydynamics.xml
+++ b/iCubMoscow01/estimators/wholebodydynamics.xml
@@ -12,6 +12,10 @@
 	<param name="forceTorqueEstimateConfidence">2</param>
         <param name="useJointVelocity">true</param>
         <param name="useJointAcceleration">false</param>
+        <param name="imuFilterCutoffInHz">3.0</param>
+        <param name="forceTorqueFilterCutoffInHz">3.0</param>
+        <param name="jointVelFilterCutoffInHz">3.0</param> <!-- used if useJointVelocity is set to true -->
+        <param name="jointAccFilterCutoffInHz">3.0</param> <!-- used if useJointAcceleration is set to true -->
 
         <!-- map between iDynTree links (identified by a name)
              and skinDynLib links (identified by their frame name, a BodyPart enum

--- a/iCubMoscow01/estimators/wholebodydynamics_standup.xml
+++ b/iCubMoscow01/estimators/wholebodydynamics_standup.xml
@@ -9,6 +9,12 @@
         <param name="defaultContactFrames">(l_hand,r_hand,root_link,l_sole,r_sole,r_upper_leg,l_upper_leg,l_elbow_1,r_elbow_1)</param>
         <param name="imuFrameName">imu_frame</param>
         <param name="publishOnROS">true</param>
+        <param name="useJointVelocity">true</param>
+        <param name="useJointAcceleration">true</param>
+        <param name="imuFilterCutoffInHz">3.0</param>
+        <param name="forceTorqueFilterCutoffInHz">3.0</param>
+        <param name="jointVelFilterCutoffInHz">3.0</param> <!-- used if useJointVelocity is set to true -->
+        <param name="jointAccFilterCutoffInHz">3.0</param> <!-- used if useJointAcceleration is set to true -->
 
         <!-- map between iDynTree links (identified by a name)
              and skinDynLib links (identified by their frame name, a BodyPart enum

--- a/iCubNancy01/estimators/wholebodydynamics.xml
+++ b/iCubNancy01/estimators/wholebodydynamics.xml
@@ -9,6 +9,12 @@
 	    <param name="assumeFixed">l_sole</param>
         <param name="defaultContactFrames">(l_hand,r_hand,root_link,l_sole,r_sole,l_lower_leg,r_lower_leg,l_elbow_1,r_elbow_1)</param>
         <param name="imuFrameName">imu_frame</param>
+        <param name="useJointVelocity">true</param>
+        <param name="useJointAcceleration">true</param>
+        <param name="imuFilterCutoffInHz">3.0</param>
+        <param name="forceTorqueFilterCutoffInHz">3.0</param>
+        <param name="jointVelFilterCutoffInHz">3.0</param> <!-- used if useJointVelocity is set to true -->
+        <param name="jointAccFilterCutoffInHz">3.0</param> <!-- used if useJointAcceleration is set to true -->
 
         <!-- map between iDynTree links (identified by a name)
              and skinDynLib links (identified by their frame name, a BodyPart enum

--- a/iCubNancy01/estimators/wholebodydynamics_BALANCING_IIT.xml
+++ b/iCubNancy01/estimators/wholebodydynamics_BALANCING_IIT.xml
@@ -9,6 +9,12 @@
     	<param name="assumeFixed">l_sole</param>
         <param name="defaultContactFrames">(l_hand,r_hand,root_link,l_sole,r_sole,l_lower_leg,r_lower_leg,l_elbow_1,r_elbow_1)</param>
         <param name="imuFrameName">imu_frame</param>
+        <param name="useJointVelocity">true</param>
+        <param name="useJointAcceleration">true</param>
+        <param name="imuFilterCutoffInHz">3.0</param>
+        <param name="forceTorqueFilterCutoffInHz">3.0</param>
+        <param name="jointVelFilterCutoffInHz">3.0</param> <!-- used if useJointVelocity is set to true -->
+        <param name="jointAccFilterCutoffInHz">3.0</param> <!-- used if useJointAcceleration is set to true -->
 
         <!-- map between iDynTree links (identified by a name)
              and skinDynLib links (identified by their frame name, a BodyPart enum

--- a/iCubNancy01/estimators/wholebodydynamics_BALANCING_NANCY.xml
+++ b/iCubNancy01/estimators/wholebodydynamics_BALANCING_NANCY.xml
@@ -9,6 +9,12 @@
     	<param name="assumeFixed">l_sole</param>
         <param name="defaultContactFrames">(l_hand,r_hand,root_link,l_sole,r_sole,l_lower_leg,r_lower_leg,l_elbow_1,r_elbow_1)</param>
         <param name="imuFrameName">imu_frame</param>
+        <param name="useJointVelocity">true</param>
+        <param name="useJointAcceleration">true</param>
+        <param name="imuFilterCutoffInHz">3.0</param>
+        <param name="forceTorqueFilterCutoffInHz">3.0</param>
+        <param name="jointVelFilterCutoffInHz">3.0</param> <!-- used if useJointVelocity is set to true -->
+        <param name="jointAccFilterCutoffInHz">3.0</param> <!-- used if useJointAcceleration is set to true -->
 
         <!-- map between iDynTree links (identified by a name)
              and skinDynLib links (identified by their frame name, a BodyPart enum

--- a/iCubNancy01/estimators/wholebodydynamics_STANDUP.xml
+++ b/iCubNancy01/estimators/wholebodydynamics_STANDUP.xml
@@ -9,6 +9,12 @@
 	    <param name="assumeFixed">l_sole</param>
         <param name="defaultContactFrames">(l_hand,r_hand,root_link,l_sole,r_sole,l_upper_leg,r_upper_leg,l_elbow_1,r_elbow_1)</param>
         <param name="imuFrameName">imu_frame</param>
+        <param name="useJointVelocity">true</param>
+        <param name="useJointAcceleration">true</param>
+        <param name="imuFilterCutoffInHz">3.0</param>
+        <param name="forceTorqueFilterCutoffInHz">3.0</param>
+        <param name="jointVelFilterCutoffInHz">3.0</param> <!-- used if useJointVelocity is set to true -->
+        <param name="jointAccFilterCutoffInHz">3.0</param> <!-- used if useJointAcceleration is set to true -->
 
         <!-- map between iDynTree links (identified by a name)
              and skinDynLib links (identified by their frame name, a BodyPart enum

--- a/iCubShenzhen/estimators/wholebodydynamics.xml
+++ b/iCubShenzhen/estimators/wholebodydynamics.xml
@@ -12,6 +12,10 @@
 	<param name="forceTorqueEstimateConfidence">2</param>
         <param name="useJointVelocity">true</param>
         <param name="useJointAcceleration">false</param>
+        <param name="imuFilterCutoffInHz">3.0</param>
+        <param name="forceTorqueFilterCutoffInHz">3.0</param>
+        <param name="jointVelFilterCutoffInHz">3.0</param> <!-- used if useJointVelocity is set to true -->
+        <param name="jointAccFilterCutoffInHz">3.0</param> <!-- used if useJointAcceleration is set to true -->
 
         <!-- map between iDynTree links (identified by a name)
              and skinDynLib links (identified by their frame name, a BodyPart enum

--- a/iCubShenzhen/estimators/wholebodydynamics_standup.xml
+++ b/iCubShenzhen/estimators/wholebodydynamics_standup.xml
@@ -9,6 +9,12 @@
         <param name="defaultContactFrames">(l_hand,r_hand,root_link,l_sole,r_sole,r_upper_leg,l_upper_leg,l_elbow_1,r_elbow_1)</param>
         <param name="imuFrameName">imu_frame</param>
         <param name="publishOnROS">true</param>
+        <param name="useJointVelocity">true</param>
+        <param name="useJointAcceleration">true</param>
+        <param name="imuFilterCutoffInHz">3.0</param>
+        <param name="forceTorqueFilterCutoffInHz">3.0</param>
+        <param name="jointVelFilterCutoffInHz">3.0</param> <!-- used if useJointVelocity is set to true -->
+        <param name="jointAccFilterCutoffInHz">3.0</param> <!-- used if useJointAcceleration is set to true -->
 
         <!-- map between iDynTree links (identified by a name)
              and skinDynLib links (identified by their frame name, a BodyPart enum

--- a/iCubShenzhen01/estimators/wholebodydynamics.xml
+++ b/iCubShenzhen01/estimators/wholebodydynamics.xml
@@ -12,6 +12,10 @@
 	<param name="forceTorqueEstimateConfidence">2</param>
         <param name="useJointVelocity">true</param>
         <param name="useJointAcceleration">false</param>
+        <param name="imuFilterCutoffInHz">3.0</param>
+        <param name="forceTorqueFilterCutoffInHz">3.0</param>
+        <param name="jointVelFilterCutoffInHz">3.0</param> <!-- used if useJointVelocity is set to true -->
+        <param name="jointAccFilterCutoffInHz">3.0</param> <!-- used if useJointAcceleration is set to true -->
 
         <!-- map between iDynTree links (identified by a name)
              and skinDynLib links (identified by their frame name, a BodyPart enum

--- a/iCubShenzhen01/estimators/wholebodydynamics_standup.xml
+++ b/iCubShenzhen01/estimators/wholebodydynamics_standup.xml
@@ -9,6 +9,12 @@
         <param name="defaultContactFrames">(l_hand,r_hand,root_link,l_sole,r_sole,r_upper_leg,l_upper_leg,l_elbow_1,r_elbow_1)</param>
         <param name="imuFrameName">imu_frame</param>
         <param name="publishOnROS">true</param>
+        <param name="useJointVelocity">true</param>
+        <param name="useJointAcceleration">true</param>
+        <param name="imuFilterCutoffInHz">3.0</param>
+        <param name="forceTorqueFilterCutoffInHz">3.0</param>
+        <param name="jointVelFilterCutoffInHz">3.0</param> <!-- used if useJointVelocity is set to true -->
+        <param name="jointAccFilterCutoffInHz">3.0</param> <!-- used if useJointAcceleration is set to true -->
 
         <!-- map between iDynTree links (identified by a name)
              and skinDynLib links (identified by their frame name, a BodyPart enum


### PR DESCRIPTION
### Background
Recently a critical bug in `wholebodydynamics` device was identified by @traversaro. This bug was related to hard-coded cut-off frequency parameters used for low-pass filtering the measurements being used by `wholebodydynamics` device. For more details on this issue, please see https://github.com/robotology/whole-body-estimators/issues/53.

A PR was opened https://github.com/robotology/whole-body-estimators/pull/63 to address this issue, which makes the cutoff frequency parameters as required parameters to be read from the configuration file for the opening of 'wholebodydynamics' device through the 'yarprobotinterface'.

### Changes suggested in this PR

In this PR, we make the required changes in the configuration files to be compatible with those changes in https://github.com/robotology/whole-body-estimators/pull/63.
Mainly we introduce the following parameters (marked as required in the documentation, [see here](https://github.com/robotology/whole-body-estimators/blob/f3055f2cc801f602f5d43a6a65cea3b147c72f1e/devices/wholeBodyDynamics/WholeBodyDynamicsDevice.h#L125)),
- `imuFilterCutoffInHz`
- `forceTorqueFilterCutoffInHz`
- `jointVelFilterCutoffInHz`
- `jointAccFilterCutoffInHz`

The parameters `jointVelFilterCutoffInHz` and `jointAccFilterCutoffInHz` are used if the parameters `useJointVelocity` and `useJointAcceleration` are set to true. The latter parameters are not required and by default set to true. However, in order to avoid any confusion, also these parameters are added to those configuration files in which they are missing.

@traversaro Please feel free to add information or make changes to this description, thank you!