### PR TITLE
Add CER robots

### DIFF
--- a/CER01/CER.xml
+++ b/CER01/CER.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<robot name="CER01" build="1" portprefix="cer" xmlns:xi="http://www.w3.org/2001/XInclude">
+<devices>
+
+    <!-- MOBILE BASE -->
+    <xi:include href="hardware/motorControl/cer_base-ems21-mc.xml" />
+    <xi:include href="wrappers/motorControl/cer_base-mc_wrapper.xml" />
+
+    <!-- LASER -->
+    <xi:include href="hardware/rpLidar/laserA2_hw.xml" /> 
+    <xi:include href="wrappers/rpLidar/laser_wrapper.xml" /> 
+
+    <!-- HEAD -->
+    <xi:include href="hardware/motorControl/cer_head-mcp10-mc.xml" />
+    <xi:include href="wrappers/motorControl/cer_head-mc_wrapper.xml" />
+
+    <!-- LEFT ARM -->
+    <xi:include href="hardware/motorControl/cer_left_upper_arm-ems17-mc.xml" />
+    <xi:include href="hardware/motorControl/cer_left_lower_arm-mcp18-mc.xml" />
+    <xi:include href="wrappers/motorControl/cer_left_arm_no_hand-mc_wrapper.xml" />
+    <xi:include href="wrappers/motorControl/cer_left_wrist_tripod-mc_wrapper.xml" />
+
+    <!-- RIGHT ARM -->
+    <xi:include href="hardware/motorControl/cer_right_upper_arm-ems19-mc.xml" />
+    <xi:include href="hardware/motorControl/cer_right_lower_arm-mcp20-mc.xml" />
+    <xi:include href="wrappers/motorControl/cer_right_arm_no_hand-mc_wrapper.xml" />
+    <xi:include href="wrappers/motorControl/cer_right_wrist_tripod-mc_wrapper.xml" />
+    
+    <!-- LEFT HAND -->
+    <xi:include href="hardware/motorControl/cer_left_hand-mcp7-mc.xml" />
+    <xi:include href="wrappers/motorControl/cer_left_hand-mc_wrapper.xml" />
+    <xi:include href="hardware/MAIS/left_hand-multi_enc.xml" />
+    <xi:include href="wrappers/MAIS/left_hand-mais_wrapper.xml" /> 
+    
+    <!-- RIGHT HAND -->
+    <xi:include href="hardware/motorControl/cer_right_hand-mcp9-mc.xml" />
+    <xi:include href="wrappers/motorControl/cer_right_hand-mc_wrapper.xml" />
+    <xi:include href="hardware/MAIS/right_hand-multi_enc.xml" />
+    <xi:include href="wrappers/MAIS/right_hand-mais_wrapper.xml" /> 
+
+    <!-- TORSO -->
+    <xi:include href="hardware/motorControl/cer_torso-ems15-mc.xml" />
+    <xi:include href="wrappers/motorControl/cer_torso_tripod-mc_wrapper.xml" />
+
+    <!-- SKIN-->
+    <!--
+    <xi:include href="hardware/skin/left_hand-mc7-skin.xml" />
+    <xi:include href="wrappers/skin/left_arm-skin_wrapper.xml" />
+    -->
+    
+     <!-- TRIPODS EQUIVALENTS-->
+    <xi:include href="hardware/motorControl/cer_torso_equivalent-mc.xml" />
+    <xi:include href="hardware/motorControl/cer_left_wrist_equivalent-mc.xml" />
+    <xi:include href="hardware/motorControl/cer_right_wrist_equivalent-mc.xml" />
+    <xi:include href="wrappers/motorControl/cer_torso-mc_wrapper.xml" />
+
+    <!--  FT -->
+    <xi:include href="hardware/FT/cer_left_upper_arm-ems17-strain.xml" />
+    <xi:include href="hardware/FT/cer_right_upper_arm-ems19-strain.xml" />
+    <xi:include href="wrappers/FT/cer_left_arm-FT_wrapper.xml" />
+    <xi:include href="wrappers/FT/cer_right_arm-FT_wrapper.xml" />
+
+    <!--  ROS -->
+    <xi:include href="wrappers/motorControl/cer_ros_wrapper.xml" />
+
+    <!--  CALIBRATORS -->
+    <xi:include href="calibrators/cer_base-calib.xml" />
+    <xi:include href="calibrators/cer_left_arm-calib.xml" />
+    <xi:include href="calibrators/cer_right_arm-calib.xml" />
+    <xi:include href="calibrators/cer_left_hand-calib.xml" />
+    <xi:include href="calibrators/cer_right_hand-calib.xml" />
+    <xi:include href="calibrators/cer_torso-calib.xml" />
+    <xi:include href="calibrators/cer_head-calib.xml" />
+
+</devices>
+</robot> 
+

--- a/CER01/CMakeLists.txt
+++ b/CER01/CMakeLists.txt
@@ -1,0 +1,11 @@
+set(appname CER01)
+
+set(scripts CER.xml yarprobotinterface.ini general.xml yarpmotorgui.ini firmwareupdater.ini)
+
+yarp_install(FILES ${scripts} DESTINATION ${ICUBCONTRIB_ROBOTS_INSTALL_DIR}/${appname})
+yarp_install(DIRECTORY calibrators DESTINATION ${ICUBCONTRIB_ROBOTS_INSTALL_DIR}/${appname})
+yarp_install(DIRECTORY wrappers DESTINATION ${ICUBCONTRIB_ROBOTS_INSTALL_DIR}/${appname})
+yarp_install(DIRECTORY hardware DESTINATION ${ICUBCONTRIB_ROBOTS_INSTALL_DIR}/${appname})
+yarp_install(DIRECTORY sensors  DESTINATION ${ICUBCONTRIB_ROBOTS_INSTALL_DIR}/${appname})
+yarp_install(DIRECTORY camera   DESTINATION ${ICUBCONTRIB_ROBOTS_INSTALL_DIR}/${appname})
+

--- a/CER01/calibrators/cer_base-calib.xml
+++ b/CER01/calibrators/cer_base-calib.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="mobile_base_calibrator" type="parametricCalibratorEth">
+        <xi:include href="../general.xml" />
+                
+		<group name="GENERAL">
+		    <param name="joints">  4  </param> <!-- the number of joints of the robot part -->
+		    <param name="deviceName"> Mobile_Base_Calibrator </param>
+		</group>
+
+<group name="HOME">
+<param name="positionHome">                       0.00            0.00        0.00      0.00          </param>
+<param name="velocityHome">                       10.00           10.00       10.00     10.00         </param>
+<param name="disableHomeAndPark">                 1               1           1         1             </param>   
+</group>
+
+<group name="CALIBRATION">
+<param name="calibrationType">                    3               3           3         3             </param>
+<param name="calibration1">                       0               0           0         0             </param>
+<param name="calibration2">                       10.0            10.0        10.0      10.0          </param>
+<param name="calibration3">                       0               0           0         0             </param>
+<param name="calibration4">                       0               0           0         0             </param>
+<param name="calibration5">                       0               0           0         0             </param>
+<param name="calibrationZero">                    0               0           0         0             </param>
+<param name="calibrationDelta">                   0.0             0.0         0.0       0.0           </param>
+<param name="startupPosition">                    0.0             0.0         0.0       0.0           </param>
+<param name="startupVelocity">                    1.0             1.0         1.0       1.0           </param>
+<param name="startupMaxPwm">                      5000            5000        20000     20000         </param>
+<param name="startupPosThreshold">                2               2           2         2             </param>
+<param name="calibrationTimeout">                 1.0             1.0         1.0       1.0           </param>
+<param name="startupDisablePosCheck">             1               1           1         1             </param>
+</group>
+
+		<param name="CALIB_ORDER">(0 1 2 3) </param>
+
+		<action phase="startup" level="10" type="calibrate">
+		    <param name="target">cer_mobile_base_mc_wrapper</param>
+		</action>
+
+		<action phase="interrupt1" level="1" type="park">
+		    <param name="target">cer_mobile_base_mc_wrapper</param>
+		</action>
+
+		<action phase="interrupt3" level="1" type="abort" />
+
+	</device>
+

--- a/CER01/calibrators/cer_head-calib.xml
+++ b/CER01/calibrators/cer_head-calib.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="head_calibrator" type="parametricCalibratorEth">
+        <xi:include href="../general.xml" />
+                
+    <group name="GENERAL">
+        <param name="joints">  2  </param> <!-- the number of joints of the robot part -->
+        <param name="deviceName"> Head_Calibrator </param>
+    </group>
+
+    <group name="HOME">
+        <param name="positionHome">                       0.00            0.00           </param>
+        <param name="velocityHome">                       10.00           10.00          </param>
+    </group>                                                                      
+
+    <group name="CALIBRATION">                                                    
+        <param name="calibrationType">                    3               3              </param>
+        <param name="calibration1">                       0               0              </param>
+        <param name="calibration2">                       0               0              </param>
+        <param name="calibration3">                       58252           24954          </param> 
+        <param name="calibration4">                       0               0              </param>
+        <param name="calibration5">                       0               0              </param>
+        <param name="calibrationZero">                    180             180            </param>
+        <param name="calibrationDelta">                   0.0             0.0            </param>
+
+        <!--     <param name="calibrationType">                    3               5              </param> 
+        <param name="calibration1">                       0               1200           </param>
+        <param name="calibration2">                       0               12743          </param>
+        <param name="calibration3">                       58072           0              </param> 
+        <param name="calibration4">                       0               0              </param>
+        <param name="calibration5">                       0               0              </param>
+        <param name="calibrationZero">                    180             0              </param>
+        <param name="calibrationDelta">                   0.0             0.0            </param> -->
+
+
+        <param name="startupPosition">                    0.0             0.0            </param>
+        <param name="startupVelocity">                    10.0            10.0           </param>
+        <param name="startupMaxPwm">                      2000            1800           </param>
+        <param name="startupPosThreshold">                4               4              </param>
+    </group>
+
+		<param name="CALIB_ORDER">(0 1) </param>
+
+		<action phase="startup" level="10" type="calibrate">
+		    <param name="target">cer_head_mc_wrapper</param>
+		</action>
+
+		<action phase="interrupt1" level="1" type="park">
+		    <param name="target">cer_head_mc_wrapper</param>
+		</action>
+
+		<action phase="interrupt3" level="1" type="abort" />
+
+	</device>
+

--- a/CER01/calibrators/cer_left_arm-calib.xml
+++ b/CER01/calibrators/cer_left_arm-calib.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm_calibrator" type="parametricCalibratorEth">
+        <xi:include href="../general.xml" />
+                
+		<group name="GENERAL">
+		    <param name="joints">  8  </param> <!-- the number of joints of the robot part -->
+		    <param name="deviceName"> Left_Arm_Calibrator </param>
+		</group>
+
+<group name="HOME">
+<param name="positionHome">                       0.00       5.00       0.00       0.00     0.00   0.03       0.0        0.0        </param>
+<param name="velocityHome">                      10.00      10.00      10.00      10.00    10.00   0.005      10.0       10.0       </param>
+</group>                                                                                                                     
+                                                                                                                             
+<group name="CALIBRATION">                                                                                                   
+<param name="calibrationType">                   3          3          3         3         10      8          8          8                  </param>
+<param name="calibration1">                      0          0          0         0         250    -1500      -1500      -1500              </param>
+<param name="calibration2">                      0          0          0         0         0       700        700        700                </param>
+<param name="calibration3">                      12868      57307      7055      38942     0       0          0          0                  </param>
+<param name="calibration4">                      0          0          0         0         0       0          0          0                  </param>
+<param name="calibration5">                      0          0          0         0         0       0          0          0                  </param>
+<param name="calibrationZero">                   180        180        180       180       85      0          0          0                  </param>
+<param name="calibrationDelta">                  0          0          0         0         0       0          0          0                  </param>
+
+<param name="startupPosition">                   -10        10        -10        45        0       0.03       0.0        0.0                </param>
+<param name="startupVelocity">                   10         10         10        10        15.0    0.007      10         10                 </param>
+<param name="startupMaxPwm">                     32000      32000      32000     32000     2000    2000       2000       2000               </param>
+<param name="startupPosThreshold">               2          2          2         2         2       0.002      2          2                  </param>
+</group>
+
+		<param name="CALIB_ORDER">(0 1 2 3) (4) (5 6 7)</param> 
+
+		<action phase="startup" level="10" type="calibrate">
+		    <param name="target">cer_left_arm_mc_wrapper</param>
+		</action>
+
+		<action phase="interrupt1" level="1" type="park">
+		    <param name="target">cer_left_arm_mc_wrapper</param>
+		</action>
+
+		<action phase="interrupt3" level="1" type="abort" />
+
+	</device>
+

--- a/CER01/calibrators/cer_left_hand-calib.xml
+++ b/CER01/calibrators/cer_left_hand-calib.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_hand_calibrator" type="parametricCalibratorEth">
+        <xi:include href="../general.xml" />
+                
+    <group name="GENERAL">
+        <param name="joints">  2  </param> <!-- the number of joints of the robot part -->
+        <param name="deviceName"> Left_Hand_Calibrator </param>
+    </group>
+
+    <group name="HOME">
+        <param name="positionHome">                       30.00           30.00          </param>
+        <param name="velocityHome">                       40.00           40.00          </param>
+    </group>                                                                      
+
+    <group name="CALIBRATION">                                                    
+        <param name="calibrationType">                       11              11          </param>
+        <param name="calibration1">                       40377           16311          </param>
+        <param name="calibration2">                        8774           63224          </param>
+        <param name="calibration3">                       62696           32185          </param>
+        <param name="calibration4">                       36000           32000          </param>
+        <param name="calibration5">                       -1500            1500          </param>
+        <param name="calibrationZero">                        0               0          </param>        
+        <param name="calibrationDelta">                       0               0          </param>
+        <param name="startupPosition">                     30.0            30.0          </param>
+        <param name="startupVelocity">                     40.0            40.0          </param>
+        <param name="startupMaxPwm">                       1500            1500          </param>
+        <param name="startupPosThreshold">                   10              10          </param>
+    </group>
+
+		<param name="CALIB_ORDER">(0 1) </param>
+
+		<action phase="startup" level="10" type="calibrate">
+		    <param name="target">cer_left_hand_mc_wrapper</param>
+		</action>
+
+		<action phase="interrupt1" level="1" type="park">
+		    <param name="target">cer_left_hand_mc_wrapper</param>
+		</action>
+
+		<action phase="interrupt3" level="1" type="abort" />
+
+	</device>

--- a/CER01/calibrators/cer_right_arm-calib.xml
+++ b/CER01/calibrators/cer_right_arm-calib.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm_calibrator" type="parametricCalibratorEth">
+        <xi:include href="../general.xml" />
+                
+		<group name="GENERAL">
+		    <param name="joints">  8  </param> <!-- the number of joints of the robot part -->
+		    <param name="deviceName"> Right_Arm_Calibrator </param>
+		</group>
+
+<group name="HOME">
+<param name="positionHome">                        0.00       5.00       0.00       0.00     0.00   0.03       0.0        0.0             </param>
+<param name="velocityHome">                       10.00      10.00      10.00      10.00    10.00   0.005      10.0       10.0            </param>
+</group>                                                                                                                       
+                                                                                                                               
+<group name="CALIBRATION">                                                                                                     
+<param name="calibrationType">                    3          3          3         3         10      8          8          8                     </param>
+<param name="calibration1">                       0          0          0         0         -250    -1500      -1500      -1500                 </param>
+<param name="calibration2">                       0          0          0         0         0       700        700        700                   </param>
+<param name="calibration3">                       22000      8000       51900     23101     0       0          0          0                     </param>
+<param name="calibration4">                       0          0          0         0         0       0          0          0                     </param>
+<param name="calibration5">                       0          0          0         0         0       0          0          0                     </param>
+<param name="calibrationZero">                   -180       -180       -180      -180       85      0          0          0                     </param>
+<param name="calibrationDelta">                   0          0          0         0         0       0          0          0                     </param>
+
+<param name="startupPosition">                   -10         10        -10        45        0.0     0.03       0.0        0.0                   </param>
+<param name="startupVelocity">                    10         10         10        10        10      0.007      10         10                    </param>
+<param name="startupMaxPwm">                      32000      32000      32000     32000     2000    2000       2000       2000                  </param>
+<param name="startupPosThreshold">                2          2          2         2         2       0.002      2          2                     </param>
+</group>
+
+		<param name="CALIB_ORDER">(0 1 2 3) (4) (5 6 7)</param> 
+
+		<action phase="startup" level="10" type="calibrate">
+		    <param name="target">cer_right_arm_mc_wrapper</param>
+		</action>
+
+		<action phase="interrupt1" level="1" type="park">
+		    <param name="target">cer_right_arm_mc_wrapper</param>
+		</action>
+
+		<action phase="interrupt3" level="1" type="abort" />
+
+	</device>
+

--- a/CER01/calibrators/cer_right_hand-calib.xml
+++ b/CER01/calibrators/cer_right_hand-calib.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_hand_calibrator" type="parametricCalibratorEth">
+        <xi:include href="../general.xml" />
+                
+    <group name="GENERAL">
+        <param name="joints">  2  </param> <!-- the number of joints of the robot part -->
+        <param name="deviceName"> Right_Hand_Calibrator </param>
+    </group>
+
+    <group name="HOME">
+        <param name="positionHome">                       30.00           30.00          </param>
+        <param name="velocityHome">                       40.00           40.00          </param>
+    </group>                                                                      
+
+    <group name="CALIBRATION">                                                    
+        <param name="calibrationType">                       11              11          </param>
+        <param name="calibration1">                       32968            9812          </param>
+        <param name="calibration2">                       60748           25395          </param>
+        <param name="calibration3">                        2967           17057          </param>
+        <param name="calibration4">                       36000           32000          </param>
+        <param name="calibration5">                        1500           -1500          </param>
+        <param name="calibrationZero">                        0               0          </param>        
+        <param name="calibrationDelta">                       0               0          </param>
+        <param name="startupPosition">                     30.0            30.0          </param>
+        <param name="startupVelocity">                     40.0            40.0          </param>
+        <param name="startupMaxPwm">                       1500            1500          </param>
+        <param name="startupPosThreshold">                   10              10          </param>
+    </group>
+
+		<param name="CALIB_ORDER">(0 1) </param>
+
+		<action phase="startup" level="10" type="calibrate">
+		    <param name="target">cer_right_hand_mc_wrapper</param>
+		</action>
+
+		<action phase="interrupt1" level="1" type="park">
+		    <param name="target">cer_right_hand_mc_wrapper</param>
+		</action>
+
+		<action phase="interrupt3" level="1" type="abort" />
+
+	</device>

--- a/CER01/calibrators/cer_torso-calib.xml
+++ b/CER01/calibrators/cer_torso-calib.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="torso_calibrator" type="parametricCalibratorEth">
+        <xi:include href="../general.xml" />
+                
+		<group name="GENERAL">
+		    <param name="joints">  4  </param> <!-- the number of joints of the robot part -->
+		    <param name="deviceName"> Torso_Calibrator </param>
+		</group>
+
+<group name="HOME">
+<param name="positionHome">                       0.03            0.0         0.0       0.0           </param>
+<param name="velocityHome">                       0.01            10          10        10.0           </param>
+</group>
+
+<group name="CALIBRATION">
+<param name="calibrationType">                    9               9           9         3             </param>
+<param name="calibration1">                       10000           10000       10000     0             </param>
+<param name="calibration2">                       280             280         280       0             </param>
+<param name="calibration3">                       0               0           0         40191.8       </param>
+
+<param name="calibration4">                       0               0           0         0             </param>
+<param name="calibration5">                       0               0           0         0             </param>
+<param name="calibrationZero">                    1700            1700        1700      -180           </param>
+<param name="calibrationDelta">                   0.0             0.0         0.0       0.0           </param>
+
+<param name="startupPosition">                    0.03            0.0         0.0       0.0           </param>
+<param name="startupVelocity">                    0.01            10          10        10.0          </param>
+<param name="startupTimeout">                     30              30          30        20            </param>
+<param name="startupMaxPwm">                      20000           20000       20000     5000          </param>
+<param name="startupPosThreshold">                0.005           2           2         2             </param>
+</group>
+
+		<param name="CALIB_ORDER">(0 1 2 3) </param>
+
+		<action phase="startup" level="10" type="calibrate">
+		    <param name="target">cer_torso_mc_wrapper</param>
+		</action>
+
+		<action phase="interrupt1" level="1" type="park">
+		    <param name="target">cer_torso_mc_wrapper</param>
+		</action>
+
+		<action phase="interrupt3" level="1" type="abort" />
+
+	</device>
+

--- a/CER01/camera/ServerGrabberDual.ini
+++ b/CER01/camera/ServerGrabberDual.ini
@@ -1,0 +1,8 @@
+device grabberDual
+subdevice usbCamera
+capabilities COLOR
+name /cer/cam
+d /dev/video0
+width  1280
+height 480
+

--- a/CER01/cer.urdf
+++ b/CER01/cer.urdf
@@ -1,0 +1,1525 @@
+
+<robot name="SIM_CER_ROBOT">
+  <link name="mobile_base_body_link">
+    <inertial>
+      <origin xyz="0.00353188 0 0.062803" rpy="0 0 0"/>
+      <mass value="14.0"/>
+      <inertia ixx="0.342401" ixy="0.0" ixz="-0.0396992" iyy="0.362542" iyz="0.0" izz="0.168981"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 -0.16" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_mobilebase_body.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="green">
+        <color rgba="0 1 0 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 -0.16" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_mobilebase_body.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <link name="base_link"/>
+  <joint name="base_link_fixed_joint" type="fixed">
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+    <parent link="mobile_base_body_link"/>
+    <child link="base_link"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="mobile_base_lidar"/>
+  <joint name="mobile_base_lidar_fixed_joint" type="fixed">
+    <origin xyz="0.07 0 0.031" rpy="0 0 0"/>
+    <parent link="mobile_base_body_link"/>
+    <child link="mobile_base_lidar"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="torso_slider_eq_link">
+    <inertial>
+      <origin xyz="0.015175 2.80975e-06 0.244533" rpy="0 0 0"/>
+      <mass value="7.5"/>
+      <inertia ixx="0.0978792" ixy="-1.83466e-06" ixz="0.00625726" iyy="0.0969511" iyz="0.0" izz="0.0746114"/>
+    </inertial>
+    <visual>
+      <origin xyz="-0.044 0 -0.231" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_torso_slider_eq.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="black">
+        <color rgba="0 0 0 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="-0.044 0 -0.231" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_torso_slider_eq.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="torso_heave_eq_joint" type="prismatic">
+    <origin xyz="0.044 0 0.071" rpy="0 0 0"/>
+    <axis xyz="0.0 0.0 1.0"/>
+    <parent link="mobile_base_body_link"/>
+    <child link="torso_slider_eq_link"/>
+    <limit effort="1200.0" lower="0.0" upper="0.17" velocity="0.5"/>
+    <dynamics damping="1000.0"/>
+  </joint>
+  <link name="torso_pin_eq_link">
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="1.5"/>
+      <inertia ixx="0.000379688" ixy="0.0" ixz="0.0" iyy="0.00143984" iyz="0.0" izz="0.00143984"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_torso_pin_eq.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="red">
+        <color rgba="1 0 0 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_torso_pin_eq.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="torso_roll_eq_joint" type="revolute">
+    <origin xyz="0 0 0.399" rpy="3.14159265359 0 0"/>
+    <axis xyz="1.0 0.0 0.0"/>
+    <parent link="torso_slider_eq_link"/>
+    <child link="torso_pin_eq_link"/>
+    <limit effort="50.0" lower="-0.523598775598" upper="0.523598775598" velocity="3.14"/>
+    <dynamics damping="100.0"/>
+  </joint>
+  <link name="torso_platform_link">
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="1.5"/>
+      <inertia ixx="0.00153125" ixy="0.0" ixz="0.0" iyy="0.00153125" iyz="0.0" izz="0.0030375"/>
+    </inertial>
+    <visual>
+      <origin xyz="-0.044 0 -0.63" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_torso_platform.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="blue">
+        <color rgba="0 0 1 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="-0.044 0 -0.63" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_torso_platform.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="torso_pitch_eq_joint" type="revolute">
+    <origin xyz="0 0 0" rpy="3.14159265359 0 0"/>
+    <axis xyz="0.0 1.0 0.0"/>
+    <parent link="torso_pin_eq_link"/>
+    <child link="torso_platform_link"/>
+    <limit effort="50.0" lower="-0.523598775598" upper="0.523598775598" velocity="3.14"/>
+    <dynamics damping="100.0"/>
+  </joint>
+  <link name="torso_tripod_root"/>
+  <joint name="torso_tripod_root_fixed_joint" type="fixed">
+    <origin xyz="0 0 0" rpy="0 0 3.14159265359"/>
+    <parent link="torso_platform_link"/>
+    <child link="torso_tripod_root"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="chest_link">
+    <inertial>
+      <origin xyz="-0.0330305 0 0.220198" rpy="0 0 0"/>
+      <mass value="13.0"/>
+      <inertia ixx="0.275816" ixy="0.0" ixz="0.0564476" iyy="0.253579" iyz="0.0" izz="0.127156"/>
+    </inertial>
+    <visual>
+      <origin xyz="-0.044 0 -0.63" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_chest.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="yellow">
+        <color rgba="1 1 0 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="-0.044 0 -0.63" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_chest.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="torso_yaw_joint" type="revolute">
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+    <axis xyz="0.0 0.0 1.0"/>
+    <parent link="torso_platform_link"/>
+    <child link="chest_link"/>
+    <limit effort="30.0" lower="-1.0471975512" upper="1.0471975512" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="torso"/>
+  <joint name="torso_fixed_joint" type="fixed">
+    <origin xyz="-0.042 0 0.185" rpy="0 0 0"/>
+    <parent link="chest_link"/>
+    <child link="torso"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_clavicle_link">
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="0.2"/>
+      <inertia ixx="0.000288" ixy="0.0" ixz="0.0" iyy="0.000288" iyz="0.0" izz="0.000288"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 0.177 -1.0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_clavicle.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="pink">
+        <color rgba="1 0 1 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.04 0.177 -1.0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_clavicle.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_shoulder_pitch_joint" type="revolute">
+    <origin xyz="-0.084 -0.177 0.37" rpy="0 0 0"/>
+    <axis xyz="0.0 -0.970296 0.241922"/>
+    <parent link="chest_link"/>
+    <child link="r_clavicle_link"/>
+    <limit effort="30.0" lower="-0.523598775598" upper="1.57079632679" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="r_shoulder_link">
+    <inertial>
+      <origin xyz="1.5e-06 -0.042148 -0.06332" rpy="0 0 0"/>
+      <mass value="0.5"/>
+      <inertia ixx="0.00076143" ixy="0.0" ixz="-2.84508e-08" iyy="0.000819748" iyz="0.000135828" izz="0.000588486"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 0.177 -1.0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_shoulder.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="cyan">
+        <color rgba="0 1 1 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.04 0.177 -1.0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_shoulder.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_shoulder_roll_joint" type="revolute">
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+    <axis xyz="-1.0 0.0 0.0"/>
+    <parent link="r_clavicle_link"/>
+    <child link="r_shoulder_link"/>
+    <limit effort="30.0" lower="-0.174532925199" upper="1.308996939" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="r_upperarm_FT_sensor_link">
+    <inertial>
+      <origin xyz="0 0 -0.014527" rpy="0 0 0"/>
+      <mass value="0.3"/>
+      <inertia ixx="6.00899e-05" ixy="0.0" ixz="0.0" iyy="6.00898e-05" iyz="0.0" izz="7.59375e-05"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 0.211 -0.89" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_upperarm_sensor.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="green"/>
+    </visual>
+    <collision>
+      <origin xyz="0.04 0.211 -0.89" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_upperarm_sensor.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_shoulder_yaw_joint" type="revolute">
+    <origin xyz="0 -0.034 -0.11" rpy="0 0 0"/>
+    <axis xyz="0.0 0.0 -1.0"/>
+    <parent link="r_shoulder_link"/>
+    <child link="r_upperarm_FT_sensor_link"/>
+    <limit effort="15.0" lower="-1.57079632679" upper="1.57079632679" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="r_upperarm_FT_sensor_frame"/>
+  <joint name="r_upperarm_FT_sensor_frame_fixed_joint" type="fixed">
+    <origin xyz="0 0 -0.0294" rpy="3.14159265359 0 1.57079632679"/>
+    <parent link="r_upperarm_FT_sensor_link"/>
+    <child link="r_upperarm_FT_sensor_frame"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_upperarm_link">
+    <inertial>
+      <origin xyz="0.000197 -0.001254 0.030305" rpy="3.14159265359 0 1.57079632679"/>
+      <mass value="0.5"/>
+      <inertia ixx="0.000849608" ixy="0.0" ixz="-3.39184e-05" iyy="0.000841002" iyz="-4.47567e-07" izz="0.000581528"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.211 0.04 0.8606" rpy="3.14159265359 0 1.57079632679"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_upperarm.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="white">
+        <color rgba="1 1 1 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.211 0.04 0.8606" rpy="3.14159265359 0 1.57079632679"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_upperarm.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_upperarm_FT_sensor" type="fixed">
+    <origin xyz="0 0 -0.0294" rpy="3.14159265359 0 1.57079632679"/>
+    <parent link="r_upperarm_FT_sensor_link"/>
+    <child link="r_upperarm_link"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_elbow_sphere_link">
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="0.2"/>
+      <inertia ixx="0.000128" ixy="0.0" ixz="0.0" iyy="0.000128" iyz="0.0" izz="0.000128"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 0.211 -0.749" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_elbow_sphere.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="dblue">
+        <color rgba="0 0 0.8 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.04 0.211 -0.749" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_elbow_sphere.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_elbow_joint" type="revolute">
+    <origin xyz="0 0 0.1116" rpy="3.14159265359 0 1.57079632679"/>
+    <axis xyz="0.0 -1.0 0.0"/>
+    <parent link="r_upperarm_link"/>
+    <child link="r_elbow_sphere_link"/>
+    <limit effort="20.0" lower="0.0" upper="1.74532925199" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="r_forearm_link">
+    <inertial>
+      <origin xyz="-0.0005116 0.000175 -0.072511" rpy="0 0 0"/>
+      <mass value="0.6"/>
+      <inertia ixx="0.00283352" ixy="0.0" ixz="3.15449e-05" iyy="0.00282953" iyz="-1.03787e-07" izz="0.000436673"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 0.211 -0.678" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_forearm.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="r_forearm_link_color">
+        <color rgba="0.929 0.933 0.91 1.0"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.04 0.211 -0.678" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_forearm.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_wrist_pronosupination_joint" type="revolute">
+    <origin xyz="0 0 -0.071" rpy="0 0 0"/>
+    <axis xyz="0.0 0.0 -1.0"/>
+    <parent link="r_elbow_sphere_link"/>
+    <child link="r_forearm_link"/>
+    <limit effort="10.0" lower="-1.57079632679" upper="1.57079632679" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="r_wrist_tripod_root"/>
+  <joint name="r_wrist_tripod_root_fixed_joint" type="fixed">
+    <origin xyz="0 0 -0.22" rpy="3.14159265359 0 1.57079632679"/>
+    <parent link="r_forearm_link"/>
+    <child link="r_wrist_tripod_root"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_wrist_slider_eq_link">
+    <inertial>
+      <origin xyz="0 5.9e-05 -0.225759" rpy="0 0 0"/>
+      <mass value="0.3"/>
+      <inertia ixx="0.00094001" ixy="0.0" ixz="0.0" iyy="0.000940012" iyz="0.0" izz="0.00022094"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 0.211 -0.749" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_wrist_slider.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="dgreen">
+        <color rgba="0.1 0.8 0.1 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.04 0.211 -0.749" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_wrist_slider.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_wrist_heave_eq_joint" type="prismatic">
+    <origin xyz="0 0 0.071" rpy="0 0 0"/>
+    <axis xyz="0.0 0.0 -1.0"/>
+    <parent link="r_forearm_link"/>
+    <child link="r_wrist_slider_eq_link"/>
+    <limit effort="200.0" lower="0.0" upper="0.13" velocity="0.25"/>
+    <dynamics damping="100.0"/>
+  </joint>
+  <link name="r_wrist_cup_eq_link">
+    <inertial>
+      <origin xyz="-1.1e-05 -0.0319409 -0.018146" rpy="0 0 0"/>
+      <mass value="0.2"/>
+      <inertia ixx="0.000102239" ixy="0.0" ixz="3.78925e-08" iyy="0.000102239" iyz="0.0" izz="0.000163555"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 0.179 -0.458" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_wrist_cup_eq.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="r_wrist_cup_eq_link_color">
+        <color rgba="0.776 0.8 0.769 1.0"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.04 0.179 -0.458" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_wrist_cup_eq.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_wrist_roll_eq_joint" type="revolute">
+    <origin xyz="-0.032 0 -0.291" rpy="0 0 1.57079632679"/>
+    <axis xyz="0.0 1.0 0.0"/>
+    <parent link="r_wrist_slider_eq_link"/>
+    <child link="r_wrist_cup_eq_link"/>
+    <limit effort="10.0" lower="-0.523598775598" upper="0.523598775598" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="r_hand_root_link">
+    <inertial>
+      <origin xyz="0.0001906 0.013614 -0.06234" rpy="0 0 0"/>
+      <mass value="0.3"/>
+      <inertia ixx="0.000294522" ixy="-1.41036e-06" ixz="6.91732e-08" iyy="0.000297774" iyz="2.11461e-05" izz="0.000189897"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 0.211 -0.458" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_hand_root.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="gray">
+        <color rgba="0.5 0.5 0.5 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.04 0.211 -0.458" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_hand_root.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_wrist_pitch_eq_joint" type="revolute">
+    <origin xyz="0 -0.032 0" rpy="0 0 -1.57079632679"/>
+    <axis xyz="0.0 -1.0 0.0"/>
+    <parent link="r_wrist_cup_eq_link"/>
+    <child link="r_hand_root_link"/>
+    <limit effort="10.0" lower="-0.523598775598" upper="0.523598775598" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="r_wrist"/>
+  <joint name="r_wrist_fixed_joint" type="fixed">
+    <origin xyz="0 0 0" rpy="3.14159265359 0 1.57079632679"/>
+    <parent link="r_hand_root_link"/>
+    <child link="r_wrist"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_gripper"/>
+  <joint name="r_gripper_fixed_joint" type="fixed">
+    <origin xyz="0 0.026917 -0.100456" rpy="0 1.30899714732 1.57079632679"/>
+    <parent link="r_hand_root_link"/>
+    <child link="r_gripper"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_hand_paddle_proximal_link">
+    <inertial>
+      <origin xyz="-9.65e-05 -0.010867 -0.022258" rpy="0 0 0"/>
+      <mass value="0.05"/>
+      <inertia ixx="0.0001" ixy="6.93652e-09" ixz="1.75564e-08" iyy="0.0001" iyz="-1.81901e-06" izz="0.0001"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 0.198143 -0.345494" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_hand_paddle_proximal.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="green"/>
+    </visual>
+    <collision>
+      <origin xyz="0.04 0.198143 -0.345494" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_hand_paddle_proximal.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_hand_paddle_proximal_joint" type="revolute">
+    <origin xyz="0 0.012857 -0.112506" rpy="0 0 0"/>
+    <axis xyz="1.0 0.0 0.0"/>
+    <parent link="r_hand_root_link"/>
+    <child link="r_hand_paddle_proximal_link"/>
+    <limit effort="5.0" lower="0.0" upper="1.2217304764" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="r_hand_paddle_distal_link">
+    <inertial>
+      <origin xyz="0.0013214 -0.005592 -0.020601" rpy="0 0 0"/>
+      <mass value="0.05"/>
+      <inertia ixx="0.0001" ixy="1.94983e-07" ixz="9.0126e-07" iyy="0.0001" iyz="-6.79853e-07" izz="0.0001"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 0.214471 -0.306748" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_hand_paddle_distal.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="black"/>
+    </visual>
+    <collision>
+      <origin xyz="0.04 0.214471 -0.306748" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_hand_paddle_distal.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_hand_paddle_distal_joint" type="revolute">
+    <origin xyz="0 -0.016328 -0.038746" rpy="0 0 0"/>
+    <axis xyz="1.0 0.0 0.0"/>
+    <parent link="r_hand_paddle_proximal_link"/>
+    <child link="r_hand_paddle_distal_link"/>
+    <limit effort="5.0" lower="0.0" upper="1.2217304764" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="r_hand_paddle_tip"/>
+  <joint name="r_hand_paddle_tip_fixed_joint" type="fixed">
+    <origin xyz="0 -0.008959 -0.044226" rpy="0 1.30899714732 1.57079632679"/>
+    <parent link="r_hand_paddle_distal_link"/>
+    <child link="r_hand_paddle_tip"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_hand_thumb_proximal_link">
+    <inertial>
+      <origin xyz="0.002515 0.017936 -0.003159" rpy="0 0 0"/>
+      <mass value="0.05"/>
+      <inertia ixx="0.0001" ixy="1.49367e-09" ixz="3.12525e-10" iyy="0.0001" iyz="2.63475e-06" izz="0.0001"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 0.171352 -0.382282" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_hand_thumb_proximal.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="red"/>
+    </visual>
+    <collision>
+      <origin xyz="0.04 0.171352 -0.382282" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_hand_thumb_proximal.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_hand_thumb_proximal_joint" type="revolute">
+    <origin xyz="0 0.039648 -0.075718" rpy="0 0 0"/>
+    <axis xyz="-1.0 0.0 0.0"/>
+    <parent link="r_hand_root_link"/>
+    <child link="r_hand_thumb_proximal_link"/>
+    <limit effort="5.0" lower="0.0" upper="1.0471975512" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="r_hand_thumb_distal_link">
+    <inertial>
+      <origin xyz="0.0024483 0.014529 -0.005865" rpy="0 0 0"/>
+      <mass value="0.05"/>
+      <inertia ixx="3.85163e-06" ixy="-1.50194e-10" ixz="4.04682e-10" iyy="7.40388e-06" iyz="9.14021e-07" izz="8.52416e-06"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 0.130827 -0.371296" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_hand_thumb_distal.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="blue"/>
+    </visual>
+    <collision>
+      <origin xyz="0.04 0.130827 -0.371296" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_hand_thumb_distal.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_hand_thumb_distal_joint" type="revolute">
+    <origin xyz="0 0.040525 -0.010986" rpy="0 0 0"/>
+    <axis xyz="-1.0 0.0 0.0"/>
+    <parent link="r_hand_thumb_proximal_link"/>
+    <child link="r_hand_thumb_distal_link"/>
+    <limit effort="5.0" lower="0.0" upper="1.2217304764" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="r_hand_thumb_tip"/>
+  <joint name="r_hand_thumb_tip_fixed_joint" type="fixed">
+    <origin xyz="0 0.028617 -0.014073" rpy="0 1.30899714732 1.57079632679"/>
+    <parent link="r_hand_thumb_distal_link"/>
+    <child link="r_hand_thumb_tip"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_clavicle_link">
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="0.2"/>
+      <inertia ixx="0.000288" ixy="0.0" ixz="0.0" iyy="0.000288" iyz="0.0" izz="0.000288"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 -0.177 -1.0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_clavicle.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="yellow"/>
+    </visual>
+    <collision>
+      <origin xyz="0.04 -0.177 -1.0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_clavicle.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_shoulder_pitch_joint" type="revolute">
+    <origin xyz="-0.084 0.177 0.37" rpy="0 0 0"/>
+    <axis xyz="0.0 -0.970296 -0.241922"/>
+    <parent link="chest_link"/>
+    <child link="l_clavicle_link"/>
+    <limit effort="30.0" lower="-0.523598775598" upper="1.57079632679" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="l_shoulder_link">
+    <inertial>
+      <origin xyz="1.5e-06 0.042148 -0.06332" rpy="0 0 0"/>
+      <mass value="0.5"/>
+      <inertia ixx="0.00076143" ixy="0.0" ixz="-2.84061e-08" iyy="0.000819748" iyz="-0.000135828" izz="0.000588486"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 -0.177 -1.0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_shoulder.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="pink"/>
+    </visual>
+    <collision>
+      <origin xyz="0.04 -0.177 -1.0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_shoulder.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_shoulder_roll_joint" type="revolute">
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+    <axis xyz="1.0 0.0 0.0"/>
+    <parent link="l_clavicle_link"/>
+    <child link="l_shoulder_link"/>
+    <limit effort="30.0" lower="-0.174532925199" upper="1.308996939" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="l_upperarm_FT_sensor_link">
+    <inertial>
+      <origin xyz="0 0 -0.014527" rpy="0 0 0"/>
+      <mass value="0.3"/>
+      <inertia ixx="6.00899e-05" ixy="0.0" ixz="0.0" iyy="6.00898e-05" iyz="0.0" izz="7.59375e-05"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 -0.211 -0.89" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_upperarm_sensor.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="cyan"/>
+    </visual>
+    <collision>
+      <origin xyz="0.04 -0.211 -0.89" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_upperarm_sensor.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_shoulder_yaw_joint" type="revolute">
+    <origin xyz="0 0.034 -0.11" rpy="0 0 0"/>
+    <axis xyz="0.0 0.0 1.0"/>
+    <parent link="l_shoulder_link"/>
+    <child link="l_upperarm_FT_sensor_link"/>
+    <limit effort="15.0" lower="-1.57079632679" upper="1.57079632679" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="l_upperarm_FT_sensor_frame"/>
+  <joint name="l_upperarm_FT_sensor_frame_fixed_joint" type="fixed">
+    <origin xyz="0 0 -0.0294" rpy="3.14159265359 0 1.57079632679"/>
+    <parent link="l_upperarm_FT_sensor_link"/>
+    <child link="l_upperarm_FT_sensor_frame"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_upperarm_link">
+    <inertial>
+      <origin xyz="-0.000197 -0.001254 0.030305" rpy="3.14159265359 0 1.57079632679"/>
+      <mass value="0.5"/>
+      <inertia ixx="0.000849607" ixy="0.0" ixz="-3.39183e-05" iyy="0.000841001" iyz="4.47458e-07" izz="0.000581528"/>
+    </inertial>
+    <visual>
+      <origin xyz="-0.211 0.04 0.8606" rpy="3.14159265359 0 1.57079632679"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_upperarm.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="green"/>
+    </visual>
+    <collision>
+      <origin xyz="-0.211 0.04 0.8606" rpy="3.14159265359 0 1.57079632679"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_upperarm.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_upperarm_FT_sensor" type="fixed">
+    <origin xyz="0 0 -0.0294" rpy="3.14159265359 0 1.57079632679"/>
+    <parent link="l_upperarm_FT_sensor_link"/>
+    <child link="l_upperarm_link"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_elbow_sphere_link">
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="0.2"/>
+      <inertia ixx="0.000128" ixy="0.0" ixz="0.0" iyy="0.000128" iyz="0.0" izz="0.000128"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 -0.211 -0.749" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_elbow_sphere.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="white"/>
+    </visual>
+    <collision>
+      <origin xyz="0.04 -0.211 -0.749" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_elbow_sphere.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_elbow_joint" type="revolute">
+    <origin xyz="0 0 0.1116" rpy="3.14159265359 0 1.57079632679"/>
+    <axis xyz="0.0 -1.0 0.0"/>
+    <parent link="l_upperarm_link"/>
+    <child link="l_elbow_sphere_link"/>
+    <limit effort="20.0" lower="0.0" upper="1.74532925199" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="l_forearm_link">
+    <inertial>
+      <origin xyz="-0.0005116 -0.000175 -0.072511" rpy="0 0 0"/>
+      <mass value="0.6"/>
+      <inertia ixx="0.00283352" ixy="0.0" ixz="3.15449e-05" iyy="0.00282953" iyz="1.0379e-07" izz="0.000436673"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 -0.211 -0.678" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_forearm.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="l_forearm_link_color">
+        <color rgba="0.929 0.933 0.91 1.0"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.04 -0.211 -0.678" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_forearm.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_wrist_pronosupination_joint" type="revolute">
+    <origin xyz="0 0 -0.071" rpy="0 0 0"/>
+    <axis xyz="0.0 0.0 1.0"/>
+    <parent link="l_elbow_sphere_link"/>
+    <child link="l_forearm_link"/>
+    <limit effort="10.0" lower="-1.57079632679" upper="1.57079632679" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="l_wrist_tripod_root"/>
+  <joint name="l_wrist_tripod_root_fixed_joint" type="fixed">
+    <origin xyz="0 0 -0.22" rpy="3.14159265359 0 -1.57079632679"/>
+    <parent link="l_forearm_link"/>
+    <child link="l_wrist_tripod_root"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_wrist_slider_eq_link">
+    <inertial>
+      <origin xyz="0 -5.9e-05 -0.225761" rpy="0 0 0"/>
+      <mass value="0.3"/>
+      <inertia ixx="0.000939997" ixy="0.0" ixz="0.0" iyy="0.00094" iyz="4.18243e-09" izz="0.000220942"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 -0.211 -0.749" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_wrist_slider.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="dblue"/>
+    </visual>
+    <collision>
+      <origin xyz="0.04 -0.211 -0.749" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_wrist_slider.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_wrist_heave_eq_joint" type="prismatic">
+    <origin xyz="0 0 0.071" rpy="0 0 0"/>
+    <axis xyz="0.0 0.0 -1.0"/>
+    <parent link="l_forearm_link"/>
+    <child link="l_wrist_slider_eq_link"/>
+    <limit effort="200.0" lower="0.0" upper="0.13" velocity="0.25"/>
+    <dynamics damping="100.0"/>
+  </joint>
+  <link name="l_wrist_cup_eq_link">
+    <inertial>
+      <origin xyz="0.0319892 -5.9e-05 -0.018146" rpy="0 0 0"/>
+      <mass value="0.2"/>
+      <inertia ixx="0.000102239" ixy="0.0" ixz="3.78925e-08" iyy="0.000102239" iyz="0.0" izz="0.000163555"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.072 -0.211 -0.458" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_wrist_cup_eq.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="l_wrist_cup_eq_link_color">
+        <color rgba="0.776 0.8 0.769 1.0"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.072 -0.211 -0.458" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_wrist_cup_eq.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_wrist_roll_eq_joint" type="revolute">
+    <origin xyz="-0.032 0 -0.291" rpy="0 0 0"/>
+    <axis xyz="1.0 0.0 0.0"/>
+    <parent link="l_wrist_slider_eq_link"/>
+    <child link="l_wrist_cup_eq_link"/>
+    <limit effort="10.0" lower="-0.523598775598" upper="0.523598775598" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="l_hand_root_link">
+    <inertial>
+      <origin xyz="0.0001906 -0.013614 -0.06234" rpy="0 0 0"/>
+      <mass value="0.3"/>
+      <inertia ixx="0.000294522" ixy="1.41029e-06" ixz="6.92026e-08" iyy="0.000297775" iyz="-2.11461e-05" izz="0.000189897"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 -0.211 -0.458" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_hand_root.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="dgreen"/>
+    </visual>
+    <collision>
+      <origin xyz="0.04 -0.211 -0.458" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_hand_root.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_wrist_pitch_eq_joint" type="revolute">
+    <origin xyz="0.032 0 0" rpy="0 0 0"/>
+    <axis xyz="0.0 -1.0 0.0"/>
+    <parent link="l_wrist_cup_eq_link"/>
+    <child link="l_hand_root_link"/>
+    <limit effort="10.0" lower="-0.523598775598" upper="0.523598775598" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="l_wrist"/>
+  <joint name="l_wrist_fixed_joint" type="fixed">
+    <origin xyz="0 0 0" rpy="3.14159265359 0 -1.57079632679"/>
+    <parent link="l_hand_root_link"/>
+    <child link="l_wrist"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_gripper"/>
+  <joint name="l_gripper_fixed_joint" type="fixed">
+    <origin xyz="0 -0.026917 -0.100456" rpy="3.14159265359 1.30899714732 -1.57079632679"/>
+    <parent link="l_hand_root_link"/>
+    <child link="l_gripper"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_hand_paddle_proximal_link">
+    <inertial>
+      <origin xyz="-9.65e-05 0.010867 -0.022259" rpy="0 0 0"/>
+      <mass value="0.05"/>
+      <inertia ixx="0.0001" ixy="-6.9439e-09" ixz="1.7549e-08" iyy="0.0001" iyz="1.81902e-06" izz="0.0001"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 -0.198143 -0.345494" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_hand_paddle_proximal.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="gray"/>
+    </visual>
+    <collision>
+      <origin xyz="0.04 -0.198143 -0.345494" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_hand_paddle_proximal.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_hand_paddle_proximal_joint" type="revolute">
+    <origin xyz="0 -0.012857 -0.112506" rpy="0 0 0"/>
+    <axis xyz="-1.0 0.0 0.0"/>
+    <parent link="l_hand_root_link"/>
+    <child link="l_hand_paddle_proximal_link"/>
+    <limit effort="5.0" lower="0.0" upper="1.2217304764" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="l_hand_paddle_distal_link">
+    <inertial>
+      <origin xyz="0.0013214 0.005592 -0.020601" rpy="0 0 0"/>
+      <mass value="0.05"/>
+      <inertia ixx="0.0001" ixy="-1.94983e-07" ixz="9.01259e-07" iyy="0.0001" iyz="6.79853e-07" izz="0.0001"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 -0.214471 -0.306748" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_hand_paddle_distal.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="green"/>
+    </visual>
+    <collision>
+      <origin xyz="0.04 -0.214471 -0.306748" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_hand_paddle_distal.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_hand_paddle_distal_joint" type="revolute">
+    <origin xyz="0 0.016328 -0.038746" rpy="0 0 0"/>
+    <axis xyz="-1.0 0.0 0.0"/>
+    <parent link="l_hand_paddle_proximal_link"/>
+    <child link="l_hand_paddle_distal_link"/>
+    <limit effort="5.0" lower="0.0" upper="1.2217304764" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="l_hand_paddle_tip"/>
+  <joint name="l_hand_paddle_tip_fixed_joint" type="fixed">
+    <origin xyz="0 0.008959 -0.044226" rpy="3.14159265359 1.30899714732 -1.57079632679"/>
+    <parent link="l_hand_paddle_distal_link"/>
+    <child link="l_hand_paddle_tip"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_hand_thumb_proximal_link">
+    <inertial>
+      <origin xyz="0.002515 -0.017936 -0.003159" rpy="0 0 0"/>
+      <mass value="0.05"/>
+      <inertia ixx="0.0001" ixy="-1.50858e-09" ixz="3.04948e-10" iyy="0.0001" iyz="-2.63475e-06" izz="0.0001"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 -0.171352 -0.382282" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_hand_thumb_proximal.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="black"/>
+    </visual>
+    <collision>
+      <origin xyz="0.04 -0.171352 -0.382282" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_hand_thumb_proximal.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_hand_thumb_proximal_joint" type="revolute">
+    <origin xyz="0 -0.039648 -0.075718" rpy="0 0 0"/>
+    <axis xyz="1.0 0.0 0.0"/>
+    <parent link="l_hand_root_link"/>
+    <child link="l_hand_thumb_proximal_link"/>
+    <limit effort="5.0" lower="0.0" upper="1.0471975512" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="l_hand_thumb_distal_link">
+    <inertial>
+      <origin xyz="0.0021933 -0.014529 -0.005865" rpy="0 0 0"/>
+      <mass value="0.05"/>
+      <inertia ixx="0.0001" ixy="1.50893e-10" ixz="4.0488e-10" iyy="0.0001" iyz="-9.14021e-07" izz="0.0001"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.039745 -0.130827 -0.371296" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_hand_thumb_distal.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="red"/>
+    </visual>
+    <collision>
+      <origin xyz="0.039745 -0.130827 -0.371296" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_hand_thumb_distal.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_hand_thumb_distal_joint" type="revolute">
+    <origin xyz="0.000255 -0.040525 -0.010986" rpy="0 0 0"/>
+    <axis xyz="1.0 0.0 0.0"/>
+    <parent link="l_hand_thumb_proximal_link"/>
+    <child link="l_hand_thumb_distal_link"/>
+    <limit effort="5.0" lower="0.0" upper="1.2217304764" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="l_hand_thumb_tip"/>
+  <joint name="l_hand_thumb_tip_fixed_joint" type="fixed">
+    <origin xyz="-0.000255 -0.028617 -0.014073" rpy="3.14159265359 1.30899714732 -1.57079632679"/>
+    <parent link="l_hand_thumb_distal_link"/>
+    <child link="l_hand_thumb_tip"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="neck_link">
+    <inertial>
+      <origin xyz="-0.0003217 0 0.07756" rpy="0 0 0"/>
+      <mass value="1.4"/>
+      <inertia ixx="0.00429793" ixy="0.0" ixz="-0.000592817" iyy="0.00443784" iyz="-6.85477e-08" izz="0.000419904"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.05 0 -1.03" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_neck.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="blue"/>
+    </visual>
+    <collision>
+      <origin xyz="0.05 0 -1.03" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_neck.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="neck_pitch_joint" type="revolute">
+    <origin xyz="-0.094 0 0.4" rpy="0 0 0"/>
+    <axis xyz="0.0 1.0 0.0"/>
+    <parent link="chest_link"/>
+    <child link="neck_link"/>
+    <limit effort="10.0" lower="-0.523598775598" upper="0.872664625997" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="head_link">
+    <inertial>
+      <origin xyz="0.0301486 -1.57202e-06 -0.00035" rpy="0 0 0"/>
+      <mass value="2.0"/>
+      <inertia ixx="0.0106536" ixy="-7.34817e-08" ixz="0.000274098" iyy="0.00398482" iyz="1.64063e-07" izz="0.00944369"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.0383205 0 -1.18838" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_head.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="head_link_color">
+        <color rgba="0.368932 0.368932 0.368932 1.0"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.0383205 0 -1.18838" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_head.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="neck_yaw_joint" type="revolute">
+    <origin xyz="0.0116795 0 0.15838" rpy="0 0 0"/>
+    <axis xyz="0.173648 0.0 0.984808"/>
+    <parent link="neck_link"/>
+    <child link="head_link"/>
+    <limit effort="10.0" lower="-1.3962634016" upper="1.3962634016" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="depth_rgb"/>
+  <joint name="depth_rgb_fixed_joint" type="fixed">
+    <origin xyz="0.0598814 0.0184871 0.04402" rpy="-1.57079632679 0 -1.57079632679"/>
+    <parent link="head_link"/>
+    <child link="depth_rgb"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="head_leopard_cyclopic"/>
+  <joint name="head_leopard_cyclopic_fixed_joint" type="fixed">
+    <origin xyz="0.0521666 0 -0.06748" rpy="-1.57079632679 0 -1.57079632679"/>
+    <parent link="head_link"/>
+    <child link="head_leopard_cyclopic"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="gaze"/>
+  <joint name="gaze_fixed_joint" type="fixed">
+    <origin xyz="0.0494817 0 -0.01388" rpy="-1.57079632679 0 -1.57079632679"/>
+    <parent link="head_link"/>
+    <child link="gaze"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="head_leopard_right"/>
+  <joint name="head_leopard_right_fixed_joint" type="fixed">
+    <origin xyz="0.0521666 -0.0335105 -0.06748" rpy="-1.57079632679 0 -1.57079632679"/>
+    <parent link="head_link"/>
+    <child link="head_leopard_right"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="head_leopard_left"/>
+  <joint name="head_leopard_left_fixed_joint" type="fixed">
+    <origin xyz="0.0521666 0.0335105 -0.06748" rpy="-1.57079632679 0 -1.57079632679"/>
+    <parent link="head_link"/>
+    <child link="head_leopard_left"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="depth"/>
+  <joint name="depth_fixed_joint" type="fixed">
+    <origin xyz="0.0598814 0.0444871 0.04402" rpy="-1.57079632679 0 -1.57079632679"/>
+    <parent link="head_link"/>
+    <child link="depth"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="depth_center"/>
+  <joint name="depth_center_fixed_joint" type="fixed">
+    <origin xyz="0.0598756 0 0.04402" rpy="-1.57079632679 0 -1.57079632679"/>
+    <parent link="head_link"/>
+    <child link="depth_center"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="mobile_base_r_tyre_link">
+    <inertial>
+      <origin xyz="0 -0.034425 8.99999999998e-06" rpy="0 0 0"/>
+      <mass value="3.0"/>
+      <inertia ixx="0.0200196" ixy="0.0" ixz="0.0" iyy="0.0376169" iyz="8.28101e-07" izz="0.0200156"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0.139 -0.16" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_mobilebase_r_tyre.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="yellow"/>
+    </visual>
+    <collision>
+      <origin xyz="0.0 -0.03 0.0" rpy="1.57079632679 0.0 0.0"/>
+      <geometry>
+        <cylinder radius="0.16" length="0.005"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="mobile_base_r_wheel_joint" type="continuous">
+    <origin xyz="0 -0.139 0" rpy="0 0 0"/>
+    <axis xyz="0.0 1.0 0.0"/>
+    <parent link="mobile_base_body_link"/>
+    <child link="mobile_base_r_tyre_link"/>
+    <limit effort="100.0" velocity="30.0"/>
+    <dynamics damping="0.5"/>
+  </joint>
+  <link name="mobile_base_l_tyre_link">
+    <inertial>
+      <origin xyz="0 0.034425 8.99999999998e-06" rpy="0 0 0"/>
+      <mass value="3.0"/>
+      <inertia ixx="0.0200196" ixy="0.0" ixz="0.0" iyy="0.0376169" iyz="-8.28446e-07" izz="0.0200156"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 -0.139 -0.16" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_mobilebase_l_tyre.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="pink"/>
+    </visual>
+    <collision>
+      <origin xyz="0.0 0.03 0.0" rpy="1.57079632679 0.0 0.0"/>
+      <geometry>
+        <cylinder radius="0.16" length="0.005"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="mobile_base_l_wheel_joint" type="continuous">
+    <origin xyz="0 0.139 0" rpy="0 0 0"/>
+    <axis xyz="0.0 1.0 0.0"/>
+    <parent link="mobile_base_body_link"/>
+    <child link="mobile_base_l_tyre_link"/>
+    <limit effort="100.0" velocity="30.0"/>
+    <dynamics damping="0.5"/>
+  </joint>
+  <gazebo reference="l_upperarm_FT_sensor">
+    <sensor name="l_upperarm_FT_sensor" type="force_torque">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <force_torque>
+        <frame>child</frame>
+        <measure_direction>child_to_parent</measure_direction>
+      </force_torque>
+    </sensor>
+  </gazebo>
+  <sensor name="l_upperarm_FT_sensor" type="force_torque">
+    <parent joint="l_upperarm_FT_sensor"/>
+    <force_torque>
+      <frame>child</frame>
+      <measure_direction>child_to_parent</measure_direction>
+    </force_torque>
+  </sensor>
+  <gazebo reference="r_upperarm_FT_sensor">
+    <sensor name="r_upperarm_FT_sensor" type="force_torque">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <force_torque>
+        <frame>child</frame>
+        <measure_direction>child_to_parent</measure_direction>
+      </force_torque>
+    </sensor>
+  </gazebo>
+  <sensor name="r_upperarm_FT_sensor" type="force_torque">
+    <parent joint="r_upperarm_FT_sensor"/>
+    <force_torque>
+      <frame>child</frame>
+      <measure_direction>child_to_parent</measure_direction>
+    </force_torque>
+  </sensor>
+  <gazebo reference="mobile_base_body_link">
+    <sensor name="base_laser" type="ray">
+      <always_on>1</always_on>
+      <update_rate>40</update_rate>
+      <pose>0.07 0.0 0.031 0.0 -0.0 0.0</pose>
+      <ray>
+ <scan>
+  <horizontal>
+   <samples>360</samples>
+   <resolution>1</resolution>
+   <min_angle>-3.14</min_angle>
+   <max_angle>3.14</max_angle>
+  </horizontal>
+ </scan>
+ <range>
+  <min>0.10</min>
+  <max>5.0</max>
+  <resolution>0.01</resolution>
+ </range>
+ <noise>
+  <type>gaussian</type>
+  <mean>0.0</mean>
+  <stddev>0.005</stddev>
+ </noise>
+</ray>
+      <plugin name="laser_sensor" filename="libgazebo_yarp_lasersensor.so">
+    <yarpConfigurationFile>package://cer/conf/gazebo_cer_laser_sensor.ini</yarpConfigurationFile>
+</plugin>
+    </sensor>
+  </gazebo>
+  <sensor name="base_laser" type="ray">
+    <parent link="mobile_base_body_link"/>
+    <origin rpy="0.0 -0.0 0.0" xyz="0.07 0.0 0.031"/>
+  </sensor>
+  <gazebo reference="head_link">
+    <sensor name="multicamera_sensor" type="multicamera">
+      <always_on>1</always_on>
+      <update_rate>30</update_rate>
+      <pose>0.0521666 0.0 -0.06748 -1.57079632679 -0.0 -1.57079632679</pose>
+      <camera name="left_camera">
+  <pose>-0.0325 0 0 -1.57079 -1.57079 3.14159</pose>
+  <horizontal_fov>1.5708</horizontal_fov>
+  <image>
+     <width>640</width>
+     <height>480</height>
+  </image>
+  <clip>
+     <near>0.1</near>
+     <far>100</far>
+  </clip>
+</camera>
+      <camera name="right_camera">
+  <pose>0.0325 0 0 -1.57079 -1.57079 3.14159</pose>
+  <horizontal_fov>1.5708</horizontal_fov>
+  <image>
+    <width>640</width>
+    <height>480</height>
+  </image>
+  <clip>
+    <near>0.1</near>
+    <far>100</far>
+  </clip>
+</camera>
+      <plugin name="multicamera_plugin" filename="libgazebo_yarp_multicamera.so">
+    <yarpConfigurationFile>package://cer/conf/gazebo_cer_multicamera.ini</yarpConfigurationFile>
+</plugin>
+    </sensor>
+  </gazebo>
+  <sensor name="multicamera_sensor" type="multicamera">
+    <parent link="head_link"/>
+    <origin rpy="-1.57079632679 -0.0 -1.57079632679" xyz="0.0521666 0.0 -0.06748"/>
+  </sensor>
+  <gazebo reference="head_link">
+    <sensor name="asus_xtion_depth" type="depth">
+      <always_on>1</always_on>
+      <update_rate>30</update_rate>
+      <pose>0.0598814 0.0444871 0.04402 -1.57079632679 -0.0 -1.57079632679</pose>
+      <camera name="asus_xtion_depth_camera">
+    <pose frame="">0 0 0 -1.57079 -1.57079 3.14159</pose>
+    <horizontal_fov>1.02259</horizontal_fov>
+    <distortion>
+        <k1>0</k1>
+        <k2>0</k2>
+        <k3>0</k3>
+        <p1>0</p1>
+        <p2>0</p2>
+        <center>319.5 239.5</center>
+    </distortion>
+    <image>
+        <width>640</width>
+        <height>480</height>
+        <format>R8G8B8</format>
+    </image>
+    <clip>
+        <near>0.02</near>
+        <far>3000</far>
+    </clip>
+</camera>
+      <plugin filename="libgazebo_yarp_depthCamera.so" name="depth_camera_plugin">
+    <yarpConfigurationFile>package://cer/conf/gazebo_cer_depthCamera.ini</yarpConfigurationFile>
+</plugin>
+    </sensor>
+  </gazebo>
+  <sensor name="asus_xtion_depth" type="depth">
+    <parent link="head_link"/>
+    <origin rpy="-1.57079632679 -0.0 -1.57079632679" xyz="0.0598814 0.0444871 0.04402"/>
+  </sensor>
+  <gazebo reference="head_link">
+    <sensor name="asus_xtion_rgb" type="camera">
+      <always_on>1</always_on>
+      <update_rate>30</update_rate>
+      <pose>0.0598814 0.0184871 0.04402 -1.57079632679 -0.0 -1.57079632679</pose>
+      <camera name="asus_xtion_rgb_camera">
+    <pose frame="">0 0 0 -1.57079 -1.57079 3.14159</pose>
+    <horizontal_fov>1.02259</horizontal_fov>
+    <distortion>
+        <k1>0</k1>
+        <k2>0</k2>
+        <k3>0</k3>
+        <p1>0</p1>
+        <p2>0</p2>
+        <center>319.5 239.5</center>
+    </distortion>
+    <image>
+        <width>640</width>
+        <height>480</height>
+        <format>R8G8B8</format>
+    </image>
+    <clip>
+        <near>0.02</near>
+        <far>3000</far>
+    </clip>
+</camera>
+      <plugin filename="libgazebo_yarp_camera.so" name="xtion_camera_rgb_plugin">
+    <yarpConfigurationFile>package://cer/conf/gazebo_cer_xtion_camera_rgb.ini</yarpConfigurationFile>
+</plugin>
+    </sensor>
+  </gazebo>
+  <sensor name="asus_xtion_rgb" type="camera">
+    <parent link="head_link"/>
+    <origin rpy="-1.57079632679 -0.0 -1.57079632679" xyz="0.0598814 0.0184871 0.04402"/>
+  </sensor>
+  <gazebo>
+<!-- TORSO user view -->
+<plugin name="controlboard_torso" filename="libgazebo_yarp_controlboard.so">
+  <yarpConfigurationFile>package://cer/conf/gazebo_cer_torso.ini</yarpConfigurationFile>
+</plugin>
+<!-- TORSO low level view -->
+<plugin name="controlboard_torso_tripod" filename="libgazeboTripod.so">
+  <yarpConfigurationFile>package://cer/conf/gazebo_cer_torso_tripod.ini</yarpConfigurationFile>
+</plugin>
+
+<plugin name="controlboard_left_upper_arm" filename="libgazebo_yarp_controlboard.so">
+  <yarpConfigurationFile>package://cer/conf/gazebo_cer_left_upper_arm.ini</yarpConfigurationFile>
+</plugin>
+<!-- LEFT WRIST user view -->  
+<plugin name="controlboard_left_wrist" filename="libgazebo_yarp_controlboard.so">
+  <yarpConfigurationFile>package://cer/conf/gazebo_cer_left_wrist.ini</yarpConfigurationFile>
+</plugin>
+<!-- LEFT WRIST low level view -->
+<plugin name="controlboard_left_wrist_tripod" filename="libgazeboTripod.so">
+  <yarpConfigurationFile>package://cer/conf/gazebo_cer_left_wrist_tripod.ini</yarpConfigurationFile>
+</plugin>
+
+<plugin name="controlboard_right_upper_arm" filename="libgazebo_yarp_controlboard.so">
+  <yarpConfigurationFile>package://cer/conf/gazebo_cer_right_upper_arm.ini</yarpConfigurationFile>
+</plugin>
+<!-- RIGHT WRIST user view -->
+<plugin name="controlboard_right_wrist" filename="libgazebo_yarp_controlboard.so">
+  <yarpConfigurationFile>package://cer/conf/gazebo_cer_right_wrist.ini</yarpConfigurationFile>
+</plugin>
+<!-- RIGHT WRIST low level view -->
+<plugin name="controlboard_right_wrist_tripod" filename="libgazeboTripod.so">
+  <yarpConfigurationFile>package://cer/conf/gazebo_cer_right_wrist_tripod.ini</yarpConfigurationFile>
+</plugin>
+
+<plugin name="controlboard_right_arm" filename="libgazebo_yarp_controlboard.so">
+  <yarpConfigurationFile>package://cer/conf/gazebo_cer_right_arm.ini</yarpConfigurationFile>
+</plugin>
+<plugin name="controlboard_left_arm" filename="libgazebo_yarp_controlboard.so">
+  <yarpConfigurationFile>package://cer/conf/gazebo_cer_left_arm.ini</yarpConfigurationFile>
+</plugin>
+
+<plugin name="controlboard_head" filename="libgazebo_yarp_controlboard.so">
+  <yarpConfigurationFile>package://cer/conf/gazebo_cer_head.ini</yarpConfigurationFile>
+</plugin>
+
+<plugin name="controlboard_left_hand" filename="libgazebo_yarp_controlboard.so">
+  <yarpConfigurationFile>package://cer/conf/gazebo_cer_left_hand.ini</yarpConfigurationFile>
+</plugin>
+
+<plugin name="controlboard_right_hand" filename="libgazebo_yarp_controlboard.so">
+  <yarpConfigurationFile>package://cer/conf/gazebo_cer_right_hand.ini</yarpConfigurationFile>
+</plugin> 
+
+<plugin name="mais_left_hand" filename="libgazebo_yarp_maissensor.so">
+  <yarpConfigurationFile>package://cer/conf/gazebo_cer_left_hand_mais.ini</yarpConfigurationFile>
+</plugin>
+<plugin name="mais_right_hand" filename="libgazebo_yarp_maissensor.so">
+  <yarpConfigurationFile>package://cer/conf/gazebo_cer_right_hand_mais.ini</yarpConfigurationFile>
+</plugin>
+
+<plugin name="controlboard_mobile_base" filename="libgazebo_yarp_controlboard.so">
+  <yarpConfigurationFile>package://cer/conf/gazebo_cer_mobile_base.ini</yarpConfigurationFile>
+</plugin>
+<plugin name="controlboard_all" filename="libgazebo_yarp_controlboard.so">
+  <yarpConfigurationFile>package://cer/conf/gazebo_cer_all.ini</yarpConfigurationFile>
+</plugin>
+<plugin name="world_interface" filename="libgazebo_yarp_worldinterface.so">
+  <yarpConfigurationFile>package://cer/conf/worldInterface.ini</yarpConfigurationFile>
+</plugin>
+</gazebo>
+  <gazebo reference="mobile_base_body_link">
+    <collision>
+      <surface>
+        <contact>
+          <ode/>
+        </contact>
+        <friction>
+          <ode>
+            <mu>0.0</mu>
+            <mu2>0.0</mu2>
+          </ode>
+        </friction>
+      </surface>
+    </collision>
+</gazebo>
+  <gazebo>
+  <pose>0 0 0.16 0 0 0</pose>
+</gazebo>
+  <gazebo reference="mobile_base_l_wheel_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="mobile_base_r_wheel_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="torso_heave_eq_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="torso_roll_eq_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="torso_pitch_eq_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="torso_yaw_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="neck_pitch_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="neck_yaw_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="l_shoulder_pitch_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="l_shoulder_roll_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="l_shoulder_yaw_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="l_elbow_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="l_wrist_pronosupination_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="l_wrist_heave_eq_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="l_wrist_roll_eq_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="l_wrist_pitch_eq_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="l_hand_paddle_proximal_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="l_hand_paddle_distal_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="l_hand_thumb_proximal_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="l_hand_thumb_distal_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="r_shoulder_pitch_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="r_shoulder_roll_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="r_shoulder_yaw_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="r_elbow_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="r_wrist_pronosupination_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="r_wrist_heave_eq_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="r_wrist_roll_eq_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="r_wrist_pitch_eq_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="r_hand_paddle_proximal_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="r_hand_paddle_distal_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="r_hand_thumb_proximal_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="r_hand_thumb_distal_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+</robot>
+

--- a/CER01/firmwareupdater.ini
+++ b/CER01/firmwareupdater.ini
@@ -1,0 +1,2 @@
+[DRIVERS]
+ETH "eth"

--- a/CER01/general.xml
+++ b/CER01/general.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER01" build="1">
+  
+  <group name="GENERAL">
+      <param name="skipCalibration">    false  </param>
+      <param name="useRawEncoderData">  false  </param>
+      <param name="useLimitedPWM">      false  </param>
+      <param name="verbose">            false  </param>
+  </group>
+</params>

--- a/CER01/hardware/FT/cer_left_upper_arm-ems17-strain.xml
+++ b/CER01/hardware/FT/cer_left_upper_arm-ems17-strain.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_upper_arm_strain" type="embObjStrain">
+    
+        <xi:include href="../../general.xml"/>
+
+        <xi:include href="../electronics/cer_left_upper_arm-ems17-eln.xml" />
+    
+        <group name="SERVICE">
+            
+            <param name="type"> eomn_serv_AS_strain </param>
+        
+            <group name="PROPERTIES">
+  
+                <group name="CANBOARDS">
+                    <param name="type">                 eobrd_strain            </param>
+
+                    <group name="PROTOCOL">
+                        <param name="major">            1                       </param>    
+                        <param name="minor">            0                       </param>     
+                    </group>                    
+                    <group name="FIRMWARE">
+                        <param name="major">            0                       </param>    
+                        <param name="minor">            0                       </param> 
+                        <param name="build">            0                       </param>
+                    </group>
+                </group>
+                
+                <group name="SENSORS">
+                    <param name="id">                   id_l_upper_arm_strain   </param>
+                    <param name="type">                 eoas_strain             </param>
+                    <param name="location">             CAN2:13                 </param>
+                </group>                
+            
+            </group>
+
+            <group name="SETTINGS">        
+                <param name="acquisitionRate">          10                      </param>
+                <param name="enabledSensors">           id_l_upper_arm_strain   </param>                
+            </group>
+            
+            <group name="STRAIN_SETTINGS">        
+                <param name="useCalibration">           true                    </param>          
+            </group>            
+            
+        </group>
+    
+  </device>
+  
+
+
+
+
+

--- a/CER01/hardware/FT/cer_right_upper_arm-ems19-strain.xml
+++ b/CER01/hardware/FT/cer_right_upper_arm-ems19-strain.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_upper_arm_strain" type="embObjStrain">
+    
+        <xi:include href="../../general.xml"/>
+
+        <xi:include href="../electronics/cer_right_upper_arm-ems19-eln.xml" />
+    
+        <group name="SERVICE">
+            
+            <param name="type"> eomn_serv_AS_strain </param>
+        
+            <group name="PROPERTIES">
+  
+                <group name="CANBOARDS">
+                    <param name="type">                 eobrd_strain            </param>
+
+                    <group name="PROTOCOL">
+                        <param name="major">            1                       </param>    
+                        <param name="minor">            0                       </param>     
+                    </group>                    
+                    <group name="FIRMWARE">
+                        <param name="major">            0                       </param>    
+                        <param name="minor">            0                       </param> 
+                        <param name="build">            0                       </param>
+                    </group>
+                </group>
+                
+                <group name="SENSORS">
+                    <param name="id">                   id_r_upper_arm_strain   </param>
+                    <param name="type">                 eoas_strain             </param>
+                    <param name="location">             CAN2:13                 </param>
+                </group>                
+            
+            </group>
+
+            <group name="SETTINGS">        
+                <param name="acquisitionRate">          10                      </param>
+                <param name="enabledSensors">           id_r_upper_arm_strain   </param>                
+            </group>
+            
+            <group name="STRAIN_SETTINGS">        
+                <param name="useCalibration">           true                    </param>          
+            </group>            
+            
+        </group>
+    
+  </device>
+  
+
+
+
+
+

--- a/CER01/hardware/MAIS/left_hand-multi_enc.xml
+++ b/CER01/hardware/MAIS/left_hand-multi_enc.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_hand_multienc" type="embObjMultiEnc"> 
+        <xi:include href="../../general.xml" />
+        <xi:include href="../electronics/cer_left_hand-mcp7-eln.xml" />
+        <group name="JOINTS">
+            <param name="listofjoints"> 0 1 </param>
+            <param name="encoderConversionFactor"> -182.044 182.044 1.0 -182.044 182.044 1.0 </param>
+        </group>
+    </device> 
+    
+
+

--- a/CER01/hardware/MAIS/right_hand-multi_enc.xml
+++ b/CER01/hardware/MAIS/right_hand-multi_enc.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_hand_multienc" type="embObjMultiEnc">
+        <xi:include href="../../general.xml" />
+        <xi:include href="../electronics/cer_right_hand-mcp9-eln.xml" />
+        <group name="JOINTS">
+            <param name="listofjoints"> 0 1 </param>
+            <param name="encoderConversionFactor"> -182.044 182.044 1.0 -182.044 182.044 1.0 </param>
+        </group>
+    </device> 
+    
+
+

--- a/CER01/hardware/electronics/cer_base-ems21-eln.xml
+++ b/CER01/hardware/electronics/cer_base-ems21-eln.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER01" build="1">
+    <xi:include href="../electronics/pc104.xml" />
+    
+        <group name="ETH_BOARD">
+
+        <group name="ETH_BOARD_PROPERTIES">
+            <param name="IpAddress">                10.0.1.21               </param>
+            <param name="IpPort">                   12345                   </param>
+            <param name="Type">                     ems4                    </param>
+            <param name="maxSizeRXpacket">          768                     </param>
+            <param name="maxSizeROP">               384                     </param>
+        </group>
+
+        <group name="ETH_BOARD_SETTINGS">
+            <param name="Name">                     "EB21"                  </param> 
+            <group name="RUNNINGMODE">
+                <param name="period">                   1000                </param>
+                <param name="maxTimeOfRXactivity">      400                 </param>
+                <param name="maxTimeOfDOactivity">      300                 </param>   
+                <param name="maxTimeOfTXactivity">      300                 </param>                
+                <param name="TXrateOfRegularROPs">      3                   </param> 
+            </group>         
+        </group>
+
+        <group name="ETH_BOARD_ACTIONS">
+            <group name="MONITOR_ITS_PRESENCE">
+                <param name="enabled">                  true                </param> 
+                <param name="timeout">                  0.020               </param> 
+                <param name="periodOfMissingReport">    60.0                </param> 
+            </group>
+        </group>
+        
+    </group>  
+
+</params>

--- a/CER01/hardware/electronics/cer_head-mcp10-eln.xml
+++ b/CER01/hardware/electronics/cer_head-mcp10-eln.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER01" build="1">
+
+    <xi:include href="../electronics/pc104.xml" />
+    
+    <group name="ETH_BOARD">
+
+        <group name="ETH_BOARD_PROPERTIES">
+            <param name="IpAddress">                10.0.1.10               </param>
+            <param name="IpPort">                   12345                   </param>
+            <param name="Type">                     mc4plus                 </param>
+            <param name="maxSizeRXpacket">          768                     </param>
+            <param name="maxSizeROP">               384                     </param>
+        </group>
+
+        <group name="ETH_BOARD_SETTINGS">
+            <param name="Name">                     "EB10"                  </param> 
+            <group name="RUNNINGMODE">
+                <param name="period">                   1000                </param>
+                <param name="maxTimeOfRXactivity">      400                 </param>
+                <param name="maxTimeOfDOactivity">      300                 </param>   
+                <param name="maxTimeOfTXactivity">      300                 </param>                
+                <param name="TXrateOfRegularROPs">      5                   </param> 
+            </group>         
+        </group>
+
+        <group name="ETH_BOARD_ACTIONS">
+            <group name="MONITOR_ITS_PRESENCE">
+                <param name="enabled">                  true                </param> 
+                <param name="timeout">                  0.020               </param> 
+                <param name="periodOfMissingReport">    60.0                </param> 
+            </group>
+        </group>        
+        
+    </group>
+    
+</params>

--- a/CER01/hardware/electronics/cer_left_hand-mcp7-eln.xml
+++ b/CER01/hardware/electronics/cer_left_hand-mcp7-eln.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER01" build="1">
+
+    <xi:include href="../electronics/pc104.xml" />
+    
+    <group name="ETH_BOARD">
+
+        <group name="ETH_BOARD_PROPERTIES">
+            <param name="IpAddress">                10.0.1.7                </param>
+            <param name="IpPort">                   12345                   </param>
+            <param name="Type">                     mc2plus                 </param>
+            <param name="maxSizeRXpacket">          768                     </param>
+            <param name="maxSizeROP">               384                     </param>
+        </group>
+
+        <group name="ETH_BOARD_SETTINGS">
+            <param name="Name">                     "EB7"                   </param> 
+            <group name="RUNNINGMODE">
+                <param name="period">                   1000                </param>
+                <param name="maxTimeOfRXactivity">      300                 </param>
+                <param name="maxTimeOfDOactivity">      400                 </param>   
+                <param name="maxTimeOfTXactivity">      300                 </param>                
+                <param name="TXrateOfRegularROPs">      5                   </param> 
+            </group>         
+        </group>
+
+        <group name="ETH_BOARD_ACTIONS">
+            <group name="MONITOR_ITS_PRESENCE">
+                <param name="enabled">                  true                </param> 
+                <param name="timeout">                  0.020               </param> 
+                <param name="periodOfMissingReport">    60.0                </param> 
+            </group>
+        </group>        
+        
+    </group>
+    
+</params>

--- a/CER01/hardware/electronics/cer_left_lower_arm-mcp18-eln.xml
+++ b/CER01/hardware/electronics/cer_left_lower_arm-mcp18-eln.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER01" build="1">
+
+    <xi:include href="../electronics/pc104.xml" />
+    
+    <group name="ETH_BOARD">
+
+        <group name="ETH_BOARD_PROPERTIES">
+            <param name="IpAddress">                10.0.1.6                </param>
+            <param name="IpPort">                   12345                   </param>
+            <param name="Type">                     ems4                    </param>
+            <param name="maxSizeRXpacket">          768                     </param>
+            <param name="maxSizeROP">               384                     </param>
+        </group>
+
+        <group name="ETH_BOARD_SETTINGS">
+            <param name="Name">                     "EB18"                  </param> 
+            <group name="RUNNINGMODE">
+                <param name="period">                   1000                </param>
+                <param name="maxTimeOfRXactivity">      400                 </param>
+                <param name="maxTimeOfDOactivity">      300                 </param>   
+                <param name="maxTimeOfTXactivity">      300                 </param>                
+                <param name="TXrateOfRegularROPs">      5                   </param> 
+            </group>         
+        </group>
+
+        <group name="ETH_BOARD_ACTIONS">
+            <group name="MONITOR_ITS_PRESENCE">
+                <param name="enabled">                  true                </param> 
+                <param name="timeout">                  0.020               </param> 
+                <param name="periodOfMissingReport">    60.0                </param> 
+            </group>
+        </group>        
+        
+    </group>
+    
+</params>

--- a/CER01/hardware/electronics/cer_left_upper_arm-ems17-eln.xml
+++ b/CER01/hardware/electronics/cer_left_upper_arm-ems17-eln.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER01" build="1">
+
+    <xi:include href="../electronics/pc104.xml" />
+    
+    <group name="ETH_BOARD">
+
+        <group name="ETH_BOARD_PROPERTIES">
+            <param name="IpAddress">                10.0.1.5                </param>
+            <param name="IpPort">                   12345                   </param>
+            <param name="Type">                     ems4                    </param>
+            <param name="maxSizeRXpacket">          768                     </param>
+            <param name="maxSizeROP">               384                     </param>
+        </group>
+
+        <group name="ETH_BOARD_SETTINGS">
+            <param name="Name">                     "EB17"                  </param> 
+            <group name="RUNNINGMODE">
+                <param name="period">                   1000                </param>
+                <param name="maxTimeOfRXactivity">      400                 </param>
+                <param name="maxTimeOfDOactivity">      300                 </param>   
+                <param name="maxTimeOfTXactivity">      300                 </param>                
+                <param name="TXrateOfRegularROPs">      5                   </param> 
+            </group>         
+        </group>
+
+        <group name="ETH_BOARD_ACTIONS">
+            <group name="MONITOR_ITS_PRESENCE">
+                <param name="enabled">                  true                </param> 
+                <param name="timeout">                  0.020               </param> 
+                <param name="periodOfMissingReport">    60.0                </param> 
+            </group>
+        </group>        
+        
+    </group>
+    
+</params>

--- a/CER01/hardware/electronics/cer_right_hand-mcp9-eln.xml
+++ b/CER01/hardware/electronics/cer_right_hand-mcp9-eln.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER01" build="1">
+
+    <xi:include href="../electronics/pc104.xml" />
+    
+    <group name="ETH_BOARD">
+
+        <group name="ETH_BOARD_PROPERTIES">
+            <param name="IpAddress">                10.0.1.9                </param>
+            <param name="IpPort">                   12345                   </param>
+            <param name="Type">                     mc2plus                 </param>
+            <param name="maxSizeRXpacket">          768                     </param>
+            <param name="maxSizeROP">               384                     </param>
+        </group>
+
+        <group name="ETH_BOARD_SETTINGS">
+            <param name="Name">                     "EB9"                   </param> 
+            <group name="RUNNINGMODE">
+                <param name="period">                   1000                </param>
+                <param name="maxTimeOfRXactivity">      300                 </param>
+                <param name="maxTimeOfDOactivity">      400                 </param>   
+                <param name="maxTimeOfTXactivity">      300                 </param>                
+                <param name="TXrateOfRegularROPs">      5                   </param> 
+            </group>         
+        </group>
+
+        <group name="ETH_BOARD_ACTIONS">
+            <group name="MONITOR_ITS_PRESENCE">
+                <param name="enabled">                  true                </param> 
+                <param name="timeout">                  0.020               </param> 
+                <param name="periodOfMissingReport">    60.0                </param> 
+            </group>
+        </group>        
+        
+    </group>
+    
+</params>

--- a/CER01/hardware/electronics/cer_right_lower_arm-mcp20-eln.xml
+++ b/CER01/hardware/electronics/cer_right_lower_arm-mcp20-eln.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER01" build="1">
+
+    <xi:include href="../electronics/pc104.xml" />
+    
+    <group name="ETH_BOARD">
+
+        <group name="ETH_BOARD_PROPERTIES">
+            <param name="IpAddress">                10.0.1.8                </param>
+            <param name="IpPort">                   12345                   </param>
+            <param name="Type">                     ems4                    </param>
+            <param name="maxSizeRXpacket">          768                     </param>
+            <param name="maxSizeROP">               384                     </param>
+        </group>
+
+        <group name="ETH_BOARD_SETTINGS">
+            <param name="Name">                     "EB20"                  </param> 
+            <group name="RUNNINGMODE">
+                <param name="period">                   1000                </param>
+                <param name="maxTimeOfRXactivity">      400                 </param>
+                <param name="maxTimeOfDOactivity">      300                 </param>   
+                <param name="maxTimeOfTXactivity">      300                 </param>                
+                <param name="TXrateOfRegularROPs">      5                   </param> 
+            </group>         
+        </group>
+
+        <group name="ETH_BOARD_ACTIONS">
+            <group name="MONITOR_ITS_PRESENCE">
+                <param name="enabled">                  true                </param> 
+                <param name="timeout">                  0.020               </param> 
+                <param name="periodOfMissingReport">    60.0                </param> 
+            </group>
+        </group>
+        
+    </group>
+    
+</params>

--- a/CER01/hardware/electronics/cer_right_upper_arm-ems19-eln.xml
+++ b/CER01/hardware/electronics/cer_right_upper_arm-ems19-eln.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER01" build="1">
+
+    <xi:include href="../electronics/pc104.xml" />
+    
+    <group name="ETH_BOARD">
+
+        <group name="ETH_BOARD_PROPERTIES">
+            <param name="IpAddress">                10.0.1.4                </param>
+            <param name="IpPort">                   12345                   </param>
+            <param name="Type">                     ems4                    </param>
+            <param name="maxSizeRXpacket">          768                     </param>
+            <param name="maxSizeROP">               384                     </param>
+        </group>
+
+        <group name="ETH_BOARD_SETTINGS">
+            <param name="Name">                     "EB19"                  </param> 
+            <group name="RUNNINGMODE">
+                <param name="period">                   1000                </param>
+                <param name="maxTimeOfRXactivity">      400                 </param>
+                <param name="maxTimeOfDOactivity">      300                 </param>   
+                <param name="maxTimeOfTXactivity">      300                 </param>                
+                <param name="TXrateOfRegularROPs">      5                   </param> 
+            </group>         
+        </group>
+
+        <group name="ETH_BOARD_ACTIONS">
+            <group name="MONITOR_ITS_PRESENCE">
+                <param name="enabled">                  true                </param> 
+                <param name="timeout">                  0.020               </param> 
+                <param name="periodOfMissingReport">    60.0                </param> 
+            </group>
+        </group>        
+        
+    </group>
+    
+</params>

--- a/CER01/hardware/electronics/cer_torso-ems15-eln.xml
+++ b/CER01/hardware/electronics/cer_torso-ems15-eln.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER01" build="1">
+
+    <xi:include href="../electronics/pc104.xml" />
+    
+    <group name="ETH_BOARD">
+
+        <group name="ETH_BOARD_PROPERTIES">
+            <param name="IpAddress">                10.0.1.15               </param>
+            <param name="IpPort">                   12345                   </param>
+            <param name="Type">                     ems4                    </param>
+            <param name="maxSizeRXpacket">          768                     </param>
+            <param name="maxSizeROP">               384                     </param>
+        </group>
+
+        <group name="ETH_BOARD_SETTINGS">
+            <param name="Name">                     "EB15"                  </param> 
+            <group name="RUNNINGMODE">
+                <param name="period">                   1000                </param>
+                <param name="maxTimeOfRXactivity">      400                 </param>
+                <param name="maxTimeOfDOactivity">      300                 </param>   
+                <param name="maxTimeOfTXactivity">      300                 </param>                
+                <param name="TXrateOfRegularROPs">      5                   </param> 
+            </group>         
+        </group>
+
+        <group name="ETH_BOARD_ACTIONS">
+            <group name="MONITOR_ITS_PRESENCE">
+                <param name="enabled">                  true                </param> 
+                <param name="timeout">                  0.020               </param> 
+                <param name="periodOfMissingReport">    60.0                </param> 
+            </group>
+        </group>
+        
+    </group>
+    
+</params>

--- a/CER01/hardware/electronics/pc104.xml
+++ b/CER01/hardware/electronics/pc104.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER01" build="1">
+  <group name="PC104">
+     <param name="PC104IpAddress"> 10.0.1.104 </param> 
+     <param name="PC104IpPort">         12345 </param> 
+     <param name="PC104TXrate">	            1 </param> 
+     <param name="PC104RXrate">	            5 </param> 
+  </group>
+</params>

--- a/CER01/hardware/mechanicals/cer_base-ems21-mec.xml
+++ b/CER01/hardware/mechanicals/cer_base-ems21-mec.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER01" build="1">
+    <group name="GENERAL">
+        <param name="MotioncontrolVersion">  5 </param>
+        <param name="Joints">  4  </param> 
+        <param name="AxisName">          "mobile_base_l_wheel_joint" "mobile_base_r_wheel_joint" "mobile_base_l_break" "mobile_base_r_break" </param>
+        <param name="AxisMap">               0           1           2           3              </param>
+        <param name="AxisType">         "revolute"  "revolute"  "revolute"  "revolute"          </param>
+        <param name="Encoder">               182.044     182.044     0           0              </param>
+        <param name="fullscalePWM">          32000       32000       32000      32000          </param>
+        <param name="ampsToSensor">          1000.0      1000.0      1000.0     1000.0         </param>
+        <param name="Gearbox_M2J">           17          17          1           1              </param>
+        <param name="Gearbox_E2J">           1           1           1           1              </param>
+        <param name="useMotorSpeedFbk">      1           1           1           1              </param>
+        
+        <param name="Verbose">   0   </param>
+    </group>
+    
+    <group name="LIMITS">
+        <param name="hardwareJntPosMax">      0          0            0          0     </param>
+        <param name="hardwareJntPosMin">      0          0            0          0     </param>
+        <param name="rotorPosMin">            0          0            0          0     </param>
+        <param name="rotorPosMax">            0          0            0          0     </param>
+   </group>
+    
+    
+     <group name="2FOC">
+        <param name="HasHallSensor">         1           1           0           0              </param>
+        <param name="HasTempSensor">         0           0           0           0              </param>
+        <param name="HasRotorEncoder">       0           0           0           0              </param>
+        <param name="HasRotorEncoderIndex">  0           0           0           0              </param>
+        <param name="HasSpeedEncoder">       1           1           0           0              </param>
+        <param name="RotorIndexOffset">      0           0           0           0              </param>
+        <param name="MotorPoles">            8           8           0           0              </param>
+    </group>
+
+ <group name="COUPLINGS"> 
+
+        <param name ="matrixJ2M"> 
+            1.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00
+            0.00    0.00    1.00    0.00
+            0.00    0.00    0.00    1.00   
+        </param>
+               
+        <param name ="matrixM2J"> 
+            1.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00
+            0.00    0.00    1.00    0.00
+            0.00    0.00    0.00    1.00   
+        </param>
+       
+        <param name ="matrixE2J">  
+            1.000   0.000   0.000   0.000   0.000   0.000
+            0.000   1.000   0.000   0.000   0.000   0.000
+            0.000   0.000   1.000   0.000   0.000   0.000
+            0.000   0.000   0.000   1.000   0.000   0.000   
+        </param>
+                
+    </group>   
+
+    <group name="JOINTSET_CFG"> 
+        <param name= "numberofsets"> 4 </param>
+        <group name="JOINTSET_0">
+            <param name="listofjoints">  0            </param>
+            <param name="constraint">    none          </param>
+            <param name="param1">        0             </param>
+            <param name="param2">        0             </param>
+        </group> 
+        <group name="JOINTSET_1">
+            <param name="listofjoints">   1             </param>
+            <param name="constraint">     none          </param>
+            <param name="param1">         0             </param>
+            <param name="param2">         0             </param>
+        </group> 
+        <group name="JOINTSET_2">
+            <param name="listofjoints">   2             </param>
+            <param name="constraint">     none          </param>
+            <param name="param1">         0             </param>
+            <param name="param2">         0             </param>
+        </group> 
+        <group name="JOINTSET_3">
+            <param name="listofjoints">   3             </param>
+            <param name="constraint">     none          </param>
+            <param name="param1">         0             </param>
+            <param name="param2">         0             </param>
+        </group> 
+    </group>                                       
+    
+</params>

--- a/CER01/hardware/mechanicals/cer_head-mcp10-mec.xml
+++ b/CER01/hardware/mechanicals/cer_head-mcp10-mec.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER01" build="1">
+    <group name="GENERAL">
+        <param name="MotioncontrolVersion">  5 </param>
+        <param name="Joints">                2  </param> 
+        <param name="AxisName">              "neck_pitch_joint" "neck_yaw_joint" </param>
+        <param name="AxisMap">               0                  1               </param>
+        <param name="AxisType">              "revolute"         "revolute"      </param>
+        <param name="Encoder">               182.044            182.044         </param>
+        <param name="Gearbox_M2J">          -1                  125             </param>
+        <param name="Gearbox_E2J">           1                  1               </param>
+        <param name="fullscalePWM">          3360            3360               </param>
+        <param name="ampsToSensor">          1000.0          1000.0             </param>
+        <param name="MotorType">             "DC"               "DC"            </param>
+        <param name="useMotorSpeedFbk">      1                   1              </param>        
+        <param name="Verbose">               0   </param>
+    </group>
+    
+    <group name="LIMITS">
+        <param name="hardwareJntPosMax">       35                70            </param>
+        <param name="hardwareJntPosMin">       -25              -45            </param>
+        <param name="rotorPosMin">              0                 0            </param>
+        <param name="rotorPosMax">              0                 0            </param>
+    </group>
+
+    <group name="COUPLINGS"> 
+
+       <param name ="matrixJ2M"> 
+            1.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00
+            0.00    0.00    1.00    0.00
+            0.00    0.00    0.00    1.00   
+        </param>
+               
+        <param name ="matrixM2J"> 
+            1.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00
+            0.00    0.00    1.00    0.00
+            0.00    0.00    0.00    1.00   
+        </param>
+       
+        <param name ="matrixE2J">  
+            1.000   0.000   0.000   0.000   0.000   0.000
+            0.000   1.000   0.000   0.000   0.000   0.000
+            0.000   0.000   1.000   0.000   0.000   0.000
+            0.000   0.000   0.000   1.000   0.000   0.000   
+        </param>
+                
+    </group>   
+
+    <group name="JOINTSET_CFG"> 
+        <param name= "numberofsets"> 2 </param>
+        <group name="JOINTSET_0">
+            <param name="listofjoints">  0            </param>
+            <param name="constraint">    none          </param>
+            <param name="param1">        0             </param>
+            <param name="param2">        0             </param>
+        </group> 
+        <group name="JOINTSET_1">
+            <param name="listofjoints">   1             </param>
+            <param name="constraint">     none          </param>
+            <param name="param1">         0             </param>
+            <param name="param2">         0             </param>
+        </group> 
+    </group>                                       
+    
+</params>

--- a/CER01/hardware/mechanicals/cer_left_hand-mcp7-mec.xml
+++ b/CER01/hardware/mechanicals/cer_left_hand-mcp7-mec.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER01" build="1">
+    <group name="GENERAL">
+        <param name="MotioncontrolVersion">  5 </param>
+        <param name="Joints">                2  </param> 
+        <param name="AxisName">              "l_palm"           "l_thumb"       </param>
+        <param name="AxisMap">               0                  1               </param>
+        <param name="AxisType">              "revolute"         "revolute"      </param>
+        <param name="Encoder">               182.044            182.044         </param>
+        <param name="Gearbox_M2J">             1                 -1             </param>
+        <param name="Gearbox_E2J">             1                  1             </param>
+         <param name="useMotorSpeedFbk">       0                  0             </param>
+        <param name="MotorType">             "DC"               "DC"            </param>
+       <param name="fullscalePWM">          3360            3360               </param>
+        <param name="ampsToSensor">          1000.0          1000.0             </param>
+        <param name="Verbose">    0   </param>
+    </group>
+
+    <group name="LIMITS">
+        <param name="hardwareJntPosMax">        140               110           </param>
+        <param name="hardwareJntPosMin">        -4                -2            </param>
+        <param name="rotorPosMin">              0                 0             </param>
+        <param name="rotorPosMax">              0                 0             </param>
+    </group>
+    
+    <group name="COUPLINGS"> 
+
+        <param name ="matrixJ2M"> 
+            1.000   0.000   0.000   0.000
+            0.000   1.000   0.000   0.000
+            0.000   0.000   1.000   0.000
+            0.000   0.000   0.000   1.000   
+        </param>
+               
+        <param name ="matrixM2J"> 
+            1.000   0.000   0.000   0.000
+            0.000   1.000   0.000   0.000
+            0.000   0.000   1.000   0.000
+            0.000   0.000   0.000   1.000   
+        </param>
+       
+        <param name ="matrixE2J">  
+           -1.000   1.000   0.000   0.000   0.000   0.000
+            0.000   0.000   0.000  -1.000   1.000   0.000
+            0.000   0.000   0.000   0.000   0.000   0.000
+            0.000   0.000   0.000   0.000   0.000   0.000   
+        </param>
+    </group>   
+
+    <group name="JOINTSET_CFG"> 
+        <param name= "numberofsets"> 2 </param>
+        <group name="JOINTSET_0">
+            <param name="listofjoints">  0             </param>
+            <param name="constraint">    cerhand       </param> <!--NOTE: set deadzone to 400 -->
+            <param name="param1">        0             </param>
+            <param name="param2">        0             </param>
+        </group> 
+        <group name="JOINTSET_1">
+            <param name="listofjoints">   1             </param>
+            <param name="constraint">     cerhand       </param>
+            <param name="param1">         0             </param>
+            <param name="param2">         0             </param>
+        </group> 
+    </group>                                       
+    
+</params>

--- a/CER01/hardware/mechanicals/cer_left_lower_arm-mcp18-mec.xml
+++ b/CER01/hardware/mechanicals/cer_left_lower_arm-mcp18-mec.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER01" build="1">
+    <group name="GENERAL">
+        <param name="MotioncontrolVersion">  5 </param>
+        <param name="Joints">                4  </param> 
+        <param name="AxisName">              "l_wrist_tripod_0" "l_wrist_tripod_1" "l_wrist_tripod_2" "l_wrist_pronosupination_joint"  </param>
+        <param name="AxisMap">               2                  0                  1                  3                        </param>
+        <param name="AxisType">              "prismatic"        "prismatic"        "prismatic"        "revolute"               </param>
+        <param name="Encoder">               56333.333          56333.333          56333.333          182.044                  </param>
+        <param name="Gearbox_M2J">               1                  1                  1                  1                    </param>
+        <param name="Gearbox_E2J">               1                  1                  1                  64                   </param>
+        <param name="useMotorSpeedFbk">          1                  1                  1                  1                    </param>
+        <param name="fullscalePWM">          3360               3360               3360               3360                     </param>
+        <param name="ampsToSensor">          1000.0             1000.0             1000.0             1000.0                   </param>
+        <param name="MotorType">             "DC"               "DC"               "DC"               "DC"                     </param>
+        <param name="Verbose">               0   </param>
+    </group>
+    
+    <group name="LIMITS">
+        <param name="hardwareJntPosMax">          0.12     0.12    0.12     80     </param>
+        <param name="hardwareJntPosMin">          0        0       0        -80    </param>
+        <param name="rotorPosMin">                0        0       0        0      </param>
+        <param name="rotorPosMax">                0        0       0        0      </param>
+    </group>
+
+   <group name="COUPLINGS"> 
+
+        <!-- 1.625 = 1/alfa = 65/40 -->                  
+        <param name ="matrixJ2M"> 
+            1.000   0.000   0.000   0.000
+            0.000   1.000   0.000   0.000
+            0.000   0.000   1.000   0.000
+            0.000   0.000   0.000   1.000   
+        </param>
+               
+        <!-- 0.615 = alfa = 40/65 --> 
+        <param name ="matrixM2J"> 
+            1.000   0.000   0.000   0.000
+            0.000   1.000   0.000   0.000
+            0.000   0.000   1.000   0.000
+            0.000   0.000   0.000   1.000   
+        </param>
+       
+        <param name ="matrixE2J">  
+            1.000   0.000   0.000   0.000   0.000   0.000
+            0.000   1.000   0.000   0.000   0.000   0.000
+            0.000   0.000   1.000   0.000   0.000   0.000
+            0.000   0.000   0.000   1.000   0.000   0.000   
+        </param>
+                
+    </group>   
+
+    <group name="JOINTSET_CFG"> 
+        <param name= "numberofsets"> 2 </param>
+        <group name="JOINTSET_0">
+            <param name="listofjoints">  0 1 2         </param>
+            <param name="constraint">    trifid        </param>
+            <param name="param1">        500000        </param>
+            <param name="param2">        0             </param>
+        </group> 
+        <group name="JOINTSET_1">
+            <param name="listofjoints">   3             </param>
+            <param name="constraint">     none          </param>
+            <param name="param1">         0             </param>
+            <param name="param2">         0             </param>
+        </group> 
+    </group>                                       
+    
+</params>

--- a/CER01/hardware/mechanicals/cer_left_upper_arm-ems17-mec.xml
+++ b/CER01/hardware/mechanicals/cer_left_upper_arm-ems17-mec.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER01" build="1">
+    <group name="GENERAL">
+        <param name="MotioncontrolVersion">     5             </param>
+        <param name="Joints">                   4             </param> 
+        <param name="AxisMap">                  0             1           2             3           </param>
+        <param name="AxisName">                 "l_shoulder_pitch_joint" "l_shoulder_roll_joint" "l_shoulder_yaw_joint" "l_elbow_joint" </param>
+        <param name="AxisType">                 "revolute"    "revolute"  "revolute"    "revolute"  </param>
+        <param name="Encoder">                  182.044       182.044     182.044       182.044     </param>
+        <param name="Gearbox_M2J">              117.333      -117.333     38           -100.0       </param>
+        <param name="Gearbox_E2J">                1              1           1              1       </param>
+        <param name="useMotorSpeedFbk">           1              1           1              1       </param>
+        <param name="MotorType">                "BLL_MECAP"   "BLL_MECAP" "BLL_MECAP"   "BLL_MECAP" </param>
+       <param name="fullscalePWM">          32000              32000              32000              32000                   </param>
+        <param name="ampsToSensor">          1000.0             1000.0             1000.0             1000.0                  </param>
+        <param name="Verbose">   0      </param>
+    </group>
+
+    <group name="LIMITS">
+    <!--    <param name="jntPosMax">                  85            70         85        95         </param>   no covers -->
+        <param name="hardwareJntPosMax">             55            65         85        95         </param>
+        <param name="hardwareJntPosMin">            -25             0        -85         5          </param>
+        <param name="rotorPosMin">                    0             0          0         0         </param> 
+        <param name="rotorPosMax">                    0             0          0         0         </param>
+    </group>
+    
+    <group name="2FOC">
+        <param name="HasHallSensor">         1             1           1             1             </param>
+        <param name="HasTempSensor">         0             0           0             0             </param>
+        <param name="HasRotorEncoder">       1             1           1             1             </param>
+        <param name="HasRotorEncoderIndex">  0             0           0             0             </param>
+        <param name="HasSpeedEncoder">       0             0           0             0             </param>
+        <param name="RotorIndexOffset">      0             0           0             0             </param>
+        <param name="MotorPoles">            8             8           8             8             </param>
+    </group>
+
+ <group name="COUPLINGS"> 
+
+        <param name ="matrixJ2M"> 
+            1.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00
+            0.00    0.00    1.00    0.00
+            0.00    0.00    0.00    1.00   
+        </param>
+               
+        <param name ="matrixM2J"> 
+            1.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00
+            0.00    0.00    1.00    0.00
+            0.00    0.00    0.00    1.00   
+        </param>
+       
+        <param name ="matrixE2J">  
+            1.000   0.000   0.000   0.000   0.000   0.000
+            0.000   1.000   0.000   0.000   0.000   0.000
+            0.000   0.000   1.000   0.000   0.000   0.000
+            0.000   0.000   0.000   1.000   0.000   0.000   
+        </param>
+                
+    </group>   
+
+    <group name="JOINTSET_CFG"> 
+        <param name= "numberofsets"> 4 </param>
+        <group name="JOINTSET_0">
+            <param name="listofjoints">  0            </param>
+            <param name="constraint">    none          </param>
+            <param name="param1">        0             </param>
+            <param name="param2">        0             </param>
+        </group> 
+        <group name="JOINTSET_1">
+            <param name="listofjoints">   1             </param>
+            <param name="constraint">     none          </param>
+            <param name="param1">         0             </param>
+            <param name="param2">         0             </param>
+        </group> 
+        <group name="JOINTSET_2">
+            <param name="listofjoints">   2             </param>
+            <param name="constraint">     none          </param>
+            <param name="param1">         0             </param>
+            <param name="param2">         0             </param>
+        </group> 
+        <group name="JOINTSET_3">
+            <param name="listofjoints">   3             </param>
+            <param name="constraint">     none          </param>
+            <param name="param1">         0             </param>
+            <param name="param2">         0             </param>
+        </group> 
+    </group>                                       
+    
+</params>

--- a/CER01/hardware/mechanicals/cer_right_hand-mcp9-mec.xml
+++ b/CER01/hardware/mechanicals/cer_right_hand-mcp9-mec.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER01" build="1">
+    <group name="GENERAL">
+        <param name="MotioncontrolVersion">  5 </param>
+        <param name="Joints">                2  </param> 
+        <param name="AxisName">              "r_palm"           "r_thumb"       </param>
+        <param name="AxisMap">               0                  1               </param>
+        <param name="AxisType">              "revolute"         "revolute"      </param>
+        <param name="Encoder">               182.044            182.044         </param>
+        <param name="fullscalePWM">          3360               3360            </param>
+        <param name="ampsToSensor">          1000.0             1000.0          </param>
+        <param name="Gearbox_M2J">            1                  -1              </param>
+        <param name="Gearbox_E2J">            1                   1              </param>
+        <param name="useMotorSpeedFbk">       0                   0              </param>
+        <param name="MotorType">             "DC"                "DC"            </param>
+        <param name="Verbose">               0   </param>
+    </group>
+
+    <group name="LIMITS">
+        <param name="hardwareJntPosMax">       140                 110           </param>
+        <param name="hardwareJntPosMin">        0                   0             </param>
+        <param name="rotorPosMin">              0                   0             </param>
+        <param name="rotorPosMax">              0                   0             </param>
+    </group>
+    
+    
+    <group name="COUPLINGS"> 
+
+        <param name ="matrixJ2M"> 
+            1.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00
+            0.00    0.00    1.00    0.00
+            0.00    0.00    0.00    1.00   
+        </param>
+               
+        <param name ="matrixM2J"> 
+            1.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00
+            0.00    0.00    1.00    0.00
+            0.00    0.00    0.00    1.00   
+        </param>
+       
+        <param name ="matrixE2J">  
+           -1.000   1.000   0.000   0.000   0.000   0.000
+            0.000   0.000   0.000  -1.000   1.000   0.000
+            0.000   0.000   0.000   0.000   0.000   0.000
+            0.000   0.000   0.000   0.000   0.000   0.000   
+        </param>
+                
+    </group>   
+
+    <group name="JOINTSET_CFG"> 
+        <param name= "numberofsets"> 2 </param>
+        <group name="JOINTSET_0">
+            <param name="listofjoints">  0              </param>
+            <param name="constraint">    cerhand        </param>
+            <param name="param1">        0              </param> 
+            <param name="param2">        0              </param>
+        </group> 
+        <group name="JOINTSET_1">
+            <param name="listofjoints">   1             </param>
+            <param name="constraint">     cerhand       </param>
+            <param name="param1">         0             </param>
+            <param name="param2">         0             </param>
+        </group> 
+    </group>                                       
+    
+</params>
+

--- a/CER01/hardware/mechanicals/cer_right_lower_arm-mcp20-mec.xml
+++ b/CER01/hardware/mechanicals/cer_right_lower_arm-mcp20-mec.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER01" build="1">
+    <group name="GENERAL">
+        <param name="MotioncontrolVersion">  5 </param>
+        <param name="Joints">                4  </param> 
+        <param name="AxisName">              "r_wrist_tripod_0" "r_wrist_tripod_1" "r_wrist_tripod_2" "r_wrist_pronosupination_joint"</param>
+        <param name="AxisMap">               2                  0                  1                  3                       </param>
+        <param name="AxisType">              "prismatic"        "prismatic"        "prismatic"        "revolute"              </param>
+        <param name="Encoder">               56333.333          56333.333          56333.333          182.044                 </param>
+        <param name="Gearbox_M2J">               1                  1                  1                  1                   </param>
+        <param name="Gearbox_E2J">               1                  1                  1                 64                   </param>
+        <param name="useMotorSpeedFbk">          1                  1                  1                  1                   </param>
+        <param name="fullscalePWM">          3360               3360               3360               3360                    </param>
+        <param name="ampsToSensor">          1000.0             1000.0             1000.0             1000.0                  </param>
+        <param name="MotorType">             "DC"               "DC"               "DC"               "DC"                    </param>
+        <param name="Verbose">               0   </param>
+    </group>
+    
+    <group name="LIMITS">
+        <param name="hardwareJntPosMax">      0.12               0.12                  0.12                 80     </param>
+        <param name="hardwareJntPosMin">      0                  0                     0                    -80    </param>
+        <param name="rotorPosMin">            0                  0                     0                    0      </param>
+        <param name="rotorPosMax">            0                  0                     0                    0      </param>
+    </group>
+
+    <group name="COUPLINGS"> 
+
+        <param name ="matrixJ2M"> 
+            1.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00
+            0.00    0.00    1.00    0.00
+            0.00    0.00    0.00    1.00   
+        </param>
+               
+        <param name ="matrixM2J"> 
+            1.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00
+            0.00    0.00    1.00    0.00
+            0.00    0.00    0.00    1.00   
+        </param>
+       
+        <param name ="matrixE2J">  
+            1.000   0.000   0.000   0.000   0.000   0.000
+            0.000   1.000   0.000   0.000   0.000   0.000
+            0.000   0.000   1.000   0.000   0.000   0.000
+            0.000   0.000   0.000   1.000   0.000   0.000   
+        </param>
+                
+    </group>   
+
+    <group name="JOINTSET_CFG"> 
+        <param name= "numberofsets"> 2 </param>
+        <group name="JOINTSET_0">
+            <param name="listofjoints">  0 1 2         </param>
+            <param name="constraint">    trifid        </param>
+            <param name="param1">        500000        </param> <!-- #define WRIST_TRIFID_LIMIT  500000 -->
+            <param name="param2">        0             </param>
+        </group> 
+        <group name="JOINTSET_1">
+            <param name="listofjoints">   3             </param>
+            <param name="constraint">     none          </param>
+            <param name="param1">         0             </param>
+            <param name="param2">         0             </param>
+        </group> 
+    </group>                                       
+    
+</params>

--- a/CER01/hardware/mechanicals/cer_right_upper_arm-ems19-mec.xml
+++ b/CER01/hardware/mechanicals/cer_right_upper_arm-ems19-mec.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER01" build="1">
+    <group name="GENERAL">
+        <param name="MotioncontrolVersion">     5             </param>
+        <param name="Joints">                   4             </param> 
+        <param name="AxisMap">                  0             1           2             3           </param>
+        <param name="AxisName">                 "r_shoulder_pitch_joint" "r_shoulder_roll_joint" "r_shoulder_yaw_joint" "r_elbow_joint" </param>
+        <param name="AxisType">                 "revolute"    "revolute"  "revolute"    "revolute"  </param>
+        <param name="Encoder">                  182.044        182.044      182.044       182.044   </param>
+        <param name="Gearbox_M2J">              117.333       -117.333       38          -100.0     </param>
+        <param name="Gearbox_E2J">                1              1           1              1       </param>
+        <param name="useMotorSpeedFbk">           1              1           1              1       </param>
+        <param name="fullscalePWM">          32000        32000        32000         32000          </param>
+        <param name="ampsToSensor">          1000.0       1000.0       1000.0        1000.0         </param>
+        <param name="MotorType">                "BLL_MECAP"   "BLL_MECAP" "BLL_MECAP"   "BLL_MECAP" </param>
+        <param name="Verbose">                  0             </param>
+    </group>
+    
+    <group name="LIMITS">
+    <!--    <param name="jntPosMax">                  85            70         85        95        </param>   no covers -->
+        <param name="hardwareJntPosMax">             55            65         85        95         </param>
+        <param name="hardwareJntPosMin">            -25             0        -85         5         </param>
+        <param name="rotorPosMin">                    0             0          0         0         </param> 
+        <param name="rotorPosMax">                    0             0          0         0         </param>
+    </group>
+
+    <group name="2FOC">
+        <param name="HasHallSensor">         1             1           1             1             </param>
+        <param name="HasTempSensor">         0             0           0             0             </param>
+        <param name="HasRotorEncoder">       1             1           1             1             </param>
+        <param name="HasRotorEncoderIndex">  0             0           0             0             </param>
+        <param name="HasSpeedEncoder">       0             0           0             0             </param>
+        <param name="RotorIndexOffset">      0             0           0             0             </param>
+        <param name="MotorPoles">            8             8           8             8             </param>
+    </group>
+
+ <group name="COUPLINGS"> 
+
+        <param name ="matrixJ2M"> 
+            1.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00
+            0.00    0.00    1.00    0.00
+            0.00    0.00    0.00    1.00   
+        </param>
+               
+        <param name ="matrixM2J"> 
+            1.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00
+            0.00    0.00    1.00    0.00
+            0.00    0.00    0.00    1.00   
+        </param>
+       
+        <param name ="matrixE2J">  
+            1.000   0.000   0.000   0.000   0.000   0.000
+            0.000   1.000   0.000   0.000   0.000   0.000
+            0.000   0.000   1.000   0.000   0.000   0.000
+            0.000   0.000   0.000   1.000   0.000   0.000   
+        </param>
+                
+    </group>   
+
+    <group name="JOINTSET_CFG"> 
+        <param name= "numberofsets"> 4 </param>
+        <group name="JOINTSET_0">
+            <param name="listofjoints">  0            </param>
+            <param name="constraint">    none          </param>
+            <param name="param1">        0             </param>
+            <param name="param2">        0             </param>
+        </group> 
+        <group name="JOINTSET_1">
+            <param name="listofjoints">   1             </param>
+            <param name="constraint">     none          </param>
+            <param name="param1">         0             </param>
+            <param name="param2">         0             </param>
+        </group> 
+        <group name="JOINTSET_2">
+            <param name="listofjoints">   2             </param>
+            <param name="constraint">     none          </param>
+            <param name="param1">         0             </param>
+            <param name="param2">         0             </param>
+        </group> 
+        <group name="JOINTSET_3">
+            <param name="listofjoints">   3             </param>
+            <param name="constraint">     none          </param>
+            <param name="param1">         0             </param>
+            <param name="param2">         0             </param>
+        </group> 
+    </group>                                       
+    
+</params>

--- a/CER01/hardware/mechanicals/cer_torso-ems15-mec.xml
+++ b/CER01/hardware/mechanicals/cer_torso-ems15-mec.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER01" build="1">
+    <group name="GENERAL">
+        <param name="MotioncontrolVersion">  5 </param>
+        <param name="Joints">                4  </param> 
+        <param name="AxisName">              "torso_tripod_0" "torso_tripod_1" "torso_tripod_2" "torso_yaw_joint" </param>
+        <param name="AxisMap">               0            1            2             3             </param>
+        <param name="AxisType">              "prismatic"  "prismatic"  "prismatic"  "revolute"     </param>
+        <param name="Encoder">               10000        10000        10000         182.044       </param>
+        <param name="Gearbox_M2J">            1            1            1             117.333       </param>
+        <param name="Gearbox_E2J">           1             1            1               1           </param>
+       <param name="useMotorSpeedFbk">      1              1            1               1           </param>
+         <param name="MotorType">             "DC"         "DC"         "DC"          "BLL_MECAP"    </param>
+        <param name="fullscalePWM">          32000        32000        32000         32000         </param>
+        <param name="ampsToSensor">          1000.0       1000.0       1000.0        1000.0        </param>
+        <param name="Verbose">               0   </param>
+    </group>
+
+    <group name="LIMITS">
+        <param name="hardwareJntPosMax">        0.17        0.17         0.17           30          </param>
+        <param name="hardwareJntPosMin">        0.0         0.0          0.0           -30          </param>
+        <param name="rotorPosMin">              0           0            0              0           </param>
+        <param name="rotorPosMax">              0           0            0              0           </param>
+    </group>
+    
+    
+    <group name="2FOC">
+        <param name="HasHallSensor">         0            0            0             1             </param>
+        <param name="HasTempSensor">         0            0            0             0             </param>
+        <param name="HasRotorEncoder">       1            1            1             1             </param>
+        <param name="HasRotorEncoderIndex">  0            0            0             0             </param>
+        <param name="HasSpeedEncoder">       0            0            0             0             </param>
+        <param name="RotorIndexOffset">      0            0            0             0             </param>
+        <param name="MotorPoles">            2            2            2             8             </param>
+    </group>
+
+    
+    <group name="COUPLINGS"> 
+
+        <param name ="matrixJ2M"> 
+            1.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00
+            0.00    0.00    1.00    0.00
+            0.00    0.00    0.00    1.00   
+        </param>
+               
+        <param name ="matrixM2J"> 
+            1.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00
+            0.00    0.00    1.00    0.00
+            0.00    0.00    0.00    1.00   
+        </param>
+       
+        <param name ="matrixE2J">  
+            1.000   0.000   0.000   0.000   0.000   0.000
+            0.000   1.000   0.000   0.000   0.000   0.000
+            0.000   0.000   1.000   0.000   0.000   0.000
+            0.000   0.000   0.000   1.000   0.000   0.000   
+        </param>
+                
+    </group>   
+
+    <group name="JOINTSET_CFG"> 
+        <param name= "numberofsets"> 2 </param>
+        <group name="JOINTSET_0">
+            <param name="listofjoints">  0 1 2         </param>
+            <param name="constraint">    trifid        </param>
+            <param name="param1">        400000        </param> <!-- #define WAIST_TRIFID_LIMIT  400000 -->
+            <param name="param2">        0             </param>
+        </group> 
+        <group name="JOINTSET_1">
+            <param name="listofjoints">   3             </param>
+            <param name="constraint">     none          </param>
+            <param name="param1">         0             </param>
+            <param name="param2">         0             </param>
+        </group> 
+    </group>                                       
+    
+</params>
+

--- a/CER01/hardware/motorControl/cer_base-ems21-mc-service.xml
+++ b/CER01/hardware/motorControl/cer_base-ems21-mc-service.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER01" build="1">
+
+    <group name="SERVICE">
+        
+        <param name="type"> eomn_serv_MC_foc </param> 
+    
+        <group name="PROPERTIES">
+        
+            <group name="ETHBOARD">
+                <param name="type">                 ems4        </param> 
+            </group>          
+
+            <group name="CANBOARDS"> 
+                <param name="type">                 foc         </param> 
+                <group name="PROTOCOL">
+                    <param name="major">            1           </param>    
+                    <param name="minor">            6           </param>     
+                </group>                    
+                <group name="FIRMWARE">
+                    <param name="major">            0           </param>    
+                    <param name="minor">            0           </param> 
+                    <param name="build">            0           </param>
+                </group>
+            </group>
+            
+
+            <group name="JOINTMAPPING">
+
+                <group name="ACTUATOR">                
+                    <param name="type">             foc                 foc                 foc             foc         </param>
+                    <param name="port">             CAN1:4:0            CAN1:2:0            CAN1:3:0        CAN1:1:0    </param>
+                </group>
+                
+                <group name="ENCODER1">  
+                    <param name="type">             hallmotor           hallmotor           none            none        </param>  
+                    <param name="port">             CAN1:4:0            CAN1:2:0            CONN:none       CONN:none    </param>
+                    <param name="position">         atmotor             atmotor             none            none        </param> 
+                    <param name="resolution">       -14400              14400               0               0           </param>
+                    <param name="tolerance">           0                0                   0               0           </param>  
+                </group>        
+                
+                <group name="ENCODER2">
+                    <param name="type">             none                none                none            none        </param>
+                    <param name="port">             CONN:none           CONN:none           CONN:none       CONN:none   </param>
+                    <param name="position">         none                none                none            none        </param>
+                    <param name="resolution">          0                0                   0               0           </param>
+                    <param name="tolerance">           0                0                   0               0           </param>  
+                </group> 
+ 
+            </group>    
+
+        </group>
+           
+    </group>
+    
+  
+</params>
+

--- a/CER01/hardware/motorControl/cer_base-ems21-mc.xml
+++ b/CER01/hardware/motorControl/cer_base-ems21-mc.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_mobile_base_mc" type="embObjMotionControl">
+      <xi:include href="../../general.xml" />
+      <xi:include href="../electronics/cer_base-ems21-eln.xml" />
+      <xi:include href="../mechanicals/cer_base-ems21-mec.xml" />
+      <xi:include href="../motorControl/cer_base-ems21-mc-service.xml" />
+
+    <group name="LIMITS">
+        <param name="jntPosMax">              0          0           0        0     </param>
+        <param name="jntPosMin">              0          0           0        0     </param>
+        <param name="jntVelMax">              360       360          0        0     </param>
+        <param name="motorOverloadCurrents">  15000   15000      10000    10000     </param>
+        <param name="motorNominalCurrents">   10000   10000      10000    10000     </param>
+        <param name="motorPeakCurrents">      15000   15000      10000    10000     </param>
+        <param name="motorPwmLimit">          10000   10000          0        0     </param>  
+   </group>
+   
+   
+    <group name="TIMEOUTS">
+        <param name="velocity">               100       100           0         0    </param>
+    </group>
+
+
+    <group name="CONTROLS">
+        <param name="positionControl">         JOINT_MINJERK_OUT_VEL_CTRL  JOINT_MINJERK_OUT_VEL_CTRL  JOINT_MINJERK_OUT_VEL_CTRL  JOINT_MINJERK_OUT_VEL_CTRL   </param>
+        <param name="velocityControl">         JOINT_MINJERK_OUT_VEL_CTRL  JOINT_MINJERK_OUT_VEL_CTRL  JOINT_MINJERK_OUT_VEL_CTRL  JOINT_MINJERK_OUT_VEL_CTRL   </param>
+        <param name="mixedControl">            JOINT_MINJERK_OUT_VEL_CTRL  JOINT_MINJERK_OUT_VEL_CTRL  JOINT_MINJERK_OUT_VEL_CTRL  JOINT_MINJERK_OUT_VEL_CTRL   </param>
+        <param name="posDirectControl">        JOINT_DIRECT_OUT_VEL_CTRL   JOINT_DIRECT_OUT_VEL_CTRL   JOINT_DIRECT_OUT_VEL_CTRL   JOINT_DIRECT_OUT_VEL_CTRL    </param>                
+        <param name="velDirectControl">        JOINT_DIRECT_OUT_VEL_CTRL   JOINT_DIRECT_OUT_VEL_CTRL   JOINT_DIRECT_OUT_VEL_CTRL   JOINT_DIRECT_OUT_VEL_CTRL    </param>
+        <param name="torqueControl">           none                        none                        none                        none                         </param>
+                                               
+        <param name="currentPid">              2FOC_CUR_CONTROL            2FOC_CUR_CONTROL            2FOC_CUR_CONTROL            2FOC_CUR_CONTROL             </param>
+        <param name="speedPid">                2FOC_VEL_CONTROL            2FOC_VEL_CONTROL            2FOC_VEL_CONTROL            2FOC_VEL_CONTROL             </param>
+    </group>
+        
+    <group name="JOINT_MINJERK_OUT_VEL_CTRL">
+	    <param name="controlLaw">             minjerk                   </param>
+        <param name="outputType">             velocity                  </param>
+        <param name="fbkControlUnits">        machine_units             </param> 
+        <param name="outputControlUnits">     machine_units             </param>
+        <param name="kff">                        1            1           0         0       </param> 
+        <param name="kp">                         5            5           0         0       </param>          
+        <param name="kd">                         0            0           0         0       </param>                       
+        <param name="maxOutput">              32000        32000           0         0       </param>                     
+    </group>
+
+    <group name="JOINT_DIRECT_OUT_VEL_CTRL">
+	    <param name="controlLaw">             direct                    </param>
+        <param name="outputType">             velocity                  </param>
+        <param name="fbkControlUnits">        machine_units             </param> 
+        <param name="outputControlUnits">     machine_units             </param>
+        <param name="kff">                        1            1           0         0       </param> 
+        <param name="kp">                         5            5           0         0       </param>          
+        <param name="kd">                         0            0           0         0       </param>                       
+        <param name="maxOutput">              32000        32000           0         0       </param>                     
+    </group>
+    
+    <group name="2FOC_CUR_CONTROL">
+        <param name="controlLaw">          low_lev_current      </param> 
+        <param name="fbkControlUnits">     machine_units        </param> 
+        <param name="outputControlUnits">  machine_units        </param>
+        <param name="kff">                     0         0   0   0   </param>
+        <param name="kp">                      8         8   0   0   </param>       
+        <param name="kd">                      0         0   0   0   </param>       
+        <param name="ki">                      2         2   0   0   </param>
+        <param name="shift">                  10        10   0   0   </param>
+        <param name="maxOutput">           32000     32000   0   0   </param>                 
+        <param name="maxInt">              32000     32000   0   0   </param>         
+    </group>
+
+    <group name="2FOC_VEL_CONTROL">
+        <param name="controlLaw">          low_lev_speed        </param> 
+        <param name="fbkControlUnits">     machine_units        </param> 
+        <param name="outputControlUnits">  machine_units        </param>
+        <param name="kff">                 0          0    0    0 </param>
+        <param name="kp">                 12         12    0    0 </param>       
+        <param name="kd">                  0          0    0    0 </param>       
+        <param name="ki">                 16         16    0    0 </param>
+        <param name="shift">              10         10    0    0 </param>
+        <param name="maxOutput">       32000      32000    0    0 </param>                 
+        <param name="maxInt">          32000      32000    0    0 </param>        
+    </group>
+
+    <group name="IMPEDANCE">
+        <param name="stiffness">       0      0      0      0     </param>    
+        <param name="damping">         0      0      0      0     </param>    
+    </group>
+    
+
+
+  </device>
+
+

--- a/CER01/hardware/motorControl/cer_head-mcp10-mc-service.xml
+++ b/CER01/hardware/motorControl/cer_head-mcp10-mc-service.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER01" build="1">
+
+    <group name="SERVICE">
+        
+        <param name="type"> eomn_serv_MC_mc4plus </param> 
+    
+        <group name="PROPERTIES">
+        
+            <group name="ETHBOARD">
+                <param name="type">                 mc4plus        </param> 
+            </group>          
+
+            
+            <group name="JOINTMAPPING">
+
+               <group name="ACTUATOR">                 
+                    <param name="type">             pwm                 pwm                 </param>
+                    <param name="port">             CONN:P3             CONN:P2             </param>
+                </group>
+                
+                <!-- <group name="ENCODER1">  
+                    <param name="type">             eomc_enc_aea        qenc                </param>  
+                    <param name="port">             CONN:P11            CONN:P2             </param>
+                    <param name="position">         eomc_pos_atjoint    atmotor             </param> 
+                    <param name="resolution">       4096                1000                </param>
+                    <param name="numofnoisebits">   3                   0                   </param> 
+                </group> -->       
+
+                <group name="ENCODER1">  
+                    <param name="type">             eomc_enc_aea        aea                 </param>  
+                    <param name="port">             CONN:P11            CONN:P10            </param>
+                    <param name="position">         eomc_pos_atjoint    atjoint             </param> 
+                    <param name="resolution">       4096                4096               </param>
+                    <param name="tolerance">        0.703                0.703                   </param>  
+                </group>
+                
+                <group name="ENCODER2">
+                    <param name="type">             eomc_enc_none       none                </param>
+                    <param name="port">             CONN:none           CONN:none           </param>
+                    <param name="position">         eomc_pos_none       none                </param>
+                    <param name="resolution">        0                  0                   </param>
+                    <param name="tolerance">         0                  0                   </param>  
+                </group> 
+ 
+            </group>    
+            
+        </group>
+           
+    </group>
+    
+  
+</params>
+

--- a/CER01/hardware/motorControl/cer_head-mcp10-mc.xml
+++ b/CER01/hardware/motorControl/cer_head-mcp10-mc.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+ <!-- Initialization file for EMS 10 - CER head, 2 dof -->
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_head_mc" type="embObjMotionControl">
+      <xi:include href="../../general.xml" />
+      <xi:include href="../electronics/cer_head-mcp10-eln.xml" />
+      <xi:include href="../mechanicals/cer_head-mcp10-mec.xml" />
+      <xi:include href="../motorControl/cer_head-mcp10-mc-service.xml" />
+
+    <group name="LIMITS">
+        <param name="jntPosMax">                35      70            </param>
+        <param name="jntPosMin">                -25    -45            </param>
+        <param name="jntVelMax">                50      50           </param>
+        <param name="motorOverloadCurrents">    5000    5000         </param>
+        <param name="motorNominalCurrents">     8000    8000         </param>
+        <param name="motorPeakCurrents">        8000    8000         </param>
+        <param name="motorPwmLimit">            3360    3360         </param>
+    </group>
+
+    
+     <group name="TIMEOUTS">
+        <param name="velocity">             100           100         </param>
+    </group>
+
+    
+    <group name="CONTROLS">
+        <param name="positionControl">         JOINT_MINJERK_OUT_PWM_CTRL  JOINT_MINJERK_OUT_PWM_CTRL   </param>
+        <param name="velocityControl">         JOINT_MINJERK_OUT_PWM_CTRL  JOINT_MINJERK_OUT_PWM_CTRL   </param>
+        <param name="mixedControl">            JOINT_MINJERK_OUT_PWM_CTRL  JOINT_MINJERK_OUT_PWM_CTRL   </param>
+        <param name="posDirectControl">        JOINT_DIRECT_OUT_PWM_CTRL   JOINT_DIRECT_OUT_PWM_CTRL    </param>                
+        <param name="velDirectControl">        JOINT_DIRECT_OUT_PWM_CTRL   JOINT_DIRECT_OUT_PWM_CTRL    </param>
+        <param name="torqueControl">           none                        none                         </param>
+        
+        <param name="currentPid">              none none </param>
+        <param name="speedPid">                none none </param>
+    </group>
+    
+    <group name="JOINT_MINJERK_OUT_PWM_CTRL">
+	    <param name="controlLaw">             minjerk                   </param>
+        <param name="outputType">             pwm                       </param>
+        <param name="fbkControlUnits">        machine_units             </param> 
+        <param name="outputControlUnits">     machine_units             </param>
+        <param name="kff">                        0            0        </param> 
+        <param name="kp">                        -2            1.5      </param>          
+        <param name="kd">                         0            0        </param>          
+        <param name="ki">                        -5            5        </param>              
+        <param name="maxOutput">               3360         3360        </param>                
+        <param name="maxInt">                  3360         1500        </param>                             
+        <param name="stictionUp">                 0            0        </param>          
+        <param name="stictionDown">               0            0        </param>        
+    </group>
+
+    <group name="JOINT_DIRECT_OUT_PWM_CTRL">
+	    <param name="controlLaw">             direct                    </param>
+        <param name="outputType">             pwm                       </param>
+        <param name="fbkControlUnits">        machine_units             </param> 
+        <param name="outputControlUnits">     machine_units             </param>
+        <param name="kff">                        0            0        </param> 
+        <param name="kp">                        -2            1.5      </param>          
+        <param name="kd">                         0            0        </param>          
+        <param name="ki">                        -5            5        </param>              
+        <param name="maxOutput">               3360         3360        </param>                
+        <param name="maxInt">                  3360         1500        </param>                             
+        <param name="stictionUp">                 0            0        </param>          
+        <param name="stictionDown">               0            0        </param>        
+    </group>
+    
+    <group name="IMPEDANCE">
+        <param name="stiffness">       0      0           </param>
+        <param name="damping">         0      0           </param>
+    </group>
+
+  </device>
+

--- a/CER01/hardware/motorControl/cer_left_hand-mcp7-mc-service.xml
+++ b/CER01/hardware/motorControl/cer_left_hand-mcp7-mc-service.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER01" build="1">
+
+    <group name="SERVICE">
+        
+        <param name="type"> eomn_serv_MC_mc4plus </param> 
+    
+        <group name="PROPERTIES">
+        
+            <group name="ETHBOARD">
+                <param name="type">             mc2plus             </param> 
+            </group>          
+
+
+            <group name="JOINTMAPPING">
+
+                <group name="ACTUATOR">                 
+                    <param name="type">             pwm                 pwm                 </param>
+                    <param name="port">             CONN:P3             CONN:P2             </param>
+                </group>
+                
+                <group name="ENCODER1">  
+                    <param name="type">             spichainof3         spichainof3         </param>  
+                    <param name="port">             CONN:P10            CONN:P11            </param>
+                    <param name="position">         atjoint             atjoint             </param> 
+                    <param name="resolution">       4096                4096                </param>
+                    <param name="tolerance">        0.703               0.703               </param>  
+                </group>        
+                
+                <group name="ENCODER2">
+                    <param name="type">             qenc                qenc                </param>
+                    <param name="port">             CONN:P3             CONN:P2             </param>
+                    <param name="position">         atmotor             atmotor             </param>
+                    <param name="resolution">       1024                1024                </param>
+                    <param name="tolerance">        0                   0                </param>  
+                </group>  
+            </group>    
+            
+        </group>
+           
+    </group>
+    
+  
+</params>
+

--- a/CER01/hardware/motorControl/cer_left_hand-mcp7-mc.xml
+++ b/CER01/hardware/motorControl/cer_left_hand-mcp7-mc.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+ <!-- Initialization file for EMS 10 - CER hand, 2 dof -->
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_left_hand_mc" type="embObjMotionControl">
+      <xi:include href="../../general.xml" />
+      <xi:include href="../electronics/cer_left_hand-mcp7-eln.xml" />
+      <xi:include href="../mechanicals/cer_left_hand-mcp7-mec.xml" />
+      <xi:include href="../motorControl/cer_left_hand-mcp7-mc-service.xml" />
+
+    <group name="LIMITS">
+        <param name="jntPosMax">                140     110           </param>
+        <param name="jntPosMin">                0       0             </param>
+        <param name="jntVelMax">                150     150           </param>
+        <param name="motorOverloadCurrents">    5000    5000          </param>
+        <param name="motorNominalCurrents">     1500    1500           </param>
+        <param name="motorPeakCurrents">        2500    2500           </param>
+        <param name="motorPwmLimit">            3360    3360          </param>  
+    </group>
+    
+    
+    <group name="TIMEOUTS">
+        <param name="velocity">                 100           100     </param>
+    </group>
+
+
+    <group name="CONTROLS">
+        <param name="positionControl">         JOINT_MINJERK_OUT_PWM_CTRL  JOINT_MINJERK_OUT_PWM_CTRL   </param>
+        <param name="velocityControl">         JOINT_MINJERK_OUT_PWM_CTRL  JOINT_MINJERK_OUT_PWM_CTRL   </param>
+        <param name="mixedControl">            JOINT_MINJERK_OUT_PWM_CTRL  JOINT_MINJERK_OUT_PWM_CTRL   </param>
+        <param name="posDirectControl">        JOINT_DIRECT_OUT_PWM_CTRL   JOINT_DIRECT_OUT_PWM_CTRL    </param>                
+        <param name="velDirectControl">        JOINT_DIRECT_OUT_PWM_CTRL   JOINT_DIRECT_OUT_PWM_CTRL    </param>
+        <param name="torqueControl">           none                        none                         </param>
+        
+        <param name="currentPid">              none none </param>
+        <param name="speedPid">                none none </param>
+    </group>
+    
+    <group name="JOINT_MINJERK_OUT_PWM_CTRL">
+	    <param name="controlLaw">             minjerk                   </param>
+        <param name="outputType">             pwm                       </param>
+        <param name="fbkControlUnits">        machine_units             </param> 
+        <param name="outputControlUnits">     machine_units             </param>
+        <param name="kff">                        0            0        </param> 
+        <param name="kp">                      -100          100        </param>          
+        <param name="kd">                         0            0        </param>          
+        <param name="ki">                       -50           50        </param>              
+        <param name="maxOutput">               2500         2500        </param>                
+        <param name="maxInt">                   500          500        </param>                             
+        <param name="stictionUp">                 0            0        </param>          
+        <param name="stictionDown">               0            0        </param>        
+    </group>
+
+    <group name="JOINT_DIRECT_OUT_PWM_CTRL">
+	    <param name="controlLaw">             direct                    </param>
+        <param name="outputType">             pwm                       </param>
+        <param name="fbkControlUnits">        machine_units             </param> 
+        <param name="outputControlUnits">     machine_units             </param>
+        <param name="kff">                        0            0        </param> 
+        <param name="kp">                      -100          100        </param>          
+        <param name="kd">                         0            0        </param>          
+        <param name="ki">                       -50           50        </param>              
+        <param name="maxOutput">               2500         2500        </param>                
+        <param name="maxInt">                   500          500        </param>                             
+        <param name="stictionUp">                 0            0        </param>          
+        <param name="stictionDown">               0            0        </param>        
+    </group>
+
+    <group name="IMPEDANCE">
+        <param name="stiffness">       0      0           </param>    
+        <param name="damping">         0      0           </param>    
+    </group>
+    
+    <group name="OTHER_CONTROL_PARAMETERS">
+        <param name="deadZone">        2.20    2.20        </param>
+	</group>
+    
+  </device>
+
+
+        

--- a/CER01/hardware/motorControl/cer_left_lower_arm-mcp18-mc-service.xml
+++ b/CER01/hardware/motorControl/cer_left_lower_arm-mcp18-mc-service.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER01" build="1">
+
+    <group name="SERVICE">
+        
+        <param name="type"> eomn_serv_MC_mc4plus </param> 
+    
+        <group name="PROPERTIES">
+        
+            <group name="ETHBOARD">
+                <param name="type">             mc4plus             </param> 
+            </group>          
+
+
+            <group name="JOINTMAPPING">
+
+                <group name="ACTUATOR">                 
+                    <param name="type">             pwm                 pwm                 pwm                 pwm                     </param>
+                    <param name="port">             CONN:P2             CONN:P4             CONN:P5             CONN:P3                 </param>
+                </group>
+                
+                <group name="ENCODER1">  
+                    <param name="type">             none                none                none                aea                      </param>  
+                    <param name="port">             CONN:none           CONN:none           CONN:none           CONN:P10                 </param>
+                    <param name="position">         none                none                none                atjoint                  </param> 
+                    <param name="resolution">       65535               65535               65535              -4096                     </param>
+                    <param name="tolerance">        0                   0                   0                   0.703                    </param>  
+                </group>        
+                
+                <group name="ENCODER2">
+                    <!-- <param name="type">             roie                roie                roie                none                    </param> -->
+                    <param name="type">             qenc                qenc                qenc                none                    </param>
+                    <param name="port">             CONN:P2             CONN:P4             CONN:P5             CONN:none               </param>
+                    <param name="position">         atmotor             atmotor             atmotor             none                    </param>
+                     <param name="resolution">      65535               65535               65535               0                       </param>
+                    <param name="tolerance">        0                   0                   0               0                       </param>  
+                </group>  
+            </group>    
+            
+            
+        </group>
+           
+    </group>
+    
+  
+</params>
+

--- a/CER01/hardware/motorControl/cer_left_lower_arm-mcp18-mc.xml
+++ b/CER01/hardware/motorControl/cer_left_lower_arm-mcp18-mc.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+ <!-- Initialization file for MC4+ 18 - CER left lower arm, 4 dof -->
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_left_lower_arm_mc" type="embObjMotionControl">
+      <xi:include href="../../general.xml" />
+      <xi:include href="../electronics/cer_left_lower_arm-mcp18-eln.xml" />
+      <xi:include href="../mechanicals/cer_left_lower_arm-mcp18-mec.xml" />
+      <xi:include href="../motorControl/cer_left_lower_arm-mcp18-mc-service.xml" />
+
+    <group name="LIMITS">
+        <param name="jntPosMax">                  0.12     0.12    0.12     80     </param>
+        <param name="jntPosMin">                  0        0       0        -80    </param>
+        <param name="jntVelMax">                  0.02     0.02    0.02     3000   </param>
+        <param name="motorOverloadCurrents">      10000    10000   10000    10000   </param>
+        <param name="motorNominalCurrents">       5000     5000    5000     5000   </param>
+        <param name="motorPeakCurrents">          5000     5000    5000     5000   </param>
+        <param name="motorPwmLimit">              3360     3360    3360     3360   </param>  
+    </group>
+
+<group name="TIMEOUTS">
+        <param name="velocity">               100       100           100        100    </param>
+    </group>
+    
+    <group name="CONTROLS">
+        <param name="positionControl">         JOINT_MINJERK_OUT_PWM_CTRL  JOINT_MINJERK_OUT_PWM_CTRL  JOINT_MINJERK_OUT_PWM_CTRL  JOINT_MINJERK_OUT_PWM_CTRL   </param>
+        <param name="velocityControl">         JOINT_MINJERK_OUT_PWM_CTRL  JOINT_MINJERK_OUT_PWM_CTRL  JOINT_MINJERK_OUT_PWM_CTRL  JOINT_MINJERK_OUT_PWM_CTRL   </param>
+        <param name="mixedControl">            JOINT_MINJERK_OUT_PWM_CTRL  JOINT_MINJERK_OUT_PWM_CTRL  JOINT_MINJERK_OUT_PWM_CTRL  JOINT_MINJERK_OUT_PWM_CTRL   </param>
+        <param name="posDirectControl">        JOINT_DIRECT_OUT_PWM_CTRL   JOINT_DIRECT_OUT_PWM_CTRL   JOINT_DIRECT_OUT_PWM_CTRL   JOINT_DIRECT_OUT_PWM_CTRL    </param>                
+        <param name="velDirectControl">        JOINT_DIRECT_OUT_PWM_CTRL   JOINT_DIRECT_OUT_PWM_CTRL   JOINT_DIRECT_OUT_PWM_CTRL   JOINT_DIRECT_OUT_PWM_CTRL    </param>
+        <param name="torqueControl">           none                        none                        none                        none                         </param>
+    
+        <param name="currentPid">              none none none none </param>
+        <param name="speedPid">                none none none none </param>
+    </group>
+    
+    <group name="JOINT_MINJERK_OUT_PWM_CTRL">
+	    <param name="controlLaw">             minjerk                   </param>
+        <param name="outputType">             pwm                       </param>
+        <param name="fbkControlUnits">        machine_units             </param> 
+        <param name="outputControlUnits">     machine_units             </param>
+        <param name="kff">                        0            0          0        0          </param> 
+        <param name="kp">                        20           20         20        0.7        </param>          
+        <param name="kd">                         0            0          0        0          </param>          
+        <param name="ki">                         0            0          0        0          </param>              
+        <param name="maxOutput">               3000         3000       3000     2000          </param>                
+        <param name="maxInt">                     0            0          0        0          </param>                             
+        <param name="stictionUp">                 0            0          0        0          </param>          
+        <param name="stictionDown">               0            0          0        0          </param>        
+    </group>
+
+    <group name="JOINT_DIRECT_OUT_PWM_CTRL">
+	    <param name="controlLaw">             direct                    </param>
+        <param name="outputType">             pwm                       </param>
+        <param name="fbkControlUnits">        machine_units             </param> 
+        <param name="outputControlUnits">     machine_units             </param>
+        <param name="kff">                        0            0          0        0          </param> 
+        <param name="kp">                        20           20         20        0.7        </param>          
+        <param name="kd">                         0            0          0        0          </param>          
+        <param name="ki">                         0            0          0        0          </param>              
+        <param name="maxOutput">               3000         3000       3000     2000          </param>                
+        <param name="maxInt">                     0            0          0        0          </param>                             
+        <param name="stictionUp">                 0            0          0        0          </param>          
+        <param name="stictionDown">               0            0          0        0          </param>        
+    </group>
+
+
+    <group name="IMPEDANCE">
+        <param name="stiffness">       0      0      0      0     </param>    
+        <param name="damping">         0      0      0      0     </param>    
+    </group>
+	
+  </device>
+
+

--- a/CER01/hardware/motorControl/cer_left_upper_arm-ems17-mc-service.xml
+++ b/CER01/hardware/motorControl/cer_left_upper_arm-ems17-mc-service.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER01" build="1">
+
+    <group name="SERVICE">
+        
+        <param name="type"> eomn_serv_MC_foc </param> 
+    
+        <group name="PROPERTIES">
+        
+            <group name="ETHBOARD">
+                <param name="type">                 ems4        </param> 
+            </group>          
+
+            <group name="CANBOARDS"> 
+                <param name="type">                 foc         </param> 
+                <group name="PROTOCOL">
+                    <param name="major">            1           </param>    
+                    <param name="minor">            6           </param>     
+                </group>                    
+                <group name="FIRMWARE">
+                    <param name="major">            0           </param>    
+                    <param name="minor">            0           </param> 
+                    <param name="build">            0           </param>
+                </group>
+            </group>
+
+            <group name="JOINTMAPPING">
+
+                <group name="ACTUATOR">                
+                    <param name="type">             foc                 foc                 foc             foc         </param>
+                    <param name="port">             CAN1:1:0            CAN1:2:0            CAN1:3:0        CAN1:4:0    </param>
+                </group>
+                
+                <group name="ENCODER1">  
+                    <param name="type">             aea                aea                 aea             aea         </param>
+                    <param name="port">             CONN:P6            CONN:P8             CONN:P7         CONN:P9     </param>
+                    <param name="position">         atjoint            atjoint             atjoint         atjoint     </param>
+                    <param name="resolution">       4096               4096                4096            4096        </param>
+                    <param name="tolerance">        0.703              0.703               0.703           0.703         </param>
+                </group>        
+                
+                <group name="ENCODER2">
+                    <param name="type">             roie                roie                roie            roie        </param>
+                    <param name="port">             CAN1:1:0            CAN1:2:0            CAN1:3:0        CAN1:4:0    </param>
+                    <param name="position">         atmotor             atmotor             atmotor         atmotor     </param>
+                    <param name="resolution">       8192                8192                8192            8192        </param>
+                    <param name="tolerance">        0                   0                   0                0        </param>  
+                </group> 
+ 
+            </group>    
+            
+        </group>
+           
+    </group>
+    
+  
+</params>
+

--- a/CER01/hardware/motorControl/cer_left_upper_arm-ems17-mc.xml
+++ b/CER01/hardware/motorControl/cer_left_upper_arm-ems17-mc.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_left_upper_arm_mc" type="embObjMotionControl">
+      <xi:include href="../../general.xml" />
+      <xi:include href="../electronics/cer_left_upper_arm-ems17-eln.xml" />
+      <xi:include href="../mechanicals/cer_left_upper_arm-ems17-mec.xml" />
+      <xi:include href="../motorControl/cer_left_upper_arm-ems17-mc-service.xml" />
+
+    <group name="LIMITS">
+    <!--    <param name="jntPosMax">                  85            70         85        95         </param>   no covers -->
+        <param name="jntPosMax">                      55            50         85        95         </param>
+        <param name="jntPosMin">                     -25             5        -85         5         </param>
+        <param name="motorOverloadCurrents">          5000          5000       5000      5000       </param>
+        <param name="motorNominalCurrents">           2500          2500       2500      2500       </param>
+        <param name="motorPeakCurrents">              5000          5000       5000      5000       </param>
+        <param name="jntVelMax">                      50            50         50        50         </param>
+        <param name="motorPwmLimit">                  32000         32000      32000     32000      </param>    
+    </group>
+
+    <group name="TIMEOUTS">
+        <param name="velocity">               100       100           100        100    </param>
+    </group>
+    
+    <group name="CONTROLS">
+        <param name="positionControl">        JOINT_MINJERK_OUT_WORM_VEL_CTRL    JOINT_MINJERK_OUT_WORM_VEL_CTRL    JOINT_MINJERK_OUT_WORM_VEL_CTRL    JOINT_MINJERK_OUT_WORM_VEL_CTRL   </param>
+        <param name="velocityControl">        JOINT_MINJERK_OUT_WORM_VEL_CTRL    JOINT_MINJERK_OUT_WORM_VEL_CTRL    JOINT_MINJERK_OUT_WORM_VEL_CTRL    JOINT_MINJERK_OUT_WORM_VEL_CTRL   </param>
+        <param name="mixedControl">           JOINT_MINJERK_OUT_WORM_VEL_CTRL    JOINT_MINJERK_OUT_WORM_VEL_CTRL    JOINT_MINJERK_OUT_WORM_VEL_CTRL    JOINT_MINJERK_OUT_WORM_VEL_CTRL   </param>
+        <param name="posDirectControl">       JOINT_DIRECT_OUT_WORM_VEL_CTRL     JOINT_DIRECT_OUT_WORM_VEL_CTRL     JOINT_DIRECT_OUT_WORM_VEL_CTRL     JOINT_DIRECT_OUT_WORM_VEL_CTRL    </param>                
+        <param name="velDirectControl">       JOINT_DIRECT_OUT_WORM_VEL_CTRL     JOINT_DIRECT_OUT_WORM_VEL_CTRL     JOINT_DIRECT_OUT_WORM_VEL_CTRL     JOINT_DIRECT_OUT_WORM_VEL_CTRL    </param>
+        <param name="torqueControl">          none                               none                               none                               none                              </param>
+                                            
+        <param name="currentPid">             2FOC_CUR_CONTROL                   2FOC_CUR_CONTROL                   2FOC_CUR_CONTROL                   2FOC_CUR_CONTROL                  </param>
+        <param name="speedPid">               2FOC_VEL_CONTROL                   2FOC_VEL_CONTROL                   2FOC_VEL_CONTROL                   2FOC_VEL_CONTROL                  </param>
+    </group>
+    
+    <group name="JOINT_MINJERK_OUT_WORM_VEL_CTRL">
+        <param name="controlLaw">             minjerk                   </param>
+        <param name="outputType">             velocity                  </param>
+        <param name="fbkControlUnits">        machine_units             </param> 
+        <param name="outputControlUnits">     machine_units             </param> 
+        <param name="kff">                        1          1         1         1        </param> 
+        <param name="kp">                         5          5         5         5        </param>       
+        <param name="kd">                         0          0         0         0        </param>             
+        <param name="maxOutput">              32000      32000     32000     32000        </param>                
+    </group>
+    
+    <group name="JOINT_DIRECT_OUT_WORM_VEL_CTRL">
+        <param name="controlLaw">             direct                    </param>
+        <param name="outputType">             velocity                  </param>
+        <param name="fbkControlUnits">        machine_units             </param> 
+        <param name="outputControlUnits">     machine_units             </param> 
+        <param name="kff">                        1          1         1         1        </param> 
+        <param name="kp">                         5          5         5         5        </param>       
+        <param name="kd">                         0          0         0         0        </param>             
+        <param name="maxOutput">              32000      32000     32000     32000        </param>                 
+    </group>
+    
+    <group name="2FOC_CUR_CONTROL">
+        <param name="controlLaw">          low_lev_current      </param> 
+        <param name="fbkControlUnits">     machine_units        </param> 
+        <param name="outputControlUnits">  machine_units        </param>
+        <param name="kff">                     0         0         0         0      </param>
+        <param name="kp">                      8         8         8         8      </param>       
+        <param name="kd">                      0         0         0         0      </param>       
+        <param name="ki">                      2         2         2         2      </param>
+        <param name="shift">                  10        10        10        10      </param>
+        <param name="maxOutput">           32000     32000     32000     32000      </param>                 
+        <param name="maxInt">              32000     32000     32000     32000      </param>         
+    </group>
+
+    <group name="2FOC_VEL_CONTROL">
+        <param name="controlLaw">          low_lev_speed        </param> 
+        <param name="fbkControlUnits">     machine_units        </param> 
+        <param name="outputControlUnits">  machine_units        </param>
+        <param name="kff">                 0      0      0      0  </param>
+        <param name="kp">               1280   1280   1280   1280  </param>       
+        <param name="kd">               6144   6144   6144   6144  </param>       
+        <param name="ki">                  1      1      1      1  </param>
+        <param name="shift">              14     14     14     14  </param>
+        <param name="maxOutput">       32000  32000  32000  32000  </param>                 
+        <param name="maxInt">          32000  32000  32000  32000  </param>        
+    </group>
+    
+
+
+    <group name="IMPEDANCE">
+        <param name="stiffness">        0          0         0        0       </param>    
+        <param name="damping">          0          0         0        0       </param>    
+    </group>
+	
+  </device>
+

--- a/CER01/hardware/motorControl/cer_left_wrist_equivalent-mc.xml
+++ b/CER01/hardware/motorControl/cer_left_wrist_equivalent-mc.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_left_wrist_equivalent_mc" type="tripodMotionControl">
+      <xi:include href="../../general.xml" />
+
+      <param name="AxisNames">  "l_wrist_heave_eq_joint" "l_wrist_pitch_eq_joint" "l_wrist_roll_eq_joint"  </param>
+
+    <group name="GENERAL">
+      <param name="Joints">      3       </param>
+     <!-- <param name="AxisMap">     0 1 2   </param> -->
+     <!-- <param name="Verbose">     true    </param> -->
+      <param name="Encoder">     1 1 1   </param>
+    </group>
+
+    <group name="TRIPOD">
+      <param name="Radius">      0.018   </param>
+      <param name="Max_el">      0.120  </param>
+      <param name="Min_el">      0.0    </param>
+      <param name="Max_alpha">   30.0   </param>
+
+      <param name="BASE_TRANSFORMATION">   1.0    0.0     0.0    0.0
+                                           0.0    1.0     0.0    0.0
+                                           0.0    0.0     1.0    0.0
+                                           0.0    0.0     0.0    1.0
+      </param>
+    </group>
+
+    <group name="LIMITS">
+        <param name="JntVelocityMax">   0.05  </param>
+    </group>
+
+    <!-- action is alternative to CONNECTION group -->
+    <action phase="startup" level="1" type="attach">
+      <paramlist name="networks">
+          <elem name="FirstSetOfJoints"> cer_left_lower_arm_mc </elem>
+      </paramlist>
+    </action>
+
+    <action phase="shutdown" level="6" type="detach" />
+
+  </device>
+

--- a/CER01/hardware/motorControl/cer_right_hand-mcp9-mc-service.xml
+++ b/CER01/hardware/motorControl/cer_right_hand-mcp9-mc-service.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER01" build="1">
+
+    <group name="SERVICE">
+        
+        <param name="type"> eomn_serv_MC_mc4plus </param> 
+    
+        <group name="PROPERTIES">
+        
+            <group name="ETHBOARD">
+                <param name="type">             mc2plus             </param> 
+            </group>          
+
+
+            <group name="JOINTMAPPING">
+
+                <group name="ACTUATOR">                 
+                    <param name="type">             pwm                 pwm                 </param>
+                    <param name="port">             CONN:P3             CONN:P2             </param>
+                </group>
+                
+                <group name="ENCODER1">  
+                    <param name="type">             spichainof3         spichainof3         </param>  
+                    <param name="port">             CONN:P10            CONN:P11            </param>
+                    <param name="position">         atjoint             atjoint             </param> 
+                    <param name="resolution">       -4096               4096                </param>
+                    <param name="tolerance">        0.703               0.703               </param> 
+                </group>        
+                
+                <group name="ENCODER2">
+                    <param name="type">             qenc                qenc                </param>
+                    <param name="port">             CONN:P3             CONN:P2             </param>
+                    <param name="position">         atmotor             atmotor             </param>
+                    <param name="resolution">       -1024              -1024                </param>
+                    <param name="tolerance">         0                   0                  </param>
+                </group>  
+            </group>    
+
+        </group>
+           
+    </group>
+    
+  
+</params>
+

--- a/CER01/hardware/motorControl/cer_right_hand-mcp9-mc.xml
+++ b/CER01/hardware/motorControl/cer_right_hand-mcp9-mc.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+ <!-- Initialization file for EMS 10 - CER hand, 2 dof -->
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_right_hand_mc" type="embObjMotionControl">
+      <xi:include href="../../general.xml" />
+      <xi:include href="../../hardware/electronics/cer_right_hand-mcp9-eln.xml" />
+      <xi:include href="../../hardware/mechanicals/cer_right_hand-mcp9-mec.xml" />
+      <xi:include href="../../hardware/motorControl/cer_right_hand-mcp9-mc-service.xml" />
+
+    <group name="LIMITS">
+        <param name="jntPosMax">                140     110           </param>
+        <param name="jntPosMin">                0       0             </param>
+        <param name="jntVelMax">                150     150           </param>
+        <param name="motorOverloadCurrents">    5000    5000          </param>
+        <param name="motorNominalCurrents">     1500    1500           </param>
+        <param name="motorPeakCurrents">        2500    2500          </param>
+        <param name="motorPwmLimit">            3360    3360          </param>  
+    </group>
+
+    
+    <group name="TIMEOUTS">
+        <param name="velocity">               100       100              </param>
+    </group>
+
+
+    <group name="CONTROLS">
+        <param name="positionControl">         JOINT_MINJERK_OUT_PWM_CTRL  JOINT_MINJERK_OUT_PWM_CTRL   </param>
+        <param name="velocityControl">         JOINT_MINJERK_OUT_PWM_CTRL  JOINT_MINJERK_OUT_PWM_CTRL   </param>
+        <param name="mixedControl">            JOINT_MINJERK_OUT_PWM_CTRL  JOINT_MINJERK_OUT_PWM_CTRL   </param>
+        <param name="posDirectControl">        JOINT_DIRECT_OUT_PWM_CTRL   JOINT_DIRECT_OUT_PWM_CTRL    </param>                
+        <param name="velDirectControl">        JOINT_DIRECT_OUT_PWM_CTRL   JOINT_DIRECT_OUT_PWM_CTRL    </param>
+        <param name="torqueControl">           none                        none                         </param>
+        
+        <param name="currentPid">              none none </param>
+        <param name="speedPid">                none none </param>
+    </group>
+    
+    <group name="JOINT_MINJERK_OUT_PWM_CTRL">
+	    <param name="controlLaw">             minjerk                   </param>
+        <param name="outputType">             pwm                       </param>
+        <param name="fbkControlUnits">        machine_units             </param> 
+        <param name="outputControlUnits">     machine_units             </param>
+        <param name="kff">                        0            0        </param> 
+        <param name="kp">                       100         -100        </param>          
+        <param name="kd">                         0            0        </param>          
+        <param name="ki">                        50          -50        </param>              
+        <param name="maxOutput">               2500         2500        </param>                
+        <param name="maxInt">                   500          500        </param>                             
+        <param name="stictionUp">                 0            0        </param>          
+        <param name="stictionDown">                0            0        </param>        
+    </group>
+
+    <group name="JOINT_DIRECT_OUT_PWM_CTRL">
+	    <param name="controlLaw">             direct                    </param>
+        <param name="outputType">             pwm                       </param>
+        <param name="fbkControlUnits">        machine_units             </param> 
+        <param name="outputControlUnits">     machine_units             </param>
+        <param name="kff">                        0            0        </param> 
+        <param name="kp">                       100         -100        </param>          
+        <param name="kd">                         0            0        </param>          
+        <param name="ki">                        50          -50        </param>              
+        <param name="maxOutput">               2500         2500        </param>                
+        <param name="maxInt">                   500          500        </param>                             
+        <param name="stictionUp">                 0            0        </param>          
+        <param name="stictionDown">               0            0        </param>        
+    </group>
+    
+    <group name="IMPEDANCE">
+        <param name="stiffness">       0      0           </param>    
+        <param name="damping">         0      0           </param>    
+    </group>
+    
+    <group name="OTHER_CONTROL_PARAMETERS">
+        <param name="deadZone">        2.20    2.20        </param>
+	</group>
+	
+  </device>
+
+
+
+

--- a/CER01/hardware/motorControl/cer_right_lower_arm-mcp20-mc-service-test.xml
+++ b/CER01/hardware/motorControl/cer_right_lower_arm-mcp20-mc-service-test.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER01" build="1">
+
+    <group name="SERVICE">
+        
+        <param name="type"> eomn_serv_MC_mc4plus </param> 
+    
+        <group name="PROPERTIES">
+        
+            <group name="ETHBOARD">
+                <param name="type">             mc4plus             </param> 
+            </group>          
+
+            
+            <group name="CONTROLLER"> 
+            
+                <param name="type"> eomc_ctrlboard_CER_LOWER_ARM </param> 
+                    
+                
+                <param name ="matrixJ2M"> 
+                    1.000   0.000   0.000   0.000
+                    0.000   1.000   0.000   0.000
+                    0.000   0.000   1.000   0.000
+                    0.000   0.000   0.000   1.000   
+                </param>
+               
+                <param name ="matrixE2J">  
+                    1.000   0.000   0.000   0.000
+                    0.000   1.000   0.000   0.000
+                    0.000   0.000   1.000   0.000
+                    0.000   0.000   0.000   1.000   
+                </param>
+
+                
+            </group>                
+
+            <group name="JOINTMAPPING">
+
+                <group name="ACTUATOR">                 
+                    <param name="type">             pwm                 pwm                 pwm                 pwm                     </param>
+                    <param name="port">             CONN:P2             CONN:P4             CONN:P5             CONN:P3                 </param>
+                </group>
+                
+                <group name="ENCODER1">  
+                    <param name="type">             none                none                none                aea                </param>  
+                    <param name="port">             CONN:none           CONN:none           CONN:none           CONN:P10           </param>
+                    <param name="position">         none                none                none                atjoint            </param> 
+                </group>        
+                
+                <group name="ENCODER2">
+                    <param name="type">             qenc                qenc                qenc                none                    </param>
+                    <param name="port">             CONN:P2             CONN:P4             CONN:P5             CONN:none               </param>
+                    <param name="position">         atmotor             atmotor             atmotor             none                    </param>
+                </group>  
+            </group>    
+            
+            <group name="JOINTSETS">
+                <param name="list">                 0                   0                   0                   1                       </param> 
+            </group>
+            
+        </group>
+           
+    </group>
+    
+  
+</params>
+

--- a/CER01/hardware/motorControl/cer_right_lower_arm-mcp20-mc-service.xml
+++ b/CER01/hardware/motorControl/cer_right_lower_arm-mcp20-mc-service.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER01" build="1">
+
+    <group name="SERVICE">
+        
+        <param name="type"> eomn_serv_MC_mc4plus </param> 
+    
+        <group name="PROPERTIES">
+        
+            <group name="ETHBOARD">
+                <param name="type">             mc4plus             </param> 
+            </group>          
+
+            
+            <group name="JOINTMAPPING">
+
+                <group name="ACTUATOR">                 
+                    <param name="type">             pwm                 pwm                 pwm                 pwm                     </param>
+                    <param name="port">             CONN:P2             CONN:P4             CONN:P5             CONN:P3                 </param>
+                </group>
+                
+                <group name="ENCODER1">  
+                    <param name="type">               none                none                none                aea                </param>  
+                    <param name="port">               CONN:none           CONN:none           CONN:none           CONN:P10           </param>
+                    <param name="position">           none                none                none                atjoint            </param> 
+                    <param name="resolution">         65535               65535               65535               4096               </param>
+                    <param name="tolerance">          0                   0                   0                   0.703              </param>  
+                </group>        
+                
+                <group name="ENCODER2">
+                    <param name="type">             qenc                qenc                qenc                none                    </param> 
+                    <!-- <param name="RotorEncoderType">      "ROIE"             "ROIE"             "ROIE"             "NONE"                  </param> -->
+                    <param name="port">             CONN:P2             CONN:P4             CONN:P5             CONN:none               </param>
+                    <param name="position">         atmotor             atmotor             atmotor             none                    </param>
+                    <param name="resolution">       65535               65535               65535               0                       </param>
+                    <param name="tolerance">        0                   0                   0                   0                       </param>  
+                </group>  
+            </group>    
+            
+        </group>
+           
+    </group>
+    
+  
+</params>
+

--- a/CER01/hardware/motorControl/cer_right_lower_arm-mcp20-mc.xml
+++ b/CER01/hardware/motorControl/cer_right_lower_arm-mcp20-mc.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+ <!-- Initialization file for MC4+ 20 - CER right lower arm, 4 dof -->
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_right_lower_arm_mc" type="embObjMotionControl">
+      <xi:include href="../../general.xml" />
+      <xi:include href="../electronics/cer_right_lower_arm-mcp20-eln.xml" />
+      <xi:include href="../mechanicals/cer_right_lower_arm-mcp20-mec.xml" />
+      <xi:include href="../motorControl/cer_right_lower_arm-mcp20-mc-service.xml" />
+
+    <group name="LIMITS">
+        <param name="jntPosMax">                  0.12     0.12    0.12     80     </param>
+        <param name="jntPosMin">                  0        0       0        -80    </param>
+        <param name="jntVelMax">                  0.02     0.02    0.02     3000   </param>
+        <param name="motorOverloadCurrents">      10000    10000   10000    10000   </param>
+        <param name="motorNominalCurrents">       5000     5000    5000     5000   </param>
+        <param name="motorPeakCurrents">          5000     5000    5000     5000   </param>
+        <param name="motorPwmLimit">              3360     3360    3360     3360   </param>  
+    </group>
+    
+    
+    <group name="TIMEOUTS">
+        <param name="velocity">               100       100           100        100    </param>
+    </group>
+
+
+    <group name="CONTROLS">
+        <param name="positionControl">         JOINT_MINJERK_OUT_PWM_CTRL  JOINT_MINJERK_OUT_PWM_CTRL  JOINT_MINJERK_OUT_PWM_CTRL  JOINT_MINJERK_OUT_PWM_CTRL   </param>
+        <param name="velocityControl">         JOINT_MINJERK_OUT_PWM_CTRL  JOINT_MINJERK_OUT_PWM_CTRL  JOINT_MINJERK_OUT_PWM_CTRL  JOINT_MINJERK_OUT_PWM_CTRL   </param>
+        <param name="mixedControl">            JOINT_MINJERK_OUT_PWM_CTRL  JOINT_MINJERK_OUT_PWM_CTRL  JOINT_MINJERK_OUT_PWM_CTRL  JOINT_MINJERK_OUT_PWM_CTRL   </param>
+        <param name="posDirectControl">        JOINT_DIRECT_OUT_PWM_CTRL   JOINT_DIRECT_OUT_PWM_CTRL   JOINT_DIRECT_OUT_PWM_CTRL   JOINT_DIRECT_OUT_PWM_CTRL    </param>                
+        <param name="velDirectControl">        JOINT_DIRECT_OUT_PWM_CTRL   JOINT_DIRECT_OUT_PWM_CTRL   JOINT_DIRECT_OUT_PWM_CTRL   JOINT_DIRECT_OUT_PWM_CTRL    </param>
+        <param name="torqueControl">           none                        none                        none                        none                         </param>
+    
+        <param name="currentPid">              none none none none </param>
+        <param name="speedPid">                none none none none </param>
+    </group>
+    
+    <group name="JOINT_MINJERK_OUT_PWM_CTRL">
+	    <param name="controlLaw">             minjerk                   </param>
+        <param name="outputType">             pwm                       </param>
+        <param name="fbkControlUnits">        machine_units             </param> 
+        <param name="outputControlUnits">     machine_units             </param>
+        <param name="kff">                        0            0          0        0          </param> 
+        <param name="kp">                        20           20         20       -0.7        </param>          
+        <param name="kd">                         0            0          0        0          </param>          
+        <param name="ki">                         0            0          0        0          </param>              
+        <param name="maxOutput">               3000         3000       3000     2000          </param>                
+        <param name="maxInt">                     0            0          0        0          </param>                             
+        <param name="stictionUp">                 0            0          0        0          </param>          
+        <param name="stictionDown">               0            0          0        0          </param>        
+    </group>
+
+    <group name="JOINT_DIRECT_OUT_PWM_CTRL">
+	    <param name="controlLaw">             direct                    </param>
+        <param name="outputType">             pwm                       </param>
+        <param name="fbkControlUnits">        machine_units             </param> 
+        <param name="outputControlUnits">     machine_units             </param>
+        <param name="kff">                        0            0          0        0          </param> 
+        <param name="kp">                        20           20         20       -0.7        </param>          
+        <param name="kd">                         0            0          0        0          </param>          
+        <param name="ki">                         0            0          0        0          </param>              
+        <param name="maxOutput">               3000         3000       3000     2000          </param>                
+        <param name="maxInt">                     0            0          0        0          </param>                             
+        <param name="stictionUp">                 0            0          0        0          </param>          
+        <param name="stictionDown">               0            0          0        0          </param>        
+    </group>
+
+    <group name="IMPEDANCE">
+        <param name="stiffness">       0      0      0      0     </param>    
+        <param name="damping">         0      0      0      0     </param>    
+    </group>
+	
+  </device>
+
+

--- a/CER01/hardware/motorControl/cer_right_upper_arm-ems19-mc-service.xml
+++ b/CER01/hardware/motorControl/cer_right_upper_arm-ems19-mc-service.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER01" build="1">
+
+    <group name="SERVICE">
+        
+        <param name="type"> eomn_serv_MC_foc </param> 
+    
+        <group name="PROPERTIES">
+        
+            <group name="ETHBOARD">
+                <param name="type">                 ems4        </param> 
+            </group>          
+
+            <group name="CANBOARDS"> 
+                <param name="type">                 foc         </param> 
+                <group name="PROTOCOL">
+                    <param name="major">            1           </param>    
+                    <param name="minor">            6           </param>     
+                </group>                    
+                <group name="FIRMWARE">
+                    <param name="major">            0           </param>    
+                    <param name="minor">            0           </param> 
+                    <param name="build">            0           </param>
+                </group>
+            </group>
+            
+
+            <group name="JOINTMAPPING">
+
+                <group name="ACTUATOR">                
+                    <param name="type">             foc                 foc                 foc             foc         </param>
+                    <param name="port">             CAN1:1:0            CAN1:2:0            CAN1:3:0        CAN1:4:0    </param>
+                </group>
+                
+                <group name="ENCODER1">  
+                    <param name="type">             aea                aea                 aea             aea          </param>  
+                    <param name="port">             CONN:P6            CONN:P8             CONN:P7         CONN:P9      </param>
+                    <param name="position">         atjoint            atjoint             atjoint         atjoint      </param> 
+                    <param name="resolution">        -4096             -4096               -4096           -4096        </param>
+                    <param name="tolerance">        0.703               0.703              0.703           0.703        </param>  
+                </group>        
+                
+                <group name="ENCODER2">
+                    <param name="type">             roie                roie                roie            roie        </param>
+                    <param name="port">             CAN1:1:0            CAN1:2:0            CAN1:3:0        CAN1:4:0    </param>
+                    <param name="position">         atmotor             atmotor             atmotor         atmotor     </param>
+                    <param name="resolution">       8192                8192                8192            8192        </param>
+                    <param name="tolerance">        0                   0                   0               0           </param>  
+                </group> 
+ 
+            </group>    
+            
+        </group>
+           
+    </group>
+    
+  
+</params>
+

--- a/CER01/hardware/motorControl/cer_right_upper_arm-ems19-mc.xml
+++ b/CER01/hardware/motorControl/cer_right_upper_arm-ems19-mc.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_right_upper_arm_mc" type="embObjMotionControl">
+      <xi:include href="../../general.xml" />
+      <xi:include href="../electronics/cer_right_upper_arm-ems19-eln.xml" />
+      <xi:include href="../mechanicals/cer_right_upper_arm-ems19-mec.xml" />
+      <xi:include href="../motorControl/cer_right_upper_arm-ems19-mc-service.xml" />
+
+    <group name="LIMITS">
+    <!--    <param name="jntPosMax">                  85            70         85        95        </param>   no covers -->
+        <param name="jntPosMax">                      55            50         85        95        </param>
+        <param name="jntPosMin">                     -25             5        -85         5        </param>
+        <param name="motorOverloadCurrents">          5000          5000       5000      5000      </param>
+        <param name="motorNominalCurrents">           2500          2500       2500      2500      </param>
+        <param name="motorPeakCurrents">              5000          5000       5000      5000      </param>
+        <param name="jntVelMax">                      50            50         50        50        </param>
+        <param name="motorPwmLimit">                  32000         32000      32000     32000     </param>    
+    </group>
+    
+    <group name="TIMEOUTS">
+        <param name="velocity">               100       100           100        100    </param>
+    </group>
+    
+    <group name="CONTROLS">
+        <param name="positionControl">        JOINT_MINJERK_OUT_WORM_VEL_CTRL    JOINT_MINJERK_OUT_WORM_VEL_CTRL    JOINT_MINJERK_OUT_WORM_VEL_CTRL    JOINT_MINJERK_OUT_WORM_VEL_CTRL   </param>
+        <param name="velocityControl">        JOINT_MINJERK_OUT_WORM_VEL_CTRL    JOINT_MINJERK_OUT_WORM_VEL_CTRL    JOINT_MINJERK_OUT_WORM_VEL_CTRL    JOINT_MINJERK_OUT_WORM_VEL_CTRL   </param>
+        <param name="mixedControl">           JOINT_MINJERK_OUT_WORM_VEL_CTRL    JOINT_MINJERK_OUT_WORM_VEL_CTRL    JOINT_MINJERK_OUT_WORM_VEL_CTRL    JOINT_MINJERK_OUT_WORM_VEL_CTRL   </param>
+        <param name="posDirectControl">       JOINT_DIRECT_OUT_WORM_VEL_CTRL     JOINT_DIRECT_OUT_WORM_VEL_CTRL     JOINT_DIRECT_OUT_WORM_VEL_CTRL     JOINT_DIRECT_OUT_WORM_VEL_CTRL    </param>                
+        <param name="velDirectControl">       JOINT_DIRECT_OUT_WORM_VEL_CTRL     JOINT_DIRECT_OUT_WORM_VEL_CTRL     JOINT_DIRECT_OUT_WORM_VEL_CTRL     JOINT_DIRECT_OUT_WORM_VEL_CTRL    </param>
+        <param name="torqueControl">          none                               none                               none                               none                              </param>
+                                            
+        <param name="currentPid">             2FOC_CUR_CONTROL                   2FOC_CUR_CONTROL                   2FOC_CUR_CONTROL                   2FOC_CUR_CONTROL                  </param>
+        <param name="speedPid">               2FOC_VEL_CONTROL                   2FOC_VEL_CONTROL                   2FOC_VEL_CONTROL                   2FOC_VEL_CONTROL                  </param>
+    </group>
+    
+    <group name="JOINT_MINJERK_OUT_WORM_VEL_CTRL">
+        <param name="controlLaw">             minjerk                   </param>
+        <param name="outputType">             velocity                  </param>
+        <param name="fbkControlUnits">        machine_units             </param> 
+        <param name="outputControlUnits">     machine_units             </param> 
+        <param name="kff">                        1          1         1         1        </param> 
+        <param name="kp">                         5          5         5         5        </param>       
+        <param name="kd">                         0          0         0         0        </param>             
+        <param name="maxOutput">              32000      32000     32000     32000        </param>                
+    </group>
+    
+    <group name="JOINT_DIRECT_OUT_WORM_VEL_CTRL">
+        <param name="controlLaw">             direct                    </param>
+        <param name="outputType">             velocity                  </param>
+        <param name="fbkControlUnits">        machine_units             </param> 
+        <param name="outputControlUnits">     machine_units             </param> 
+        <param name="kff">                        1          1         1         1        </param> 
+        <param name="kp">                         5          5         5         5        </param>       
+        <param name="kd">                         0          0         0         0        </param>             
+        <param name="maxOutput">              32000      32000     32000     32000        </param>                 
+    </group>
+    
+    <group name="2FOC_CUR_CONTROL">
+        <param name="controlLaw">          low_lev_current      </param> 
+        <param name="fbkControlUnits">     machine_units        </param> 
+        <param name="outputControlUnits">  machine_units        </param>
+        <param name="kff">                     0         0         0         0      </param>
+        <param name="kp">                      8         8         8         8      </param>       
+        <param name="kd">                      0         0         0         0      </param>       
+        <param name="ki">                      2         2         2         2      </param>
+        <param name="shift">                  10        10        10        10      </param>
+        <param name="maxOutput">           32000     32000     32000     32000      </param>                 
+        <param name="maxInt">              32000     32000     32000     32000      </param>         
+    </group>
+
+    <group name="2FOC_VEL_CONTROL">
+        <param name="controlLaw">          low_lev_speed        </param> 
+        <param name="fbkControlUnits">     machine_units        </param> 
+        <param name="outputControlUnits">  machine_units        </param>
+        <param name="kff">                 0      0      0      0  </param>
+        <param name="kp">               1280   1280   1280   1280  </param>       
+        <param name="kd">               6144   6144   6144   6144  </param>       
+        <param name="ki">                  1      1      1      1  </param>
+        <param name="shift">              14     14     14     14  </param>
+        <param name="maxOutput">       32000  32000  32000  32000  </param>                 
+        <param name="maxInt">          32000  32000  32000  32000  </param>        
+    </group>
+    
+    <group name="IMPEDANCE">
+        <param name="stiffness">        0          0         0        0       </param>    
+        <param name="damping">          0          0         0        0       </param>    
+    </group>
+
+  </device>
+

--- a/CER01/hardware/motorControl/cer_right_wrist_equivalent-mc.xml
+++ b/CER01/hardware/motorControl/cer_right_wrist_equivalent-mc.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_right_wrist_equivalent_mc" type="tripodMotionControl">
+      <xi:include href="../../general.xml" />
+
+    <param name="AxisNames">  "r_wrist_heave_eq_joint" "r_wrist_pitch_eq_joint" "r_wrist_roll_eq_joint"  </param>
+
+    <group name="GENERAL">
+      <param name="Joints">    3       </param>
+     <!-- <param name="AxisMap">   0 1 2   </param> -->
+     <!-- <param name="Verbose">   true    </param> -->
+      <param name="Encoder">   1 1 1   </param>
+    </group>
+
+    <group name="TRIPOD">
+      <param name="Radius">      0.018   </param>
+      <param name="Max_el">      0.120  </param>
+      <param name="Min_el">      0.0    </param>
+      <param name="Max_alpha">   30.0   </param>
+
+      <param name="BASE_TRANSFORMATION">   1.0    0.0     0.0    0.0
+                                           0.0    1.0     0.0    0.0
+                                           0.0    0.0     1.0    0.0
+                                           0.0    0.0     0.0    1.0
+      </param>
+    </group>
+
+    <group name="LIMITS">
+        <param name="JntVelocityMax">   0.05  </param>
+    </group>
+
+    <!-- action is alternative to CONNECTION group -->
+    <action phase="startup" level="1" type="attach">
+      <paramlist name="networks">
+          <elem name="FirstSetOfJoints"> cer_right_lower_arm_mc </elem>
+      </paramlist>
+    </action>
+
+    <action phase="shutdown" level="6" type="detach" />
+
+  </device>
+

--- a/CER01/hardware/motorControl/cer_torso-ems15-mc-service.xml
+++ b/CER01/hardware/motorControl/cer_torso-ems15-mc-service.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER01" build="1">
+
+    <group name="SERVICE">
+        
+        <param name="type"> eomn_serv_MC_foc </param> 
+    
+        <group name="PROPERTIES">
+        
+            <group name="ETHBOARD">
+                <param name="type">                 ems4        </param> 
+            </group>          
+
+            <group name="CANBOARDS"> 
+                <param name="type">                 foc         </param> 
+                <group name="PROTOCOL">
+                    <param name="major">            1           </param>    
+                    <param name="minor">            6           </param>     
+                </group>                    
+                <group name="FIRMWARE">
+                    <param name="major">            0           </param>    
+                    <param name="minor">            0           </param> 
+                    <param name="build">            0           </param>
+                </group>
+            </group>
+
+
+            <group name="JOINTMAPPING">
+
+                <group name="ACTUATOR">                
+                    <param name="type">             eomc_act_foc        foc                 foc             foc         </param>
+                    <param name="port">             CAN1:1:0            CAN1:2:0            CAN1:3:0        CAN1:4:0    </param>
+                </group>
+                
+                <group name="ENCODER1">  
+                    <param name="type">             none                none                none             aea         </param>  
+                    <param name="port">             CONN:none           CONN:none           CONN:none        CONN:P8     </param>
+                    <param name="position">         none                none                none             atjoint     </param> 
+                    <param name="resolution">       0                   0                   0                -4096       </param>
+                    <param name="tolerance">        0                   0                   0                0.703        </param> 
+                </group>        
+                
+                <group name="ENCODER2">
+                    <param name="type">             roie                roie                roie            roie         </param>
+                    <param name="port">             CAN1:1:0            CAN1:2:0            CAN1:3:0        CAN1:4:0     </param>
+                    <param name="position">         atmotor             atmotor             atmotor         atmotor      </param>
+                    <param name="resolution">       65535               65535               65535           8192         </param>
+                    <param name="tolerance">        0                   0                   0                  0         </param> 
+                </group> 
+ 
+            </group>    
+            
+        </group>
+           
+    </group>
+    
+  
+</params>
+

--- a/CER01/hardware/motorControl/cer_torso-ems15-mc.xml
+++ b/CER01/hardware/motorControl/cer_torso-ems15-mc.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+ <!-- Initialization file for EMS 15 - CER torso tripod + yaw, 4 dof -->
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_torso_mc" type="embObjMotionControl">
+      <xi:include href="../../general.xml" />
+      <xi:include href="../electronics/cer_torso-ems15-eln.xml" />
+      <xi:include href="../mechanicals/cer_torso-ems15-mec.xml" />
+      <xi:include href="../motorControl/cer_torso-ems15-mc-service.xml" />
+
+    <group name="LIMITS">
+        <param name="jntPosMax">                0.17    0.17         0.17       30     </param>
+        <param name="jntPosMin">                0.0     0.0          0.0       -30     </param>
+        <param name="jntVelMax">                0.1     0.1          0.1        30000   </param>
+        <param name="motorOverloadCurrents">    5000    5000         5000       5000      </param>
+        <param name="motorNominalCurrents">     2500    2500         2500       2500      </param>
+        <param name="motorPeakCurrents">        5000    5000         5000       5000      </param>
+        <param name="motorPwmLimit">            32000   32000        32000      32000      </param>  
+    </group>
+    
+    
+    <group name="TIMEOUTS">
+        <param name="velocity">               100       100           100        100    </param>
+    </group>
+
+
+    <!--
+    <group name="CONTROLS">
+       <param name="positionControl">  JOINT_PID_V1         JOINT_PID_V1          JOINT_PID_V1         JOINT_POS_VEL_CTRL           </param> 
+       <param name="velocityControl">  VEL_CTRL              VEL_CTRL             VEL_CTRL             VEL_CTRL                     </param> 
+       <param name="torqueControl">    none                  none                 none                 none                         </param>
+        <param name="currentPid">      2FOC_FEEDBACK         2FOC_FEEDBACK        2FOC_FEEDBACK        2FOC_FEEDBACK                </param> 
+    </group>
+    -->
+    
+    <group name="CONTROLS">
+        <param name="positionControl">         JOINT_MINJERK_OUT_DC_PWM_CTRL  JOINT_MINJERK_OUT_DC_PWM_CTRL  JOINT_MINJERK_OUT_DC_PWM_CTRL       JOINT_MINJERK_OUT_WORM_VEL_CTRL   </param>
+        <param name="velocityControl">         JOINT_MINJERK_OUT_DC_PWM_CTRL  JOINT_MINJERK_OUT_DC_PWM_CTRL  JOINT_MINJERK_OUT_DC_PWM_CTRL       JOINT_MINJERK_OUT_WORM_VEL_CTRL   </param>
+        <param name="mixedControl">            JOINT_MINJERK_OUT_DC_PWM_CTRL  JOINT_MINJERK_OUT_DC_PWM_CTRL  JOINT_MINJERK_OUT_DC_PWM_CTRL       JOINT_MINJERK_OUT_WORM_VEL_CTRL   </param>
+        <param name="posDirectControl">        JOINT_DIRECT_OUT_DC_PWM_CTRL   JOINT_DIRECT_OUT_DC_PWM_CTRL   JOINT_DIRECT_OUT_DC_PWM_CTRL        JOINT_DIRECT_OUT_WORM_VEL_CTRL    </param>                
+        <param name="velDirectControl">        JOINT_DIRECT_OUT_DC_PWM_CTRL   JOINT_DIRECT_OUT_DC_PWM_CTRL   JOINT_DIRECT_OUT_DC_PWM_CTRL        JOINT_DIRECT_OUT_WORM_VEL_CTRL    </param>
+        <param name="torqueControl">           none                           none                           none                                none                              </param>
+                                               
+        <param name="currentPid">              2FOC_CUR_CONTROL               2FOC_CUR_CONTROL               2FOC_CUR_CONTROL                    2FOC_CUR_CONTROL                  </param>
+        <param name="speedPid">                2FOC_VEL_CONTROL               2FOC_VEL_CONTROL               2FOC_VEL_CONTROL                    2FOC_VEL_CONTROL                  </param>
+    </group>
+    
+    
+    <group name="JOINT_MINJERK_OUT_DC_PWM_CTRL">
+	    <param name="controlLaw">             minjerk                   </param>
+        <param name="outputType">             pwm                       </param>
+        <param name="fbkControlUnits">        machine_units             </param> 
+        <param name="outputControlUnits">     machine_units             </param>
+        <param name="kff">                        0            0           0         0       </param> 
+        <param name="kp">                      3000         3000        3000         0       </param>          
+        <param name="kd">                         0            0           0         0       </param>          
+        <param name="ki">                      5000         5000        5000         0       </param>              
+        <param name="maxOutput">              32000        32000       32000         0       </param>                
+        <param name="maxInt">                  4000         4000        4000         0       </param>                             
+        <param name="stictionUp">                 0            0           0         0       </param>          
+        <param name="stictionDown">                0            0           0         0       </param>        
+    </group>
+
+    <group name="JOINT_DIRECT_OUT_DC_PWM_CTRL">
+	    <param name="controlLaw">             direct                    </param>
+        <param name="outputType">             pwm                       </param>
+        <param name="fbkControlUnits">        machine_units             </param> 
+        <param name="outputControlUnits">     machine_units             </param>
+        <param name="kff">                        0            0           0         0       </param> 
+        <param name="kp">                      3000         3000        3000         0       </param>          
+        <param name="kd">                         0            0           0         0       </param>          
+        <param name="ki">                      5000         5000        5000         0       </param>              
+        <param name="maxOutput">              32000        32000       32000         0       </param>                
+        <param name="maxInt">                  4000         4000        4000         0       </param>                             
+        <param name="stictionUp">                 0            0           0         0       </param>          
+        <param name="stictionDown">               0            0           0         0       </param>        
+    </group>
+    
+    <group name="JOINT_MINJERK_OUT_WORM_VEL_CTRL">
+        <param name="controlLaw">             minjerk                   </param>
+        <param name="outputType">             velocity                  </param>
+        <param name="fbkControlUnits">        machine_units             </param> 
+        <param name="outputControlUnits">     machine_units             </param> 
+        <param name="kff">                    0 0 0           1         </param> 
+        <param name="kp">                     0 0 0           5         </param>       
+        <param name="kd">                     0 0 0           0         </param>             
+        <param name="maxOutput">              0 0 0       32000         </param>                
+    </group>
+    
+    <group name="JOINT_DIRECT_OUT_WORM_VEL_CTRL">
+        <param name="controlLaw">             direct                    </param>
+        <param name="outputType">             velocity                  </param>
+        <param name="fbkControlUnits">        machine_units             </param> 
+        <param name="outputControlUnits">     machine_units             </param> 
+        <param name="kff">                    0 0 0           1         </param> 
+        <param name="kp">                     0 0 0           5         </param>       
+        <param name="kd">                     0 0 0           0         </param>             
+        <param name="maxOutput">              0 0 0       32000         </param>                
+    </group>
+    
+    <group name="2FOC_CUR_CONTROL">
+        <param name="controlLaw">          low_lev_current      </param> 
+        <param name="fbkControlUnits">     machine_units        </param> 
+        <param name="outputControlUnits">  machine_units        </param>
+        <param name="kff">                     0         0         0         0      </param>
+        <param name="kp">                      8         8         8         8      </param>       
+        <param name="kd">                      0         0         0         0      </param>       
+        <param name="ki">                      2         2         2         2      </param>
+        <param name="shift">                  10        10        10        10      </param>
+        <param name="maxOutput">           32000     32000     32000     32000      </param>                 
+        <param name="maxInt">              32000     32000     32000     32000      </param>         
+    </group>
+
+    <group name="2FOC_VEL_CONTROL">
+        <param name="controlLaw">          low_lev_speed        </param> 
+        <param name="fbkControlUnits">     machine_units        </param> 
+        <param name="outputControlUnits">  machine_units        </param>
+        <param name="kff">                 0          0         0         0  </param>
+        <param name="kp">                 12         12        12      1280  </param>       
+        <param name="kd">                  0          0         0      6144  </param>       
+        <param name="ki">                 16         16        16         1  </param>
+        <param name="shift">              10         10        10        14  </param>
+        <param name="maxOutput">       32000      32000     32000     32000  </param>                 
+        <param name="maxInt">          32000      32000     32000     32000  </param>        
+    </group>
+            
+    <group name="IMPEDANCE">
+        <param name="stiffness">       0      0      0      0     </param>    
+        <param name="damping">         0      0      0      0     </param>    
+    </group>
+	
+  </device>
+
+

--- a/CER01/hardware/motorControl/cer_torso_equivalent-mc.xml
+++ b/CER01/hardware/motorControl/cer_torso_equivalent-mc.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_torso_equivalent_mc" type="tripodMotionControl">
+      <xi:include href="../../general.xml" />
+
+    <param name="AxisNames">  "torso_heave_eq_joint"   "torso_pitch_eq_joint"   "torso_roll_eq_joint"  </param>
+
+    <group name="GENERAL">
+      <param name="Joints">    3       </param>
+      <!-- <param name="AxisMap">   0 1 2   </param> -->
+      <!-- <param name="Verbose">   true    </param> -->
+      <param name="Encoder">   1 1 1   </param>
+    </group>
+
+    <group name="TRIPOD">
+      <param name="Radius">      0.09   </param>
+      <param name="Max_el">      0.170  </param>
+      <param name="Min_el">      0.0    </param>
+      <param name="Max_alpha">   10.0   </param>
+
+      <param name="BASE_TRANSFORMATION">   1.0    0.0     0.0    0.0
+                                           0.0    1.0     0.0    0.0
+                                           0.0    0.0     1.0    0.0
+                                           0.0    0.0     0.0    1.0
+      </param>
+    </group>
+
+    <group name="LIMITS">
+        <param name="JntVelocityMax">   0.05  </param>
+    </group>
+
+
+    <!--
+    <group name="CONNECTION">
+      <param name="local">         /cerGazeboSim/torso_out  </param>
+      <param name="remote">        /cerGazeboSim/torso      </param>
+      <param name="writeStrict">   off                       </param>
+    </group>
+     -->
+
+    <!-- action is alternative to CONNECTION group -->
+    <action phase="startup" level="5" type="attach">
+      <paramlist name="networks">
+          <elem name="FirstSetOfJoints"> cer_torso_mc </elem>
+      </paramlist>
+    </action>
+
+    <action phase="shutdown" level="6" type="detach" />
+
+  </device>
+

--- a/CER01/hardware/rpLidar/laserA2_hw.xml
+++ b/CER01/hardware/rpLidar/laserA2_hw.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" ?>    
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cerLaser" type="rpLidar2">  
+       <group name="GENERAL">
+            <param name="name">            cer_laser     </param>
+            <param name="clip_max">        7.0          </param>
+            <param name="clip_min">        0.1          </param>
+            <param name="max_angle">       360          </param>
+            <param name="min_angle">       0            </param>
+            <param name="resolution">      0.5           </param>
+            <param name="allow_infinity">  1            </param>
+            <param name="serial_baudrate"> 115200       </param>
+            <param name="serial_port">     /dev/ttyUSB0 </param>
+            <param name="sample_buffer_life">  1        </param>
+        </group>
+        <group name="SKIP">
+            <param name="min">  35     </param>
+            <param name="max">  325    </param>
+        </group> 
+    </device>
+
+
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 

--- a/CER01/hardware/rpLidar/laser_hw.xml
+++ b/CER01/hardware/rpLidar/laser_hw.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" ?>    
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cerLaser" type="rpLidar">  
+
+    <group name="GENERAL">
+       <param name="name">      cer_laser        </param>
+       <param name="clip_max">  3.5 </param>
+       <param name="clip_min">  0.1 </param>
+       <param name="max_angle">  359 </param>
+       <param name="min_angle">  0   </param>
+       <param name="resolution">  1   </param>
+       <param name="allow_infinity">  1 </param>
+       <param name="Serial_Configuration">  hardware/rpLidar/serial.ini </param>
+    </group>
+
+    <group name="SKIP">
+       <param name="min">  0  160  </param>
+       <param name="max">  30 360  </param>
+    </group>
+
+    </device>
+
+
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 

--- a/CER01/hardware/rpLidar/serial.ini
+++ b/CER01/hardware/rpLidar/serial.ini
@@ -1,0 +1,24 @@
+/// configuration file for iKart serial port
+
+verbose 4
+//comport COM4  //windows
+comport /dev/ttyUSB0 //linux
+baudrate 115200
+xonlim 0
+xofflim 0
+readmincharacters 0
+readtimeoutmsec 2
+parityenb 0
+paritymode none
+ctsenb 0
+rtsenb 0
+xinenb 0
+xoutenb 0
+modem 0
+rcvenb 0
+dsrenb 0
+dtrdisable 1
+databits 8
+stopbits 1
+line_terminator_char1 10
+line_terminator_char2 10

--- a/CER01/hardware/skin/left_hand-mc7-skin.xml
+++ b/CER01/hardware/skin/left_hand-mc7-skin.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_hand_skin" type="embObjSkin">
+        <xi:include href="../../general.xml" />
+ 
+        <xi:include href="../electronics/cer_left_hand-mcp7-eln.xml" />
+        <group name="patches">
+            <param name="skinCanAddrsPatch1"> 5 </param> 
+        </group>
+        <xi:include href="./left_hand-mc7-skinSpec.xml" />
+    </device>
+
+  

--- a/CER01/hardware/skin/left_hand-mc7-skinSpec.xml
+++ b/CER01/hardware/skin/left_hand-mc7-skinSpec.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER01" build="1">
+
+        <group name="defaultCfgBoard">
+            <param name="period">        50  </param> 
+            <param name="skinType">      0  </param> <!-- 0 ==> new skin
+                                                              1 ==> palm and fingertips skin
+                                                              2 ==> old skin without temperature compensation -->
+            <param name="noLoad">         0xf0  </param>
+            <param name="diagnostic">    false  </param>     <!-- used to config high level -->
+        </group>
+        
+        
+       <group name="defaultCfgTriangle">
+            <param name="enabled">         true  </param> 
+            <param name="shift">           0  </param>
+            <param name="cdcOffset">       0x2200  </param>
+        </group>
+
+        
+   <!--    <group name="specialCfgTriangles">
+           <param name="numOfSets">            1  </param> 
+     	   <param name="triangleSetCfg1">      2            5        0             6             1              0            0x2000      </param>
+        </group> -->
+        
+</params>

--- a/CER01/robotStatePublisher.launch
+++ b/CER01/robotStatePublisher.launch
@@ -1,0 +1,9 @@
+<launch>
+
+  <arg name="model" default="./cer.urdf"/>
+
+  <param name="robot_description" command="$(find xacro)/xacro --inorder $(arg model)" />
+
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
+
+</launch>

--- a/CER01/sensors/Orbecc_Astra.ini
+++ b/CER01/sensors/Orbecc_Astra.ini
@@ -1,0 +1,58 @@
+device    RGBDSensorWrapper
+subdevice depthCamera
+name      /depthCamera
+[ROS]
+use_ROS             true
+forceInfoSync       true
+ROS_frame_Id        depth_center
+ROS_nodeName        /YarpRGBDSensor
+ROS_colorTopicName  /yarpColor
+ROS_depthTopicName  /yarpDepth
+ROS_colorInfoTopicName /yarpColor_info
+ROS_depthinfoTopicName /yarpDepth_info
+[SETTINGS]
+
+rgbMirroring false
+depthMirroring false
+
+[HW_DESCRIPTION]
+
+
+[RGB_INTRINSIC_PARAMETERS]
+
+focalLengthX			570.3422241210938
+focalLengthY			570.3422241210938
+principalPointX			314.5
+principalPointY			235.5
+distortionModel 		rgb_distortion
+
+[rgb_distortion]
+name					plumb_bob
+k1						0.0
+k2						0.0
+t1						0.0
+t2						0.0
+k3						0.0
+
+
+[DEPTH_INTRINSIC_PARAMETERS]
+
+focalLengthX			570.3422241210938
+focalLengthY			570.3422241210938
+principalPointX			314.5
+principalPointY			235.5
+distortionModel 		depth_distortion
+
+[depth_distortion]
+name					plumb_bob
+k1						0.0
+k2						0.0
+t1						0.0
+t2						0.0
+k3						0.0
+
+
+[EXTRINSIC_PARAMETERS]
+transformation   (1.0 0.0 0.0 0.0   0.0 1.0 0.0 0.0   0.0 0.0 1.0 0.0  0.0 0.0 0.0 1.0)
+
+

--- a/CER01/sensors/RealSense_conf.ini
+++ b/CER01/sensors/RealSense_conf.ini
@@ -1,0 +1,14 @@
+
+device       RGBDSensorWrapper
+subdevice    realsense2
+name         /depthCamera
+
+[SETTINGS]
+depthResolution (640 480)    #Note the parentesys
+rgbResolution   (640 480)
+framerate       30
+enableEmitter   true
+alignmentFrame  RGB
+
+[HW_DESCRIPTION]
+clipPlanes (0.2 10.0)

--- a/CER01/sensors/Xtion_depthCamera.ini
+++ b/CER01/sensors/Xtion_depthCamera.ini
@@ -1,0 +1,48 @@
+device       RGBDSensorWrapper
+subdevice    depthCamera
+name         /depthCamera
+
+[SETTINGS]
+accuracy     0.001
+depthResolution (320 240)    #Note the parentesys
+rgbResolution   (320 240)
+#enable mirroring for back compatibility with old driver version
+rgbMirroring    true
+depthMirroring  true
+
+[HW_DESCRIPTION]
+clipPlanes (0.4 4.5)
+
+[RGB_INTRINSIC_PARAMETERS]
+focalLengthX            1.0
+focalLengthY            2.0
+principalPointX         256.0
+principalPointY         128.0
+distortionModel         rgb_distortion
+
+[rgb_distortion]
+name                    plumb_bob
+k1                      1.0
+k2                      2.0
+t1                      3.0
+t2                      4.0
+k3                      5.0
+
+[DEPTH_INTRINSIC_PARAMETERS]
+focalLengthX            1.0
+focalLengthY            2.0
+principalPointX         256.0
+principalPointY         128.0
+distortionModel         depth_distortion
+
+[depth_distortion]
+name                    plumb_bob
+k1                      1.0
+k2                      2.0
+t1                      3.0
+t2                      4.0
+k3                      5.0
+
+[EXTRINSIC_PARAMETERS]
+transformation          (1.0 0.0 0.0 0.0   0.0 1.0 0.0 0.0   0.0 0.0 1.0 0.0  0.0 0.0 0.0 1.0)
+

--- a/CER01/wrappers/FT/cer_left_arm-FT_wrapper.xml
+++ b/CER01/wrappers/FT/cer_left_arm-FT_wrapper.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm_as_wrapper" type="analogServer">
+		<param name="period">   10  				</param>
+		<param name="name">     /cer/left_arm/FT:o  	        </param>
+		
+		<action phase="startup" level="5" type="attach">
+		    <paramlist name="networks">
+		<!-- The param value must match the device name in the corresponding emsX file -->
+		        <elem name="FirstStrain">  left_upper_arm_strain </elem>
+		    </paramlist>
+		</action>
+
+      <group name ="ROS">
+         <param name ="useROS"> true </param>
+         <param name ="ROS_nodeName"> /cer-left_arm_FT </param>
+         <param name ="ROS_topicName"> /left_arm_FT </param>
+         <param name ="frame_id"> /l_clavicle_link  </param>
+         <param name ="ROS_msgType"> geometry_msgs/WrenchStamped </param>
+      </group>
+
+		<action phase="shutdown" level="5" type="detach" />
+	</device>
+

--- a/CER01/wrappers/FT/cer_right_arm-FT_wrapper.xml
+++ b/CER01/wrappers/FT/cer_right_arm-FT_wrapper.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm_as_wrapper" type="analogServer">
+		<param name="period">       10  				</param>
+		<param name="name">     /cer/right_arm/FT:o				</param>
+		
+		<action phase="startup" level="5" type="attach">
+		    <paramlist name="networks">
+		<!-- The param value must match the device name in the corresponding emsX file -->
+		        <elem name="FirstStrain">  right_upper_arm_strain </elem>
+		    </paramlist>
+		</action>
+
+      <group name ="ROS">
+         <param name ="useROS"> true </param>
+         <param name ="ROS_nodeName"> /cer-right_arm_FT </param>
+         <param name ="ROS_topicName"> /right_arm_FT </param>
+         <param name ="frame_id"> /r_clavicle_link  </param>
+         <param name ="ROS_msgType"> geometry_msgs/WrenchStamped </param>
+      </group>
+
+		<action phase="shutdown" level="5" type="detach" />
+	</device>
+

--- a/CER01/wrappers/MAIS/left_hand-mais_wrapper.xml
+++ b/CER01/wrappers/MAIS/left_hand-mais_wrapper.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_hand_as_wrapperMais" type="analogServer">
+        <param name="period">       10                  </param>
+        <param name="name">     /cer/left_hand/analog:o           </param>
+
+        <action phase="startup" level="5" type="attach">
+            <paramlist name="networks">
+                <elem name="left_hand_mais_network">  left_hand_multienc </elem>
+            </paramlist>
+        </action>
+
+        <group name ="ROS">
+           <param name ="useROS"> true </param>
+           <param name ="ROS_nodeName"> /cer-left_hand_MAIS </param>
+           <param name ="ROS_topicName"> /joint_states </param>
+           <param name ="ROS_msgType"> sensor_msgs/JointState </param>
+           <param name ="joint_names"> l_hand_paddle_distal_joint l_hand_paddle_proximal_joint l_dummy_1 l_hand_thumb_proximal_joint l_hand_thumb_distal_joint l_dummy_2 </param>
+        </group>
+      
+        <action phase="shutdown" level="5" type="detach" />
+        </device>
+

--- a/CER01/wrappers/MAIS/right_hand-mais_wrapper.xml
+++ b/CER01/wrappers/MAIS/right_hand-mais_wrapper.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_hand_as_wrapperMais" type="analogServer">
+        <param name="period">       10                  </param>
+        <param name="name">     /cer/right_hand/analog:o          </param>
+
+        <action phase="startup" level="5" type="attach">
+            <paramlist name="networks">
+                <elem name="right_hand_mais_network">  right_hand_multienc </elem>
+            </paramlist>
+        </action>
+
+        <group name ="ROS">
+           <param name ="useROS"> true </param>
+           <param name ="ROS_nodeName"> /cer-right_hand_MAIS </param>
+           <param name ="ROS_topicName"> /joint_states </param>
+           <param name ="ROS_msgType"> sensor_msgs/JointState </param>
+           <param name ="joint_names"> r_hand_paddle_distal_joint r_hand_paddle_proximal_joint r_dummy_1 r_hand_thumb_distal_joint r_hand_thumb_proximal_joint r_dummy_2 </param>
+        </group>
+        
+        <action phase="shutdown" level="5" type="detach" />
+        </device>
+

--- a/CER01/wrappers/VFT/left_arm-VFT_wrapper.xml
+++ b/CER01/wrappers/VFT/left_arm-VFT_wrapper.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<devices robot="CER01" build="1">
+	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm_VFTserver" type="virtualAnalogServer">
+		<param name="period">       10  				</param>
+		<param name="deviceId">     left_arm				</param>
+		
+		 <paramlist name="networks">
+		      <!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+			<elem name="FirstSetOfJoints">  0  3  0  3 </elem> 
+			<elem name="SecondSetOfJoints"> 4  6  0  2 </elem> 	
+		    </paramlist>
+
+		<param name="channels">       7  				</param>
+		<param name="name"> 	     /left_arm				</param>
+
+		<action phase="startup" level="5" type="attach">
+		    <paramlist name="networks">
+			<!-- The param value must match the device name in the corresponding emsX file -->
+			 <elem name="FirstSetOfJoints">  left_upper_arm_mc </elem>	
+	     		 <elem name="SecondSetOfJoints"> left_lower_arm_mc </elem>  
+		    </paramlist>
+		</action>
+
+		<action phase="shutdown" level="5" type="detach" />
+	</device>
+
+
+

--- a/CER01/wrappers/VFT/left_leg-VFT_wrapper.xml
+++ b/CER01/wrappers/VFT/left_leg-VFT_wrapper.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<devices robot="CER01" build="1">
+	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg_VFTserver" type="virtualAnalogServer">
+		<param name="period">       10  				</param>
+		<param name="deviceId">     left_leg				</param>
+		
+		 <paramlist name="networks">
+		      <!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+			<elem name="FirstSetOfJoints">  0  3  0  3 </elem> 
+			<elem name="SecondSetOfJoints"> 4 5  0 1 </elem> 	
+		    </paramlist>
+
+		<param name="channels">       6  				</param>
+		<param name="name"> 	     /left_leg				</param>
+
+		<action phase="startup" level="5" type="attach">
+		    <paramlist name="networks">
+			<!-- The param value must match the device name in the corresponding emsX file -->
+			 <elem name="FirstSetOfJoints">  left_upper_leg_mc </elem>	
+	     		 <elem name="SecondSetOfJoints"> left_lower_leg_mc </elem>  
+		    </paramlist>
+		</action>
+
+		<action phase="shutdown" level="5" type="detach" />
+	</device>
+
+
+

--- a/CER01/wrappers/VFT/right_arm-VFT_wrapper.xml
+++ b/CER01/wrappers/VFT/right_arm-VFT_wrapper.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<devices robot="CER01" build="1">
+	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm_VFTserver" type="virtualAnalogServer">
+		<param name="period">       10  				</param>
+		<param name="deviceId">     right_arm				</param>
+		
+		 <paramlist name="networks">
+		      <!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+			<elem name="FirstSetOfJoints">  0  3  0  3 </elem> 
+			<elem name="SecondSetOfJoints"> 4  6  0  2 </elem> 	
+		    </paramlist>
+
+		<param name="channels">       7  				</param>
+		<param name="name"> 	      /right_arm				</param>
+
+		<action phase="startup" level="5" type="attach">
+		    <paramlist name="networks">
+			<!-- The param value must match the device name in the corresponding emsX file -->
+			 <elem name="FirstSetOfJoints">  right_upper_arm_mc </elem>	
+	     		 <elem name="SecondSetOfJoints"> right_lower_arm_mc </elem>  
+		    </paramlist>
+		</action>
+
+		<action phase="shutdown" level="5" type="detach" />
+	</device>
+
+
+

--- a/CER01/wrappers/VFT/right_leg-VFT_wrapper.xml
+++ b/CER01/wrappers/VFT/right_leg-VFT_wrapper.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<devices robot="CER01" build="1">
+	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg_VFTserver" type="virtualAnalogServer">
+		<param name="period">       10  				</param>
+		<param name="deviceId">     right_leg				</param>
+		
+		 <paramlist name="networks">
+		      <!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+			<elem name="FirstSetOfJoints">  0  3  0  3 </elem> 
+			<elem name="SecondSetOfJoints"> 4  5  0  1 </elem> 	
+		    </paramlist>
+
+		<param name="channels">       6  				</param>
+		<param name="name"> 	      /right_leg				</param>
+
+		<action phase="startup" level="5" type="attach">
+		    <paramlist name="networks">
+			<!-- The param value must match the device name in the corresponding emsX file -->
+			 <elem name="FirstSetOfJoints">  right_upper_leg_mc </elem>	
+	     		 <elem name="SecondSetOfJoints"> right_lower_leg_mc </elem>  
+		    </paramlist>
+		</action>
+
+		<action phase="shutdown" level="5" type="detach" />
+	</device>
+
+
+

--- a/CER01/wrappers/VFT/torso-VFT_wrapper.xml
+++ b/CER01/wrappers/VFT/torso-VFT_wrapper.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<devices robot="CER01" build="1">
+	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="torso_VFTserver" type="virtualAnalogServer">
+		<param name="period">       10  				</param>
+		<param name="deviceId">     torso				</param>
+		
+		 <paramlist name="networks">
+		      <!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+			<elem name="FirstSetOfJoints">  0  2  0  2 </elem> 
+		    </paramlist>
+
+		<param name="channels">       3  				</param>
+		<param name="name"> 	     /torso				</param>
+
+		<action phase="startup" level="5" type="attach">
+		    <paramlist name="networks">
+			<!-- The param value must match the device name in the corresponding emsX file -->
+			 <elem name="FirstSetOfJoints">  torso_mc </elem>	
+		    </paramlist>
+		</action>
+
+		<action phase="shutdown" level="5" type="detach" />
+	</device>
+
+
+

--- a/CER01/wrappers/motorControl/cer_base-mc_wrapper.xml
+++ b/CER01/wrappers/motorControl/cer_base-mc_wrapper.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_mobile_base_mc_wrapper" type="controlboardwrapper2">
+      <paramlist name="networks">
+	<!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+	  <elem name="FirstSetOfJoints"> 0  3  0  3 </elem>
+      </paramlist>
+
+      <param name="period"> 10 </param>
+      <param name="name">   /cer/mobile_base </param>
+      <param name="ports">  mobile_base		 </param>
+      <param name="joints"> 4		     	 </param>
+
+      <action phase="startup" level="5" type="attach">
+	  <paramlist name="networks">
+	  <!-- The param value must match the device name in the corresponding emsX file -->
+	      <elem name="FirstSetOfJoints"> cer_mobile_base_mc </elem>
+	  </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER01/wrappers/motorControl/cer_head-mc_wrapper.xml
+++ b/CER01/wrappers/motorControl/cer_head-mc_wrapper.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_head_mc_wrapper" type="controlboardwrapper2">
+      <paramlist name="networks">
+	<!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+	  <elem name="FirstSetOfJoints"> 0  1  0  1 </elem>
+      </paramlist>
+
+      <param name="period"> 10 </param>
+      <param name="name">   /cer/head	</param>
+      <param name="ports">  head		</param>
+      <param name="joints"> 2			</param>
+
+      <action phase="startup" level="5" type="attach">
+	  <paramlist name="networks">
+	  <!-- The param value must match the device name in the corresponding emsX file -->
+	      <elem name="FirstSetOfJoints"> cer_head_mc </elem>
+	  </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER01/wrappers/motorControl/cer_left_arm-mc_wrapper.xml
+++ b/CER01/wrappers/motorControl/cer_left_arm-mc_wrapper.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_left_arm_mc_wrapper" type="controlboardwrapper2">
+      <paramlist name="networks">
+	<!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+        <elem name="FirstSetOfJoints">  0  3  0  3 </elem>
+        <elem name="YawSetOfJoints">    4  4  3  3 </elem>
+        <elem name="SecondSetOfJoints"> 5  7  0  2 </elem>
+        <elem name="HandSetOfJoints">   8  9  0  1 </elem>
+      </paramlist>
+
+      <param name="period"> 10 </param>
+      <param name="name">   /cer/left_arm	</param>
+      <param name="ports">  left_arm		</param>
+      <param name="joints"> 10			</param>
+
+      <action phase="startup" level="5" type="attach">
+	  <paramlist name="networks">
+	  <!-- The param value must match the device name in the corresponding emsX file -->
+	  <elem name="FirstSetOfJoints">  cer_left_upper_arm_mc</elem>
+          <elem name="SecondSetOfJoints"> cer_left_wrist_equivalent_mc</elem>
+          <elem name="YawSetOfJoints">    cer_left_lower_arm_mc</elem>
+	  <elem name="HandSetOfJoints">   cer_left_hand_mc </elem>
+	  </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER01/wrappers/motorControl/cer_left_arm_no_hand-mc_wrapper.xml
+++ b/CER01/wrappers/motorControl/cer_left_arm_no_hand-mc_wrapper.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_left_arm_mc_wrapper" type="controlboardwrapper2">
+      <paramlist name="networks">
+	<!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+        <elem name="FirstSetOfJoints">  0  3  0  3 </elem>
+        <elem name="YawSetOfJoints">    4  4  3  3 </elem>
+        <elem name="SecondSetOfJoints"> 5  7  0  2 </elem>
+      <!--  <elem name="HandSetOfJoints">   8  9  0  1 </elem> -->
+      </paramlist>
+
+      <param name="period"> 10 </param>
+      <param name="name">   /cer/left_arm	</param>
+      <param name="ports">  left_arm		</param>
+      <param name="joints"> 8			</param>
+
+      <action phase="startup" level="5" type="attach">
+	  <paramlist name="networks">
+	  <!-- The param value must match the device name in the corresponding emsX file -->
+	  <elem name="FirstSetOfJoints">  cer_left_upper_arm_mc</elem>
+          <elem name="SecondSetOfJoints"> cer_left_wrist_equivalent_mc</elem>
+          <elem name="YawSetOfJoints">    cer_left_lower_arm_mc</elem>
+	<!--  <elem name="HandSetOfJoints">   cer_left_hand_mc </elem> -->
+	  </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER01/wrappers/motorControl/cer_left_hand-mc_wrapper.xml
+++ b/CER01/wrappers/motorControl/cer_left_hand-mc_wrapper.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_left_hand_mc_wrapper" type="controlboardwrapper2">
+      <paramlist name="networks">
+	<!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+	  <elem name="FirstSetOfJoints"> 0  1  0  1 </elem>
+      </paramlist>
+
+      <param name="period"> 10 </param>
+      <param name="name">   /cer/left_hand	</param>
+      <param name="ports">  left_hand		</param>
+      <param name="joints"> 2	     		</param>
+
+      <action phase="startup" level="5" type="attach">
+	  <paramlist name="networks">
+	  <!-- The param value must match the device name in the corresponding emsX file -->
+	      <elem name="FirstSetOfJoints"> cer_left_hand_mc </elem>
+	  </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER01/wrappers/motorControl/cer_left_upper_arm-mc_wrapper.xml
+++ b/CER01/wrappers/motorControl/cer_left_upper_arm-mc_wrapper.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_left_upper_arm_mc_wrapper" type="controlboardwrapper2">
+      <paramlist name="networks">
+	<!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+	  <elem name="FirstSetOfJoints">  0  3  0  3 </elem>
+      </paramlist>
+
+<param name="period"> 10 </param>
+      <param name="name">   /cer/left_upper_arm	</param>
+      <param name="ports">  left_upper_arm	</param>
+      <param name="joints"> 4			</param>
+
+      <action phase="startup" level="5" type="attach">
+	  <paramlist name="networks">
+	  <!-- The param value must match the device name in the corresponding emsX file -->
+	      <elem name="FirstSetOfJoints"> cer_left_upper_arm_mc</elem>
+	  </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER01/wrappers/motorControl/cer_left_wrist-mc_wrapper.xml
+++ b/CER01/wrappers/motorControl/cer_left_wrist-mc_wrapper.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_left_wrist_mc_wrapper" type="controlboardwrapper2">
+      <param name="period">   10   </param>
+      <paramlist name="networks">
+	  <!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+	  <elem name="FirstSetOfJoints">  0  2  0  2 </elem>
+      </paramlist>
+
+      <param name="name">   /cer/left_wrist  </param>
+      <param name="ports">  left_wrist       </param>
+      <param name="joints"> 3                </param>
+
+      <action phase="startup" level="5" type="attach">
+	  <paramlist name="networks">
+	  <!-- The param value must match the device name in the corresponding emsX file -->
+	      <elem name="FirstSetOfJoints"> cer_left_lower_arm_mc</elem>
+
+	  </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER01/wrappers/motorControl/cer_left_wrist_tripod-mc_wrapper.xml
+++ b/CER01/wrappers/motorControl/cer_left_wrist_tripod-mc_wrapper.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_left_wrist_tripod_mc_wrapper" type="controlboardwrapper2">
+      <param name="period">   10   </param>
+      <paramlist name="networks">
+	  <!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+	  <elem name="FirstSetOfJoints">  0  2  0  2 </elem>
+      </paramlist>
+
+      <param name="name">   /cer/left_wrist_tripod  </param>
+      <param name="ports">  left_wrist_tripod       </param>
+      <param name="joints"> 3                       </param>
+
+      <action phase="startup" level="5" type="attach">
+	  <paramlist name="networks">
+	  <!-- The param value must match the device name in the corresponding emsX file -->
+	      <elem name="FirstSetOfJoints"> cer_left_lower_arm_mc </elem>
+
+	  </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER01/wrappers/motorControl/cer_right_arm-mc_wrapper.xml
+++ b/CER01/wrappers/motorControl/cer_right_arm-mc_wrapper.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_right_arm_mc_wrapper" type="controlboardwrapper2">
+      <paramlist name="networks">
+	<!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+        <elem name="FirstSetOfJoints">  0  3  0  3 </elem>
+        <elem name="YawSetOfJoints">    4  4  3  3 </elem>
+  	<elem name="SecondSetOfJoints"> 5  7  0  2 </elem>
+        <elem name="HandSetOfJoints">   8  9  0  1 </elem>
+      </paramlist>
+
+      <param name="period"> 10 </param>
+      <param name="name">   /cer/right_arm	</param>
+      <param name="ports">  right_arm		</param>
+      <param name="joints"> 10			</param>
+
+      <action phase="startup" level="5" type="attach">
+	  <paramlist name="networks">
+	  <!-- The param value must match the device name in the corresponding emsX file -->
+	  <elem name="FirstSetOfJoints">  cer_right_upper_arm_mc</elem>
+          <elem name="SecondSetOfJoints"> cer_right_wrist_equivalent_mc</elem>
+          <elem name="YawSetOfJoints">    cer_right_lower_arm_mc</elem>
+	  <elem name="HandSetOfJoints">   cer_right_hand_mc </elem>
+	  </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER01/wrappers/motorControl/cer_right_arm_no_hand-mc_wrapper.xml
+++ b/CER01/wrappers/motorControl/cer_right_arm_no_hand-mc_wrapper.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_right_arm_mc_wrapper" type="controlboardwrapper2">
+      <paramlist name="networks">
+	<!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+        <elem name="FirstSetOfJoints">  0  3  0  3 </elem>
+        <elem name="YawSetOfJoints">    4  4  3  3 </elem>
+  	<elem name="SecondSetOfJoints"> 5  7  0  2 </elem>
+      <!--  <elem name="HandSetOfJoints">   8  9  0  1 </elem> -->
+      </paramlist>
+
+      <param name="period"> 10 </param>
+      <param name="name">   /cer/right_arm	</param>
+      <param name="ports">  right_arm		</param>
+      <param name="joints"> 8			</param>
+
+      <action phase="startup" level="5" type="attach">
+	  <paramlist name="networks">
+	  <!-- The param value must match the device name in the corresponding emsX file -->
+	  <elem name="FirstSetOfJoints">  cer_right_upper_arm_mc</elem>
+          <elem name="SecondSetOfJoints"> cer_right_wrist_equivalent_mc</elem>
+          <elem name="YawSetOfJoints">    cer_right_lower_arm_mc</elem>
+ <!--	  <elem name="HandSetOfJoints">   cer_right_hand_mc </elem> -->
+	  </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER01/wrappers/motorControl/cer_right_hand-mc_wrapper.xml
+++ b/CER01/wrappers/motorControl/cer_right_hand-mc_wrapper.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_right_hand_mc_wrapper" type="controlboardwrapper2">
+      <paramlist name="networks">
+	<!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+	  <elem name="FirstSetOfJoints"> 0  1  0  1 </elem>
+      </paramlist>
+
+      <param name="period"> 10 </param>
+      <param name="name">   /cer/right_hand	</param>
+      <param name="ports">  right_hand		</param>
+      <param name="joints"> 2	     		</param>
+
+      <action phase="startup" level="5" type="attach">
+	  <paramlist name="networks">
+	  <!-- The param value must match the device name in the corresponding emsX file -->
+	      <elem name="FirstSetOfJoints"> cer_right_hand_mc </elem>
+	  </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER01/wrappers/motorControl/cer_right_upper_arm-mc_wrapper.xml
+++ b/CER01/wrappers/motorControl/cer_right_upper_arm-mc_wrapper.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_right_upper_arm_mc_wrapper" type="controlboardwrapper2">
+      <paramlist name="networks">
+	<!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+	  <elem name="FirstSetOfJoints">  0  3  0  3 </elem>
+      </paramlist>
+
+<param name="period"> 10 </param>
+      <param name="name">   /cer/right_upper_arm </param>
+      <param name="ports">  right_upper_arm 	 </param>
+      <param name="joints"> 4			 </param>
+
+      <action phase="startup" level="5" type="attach">
+	  <paramlist name="networks">
+	  <!-- The param value must match the device name in the corresponding emsX file -->
+	      <elem name="FirstSetOfJoints"> cer_right_upper_arm_mc</elem>
+	  </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER01/wrappers/motorControl/cer_right_wrist-mc_wrapper.xml
+++ b/CER01/wrappers/motorControl/cer_right_wrist-mc_wrapper.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_right_wrist_mc_wrapper" type="controlboardwrapper2">
+      <param name="period">   10   </param>
+      <paramlist name="networks">
+	  <!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+	  <elem name="FirstSetOfJoints">  0  2  0  2 </elem>
+      </paramlist>
+
+      <param name="name">   /cer/right_wrist  </param>
+      <param name="ports">  right_wrist       </param>
+      <param name="joints"> 3                       </param>
+
+      <action phase="startup" level="5" type="attach">
+	  <paramlist name="networks">
+	  <!-- The param value must match the device name in the corresponding emsX file -->
+	      <elem name="FirstSetOfJoints"> cer_right_lower_arm_mc </elem>
+
+	  </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER01/wrappers/motorControl/cer_right_wrist_tripod-mc_wrapper.xml
+++ b/CER01/wrappers/motorControl/cer_right_wrist_tripod-mc_wrapper.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_right_wrist_tripod_mc_wrapper" type="controlboardwrapper2">
+      <param name="period">   10   </param>
+      <paramlist name="networks">
+	  <!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+	  <elem name="FirstSetOfJoints">  0  2  0  2 </elem>
+      </paramlist>
+
+      <param name="name">   /cer/right_wrist_tripod  </param>
+      <param name="ports">  right_wrist_tripod       </param>
+      <param name="joints"> 3                       </param>
+
+      <action phase="startup" level="5" type="attach">
+	  <paramlist name="networks">
+	  <!-- The param value must match the device name in the corresponding emsX file -->
+	      <elem name="FirstSetOfJoints"> cer_right_lower_arm_mc  </elem>
+
+	  </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER01/wrappers/motorControl/cer_ros_wrapper.xml
+++ b/CER01/wrappers/motorControl/cer_ros_wrapper.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_all_joints_mc_wrapper" type="controlboardwrapper2">
+
+      <param name="period"> 10 </param>
+      <param name="name">   /cer/all_joints </param>
+      <param name="joints"> 28 </param>
+      
+      <paramlist name="networks">
+
+        <elem name="head">            0  1   0  1 </elem>  <!-- 2 -->
+        <elem name="torso">           2  5   0  3 </elem>  <!-- 4 -->
+        
+        <elem name="right_arm">       6  13  0  7 </elem>  <!-- 8 -->
+        <elem name="left_arm">        14 21  0  7 </elem>  <!-- 8 -->
+        <elem name="right_hand">      22 23  0  1 </elem>  <!-- 2 -->
+        <elem name="left_hand">       24 25  0  1 </elem>  <!-- 2 -->
+        <elem name="base">            26 27  0  1 </elem>  <!-- 2 -->
+
+      </paramlist>
+
+      <group name ="ROS">
+        <param name="useROS"> true </param>
+        <param name="ROS_topicName">  /joint_states </param>
+        <param name="ROS_nodeName">   /cer </param>
+      </group>
+      
+      <action phase="startup" level="5" type="attach">
+        <paramlist name="networks">  
+   
+         <elem name="head">        cer_head_mc_wrapper    </elem>     
+         <elem name="torso">       cer_torso_mc_wrapper   </elem>
+         <elem name="base">            cer_mobile_base_mc_wrapper </elem>
+
+         <elem name="right_arm">       cer_right_arm_mc_wrapper </elem>
+         <elem name="right_hand">      cer_right_hand_mc </elem>
+
+         <elem name="left_arm">        cer_left_arm_mc_wrapper </elem>
+         <elem name="left_hand">       cer_left_hand_mc </elem>
+
+         </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER01/wrappers/motorControl/cer_ros_wrapper_base_only.xml
+++ b/CER01/wrappers/motorControl/cer_ros_wrapper_base_only.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_all_joints_mc_wrapper" type="controlboardwrapper2">
+
+      <param name="period"> 10 </param>
+      <param name="name">   /cer/all_joints </param>
+      <param name="joints"> 2 </param>
+      
+      <paramlist name="networks">
+       <elem name="base">            0  1  0  1 </elem>
+
+      </paramlist>
+
+      <group name ="ROS">
+        <param name="useROS"> only </param>
+        <param name="ROS_topicName">  /base_joint_states </param>
+        <param name="ROS_nodeName">   /cer </param>
+      </group>
+      
+      <action phase="startup" level="5" type="attach">
+        <paramlist name="networks">
+
+         <elem name="base">            cer_mobile_base_mc_wrapper </elem>
+   
+         </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER01/wrappers/motorControl/cer_ros_wrapper_fix.xml
+++ b/CER01/wrappers/motorControl/cer_ros_wrapper_fix.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_all_joints_mc_wrapper" type="controlboardwrapper2">
+
+      <param name="period"> 10 </param>
+      <param name="name">   /cer/all_joints </param>
+      <param name="joints"> 28 </param>
+      
+      <paramlist name="networks">
+
+        <elem name="head">            0  1   0  1 </elem>  <!-- 2 -->
+        <elem name="torso">           2  5   0  3 </elem>  <!-- 4 -->
+        
+        <elem name="right_arm">       6  13  0  7 </elem>  <!-- 8 -->
+        <elem name="left_arm">        14 21  0  7 </elem>  <!-- 8 -->
+        <elem name="right_hand">      22 23  0  1 </elem>  <!-- 2 -->
+        <elem name="left_hand">       24 25  0  1 </elem>  <!-- 2 -->
+        <elem name="base">            26 27  0  1 </elem>  <!-- 2 -->
+
+      </paramlist>
+
+      <group name ="ROS">
+        <param name="useROS"> true </param>
+        <param name="ROS_topicName">  /joint_states </param>
+        <param name="ROS_nodeName">   /cer </param>
+      </group>
+      
+      <action phase="startup" level="5" type="attach">
+        <paramlist name="networks">  
+   
+         <elem name="head">        cer_head_mc_wrapper    </elem>     
+         <elem name="torso">       cer_torso_mc_wrapper   </elem>
+         <elem name="base">            cer_mobile_base_mc_wrapper </elem>
+
+         <elem name="right_arm">       cer_right_arm_mc_wrapper </elem>
+         <elem name="right_hand">      cer_right_hand_mc </elem>
+
+         <elem name="left_arm">        cer_left_arm_mc_wrapper </elem>
+         <elem name="left_hand">       cer_left_hand_mc </elem>
+
+         </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER01/wrappers/motorControl/cer_torso-mc_wrapper.xml
+++ b/CER01/wrappers/motorControl/cer_torso-mc_wrapper.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_torso_mc_wrapper" type="controlboardwrapper2">
+      <paramlist name="networks">
+	<!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+	<elem name="FirstSetOfJoints"> 0  2  0  2 </elem>
+	<elem name="SecondSetOfJoints"> 3  3  3  3 </elem>
+      </paramlist>
+
+      <param name="period"> 10 </param>
+      <param name="name">   /cer/torso	</param>
+      <param name="ports">  torso		</param>
+      <param name="joints"> 4			</param>
+
+      <action phase="startup" level="5" type="attach">
+	  <paramlist name="networks">
+	  <!-- The param value must match the device name in the corresponding emsX file -->
+	      <elem name="FirstSetOfJoints">  cer_torso_equivalent_mc </elem>
+	      <elem name="SecondSetOfJoints"> cer_torso_mc </elem>
+	  </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER01/wrappers/motorControl/cer_torso_tripod-mc_wrapper.xml
+++ b/CER01/wrappers/motorControl/cer_torso_tripod-mc_wrapper.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_torso_tripod_mc_wrapper" type="controlboardwrapper2">
+      <param name="period">   10   </param>
+      <paramlist name="networks">
+	  <!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+	  <elem name="FirstSetOfJoints">  0  2  0  2 </elem>
+      </paramlist>
+
+      <param name="name">   /cer/torso_tripod  </param>
+      <param name="ports">  torso_tripod       </param>
+      <param name="joints"> 3                  </param>
+
+      <action phase="startup" level="5" type="attach">
+	  <paramlist name="networks">
+	  <!-- The param value must match the device name in the corresponding emsX file -->
+	      <elem name="FirstSetOfJoints"> cer_torso_mc </elem>
+
+	  </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>

--- a/CER01/wrappers/rpLidar/laser_wrapper.xml
+++ b/CER01/wrappers/rpLidar/laser_wrapper.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cerLaserWrapper" type="Rangefinder2DWrapper">
+
+      <param name="period"> 10 </param>
+      <param name="name">   /cer/laser:o       </param>
+
+      <action phase="startup" level="5" type="attach">
+         <paramlist name="networks">
+            <elem name="cer_laser">  cerLaser </elem>
+         </paramlist>
+      </action>
+
+      <group name ="ROS">
+         <param name ="useROS"> true </param>
+         <param name ="ROS_nodeName"> /cer-laser </param>
+         <param name ="ROS_topicName"> /laser </param>
+         <param name ="frame_id"> /mobile_base_lidar </param>
+      </group>
+
+      <action phase="shutdown" level="5" type="detach" />
+  </device>
+

--- a/CER01/wrappers/skin/left_arm-skin_wrapper.xml
+++ b/CER01/wrappers/skin/left_arm-skin_wrapper.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_hand_skin_wrapper" type="skinWrapper">
+		<param name="period">       20  				</param>
+		<param name="total_taxels"> 36					</param>
+		<param name="device">       skinWrapper				</param>
+		
+		<paramlist name="ports">
+		  <elem name="left_hand_skin"> 	0 35 0 35	</elem>
+		</paramlist>
+		
+		<action phase="startup" level="5" type="attach">
+		    <paramlist name="networks">
+		<!-- The param value must match the device name in the corresponding emsX file -->
+		        <elem name="FirstSetOfSkins"> left_hand_skin </elem>
+		    </paramlist>
+		</action>
+
+		<action phase="shutdown" level="5" type="detach" />
+	</device>
+

--- a/CER01/yarplaserscannergui.ini
+++ b/CER01/yarplaserscannergui.ini
@@ -1,0 +1,5 @@
+scale            100 
+robot_radius     0.3575 // 715.0 / 2.0 / 1000.0m
+laser_position   0.245  // 245.0 / 1000.0m
+period           50
+sens_port        /cer/laser:o

--- a/CER01/yarpmotorgui.ini
+++ b/CER01/yarpmotorgui.ini
@@ -1,0 +1,4 @@
+name cer
+
+parts (torso torso_tripod mobile_base head left_arm right_arm left_wrist_tripod right_wrist_tripod left_hand right_hand all_joints)
+

--- a/CER01/yarprobotinterface.ini
+++ b/CER01/yarprobotinterface.ini
@@ -1,0 +1,2 @@
+config ./CER.xml
+

--- a/CER02/CER.xml
+++ b/CER02/CER.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<robot name="CER02" build="1" portprefix="cer" xmlns:xi="http://www.w3.org/2001/XInclude">
+<devices>
+ 
+    <!-- LASER -->
+    <xi:include href="hardware/rpLidar/laserA2_hw_back.xml" /> 
+    <xi:include href="wrappers/rpLidar/laser_back_wrapper.xml" /> 
+    <xi:include href="hardware/rpLidar/laserA2_hw_front.xml" /> 
+    <xi:include href="wrappers/rpLidar/laser_front_wrapper.xml" /> 
+    <xi:include href="hardware/rpLidar/laserA2_hw_double.xml" /> 
+    <xi:include href="wrappers/rpLidar/laser_double_wrapper.xml" /> 
+
+    <!-- BASE -->
+    <xi:include href="hardware/motorControl/cer_base-ems1-mc.xml" />
+    <xi:include href="wrappers/motorControl/cer_base-mc_wrapper.xml" />
+
+    <!-- TORSO -->
+    <xi:include href="hardware/motorControl/cer_torso-ems3-mc.xml" />
+    <xi:include href="wrappers/motorControl/cer_torso_tripod-mc_wrapper.xml" />
+    <xi:include href="hardware/motorControl/cer_torso_equivalent-mc.xml" />
+    <xi:include href="wrappers/motorControl/cer_torso-mc_wrapper.xml" />
+    
+    <!-- LEFT ARM -->
+    <xi:include href="hardware/motorControl/cer_left_shoulder-ems5-mc.xml" />
+    <xi:include href="hardware/motorControl/cer_left_upper_arm-ems12-mc.xml" />
+    <xi:include href="hardware/motorControl/cer_left_lower_arm-mcp8-mc.xml" />
+    <xi:include href="hardware/motorControl/cer_left_wrist_equivalent-mc.xml" />
+    <xi:include href="wrappers/motorControl/cer_left_wrist_tripod-mc_wrapper.xml" />
+    <xi:include href="wrappers/motorControl/cer_left_arm_no_hand-mc_wrapper.xml" />
+    
+    <!-- LEFT HAND -->
+    <xi:include href="hardware/motorControl/cer_left_hand-mcp9-mc.xml" />
+    <xi:include href="wrappers/motorControl/cer_left_hand-mc_wrapper.xml" />
+   
+    <!-- RIGHT ARM -->
+    <xi:include href="hardware/motorControl/cer_right_shoulder-ems4-mc.xml" />
+    <xi:include href="hardware/motorControl/cer_right_upper_arm-ems11-mc.xml" />
+    <xi:include href="hardware/motorControl/cer_right_lower_arm-mcp6-mc.xml" />
+    <xi:include href="hardware/motorControl/cer_right_wrist_equivalent-mc.xml" />
+    <xi:include href="wrappers/motorControl/cer_right_wrist_tripod-mc_wrapper.xml" />
+    <xi:include href="wrappers/motorControl/cer_right_arm_no_hand-mc_wrapper.xml" />
+    
+    <!-- RIGHT HAND -->
+    <xi:include href="hardware/motorControl/cer_right_hand-mcp7-mc.xml" />
+    <xi:include href="wrappers/motorControl/cer_right_hand-mc_wrapper.xml" />
+
+    <!-- HEAD -->
+    <xi:include href="hardware/motorControl/cer_head-mcp10-mc.xml" />
+    <xi:include href="wrappers/motorControl/cer_head-mc_wrapper.xml" />
+
+    <!--  CALIBRATORS -->
+    <xi:include href="calibrators/cer_torso-calib.xml" />
+    <xi:include href="calibrators/cer_left_arm_no_hand-calib.xml" />
+    <xi:include href="calibrators/cer_right_arm_no_hand-calib.xml" />
+    <xi:include href="calibrators/cer_head-calib.xml" />
+    <xi:include href="calibrators/cer_base-calib.xml" /> 
+    <xi:include href="calibrators/cer_left_hand-calib.xml" />
+    <xi:include href="calibrators/cer_right_hand-calib.xml" />
+
+    <!-- SKIN-->
+    <xi:include href="hardware/skin/left_hand-mc9-skin.xml" />
+    <xi:include href="wrappers/skin/left_arm-skin_wrapper.xml" />
+    <xi:include href="hardware/skin/right_hand-mc7-skin.xml" />
+    <xi:include href="wrappers/skin/right_arm-skin_wrapper.xml" />
+
+    <!--  FT -->
+   <!-- <xi:include href="hardware/FT/cer_left_shoulder-ems5-strain.xml" />
+    <xi:include href="hardware/FT/cer_right_shoulder-ems4-strain.xml" />
+    <xi:include href="wrappers/FT/cer_left_arm-FT_wrapper.xml" />
+    <xi:include href="wrappers/FT/cer_right_arm-FT_wrapper.xml" /> -->
+
+    <!--  MAIS -->
+   <!--  <xi:include href="hardware/MAIS/right_hand-multi_enc.xml" />
+    <xi:include href="wrappers/MAIS/right_hand-mais_wrapper.xml" />
+    <xi:include href="hardware/MAIS/left_hand-multi_enc.xml" />
+    <xi:include href="wrappers/MAIS/left_hand-mais_wrapper.xml" />-->
+
+    <!--  ROS -->
+    <xi:include href="wrappers/motorControl/cer_ros_wrapper.xml" />
+</devices>
+</robot> 

--- a/CER02/CER_Laser_backonly.xml
+++ b/CER02/CER_Laser_backonly.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<robot name="CER02" build="1" portprefix="cer" xmlns:xi="http://www.w3.org/2001/XInclude">
+<devices>
+
+    <!-- LASER -->
+    <devices file="hardware/rpLidar/laserA2_hw_back.xml" /> 
+    <devices file="wrappers/rpLidar/laser_back_wrapper.xml" /> 
+
+</devices>
+</robot> 

--- a/CER02/CER_Laser_frontonly.xml
+++ b/CER02/CER_Laser_frontonly.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<robot name="CER02" build="1" portprefix="cer" xmlns:xi="http://www.w3.org/2001/XInclude">
+<devices>
+
+    <!-- LASER -->
+
+
+    <devices file="hardware/rpLidar/laserA2_hw_front.xml" /> 
+    <devices file="wrappers/rpLidar/laser_front_wrapper.xml" /> 
+
+
+
+</devices>
+</robot> 

--- a/CER02/CER_doubleLaser_only.xml
+++ b/CER02/CER_doubleLaser_only.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<robot name="CER02" build="1" portprefix="cer" xmlns:xi="http://www.w3.org/2001/XInclude">
+<devices>
+
+    <!-- LASER -->
+    <devices file="hardware/rpLidar/laserA2_hw_back.xml" /> 
+    <devices file="wrappers/rpLidar/laser_back_wrapper.xml" /> 
+
+    <devices file="hardware/rpLidar/laserA2_hw_front.xml" /> 
+    <devices file="wrappers/rpLidar/laser_front_wrapper.xml" /> 
+
+    <devices file="hardware/rpLidar/laserA2_hw_double.xml" /> 
+    <devices file="wrappers/rpLidar/laser_double_wrapper.xml" /> 
+</devices>
+</robot> 
+

--- a/CER02/CMakeLists.txt
+++ b/CER02/CMakeLists.txt
@@ -1,0 +1,11 @@
+set(appname CER02)
+
+set(scripts CER.xml yarprobotinterface.ini general.xml yarpmotorgui.ini firmwareupdater.ini)
+
+yarp_install(FILES ${scripts} DESTINATION ${ICUBCONTRIB_ROBOTS_INSTALL_DIR}/${appname})
+yarp_install(DIRECTORY calibrators DESTINATION ${ICUBCONTRIB_ROBOTS_INSTALL_DIR}/${appname})
+yarp_install(DIRECTORY wrappers DESTINATION ${ICUBCONTRIB_ROBOTS_INSTALL_DIR}/${appname})
+yarp_install(DIRECTORY hardware DESTINATION ${ICUBCONTRIB_ROBOTS_INSTALL_DIR}/${appname})
+yarp_install(DIRECTORY sensors  DESTINATION ${ICUBCONTRIB_ROBOTS_INSTALL_DIR}/${appname})
+yarp_install(DIRECTORY camera   DESTINATION ${ICUBCONTRIB_ROBOTS_INSTALL_DIR}/${appname})
+

--- a/CER02/calibrators/cer_base-calib.xml
+++ b/CER02/calibrators/cer_base-calib.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="mobile_base_calibrator" type="parametricCalibratorEth">
+        <xi:include href="../general.xml" />
+                
+		<group name="GENERAL">
+		    <param name="joints">  2  </param> <!-- the number of joints of the robot part -->
+		    <param name="deviceName"> Mobile_Base_Calibrator </param>
+		</group>
+
+<group name="HOME">
+<param name="positionHome">                       0.00            0.00     </param>
+<param name="velocityHome">                       10.00           10.00    </param>
+<param name="disableHomeAndPark">                 1               1        </param>   
+</group>
+
+<group name="CALIBRATION">
+<param name="calibrationType">                    3               3        </param>
+<param name="calibration1">                       0               0        </param>
+<param name="calibration2">                       10.0            10.0     </param>
+<param name="calibration3">                       0               0        </param>
+<param name="calibration4">                       0               0        </param>
+<param name="calibration5">                       0               0        </param>
+<param name="calibrationZero">                    0               0        </param>
+<param name="calibrationDelta">                   0.0             0.0      </param>
+<param name="startupPosition">                    0.0             0.0      </param>
+<param name="startupVelocity">                    1.0             1.0      </param>
+<param name="startupMaxPwm">                      5000            5000     </param>
+<param name="startupPosThreshold">                2               2        </param>
+<param name="calibrationTimeout">                 1.0             1.0      </param>
+<param name="startupDisablePosCheck">             1               1        </param>
+</group>
+
+		<param name="CALIB_ORDER">(0 1) </param>
+
+		<action phase="startup" level="10" type="calibrate">
+		    <param name="target">cer_mobile_base_mc_wrapper</param>
+		</action>
+
+		<action phase="interrupt1" level="1" type="park">
+		    <param name="target">cer_mobile_base_mc_wrapper</param>
+		</action>
+
+		<action phase="interrupt3" level="1" type="abort" />
+
+	</device>
+

--- a/CER02/calibrators/cer_head-calib.xml
+++ b/CER02/calibrators/cer_head-calib.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="head_calibrator" type="parametricCalibratorEth">
+        <xi:include href="../general.xml" />
+                
+    <group name="GENERAL">
+        <param name="joints">  2  </param> <!-- the number of joints of the robot part -->
+        <param name="deviceName"> Head_Calibrator </param>
+    </group>
+
+    <group name="HOME">
+        <param name="positionHome">                       0.00            0.00           </param>
+        <param name="velocityHome">                       10.00           10.00          </param>
+    </group>                                                                      
+
+    <group name="CALIBRATION">                                                    
+        <param name="calibrationType">                    12              12             </param>
+        <param name="calibration1">                       35932           11361          </param>
+        <param name="calibration2">                       0               0              </param>
+        <param name="calibration3">                       0               0              </param> 
+        <param name="calibration4">                       0               0              </param>
+        <param name="calibration5">                       0               0              </param>
+        <param name="calibrationZero">                    0               0              </param>
+        <param name="calibrationDelta">                   0.0             0.0            </param>
+
+        <param name="startupPosition">                    0.0             0.0            </param>
+        <param name="startupVelocity">                    10.0            10.0           </param>
+        <param name="startupMaxPwm">                      2000            1800           </param>
+        <param name="startupPosThreshold">                4               4              </param>
+    </group>
+
+		<param name="CALIB_ORDER">(0 1) </param>
+
+		<action phase="startup" level="10" type="calibrate">
+		    <param name="target">cer_head_mc_wrapper</param>
+		</action>
+
+		<action phase="interrupt1" level="1" type="park">
+		    <param name="target">cer_head_mc_wrapper</param>
+		</action>
+
+		<action phase="interrupt3" level="1" type="abort" />
+
+	</device>
+

--- a/CER02/calibrators/cer_left_arm_no_hand-calib.xml
+++ b/CER02/calibrators/cer_left_arm_no_hand-calib.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm_no_hand_calibrator" type="parametricCalibratorEth">
+        <xi:include href="../general.xml" />
+                
+		<group name="GENERAL">
+		    <param name="joints">  8  </param> <!-- the number of joints of the robot part -->
+		    <param name="deviceName"> Left_Arm_No_Hand_Calibrator </param>
+		</group>
+
+<group name="HOME">
+<param name="positionHome">                       0.00       5.00      0.00       0.00      0.00   0.03       0.0        0.0      </param>
+<param name="velocityHome">                      10.00      10.00     10.00      10.00     10.00   0.005      10.0       10.0     </param>
+</group>                                                                                                                     
+                                                                                                                             
+<group name="CALIBRATION">                                                                                                   
+<param name="calibrationType">                   12         12        12         12        10      8          8          8        </param>
+<param name="calibration1">                      63668     -29279     23759      31823     400     1500       1500       1500     </param>
+<param name="calibration2">                      0          0         0          0         0       700        700        700      </param>
+<param name="calibration3">                      0          0         0          0         0       0          0          0        </param>
+<param name="calibration4">                      0          0         0          0         0       0          0          0        </param>
+<param name="calibration5">                      0          0         0          0         0       0          0          0        </param>
+<param name="calibrationZero">                   0          0         0          0         90      0          0          0        </param>
+<param name="calibrationDelta">                  0          0         0          0         0       0          0          0        </param>
+                                                                                          
+<param name="startupPosition">                  -10         20       -10         35        0       0.03       0.0        0.0      </param>
+<param name="startupVelocity">                   10         10        10         10        15.0    0.007      10         10       </param>
+<param name="startupMaxPwm">                     32000      32000     32000      32000     2000    2000       2000       2000     </param>
+<param name="startupPosThreshold">               2          2         2          2         2       0.002      2          2        </param>
+</group>
+
+		<param name="CALIB_ORDER">(0 1 2) (3) (4) (5 6 7)</param> 
+
+		<action phase="startup" level="10" type="calibrate">
+		    <param name="target">cer_left_arm_no_hand_mc_wrapper</param>
+		</action>
+
+		<action phase="interrupt1" level="1" type="park">
+		    <param name="target">cer_left_arm_no_hand_mc_wrapper</param>
+		</action>
+
+		<action phase="interrupt3" level="1" type="abort" />
+
+	</device>
+

--- a/CER02/calibrators/cer_left_hand-calib.xml
+++ b/CER02/calibrators/cer_left_hand-calib.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_hand_calibrator" type="parametricCalibratorEth">
+        <xi:include href="../general.xml" />
+                
+    <group name="GENERAL">
+        <param name="joints">  2  </param> <!-- the number of joints of the robot part -->
+        <param name="deviceName"> Left_Hand_Calibrator </param>
+    </group>
+
+    <group name="HOME">
+        <param name="positionHome">                       30.00           30.00          </param>
+        <param name="velocityHome">                       40.00           40.00          </param>
+    </group>                                                                      
+
+    <group name="CALIBRATION">                                                    
+        <param name="calibrationType">                       11              11          </param>
+        <param name="calibration1">                       43776            2848          </param>
+        <param name="calibration2">                       49568           51504          </param>
+        <param name="calibration3">                        9840           21616          </param>
+        <param name="calibration4">                       36000           32000          </param>
+        <param name="calibration5">                       -1500            1500          </param>
+        <param name="calibrationZero">                        0               0          </param>        
+        <param name="calibrationDelta">                       0               0          </param>
+        <param name="startupPosition">                     30.0            30.0          </param>
+        <param name="startupVelocity">                     40.0            40.0          </param>
+        <param name="startupMaxPwm">                       1500            1500          </param>
+        <param name="startupPosThreshold">                   10              10          </param>
+    </group>
+
+		<param name="CALIB_ORDER">(0 1) </param>
+
+		<action phase="startup" level="10" type="calibrate">
+		    <param name="target">cer_left_hand_mc_wrapper</param>
+		</action>
+
+		<action phase="interrupt1" level="1" type="park">
+		    <param name="target">cer_left_hand_mc_wrapper</param>
+		</action>
+
+		<action phase="interrupt3" level="1" type="abort" />
+
+	</device>
+
+

--- a/CER02/calibrators/cer_right_arm_no_hand-calib.xml
+++ b/CER02/calibrators/cer_right_arm_no_hand-calib.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm_no_hand_calibrator" type="parametricCalibratorEth">
+        <xi:include href="../general.xml" />
+                
+		<group name="GENERAL">
+		    <param name="joints">  8  </param> <!-- the number of joints of the robot part -->
+		    <param name="deviceName"> Right_Arm_No_Hand_Calibrator </param>
+		</group>
+
+<group name="HOME">
+<param name="positionHome">                        0.00       5.00      0        0            0.00   0.03       0.0        0.0           </param>
+<param name="velocityHome">                       10.00      10.00     10.0     10.0         10.00   0.005      10.0       10.0          </param>
+</group>                                                                                                                        
+                                                                                                                                
+<group name="CALIBRATION">                                                                                                      
+<param name="calibrationType">                    12         12        12         12         10      8          8          8             </param>
+<param name="calibration1">                      -7273       31647    -64063      13311     -400     1500       1500       1500          </param>
+<param name="calibration2">                       0          0         0          0          0       700        700        700           </param>
+<param name="calibration3">                       0          0         0          0          0       0          0          0             </param>
+<param name="calibration4">                       0          0         0          0          0       0          0          0             </param>
+<param name="calibration5">                       0          0         0          0          0       0          0          0             </param>
+<param name="calibrationZero">                    0          0         0          0          90      0          0          0             </param>
+<param name="calibrationDelta">                   0          0         0          0          0       0          0          0             </param>
+                                                                                           
+<param name="startupPosition">                   -10         20       -10         35         0.0     0.03       0.0        0.0           </param>
+<param name="startupVelocity">                    10         10        10         10         10      0.007      10         10            </param>
+<param name="startupMaxPwm">                      32000      32000     32000      32000      2000    2000       2000       2000          </param>
+<param name="startupPosThreshold">                2          2         2          2          2       0.002      2          2             </param>
+</group>
+
+		<param name="CALIB_ORDER">(0 1 2) (3) (4) (5 6 7)</param> 
+
+		<action phase="startup" level="10" type="calibrate">
+		    <param name="target">cer_right_arm_no_hand_mc_wrapper</param>
+		</action>
+
+		<action phase="interrupt1" level="1" type="park">
+		    <param name="target">cer_right_arm_no_hand_mc_wrapper</param>
+		</action>
+
+		<action phase="interrupt3" level="1" type="abort" />
+
+	</device>
+

--- a/CER02/calibrators/cer_right_hand-calib.xml
+++ b/CER02/calibrators/cer_right_hand-calib.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_hand_calibrator" type="parametricCalibratorEth">
+        <xi:include href="../general.xml" />
+                
+    <group name="GENERAL">
+        <param name="joints">  2  </param> <!-- the number of joints of the robot part -->
+        <param name="deviceName"> Right_Hand_Calibrator </param>
+    </group>
+
+    <group name="HOME">
+        <param name="positionHome">                       30.00           30.00          </param>
+        <param name="velocityHome">                       40.00           40.00          </param>
+    </group>                                                                      
+
+    <group name="CALIBRATION">                                                    
+        <param name="calibrationType">                       11              11          </param>
+        <param name="calibration1">                       21968           27216          </param>
+        <param name="calibration2">                       38240           35024          </param>
+        <param name="calibration3">                        2960           36464          </param>
+        <param name="calibration4">                       36000           32000          </param>
+        <param name="calibration5">                       -1500            1500          </param>
+        <param name="calibrationZero">                        0               0          </param>        
+        <param name="calibrationDelta">                       0               0          </param>
+        <param name="startupPosition">                     30.0            30.0          </param>
+        <param name="startupVelocity">                     40.0            40.0          </param>
+        <param name="startupMaxPwm">                       1500            1500          </param>
+        <param name="startupPosThreshold">                   10              10          </param>
+    </group>
+
+		<param name="CALIB_ORDER">(0 1) </param>
+
+		<action phase="startup" level="10" type="calibrate">
+		    <param name="target">cer_right_hand_mc_wrapper</param>
+		</action>
+
+		<action phase="interrupt1" level="1" type="park">
+		    <param name="target">cer_right_hand_mc_wrapper</param>
+		</action>
+
+		<action phase="interrupt3" level="1" type="abort" />
+
+	</device>
+
+

--- a/CER02/calibrators/cer_torso-calib.xml
+++ b/CER02/calibrators/cer_torso-calib.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="torso_calibrator" type="parametricCalibratorEth">
+        <xi:include href="../general.xml" />
+                
+		<group name="GENERAL">
+		    <param name="joints">  4  </param> <!-- the number of joints of the robot part -->
+		    <param name="deviceName"> Torso_Calibrator </param>
+		</group>
+
+<group name="HOME">
+<param name="positionHome">                       0.05            0.0         0.0       0.0           </param>
+<param name="velocityHome">                       0.01            10          10        10            </param>
+</group>
+
+<group name="CALIBRATION">
+<param name="calibrationType">                    9               9           9         12            </param>
+<param name="calibration1">                       10000           10000       10000    -54127         </param>
+<param name="calibration2">                       280             280         280       0             </param>
+<param name="calibration3">                       0               0           0         0             </param>
+<param name="calibration4">                       0               0           0         0             </param>
+<param name="calibration5">                       0               0           0         0             </param>
+<param name="calibrationZero">                    1500            1500        1500      0             </param>
+<param name="calibrationDelta">                   0.0             0.0         0.0       0.0           </param>
+
+<param name="startupPosition">                    0.12            0.0         0.0       0.0           </param>
+<param name="startupVelocity">                    0.01            10          10        10.0          </param>
+<param name="startupTimeout">                     30              30          30        20            </param>
+<param name="startupMaxPwm">                      20000           20000       20000     5000          </param>
+<param name="startupPosThreshold">                0.005           2           2         2             </param>
+</group>
+
+		<param name="CALIB_ORDER">(0 1 2 3) </param>
+
+		<action phase="startup" level="10" type="calibrate">
+		    <param name="target">cer_torso_mc_wrapper</param>
+		</action>
+
+		<action phase="interrupt1" level="1" type="park">
+		    <param name="target">cer_torso_mc_wrapper</param>
+		</action>
+
+		<action phase="interrupt3" level="1" type="abort" />
+
+	</device>
+

--- a/CER02/camera/ServerGrabberDual.ini
+++ b/CER02/camera/ServerGrabberDual.ini
@@ -1,0 +1,8 @@
+device grabberDual
+subdevice usbCamera
+capabilities COLOR
+name /cer/cam
+d /dev/video0
+width  1280
+height 480
+

--- a/CER02/cer.urdf
+++ b/CER02/cer.urdf
@@ -1,0 +1,1539 @@
+<robot name="SIM_CER_ROBOT">
+  <link name="mobile_base_body_link">
+    <inertial>
+      <origin xyz="0.00353188 0 0.062803" rpy="0 0 0"/>
+      <mass value="14.0"/>
+      <inertia ixx="0.342401" ixy="0.0" ixz="-0.0396992" iyy="0.362542" iyz="0.0" izz="0.168981"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 -0.16" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_mobilebase_body.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="green">
+        <color rgba="0 1 0 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 -0.16" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_mobilebase_body.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <link name="base_link"/>
+  <joint name="base_link_fixed_joint" type="fixed">
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+    <parent link="mobile_base_body_link"/>
+    <child link="base_link"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="mobile_base_lidar_F"/>
+  <joint name="mobile_base_lidar_F_fixed_joint" type="fixed">
+    <origin xyz="0.07 0 0.031" rpy="0 0 0"/>
+    <parent link="mobile_base_body_link"/>
+    <child link="mobile_base_lidar_F"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="mobile_base_lidar_B"/>
+  <joint name="mobile_base_lidar_B_fixed_joint" type="fixed">
+    <origin xyz="-0.085 0 0.031" rpy="0 0 3.14"/>
+    <parent link="mobile_base_body_link"/>
+    <child link="mobile_base_lidar_B"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="mobile_base_double_lidar"/>
+  <joint name="mobile_base_double_lidar_fixed_joint" type="fixed">
+    <origin xyz="0.0 0 0.031" rpy="0 0 0"/>
+    <parent link="mobile_base_body_link"/>
+    <child link="mobile_base_double_lidar"/>
+    <dynamics damping="0.1"/>
+  </joint>
+
+  <link name="torso_slider_eq_link">
+    <inertial>
+      <origin xyz="0.015175 2.80975e-06 0.244533" rpy="0 0 0"/>
+      <mass value="7.5"/>
+      <inertia ixx="0.0978792" ixy="-1.83466e-06" ixz="0.00625726" iyy="0.0969511" iyz="0.0" izz="0.0746114"/>
+    </inertial>
+    <visual>
+      <origin xyz="-0.044 0 -0.231" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_torso_slider_eq.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="black">
+        <color rgba="0 0 0 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="-0.044 0 -0.231" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_torso_slider_eq.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="torso_heave_eq_joint" type="prismatic">
+    <origin xyz="0.044 0 0.071" rpy="0 0 0"/>
+    <axis xyz="0.0 0.0 1.0"/>
+    <parent link="mobile_base_body_link"/>
+    <child link="torso_slider_eq_link"/>
+    <limit effort="1200.0" lower="0.0" upper="0.17" velocity="0.5"/>
+    <dynamics damping="1000.0"/>
+  </joint>
+  <link name="torso_pin_eq_link">
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="1.5"/>
+      <inertia ixx="0.000379688" ixy="0.0" ixz="0.0" iyy="0.00143984" iyz="0.0" izz="0.00143984"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_torso_pin_eq.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="red">
+        <color rgba="1 0 0 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_torso_pin_eq.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="torso_roll_eq_joint" type="revolute">
+    <origin xyz="0 0 0.399" rpy="3.14159265359 0 0"/>
+    <axis xyz="1.0 0.0 0.0"/>
+    <parent link="torso_slider_eq_link"/>
+    <child link="torso_pin_eq_link"/>
+    <limit effort="50.0" lower="-0.523598775598" upper="0.523598775598" velocity="3.14"/>
+    <dynamics damping="100.0"/>
+  </joint>
+  <link name="torso_platform_link">
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="1.5"/>
+      <inertia ixx="0.00153125" ixy="0.0" ixz="0.0" iyy="0.00153125" iyz="0.0" izz="0.0030375"/>
+    </inertial>
+    <visual>
+      <origin xyz="-0.044 0 -0.63" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_torso_platform.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="blue">
+        <color rgba="0 0 1 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="-0.044 0 -0.63" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_torso_platform.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="torso_pitch_eq_joint" type="revolute">
+    <origin xyz="0 0 0" rpy="3.14159265359 0 0"/>
+    <axis xyz="0.0 1.0 0.0"/>
+    <parent link="torso_pin_eq_link"/>
+    <child link="torso_platform_link"/>
+    <limit effort="50.0" lower="-0.523598775598" upper="0.523598775598" velocity="3.14"/>
+    <dynamics damping="100.0"/>
+  </joint>
+  <link name="torso_tripod_root"/>
+  <joint name="torso_tripod_root_fixed_joint" type="fixed">
+    <origin xyz="0 0 0" rpy="0 0 3.14159265359"/>
+    <parent link="torso_platform_link"/>
+    <child link="torso_tripod_root"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="chest_link">
+    <inertial>
+      <origin xyz="-0.0330305 0 0.220198" rpy="0 0 0"/>
+      <mass value="13.0"/>
+      <inertia ixx="0.275816" ixy="0.0" ixz="0.0564476" iyy="0.253579" iyz="0.0" izz="0.127156"/>
+    </inertial>
+    <visual>
+      <origin xyz="-0.044 0 -0.63" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_chest.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="yellow">
+        <color rgba="1 1 0 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="-0.044 0 -0.63" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_chest.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="torso_yaw_joint" type="revolute">
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+    <axis xyz="0.0 0.0 1.0"/>
+    <parent link="torso_platform_link"/>
+    <child link="chest_link"/>
+    <limit effort="30.0" lower="-1.0471975512" upper="1.0471975512" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="torso"/>
+  <joint name="torso_fixed_joint" type="fixed">
+    <origin xyz="-0.042 0 0.185" rpy="0 0 0"/>
+    <parent link="chest_link"/>
+    <child link="torso"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_clavicle_link">
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="0.2"/>
+      <inertia ixx="0.000288" ixy="0.0" ixz="0.0" iyy="0.000288" iyz="0.0" izz="0.000288"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 0.177 -1.0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_clavicle.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="pink">
+        <color rgba="1 0 1 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.04 0.177 -1.0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_clavicle.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_shoulder_pitch_joint" type="revolute">
+    <origin xyz="-0.084 -0.177 0.37" rpy="0 0 0"/>
+    <axis xyz="0.0 -0.970296 0.241922"/>
+    <parent link="chest_link"/>
+    <child link="r_clavicle_link"/>
+    <limit effort="30.0" lower="-0.523598775598" upper="1.57079632679" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="r_shoulder_link">
+    <inertial>
+      <origin xyz="1.5e-06 -0.042148 -0.06332" rpy="0 0 0"/>
+      <mass value="0.5"/>
+      <inertia ixx="0.00076143" ixy="0.0" ixz="-2.84508e-08" iyy="0.000819748" iyz="0.000135828" izz="0.000588486"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 0.177 -1.0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_shoulder.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="cyan">
+        <color rgba="0 1 1 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.04 0.177 -1.0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_shoulder.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_shoulder_roll_joint" type="revolute">
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+    <axis xyz="-1.0 0.0 0.0"/>
+    <parent link="r_clavicle_link"/>
+    <child link="r_shoulder_link"/>
+    <limit effort="30.0" lower="-0.174532925199" upper="1.308996939" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="r_upperarm_FT_sensor_link">
+    <inertial>
+      <origin xyz="0 0 -0.014527" rpy="0 0 0"/>
+      <mass value="0.3"/>
+      <inertia ixx="6.00899e-05" ixy="0.0" ixz="0.0" iyy="6.00898e-05" iyz="0.0" izz="7.59375e-05"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 0.211 -0.89" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_upperarm_sensor.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="green"/>
+    </visual>
+    <collision>
+      <origin xyz="0.04 0.211 -0.89" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_upperarm_sensor.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_shoulder_yaw_joint" type="revolute">
+    <origin xyz="0 -0.034 -0.11" rpy="0 0 0"/>
+    <axis xyz="0.0 0.0 -1.0"/>
+    <parent link="r_shoulder_link"/>
+    <child link="r_upperarm_FT_sensor_link"/>
+    <limit effort="15.0" lower="-1.57079632679" upper="1.57079632679" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="r_upperarm_FT_sensor_frame"/>
+  <joint name="r_upperarm_FT_sensor_frame_fixed_joint" type="fixed">
+    <origin xyz="0 0 -0.0294" rpy="3.14159265359 0 1.57079632679"/>
+    <parent link="r_upperarm_FT_sensor_link"/>
+    <child link="r_upperarm_FT_sensor_frame"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_upperarm_link">
+    <inertial>
+      <origin xyz="0.000197 -0.001254 0.030305" rpy="3.14159265359 0 1.57079632679"/>
+      <mass value="0.5"/>
+      <inertia ixx="0.000849608" ixy="0.0" ixz="-3.39184e-05" iyy="0.000841002" iyz="-4.47567e-07" izz="0.000581528"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.211 0.04 0.8606" rpy="3.14159265359 0 1.57079632679"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_upperarm.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="white">
+        <color rgba="1 1 1 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.211 0.04 0.8606" rpy="3.14159265359 0 1.57079632679"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_upperarm.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_upperarm_FT_sensor" type="fixed">
+    <origin xyz="0 0 -0.0294" rpy="3.14159265359 0 1.57079632679"/>
+    <parent link="r_upperarm_FT_sensor_link"/>
+    <child link="r_upperarm_link"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_elbow_sphere_link">
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="0.2"/>
+      <inertia ixx="0.000128" ixy="0.0" ixz="0.0" iyy="0.000128" iyz="0.0" izz="0.000128"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 0.211 -0.749" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_elbow_sphere.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="dblue">
+        <color rgba="0 0 0.8 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.04 0.211 -0.749" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_elbow_sphere.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_elbow_joint" type="revolute">
+    <origin xyz="0 0 0.1116" rpy="3.14159265359 0 1.57079632679"/>
+    <axis xyz="0.0 -1.0 0.0"/>
+    <parent link="r_upperarm_link"/>
+    <child link="r_elbow_sphere_link"/>
+    <limit effort="20.0" lower="0.0" upper="1.74532925199" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="r_forearm_link">
+    <inertial>
+      <origin xyz="-0.0005116 0.000175 -0.072511" rpy="0 0 0"/>
+      <mass value="0.6"/>
+      <inertia ixx="0.00283352" ixy="0.0" ixz="3.15449e-05" iyy="0.00282953" iyz="-1.03787e-07" izz="0.000436673"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 0.211 -0.678" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_forearm.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="r_forearm_link_color">
+        <color rgba="0.929 0.933 0.91 1.0"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.04 0.211 -0.678" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_forearm.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_wrist_pronosupination_joint" type="revolute">
+    <origin xyz="0 0 -0.071" rpy="0 0 0"/>
+    <axis xyz="0.0 0.0 -1.0"/>
+    <parent link="r_elbow_sphere_link"/>
+    <child link="r_forearm_link"/>
+    <limit effort="10.0" lower="-1.57079632679" upper="1.57079632679" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="r_wrist_tripod_root"/>
+  <joint name="r_wrist_tripod_root_fixed_joint" type="fixed">
+    <origin xyz="0 0 -0.22" rpy="3.14159265359 0 1.57079632679"/>
+    <parent link="r_forearm_link"/>
+    <child link="r_wrist_tripod_root"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_wrist_slider_eq_link">
+    <inertial>
+      <origin xyz="0 5.9e-05 -0.225759" rpy="0 0 0"/>
+      <mass value="0.3"/>
+      <inertia ixx="0.00094001" ixy="0.0" ixz="0.0" iyy="0.000940012" iyz="0.0" izz="0.00022094"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 0.211 -0.749" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_wrist_slider.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="dgreen">
+        <color rgba="0.1 0.8 0.1 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.04 0.211 -0.749" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_wrist_slider.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_wrist_heave_eq_joint" type="prismatic">
+    <origin xyz="0 0 0.071" rpy="0 0 0"/>
+    <axis xyz="0.0 0.0 -1.0"/>
+    <parent link="r_forearm_link"/>
+    <child link="r_wrist_slider_eq_link"/>
+    <limit effort="200.0" lower="0.0" upper="0.13" velocity="0.25"/>
+    <dynamics damping="100.0"/>
+  </joint>
+  <link name="r_wrist_cup_eq_link">
+    <inertial>
+      <origin xyz="-1.1e-05 -0.0319409 -0.018146" rpy="0 0 0"/>
+      <mass value="0.2"/>
+      <inertia ixx="0.000102239" ixy="0.0" ixz="3.78925e-08" iyy="0.000102239" iyz="0.0" izz="0.000163555"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 0.179 -0.458" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_wrist_cup_eq.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="r_wrist_cup_eq_link_color">
+        <color rgba="0.776 0.8 0.769 1.0"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.04 0.179 -0.458" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_wrist_cup_eq.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_wrist_roll_eq_joint" type="revolute">
+    <origin xyz="-0.032 0 -0.291" rpy="0 0 1.57079632679"/>
+    <axis xyz="0.0 1.0 0.0"/>
+    <parent link="r_wrist_slider_eq_link"/>
+    <child link="r_wrist_cup_eq_link"/>
+    <limit effort="10.0" lower="-0.523598775598" upper="0.523598775598" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="r_hand_root_link">
+    <inertial>
+      <origin xyz="0.0001906 0.013614 -0.06234" rpy="0 0 0"/>
+      <mass value="0.3"/>
+      <inertia ixx="0.000294522" ixy="-1.41036e-06" ixz="6.91732e-08" iyy="0.000297774" iyz="2.11461e-05" izz="0.000189897"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 0.211 -0.458" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_hand_root.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="gray">
+        <color rgba="0.5 0.5 0.5 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.04 0.211 -0.458" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_hand_root.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_wrist_pitch_eq_joint" type="revolute">
+    <origin xyz="0 -0.032 0" rpy="0 0 -1.57079632679"/>
+    <axis xyz="0.0 -1.0 0.0"/>
+    <parent link="r_wrist_cup_eq_link"/>
+    <child link="r_hand_root_link"/>
+    <limit effort="10.0" lower="-0.523598775598" upper="0.523598775598" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="r_wrist"/>
+  <joint name="r_wrist_fixed_joint" type="fixed">
+    <origin xyz="0 0 0" rpy="3.14159265359 0 1.57079632679"/>
+    <parent link="r_hand_root_link"/>
+    <child link="r_wrist"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_gripper"/>
+  <joint name="r_gripper_fixed_joint" type="fixed">
+    <origin xyz="0 0.026917 -0.100456" rpy="0 1.30899714732 1.57079632679"/>
+    <parent link="r_hand_root_link"/>
+    <child link="r_gripper"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_hand_paddle_proximal_link">
+    <inertial>
+      <origin xyz="-9.65e-05 -0.010867 -0.022258" rpy="0 0 0"/>
+      <mass value="0.05"/>
+      <inertia ixx="0.0001" ixy="6.93652e-09" ixz="1.75564e-08" iyy="0.0001" iyz="-1.81901e-06" izz="0.0001"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 0.198143 -0.345494" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_hand_paddle_proximal.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="green"/>
+    </visual>
+    <collision>
+      <origin xyz="0.04 0.198143 -0.345494" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_hand_paddle_proximal.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_hand_paddle_proximal_joint" type="revolute">
+    <origin xyz="0 0.012857 -0.112506" rpy="0 0 0"/>
+    <axis xyz="1.0 0.0 0.0"/>
+    <parent link="r_hand_root_link"/>
+    <child link="r_hand_paddle_proximal_link"/>
+    <limit effort="5.0" lower="0.0" upper="1.2217304764" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="r_hand_paddle_distal_link">
+    <inertial>
+      <origin xyz="0.0013214 -0.005592 -0.020601" rpy="0 0 0"/>
+      <mass value="0.05"/>
+      <inertia ixx="0.0001" ixy="1.94983e-07" ixz="9.0126e-07" iyy="0.0001" iyz="-6.79853e-07" izz="0.0001"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 0.214471 -0.306748" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_hand_paddle_distal.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="black"/>
+    </visual>
+    <collision>
+      <origin xyz="0.04 0.214471 -0.306748" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_hand_paddle_distal.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_hand_paddle_distal_joint" type="revolute">
+    <origin xyz="0 -0.016328 -0.038746" rpy="0 0 0"/>
+    <axis xyz="1.0 0.0 0.0"/>
+    <parent link="r_hand_paddle_proximal_link"/>
+    <child link="r_hand_paddle_distal_link"/>
+    <limit effort="5.0" lower="0.0" upper="1.2217304764" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="r_hand_paddle_tip"/>
+  <joint name="r_hand_paddle_tip_fixed_joint" type="fixed">
+    <origin xyz="0 -0.008959 -0.044226" rpy="0 1.30899714732 1.57079632679"/>
+    <parent link="r_hand_paddle_distal_link"/>
+    <child link="r_hand_paddle_tip"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_hand_thumb_proximal_link">
+    <inertial>
+      <origin xyz="0.002515 0.017936 -0.003159" rpy="0 0 0"/>
+      <mass value="0.05"/>
+      <inertia ixx="0.0001" ixy="1.49367e-09" ixz="3.12525e-10" iyy="0.0001" iyz="2.63475e-06" izz="0.0001"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 0.171352 -0.382282" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_hand_thumb_proximal.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="red"/>
+    </visual>
+    <collision>
+      <origin xyz="0.04 0.171352 -0.382282" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_hand_thumb_proximal.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_hand_thumb_proximal_joint" type="revolute">
+    <origin xyz="0 0.039648 -0.075718" rpy="0 0 0"/>
+    <axis xyz="-1.0 0.0 0.0"/>
+    <parent link="r_hand_root_link"/>
+    <child link="r_hand_thumb_proximal_link"/>
+    <limit effort="5.0" lower="0.0" upper="1.0471975512" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="r_hand_thumb_distal_link">
+    <inertial>
+      <origin xyz="0.0024483 0.014529 -0.005865" rpy="0 0 0"/>
+      <mass value="0.05"/>
+      <inertia ixx="3.85163e-06" ixy="-1.50194e-10" ixz="4.04682e-10" iyy="7.40388e-06" iyz="9.14021e-07" izz="8.52416e-06"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 0.130827 -0.371296" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_hand_thumb_distal.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="blue"/>
+    </visual>
+    <collision>
+      <origin xyz="0.04 0.130827 -0.371296" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_hand_thumb_distal.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_hand_thumb_distal_joint" type="revolute">
+    <origin xyz="0 0.040525 -0.010986" rpy="0 0 0"/>
+    <axis xyz="-1.0 0.0 0.0"/>
+    <parent link="r_hand_thumb_proximal_link"/>
+    <child link="r_hand_thumb_distal_link"/>
+    <limit effort="5.0" lower="0.0" upper="1.2217304764" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="r_hand_thumb_tip"/>
+  <joint name="r_hand_thumb_tip_fixed_joint" type="fixed">
+    <origin xyz="0 0.028617 -0.014073" rpy="0 1.30899714732 1.57079632679"/>
+    <parent link="r_hand_thumb_distal_link"/>
+    <child link="r_hand_thumb_tip"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_clavicle_link">
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="0.2"/>
+      <inertia ixx="0.000288" ixy="0.0" ixz="0.0" iyy="0.000288" iyz="0.0" izz="0.000288"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 -0.177 -1.0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_clavicle.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="yellow"/>
+    </visual>
+    <collision>
+      <origin xyz="0.04 -0.177 -1.0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_clavicle.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_shoulder_pitch_joint" type="revolute">
+    <origin xyz="-0.084 0.177 0.37" rpy="0 0 0"/>
+    <axis xyz="0.0 -0.970296 -0.241922"/>
+    <parent link="chest_link"/>
+    <child link="l_clavicle_link"/>
+    <limit effort="30.0" lower="-0.523598775598" upper="1.57079632679" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="l_shoulder_link">
+    <inertial>
+      <origin xyz="1.5e-06 0.042148 -0.06332" rpy="0 0 0"/>
+      <mass value="0.5"/>
+      <inertia ixx="0.00076143" ixy="0.0" ixz="-2.84061e-08" iyy="0.000819748" iyz="-0.000135828" izz="0.000588486"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 -0.177 -1.0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_shoulder.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="pink"/>
+    </visual>
+    <collision>
+      <origin xyz="0.04 -0.177 -1.0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_shoulder.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_shoulder_roll_joint" type="revolute">
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+    <axis xyz="1.0 0.0 0.0"/>
+    <parent link="l_clavicle_link"/>
+    <child link="l_shoulder_link"/>
+    <limit effort="30.0" lower="-0.174532925199" upper="1.308996939" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="l_upperarm_FT_sensor_link">
+    <inertial>
+      <origin xyz="0 0 -0.014527" rpy="0 0 0"/>
+      <mass value="0.3"/>
+      <inertia ixx="6.00899e-05" ixy="0.0" ixz="0.0" iyy="6.00898e-05" iyz="0.0" izz="7.59375e-05"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 -0.211 -0.89" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_upperarm_sensor.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="cyan"/>
+    </visual>
+    <collision>
+      <origin xyz="0.04 -0.211 -0.89" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_upperarm_sensor.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_shoulder_yaw_joint" type="revolute">
+    <origin xyz="0 0.034 -0.11" rpy="0 0 0"/>
+    <axis xyz="0.0 0.0 1.0"/>
+    <parent link="l_shoulder_link"/>
+    <child link="l_upperarm_FT_sensor_link"/>
+    <limit effort="15.0" lower="-1.57079632679" upper="1.57079632679" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="l_upperarm_FT_sensor_frame"/>
+  <joint name="l_upperarm_FT_sensor_frame_fixed_joint" type="fixed">
+    <origin xyz="0 0 -0.0294" rpy="3.14159265359 0 1.57079632679"/>
+    <parent link="l_upperarm_FT_sensor_link"/>
+    <child link="l_upperarm_FT_sensor_frame"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_upperarm_link">
+    <inertial>
+      <origin xyz="-0.000197 -0.001254 0.030305" rpy="3.14159265359 0 1.57079632679"/>
+      <mass value="0.5"/>
+      <inertia ixx="0.000849607" ixy="0.0" ixz="-3.39183e-05" iyy="0.000841001" iyz="4.47458e-07" izz="0.000581528"/>
+    </inertial>
+    <visual>
+      <origin xyz="-0.211 0.04 0.8606" rpy="3.14159265359 0 1.57079632679"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_upperarm.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="green"/>
+    </visual>
+    <collision>
+      <origin xyz="-0.211 0.04 0.8606" rpy="3.14159265359 0 1.57079632679"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_upperarm.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_upperarm_FT_sensor" type="fixed">
+    <origin xyz="0 0 -0.0294" rpy="3.14159265359 0 1.57079632679"/>
+    <parent link="l_upperarm_FT_sensor_link"/>
+    <child link="l_upperarm_link"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_elbow_sphere_link">
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="0.2"/>
+      <inertia ixx="0.000128" ixy="0.0" ixz="0.0" iyy="0.000128" iyz="0.0" izz="0.000128"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 -0.211 -0.749" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_elbow_sphere.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="white"/>
+    </visual>
+    <collision>
+      <origin xyz="0.04 -0.211 -0.749" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_elbow_sphere.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_elbow_joint" type="revolute">
+    <origin xyz="0 0 0.1116" rpy="3.14159265359 0 1.57079632679"/>
+    <axis xyz="0.0 -1.0 0.0"/>
+    <parent link="l_upperarm_link"/>
+    <child link="l_elbow_sphere_link"/>
+    <limit effort="20.0" lower="0.0" upper="1.74532925199" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="l_forearm_link">
+    <inertial>
+      <origin xyz="-0.0005116 -0.000175 -0.072511" rpy="0 0 0"/>
+      <mass value="0.6"/>
+      <inertia ixx="0.00283352" ixy="0.0" ixz="3.15449e-05" iyy="0.00282953" iyz="1.0379e-07" izz="0.000436673"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 -0.211 -0.678" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_forearm.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="l_forearm_link_color">
+        <color rgba="0.929 0.933 0.91 1.0"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.04 -0.211 -0.678" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_forearm.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_wrist_pronosupination_joint" type="revolute">
+    <origin xyz="0 0 -0.071" rpy="0 0 0"/>
+    <axis xyz="0.0 0.0 1.0"/>
+    <parent link="l_elbow_sphere_link"/>
+    <child link="l_forearm_link"/>
+    <limit effort="10.0" lower="-1.57079632679" upper="1.57079632679" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="l_wrist_tripod_root"/>
+  <joint name="l_wrist_tripod_root_fixed_joint" type="fixed">
+    <origin xyz="0 0 -0.22" rpy="3.14159265359 0 -1.57079632679"/>
+    <parent link="l_forearm_link"/>
+    <child link="l_wrist_tripod_root"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_wrist_slider_eq_link">
+    <inertial>
+      <origin xyz="0 -5.9e-05 -0.225761" rpy="0 0 0"/>
+      <mass value="0.3"/>
+      <inertia ixx="0.000939997" ixy="0.0" ixz="0.0" iyy="0.00094" iyz="4.18243e-09" izz="0.000220942"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 -0.211 -0.749" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_wrist_slider.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="dblue"/>
+    </visual>
+    <collision>
+      <origin xyz="0.04 -0.211 -0.749" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_wrist_slider.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_wrist_heave_eq_joint" type="prismatic">
+    <origin xyz="0 0 0.071" rpy="0 0 0"/>
+    <axis xyz="0.0 0.0 -1.0"/>
+    <parent link="l_forearm_link"/>
+    <child link="l_wrist_slider_eq_link"/>
+    <limit effort="200.0" lower="0.0" upper="0.13" velocity="0.25"/>
+    <dynamics damping="100.0"/>
+  </joint>
+  <link name="l_wrist_cup_eq_link">
+    <inertial>
+      <origin xyz="0.0319892 -5.9e-05 -0.018146" rpy="0 0 0"/>
+      <mass value="0.2"/>
+      <inertia ixx="0.000102239" ixy="0.0" ixz="3.78925e-08" iyy="0.000102239" iyz="0.0" izz="0.000163555"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.072 -0.211 -0.458" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_wrist_cup_eq.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="l_wrist_cup_eq_link_color">
+        <color rgba="0.776 0.8 0.769 1.0"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.072 -0.211 -0.458" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_wrist_cup_eq.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_wrist_roll_eq_joint" type="revolute">
+    <origin xyz="-0.032 0 -0.291" rpy="0 0 0"/>
+    <axis xyz="1.0 0.0 0.0"/>
+    <parent link="l_wrist_slider_eq_link"/>
+    <child link="l_wrist_cup_eq_link"/>
+    <limit effort="10.0" lower="-0.523598775598" upper="0.523598775598" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="l_hand_root_link">
+    <inertial>
+      <origin xyz="0.0001906 -0.013614 -0.06234" rpy="0 0 0"/>
+      <mass value="0.3"/>
+      <inertia ixx="0.000294522" ixy="1.41029e-06" ixz="6.92026e-08" iyy="0.000297775" iyz="-2.11461e-05" izz="0.000189897"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 -0.211 -0.458" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_hand_root.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="dgreen"/>
+    </visual>
+    <collision>
+      <origin xyz="0.04 -0.211 -0.458" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_hand_root.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_wrist_pitch_eq_joint" type="revolute">
+    <origin xyz="0.032 0 0" rpy="0 0 0"/>
+    <axis xyz="0.0 -1.0 0.0"/>
+    <parent link="l_wrist_cup_eq_link"/>
+    <child link="l_hand_root_link"/>
+    <limit effort="10.0" lower="-0.523598775598" upper="0.523598775598" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="l_wrist"/>
+  <joint name="l_wrist_fixed_joint" type="fixed">
+    <origin xyz="0 0 0" rpy="3.14159265359 0 -1.57079632679"/>
+    <parent link="l_hand_root_link"/>
+    <child link="l_wrist"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_gripper"/>
+  <joint name="l_gripper_fixed_joint" type="fixed">
+    <origin xyz="0 -0.026917 -0.100456" rpy="3.14159265359 1.30899714732 -1.57079632679"/>
+    <parent link="l_hand_root_link"/>
+    <child link="l_gripper"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_hand_paddle_proximal_link">
+    <inertial>
+      <origin xyz="-9.65e-05 0.010867 -0.022259" rpy="0 0 0"/>
+      <mass value="0.05"/>
+      <inertia ixx="0.0001" ixy="-6.9439e-09" ixz="1.7549e-08" iyy="0.0001" iyz="1.81902e-06" izz="0.0001"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 -0.198143 -0.345494" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_hand_paddle_proximal.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="gray"/>
+    </visual>
+    <collision>
+      <origin xyz="0.04 -0.198143 -0.345494" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_hand_paddle_proximal.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_hand_paddle_proximal_joint" type="revolute">
+    <origin xyz="0 -0.012857 -0.112506" rpy="0 0 0"/>
+    <axis xyz="-1.0 0.0 0.0"/>
+    <parent link="l_hand_root_link"/>
+    <child link="l_hand_paddle_proximal_link"/>
+    <limit effort="5.0" lower="0.0" upper="1.2217304764" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="l_hand_paddle_distal_link">
+    <inertial>
+      <origin xyz="0.0013214 0.005592 -0.020601" rpy="0 0 0"/>
+      <mass value="0.05"/>
+      <inertia ixx="0.0001" ixy="-1.94983e-07" ixz="9.01259e-07" iyy="0.0001" iyz="6.79853e-07" izz="0.0001"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 -0.214471 -0.306748" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_hand_paddle_distal.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="green"/>
+    </visual>
+    <collision>
+      <origin xyz="0.04 -0.214471 -0.306748" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_hand_paddle_distal.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_hand_paddle_distal_joint" type="revolute">
+    <origin xyz="0 0.016328 -0.038746" rpy="0 0 0"/>
+    <axis xyz="-1.0 0.0 0.0"/>
+    <parent link="l_hand_paddle_proximal_link"/>
+    <child link="l_hand_paddle_distal_link"/>
+    <limit effort="5.0" lower="0.0" upper="1.2217304764" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="l_hand_paddle_tip"/>
+  <joint name="l_hand_paddle_tip_fixed_joint" type="fixed">
+    <origin xyz="0 0.008959 -0.044226" rpy="3.14159265359 1.30899714732 -1.57079632679"/>
+    <parent link="l_hand_paddle_distal_link"/>
+    <child link="l_hand_paddle_tip"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_hand_thumb_proximal_link">
+    <inertial>
+      <origin xyz="0.002515 -0.017936 -0.003159" rpy="0 0 0"/>
+      <mass value="0.05"/>
+      <inertia ixx="0.0001" ixy="-1.50858e-09" ixz="3.04948e-10" iyy="0.0001" iyz="-2.63475e-06" izz="0.0001"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 -0.171352 -0.382282" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_hand_thumb_proximal.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="black"/>
+    </visual>
+    <collision>
+      <origin xyz="0.04 -0.171352 -0.382282" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_hand_thumb_proximal.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_hand_thumb_proximal_joint" type="revolute">
+    <origin xyz="0 -0.039648 -0.075718" rpy="0 0 0"/>
+    <axis xyz="1.0 0.0 0.0"/>
+    <parent link="l_hand_root_link"/>
+    <child link="l_hand_thumb_proximal_link"/>
+    <limit effort="5.0" lower="0.0" upper="1.0471975512" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="l_hand_thumb_distal_link">
+    <inertial>
+      <origin xyz="0.0021933 -0.014529 -0.005865" rpy="0 0 0"/>
+      <mass value="0.05"/>
+      <inertia ixx="0.0001" ixy="1.50893e-10" ixz="4.0488e-10" iyy="0.0001" iyz="-9.14021e-07" izz="0.0001"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.039745 -0.130827 -0.371296" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_hand_thumb_distal.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="red"/>
+    </visual>
+    <collision>
+      <origin xyz="0.039745 -0.130827 -0.371296" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_hand_thumb_distal.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_hand_thumb_distal_joint" type="revolute">
+    <origin xyz="0.000255 -0.040525 -0.010986" rpy="0 0 0"/>
+    <axis xyz="1.0 0.0 0.0"/>
+    <parent link="l_hand_thumb_proximal_link"/>
+    <child link="l_hand_thumb_distal_link"/>
+    <limit effort="5.0" lower="0.0" upper="1.2217304764" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="l_hand_thumb_tip"/>
+  <joint name="l_hand_thumb_tip_fixed_joint" type="fixed">
+    <origin xyz="-0.000255 -0.028617 -0.014073" rpy="3.14159265359 1.30899714732 -1.57079632679"/>
+    <parent link="l_hand_thumb_distal_link"/>
+    <child link="l_hand_thumb_tip"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="neck_link">
+    <inertial>
+      <origin xyz="-0.0003217 0 0.07756" rpy="0 0 0"/>
+      <mass value="1.4"/>
+      <inertia ixx="0.00429793" ixy="0.0" ixz="-0.000592817" iyy="0.00443784" iyz="-6.85477e-08" izz="0.000419904"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.05 0 -1.03" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_neck.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="blue"/>
+    </visual>
+    <collision>
+      <origin xyz="0.05 0 -1.03" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_neck.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="neck_pitch_joint" type="revolute">
+    <origin xyz="-0.094 0 0.4" rpy="0 0 0"/>
+    <axis xyz="0.0 1.0 0.0"/>
+    <parent link="chest_link"/>
+    <child link="neck_link"/>
+    <limit effort="10.0" lower="-0.523598775598" upper="0.872664625997" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="head_link">
+    <inertial>
+      <origin xyz="0.0301486 -1.57202e-06 -0.00035" rpy="0 0 0"/>
+      <mass value="2.0"/>
+      <inertia ixx="0.0106536" ixy="-7.34817e-08" ixz="0.000274098" iyy="0.00398482" iyz="1.64063e-07" izz="0.00944369"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.0383205 0 -1.18838" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_head.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="head_link_color">
+        <color rgba="0.368932 0.368932 0.368932 1.0"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.0383205 0 -1.18838" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_head.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="neck_yaw_joint" type="revolute">
+    <origin xyz="0.0116795 0 0.15838" rpy="0 0 0"/>
+    <axis xyz="0.173648 0.0 0.984808"/>
+    <parent link="neck_link"/>
+    <child link="head_link"/>
+    <limit effort="10.0" lower="-1.3962634016" upper="1.3962634016" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="depth_rgb"/>
+  <joint name="depth_rgb_fixed_joint" type="fixed">
+    <origin xyz="0.0598814 0.0184871 0.04402" rpy="-1.57079632679 0 -1.57079632679"/>
+    <parent link="head_link"/>
+    <child link="depth_rgb"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="head_leopard_cyclopic"/>
+  <joint name="head_leopard_cyclopic_fixed_joint" type="fixed">
+    <origin xyz="0.0521666 0 -0.06748" rpy="-1.57079632679 0 -1.57079632679"/>
+    <parent link="head_link"/>
+    <child link="head_leopard_cyclopic"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="gaze"/>
+  <joint name="gaze_fixed_joint" type="fixed">
+    <origin xyz="0.0494817 0 -0.01388" rpy="-1.57079632679 0 -1.57079632679"/>
+    <parent link="head_link"/>
+    <child link="gaze"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="head_leopard_right"/>
+  <joint name="head_leopard_right_fixed_joint" type="fixed">
+    <origin xyz="0.0521666 -0.0335105 -0.06748" rpy="-1.57079632679 0 -1.57079632679"/>
+    <parent link="head_link"/>
+    <child link="head_leopard_right"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="head_leopard_left"/>
+  <joint name="head_leopard_left_fixed_joint" type="fixed">
+    <origin xyz="0.0521666 0.0335105 -0.06748" rpy="-1.57079632679 0 -1.57079632679"/>
+    <parent link="head_link"/>
+    <child link="head_leopard_left"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="depth"/>
+  <joint name="depth_fixed_joint" type="fixed">
+    <origin xyz="0.0598814 0.0444871 0.04402" rpy="-1.57079632679 0 -1.57079632679"/>
+    <parent link="head_link"/>
+    <child link="depth"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="depth_center"/>
+  <joint name="depth_center_fixed_joint" type="fixed">
+    <origin xyz="0.0598756 0 0.04402" rpy="-1.57079632679 0 -1.57079632679"/>
+    <parent link="head_link"/>
+    <child link="depth_center"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="mobile_base_r_tyre_link">
+    <inertial>
+      <origin xyz="0 -0.034425 8.99999999998e-06" rpy="0 0 0"/>
+      <mass value="3.0"/>
+      <inertia ixx="0.0200196" ixy="0.0" ixz="0.0" iyy="0.0376169" iyz="8.28101e-07" izz="0.0200156"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0.139 -0.16" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_mobilebase_r_tyre.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="yellow"/>
+    </visual>
+    <collision>
+      <origin xyz="0.0 -0.03 0.0" rpy="1.57079632679 0.0 0.0"/>
+      <geometry>
+        <cylinder radius="0.16" length="0.005"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="mobile_base_r_wheel_joint" type="continuous">
+    <origin xyz="0 -0.139 0" rpy="0 0 0"/>
+    <axis xyz="0.0 1.0 0.0"/>
+    <parent link="mobile_base_body_link"/>
+    <child link="mobile_base_r_tyre_link"/>
+    <limit effort="100.0" velocity="30.0"/>
+    <dynamics damping="0.5"/>
+  </joint>
+  <link name="mobile_base_l_tyre_link">
+    <inertial>
+      <origin xyz="0 0.034425 8.99999999998e-06" rpy="0 0 0"/>
+      <mass value="3.0"/>
+      <inertia ixx="0.0200196" ixy="0.0" ixz="0.0" iyy="0.0376169" iyz="-8.28446e-07" izz="0.0200156"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 -0.139 -0.16" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_mobilebase_l_tyre.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="pink"/>
+    </visual>
+    <collision>
+      <origin xyz="0.0 0.03 0.0" rpy="1.57079632679 0.0 0.0"/>
+      <geometry>
+        <cylinder radius="0.16" length="0.005"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="mobile_base_l_wheel_joint" type="continuous">
+    <origin xyz="0 0.139 0" rpy="0 0 0"/>
+    <axis xyz="0.0 1.0 0.0"/>
+    <parent link="mobile_base_body_link"/>
+    <child link="mobile_base_l_tyre_link"/>
+    <limit effort="100.0" velocity="30.0"/>
+    <dynamics damping="0.5"/>
+  </joint>
+  <gazebo reference="l_upperarm_FT_sensor">
+    <sensor name="l_upperarm_FT_sensor" type="force_torque">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <force_torque>
+        <frame>child</frame>
+        <measure_direction>child_to_parent</measure_direction>
+      </force_torque>
+    </sensor>
+  </gazebo>
+  <sensor name="l_upperarm_FT_sensor" type="force_torque">
+    <parent joint="l_upperarm_FT_sensor"/>
+    <force_torque>
+      <frame>child</frame>
+      <measure_direction>child_to_parent</measure_direction>
+    </force_torque>
+  </sensor>
+  <gazebo reference="r_upperarm_FT_sensor">
+    <sensor name="r_upperarm_FT_sensor" type="force_torque">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <force_torque>
+        <frame>child</frame>
+        <measure_direction>child_to_parent</measure_direction>
+      </force_torque>
+    </sensor>
+  </gazebo>
+  <sensor name="r_upperarm_FT_sensor" type="force_torque">
+    <parent joint="r_upperarm_FT_sensor"/>
+    <force_torque>
+      <frame>child</frame>
+      <measure_direction>child_to_parent</measure_direction>
+    </force_torque>
+  </sensor>
+  <gazebo reference="mobile_base_body_link">
+    <sensor name="base_laser" type="ray">
+      <always_on>1</always_on>
+      <update_rate>40</update_rate>
+      <pose>0.07 0.0 0.031 0.0 -0.0 0.0</pose>
+      <ray>
+ <scan>
+  <horizontal>
+   <samples>360</samples>
+   <resolution>1</resolution>
+   <min_angle>-3.14</min_angle>
+   <max_angle>3.14</max_angle>
+  </horizontal>
+ </scan>
+ <range>
+  <min>0.10</min>
+  <max>5.0</max>
+  <resolution>0.01</resolution>
+ </range>
+ <noise>
+  <type>gaussian</type>
+  <mean>0.0</mean>
+  <stddev>0.005</stddev>
+ </noise>
+</ray>
+      <plugin name="laser_sensor" filename="libgazebo_yarp_lasersensor.so">
+    <yarpConfigurationFile>package://cer/conf/gazebo_cer_laser_sensor.ini</yarpConfigurationFile>
+</plugin>
+    </sensor>
+  </gazebo>
+  <sensor name="base_laser" type="ray">
+    <parent link="mobile_base_body_link"/>
+    <origin rpy="0.0 -0.0 0.0" xyz="0.07 0.0 0.031"/>
+  </sensor>
+  <gazebo reference="head_link">
+    <sensor name="multicamera_sensor" type="multicamera">
+      <always_on>1</always_on>
+      <update_rate>30</update_rate>
+      <pose>0.0521666 0.0 -0.06748 -1.57079632679 -0.0 -1.57079632679</pose>
+      <camera name="left_camera">
+  <pose>-0.0325 0 0 -1.57079 -1.57079 3.14159</pose>
+  <horizontal_fov>1.5708</horizontal_fov>
+  <image>
+     <width>640</width>
+     <height>480</height>
+  </image>
+  <clip>
+     <near>0.1</near>
+     <far>100</far>
+  </clip>
+</camera>
+      <camera name="right_camera">
+  <pose>0.0325 0 0 -1.57079 -1.57079 3.14159</pose>
+  <horizontal_fov>1.5708</horizontal_fov>
+  <image>
+    <width>640</width>
+    <height>480</height>
+  </image>
+  <clip>
+    <near>0.1</near>
+    <far>100</far>
+  </clip>
+</camera>
+      <plugin name="multicamera_plugin" filename="libgazebo_yarp_multicamera.so">
+    <yarpConfigurationFile>package://cer/conf/gazebo_cer_multicamera.ini</yarpConfigurationFile>
+</plugin>
+    </sensor>
+  </gazebo>
+  <sensor name="multicamera_sensor" type="multicamera">
+    <parent link="head_link"/>
+    <origin rpy="-1.57079632679 -0.0 -1.57079632679" xyz="0.0521666 0.0 -0.06748"/>
+  </sensor>
+  <gazebo reference="head_link">
+    <sensor name="asus_xtion_depth" type="depth">
+      <always_on>1</always_on>
+      <update_rate>30</update_rate>
+      <pose>0.0598814 0.0444871 0.04402 -1.57079632679 -0.0 -1.57079632679</pose>
+      <camera name="asus_xtion_depth_camera">
+    <pose frame="">0 0 0 -1.57079 -1.57079 3.14159</pose>
+    <horizontal_fov>1.02259</horizontal_fov>
+    <distortion>
+        <k1>0</k1>
+        <k2>0</k2>
+        <k3>0</k3>
+        <p1>0</p1>
+        <p2>0</p2>
+        <center>319.5 239.5</center>
+    </distortion>
+    <image>
+        <width>640</width>
+        <height>480</height>
+        <format>R8G8B8</format>
+    </image>
+    <clip>
+        <near>0.02</near>
+        <far>3000</far>
+    </clip>
+</camera>
+      <plugin filename="libgazebo_yarp_depthCamera.so" name="depth_camera_plugin">
+    <yarpConfigurationFile>package://cer/conf/gazebo_cer_depthCamera.ini</yarpConfigurationFile>
+</plugin>
+    </sensor>
+  </gazebo>
+  <sensor name="asus_xtion_depth" type="depth">
+    <parent link="head_link"/>
+    <origin rpy="-1.57079632679 -0.0 -1.57079632679" xyz="0.0598814 0.0444871 0.04402"/>
+  </sensor>
+  <gazebo reference="head_link">
+    <sensor name="asus_xtion_rgb" type="camera">
+      <always_on>1</always_on>
+      <update_rate>30</update_rate>
+      <pose>0.0598814 0.0184871 0.04402 -1.57079632679 -0.0 -1.57079632679</pose>
+      <camera name="asus_xtion_rgb_camera">
+    <pose frame="">0 0 0 -1.57079 -1.57079 3.14159</pose>
+    <horizontal_fov>1.02259</horizontal_fov>
+    <distortion>
+        <k1>0</k1>
+        <k2>0</k2>
+        <k3>0</k3>
+        <p1>0</p1>
+        <p2>0</p2>
+        <center>319.5 239.5</center>
+    </distortion>
+    <image>
+        <width>640</width>
+        <height>480</height>
+        <format>R8G8B8</format>
+    </image>
+    <clip>
+        <near>0.02</near>
+        <far>3000</far>
+    </clip>
+</camera>
+      <plugin filename="libgazebo_yarp_camera.so" name="xtion_camera_rgb_plugin">
+    <yarpConfigurationFile>package://cer/conf/gazebo_cer_xtion_camera_rgb.ini</yarpConfigurationFile>
+</plugin>
+    </sensor>
+  </gazebo>
+  <sensor name="asus_xtion_rgb" type="camera">
+    <parent link="head_link"/>
+    <origin rpy="-1.57079632679 -0.0 -1.57079632679" xyz="0.0598814 0.0184871 0.04402"/>
+  </sensor>
+  <gazebo>
+<!-- TORSO user view -->
+<plugin name="controlboard_torso" filename="libgazebo_yarp_controlboard.so">
+  <yarpConfigurationFile>package://cer/conf/gazebo_cer_torso.ini</yarpConfigurationFile>
+</plugin>
+<!-- TORSO low level view -->
+<plugin name="controlboard_torso_tripod" filename="libgazeboTripod.so">
+  <yarpConfigurationFile>package://cer/conf/gazebo_cer_torso_tripod.ini</yarpConfigurationFile>
+</plugin>
+
+<plugin name="controlboard_left_upper_arm" filename="libgazebo_yarp_controlboard.so">
+  <yarpConfigurationFile>package://cer/conf/gazebo_cer_left_upper_arm.ini</yarpConfigurationFile>
+</plugin>
+<!-- LEFT WRIST user view -->  
+<plugin name="controlboard_left_wrist" filename="libgazebo_yarp_controlboard.so">
+  <yarpConfigurationFile>package://cer/conf/gazebo_cer_left_wrist.ini</yarpConfigurationFile>
+</plugin>
+<!-- LEFT WRIST low level view -->
+<plugin name="controlboard_left_wrist_tripod" filename="libgazeboTripod.so">
+  <yarpConfigurationFile>package://cer/conf/gazebo_cer_left_wrist_tripod.ini</yarpConfigurationFile>
+</plugin>
+
+<plugin name="controlboard_right_upper_arm" filename="libgazebo_yarp_controlboard.so">
+  <yarpConfigurationFile>package://cer/conf/gazebo_cer_right_upper_arm.ini</yarpConfigurationFile>
+</plugin>
+<!-- RIGHT WRIST user view -->
+<plugin name="controlboard_right_wrist" filename="libgazebo_yarp_controlboard.so">
+  <yarpConfigurationFile>package://cer/conf/gazebo_cer_right_wrist.ini</yarpConfigurationFile>
+</plugin>
+<!-- RIGHT WRIST low level view -->
+<plugin name="controlboard_right_wrist_tripod" filename="libgazeboTripod.so">
+  <yarpConfigurationFile>package://cer/conf/gazebo_cer_right_wrist_tripod.ini</yarpConfigurationFile>
+</plugin>
+
+<plugin name="controlboard_right_arm" filename="libgazebo_yarp_controlboard.so">
+  <yarpConfigurationFile>package://cer/conf/gazebo_cer_right_arm.ini</yarpConfigurationFile>
+</plugin>
+<plugin name="controlboard_left_arm" filename="libgazebo_yarp_controlboard.so">
+  <yarpConfigurationFile>package://cer/conf/gazebo_cer_left_arm.ini</yarpConfigurationFile>
+</plugin>
+
+<plugin name="controlboard_head" filename="libgazebo_yarp_controlboard.so">
+  <yarpConfigurationFile>package://cer/conf/gazebo_cer_head.ini</yarpConfigurationFile>
+</plugin>
+
+<plugin name="controlboard_left_hand" filename="libgazebo_yarp_controlboard.so">
+  <yarpConfigurationFile>package://cer/conf/gazebo_cer_left_hand.ini</yarpConfigurationFile>
+</plugin>
+
+<plugin name="controlboard_right_hand" filename="libgazebo_yarp_controlboard.so">
+  <yarpConfigurationFile>package://cer/conf/gazebo_cer_right_hand.ini</yarpConfigurationFile>
+</plugin> 
+
+<plugin name="mais_left_hand" filename="libgazebo_yarp_maissensor.so">
+  <yarpConfigurationFile>package://cer/conf/gazebo_cer_left_hand_mais.ini</yarpConfigurationFile>
+</plugin>
+<plugin name="mais_right_hand" filename="libgazebo_yarp_maissensor.so">
+  <yarpConfigurationFile>package://cer/conf/gazebo_cer_right_hand_mais.ini</yarpConfigurationFile>
+</plugin>
+
+<plugin name="controlboard_mobile_base" filename="libgazebo_yarp_controlboard.so">
+  <yarpConfigurationFile>package://cer/conf/gazebo_cer_mobile_base.ini</yarpConfigurationFile>
+</plugin>
+<plugin name="controlboard_all" filename="libgazebo_yarp_controlboard.so">
+  <yarpConfigurationFile>package://cer/conf/gazebo_cer_all.ini</yarpConfigurationFile>
+</plugin>
+<plugin name="world_interface" filename="libgazebo_yarp_worldinterface.so">
+  <yarpConfigurationFile>package://cer/conf/worldInterface.ini</yarpConfigurationFile>
+</plugin>
+</gazebo>
+  <gazebo reference="mobile_base_body_link">
+    <collision>
+      <surface>
+        <contact>
+          <ode/>
+        </contact>
+        <friction>
+          <ode>
+            <mu>0.0</mu>
+            <mu2>0.0</mu2>
+          </ode>
+        </friction>
+      </surface>
+    </collision>
+</gazebo>
+  <gazebo>
+  <pose>0 0 0.16 0 0 0</pose>
+</gazebo>
+  <gazebo reference="mobile_base_l_wheel_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="mobile_base_r_wheel_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="torso_heave_eq_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="torso_roll_eq_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="torso_pitch_eq_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="torso_yaw_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="neck_pitch_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="neck_yaw_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="l_shoulder_pitch_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="l_shoulder_roll_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="l_shoulder_yaw_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="l_elbow_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="l_wrist_pronosupination_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="l_wrist_heave_eq_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="l_wrist_roll_eq_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="l_wrist_pitch_eq_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="l_hand_paddle_proximal_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="l_hand_paddle_distal_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="l_hand_thumb_proximal_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="l_hand_thumb_distal_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="r_shoulder_pitch_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="r_shoulder_roll_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="r_shoulder_yaw_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="r_elbow_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="r_wrist_pronosupination_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="r_wrist_heave_eq_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="r_wrist_roll_eq_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="r_wrist_pitch_eq_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="r_hand_paddle_proximal_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="r_hand_paddle_distal_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="r_hand_thumb_proximal_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="r_hand_thumb_distal_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+</robot>
+

--- a/CER02/firmwareupdater.ini
+++ b/CER02/firmwareupdater.ini
@@ -1,0 +1,2 @@
+[DRIVERS]
+ETH "eth"

--- a/CER02/general.xml
+++ b/CER02/general.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER02" build="1">
+  
+  <group name="GENERAL">
+      <param name="skipCalibration">    false   </param>
+      <param name="useRawEncoderData">  false  </param>
+      <param name="useLimitedPWM">      false  </param>
+      <param name="verbose">            false  </param>
+  </group>
+</params>

--- a/CER02/hardware/FT/cer_left_shoulder-ems5-strain.xml
+++ b/CER02/hardware/FT/cer_left_shoulder-ems5-strain.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_left_arm-eb5-strain" type="embObjStrain">
+    
+      <xi:include href="../../general.xml" />
+      <xi:include href="../electronics/cer_left_shoulder-ems5-eln.xml" />
+
+        <group name="SERVICE">
+            
+            <param name="type"> eomn_serv_AS_strain </param>
+        
+            <group name="PROPERTIES">
+  
+                <group name="CANBOARDS">
+                    <param name="type">                 eobrd_strain            </param>
+
+                    <group name="PROTOCOL">
+                        <param name="major">            1                       </param>    
+                        <param name="minor">            0                       </param>     
+                    </group>                    
+                    <group name="FIRMWARE">
+                        <param name="major">            0                       </param>    
+                        <param name="minor">            0                       </param> 
+                        <param name="build">            0                       </param>
+                    </group>
+                </group>
+                
+                <group name="SENSORS">
+                    <param name="id">                   id_l_upper_arm_strain   </param>
+                    <param name="type">                 eoas_strain             </param>
+                    <param name="location">             CAN2:13                 </param>
+                </group>                
+            
+            </group>
+
+            <group name="SETTINGS">        
+                <param name="acquisitionRate">          10                      </param>
+                <param name="enabledSensors">           id_l_upper_arm_strain   </param>                
+            </group>
+            
+            <group name="STRAIN_SETTINGS">        
+                <param name="useCalibration">           true                    </param>          
+            </group>            
+            
+        </group>
+    
+</device>
+
+

--- a/CER02/hardware/FT/cer_right_shoulder-ems4-strain.xml
+++ b/CER02/hardware/FT/cer_right_shoulder-ems4-strain.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_right_arm-eb4-strain" type="embObjStrain">
+    
+      <xi:include href="../../general.xml" />
+      <xi:include href="../electronics/cer_right_shoulder-ems4-eln.xml" />
+
+        <group name="SERVICE">
+            
+            <param name="type"> eomn_serv_AS_strain </param>
+        
+            <group name="PROPERTIES">
+  
+                <group name="CANBOARDS">
+                    <param name="type">                 eobrd_strain            </param>
+
+                    <group name="PROTOCOL">
+                        <param name="major">            1                       </param>    
+                        <param name="minor">            0                       </param>     
+                    </group>                    
+                    <group name="FIRMWARE">
+                        <param name="major">            0                       </param>    
+                        <param name="minor">            0                       </param> 
+                        <param name="build">            0                       </param>
+                    </group>
+                </group>
+                
+                <group name="SENSORS">
+                    <param name="id">                   id_r_upper_arm_strain   </param>
+                    <param name="type">                 eoas_strain             </param>
+                    <param name="location">             CAN2:13                 </param>
+                </group>                
+            
+            </group>
+
+            <group name="SETTINGS">        
+                <param name="acquisitionRate">          10                      </param>
+                <param name="enabledSensors">           id_r_upper_arm_strain   </param>                
+            </group>
+            
+            <group name="STRAIN_SETTINGS">        
+                <param name="useCalibration">           true                    </param>          
+            </group>            
+            
+        </group>
+    
+</device>
+
+

--- a/CER02/hardware/MAIS/left_hand-multi_enc.xml
+++ b/CER02/hardware/MAIS/left_hand-multi_enc.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_hand_multienc" type="embObjMultiEnc"> 
+        <xi:include href="general.xml" />
+        <xi:include href="hardware/electronics/cer_left_hand-mcp7-eln.xml" />
+        <group name="JOINTS">
+            <param name="listofjoints"> 0 1 </param>
+            <param name="encoderConversionFactor"> -182.044 182.044 1.0 -182.044 182.044 1.0 </param>
+        </group>
+    </device> 
+    
+
+

--- a/CER02/hardware/MAIS/right_hand-multi_enc.xml
+++ b/CER02/hardware/MAIS/right_hand-multi_enc.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_hand_multienc" type="embObjMultiEnc">
+        <xi:include href="general.xml" />
+        <xi:include href="hardware/electronics/cer_right_hand-mcp9-eln.xml" />
+        <group name="JOINTS">
+            <param name="listofjoints"> 0 1 </param>
+            <param name="encoderConversionFactor"> -182.044 182.044 1.0 -182.044 182.044 1.0 </param>
+        </group>
+    </device> 
+    
+
+

--- a/CER02/hardware/electronics/cer_base-ems1-eln.xml
+++ b/CER02/hardware/electronics/cer_base-ems1-eln.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER02" build="1">
+    <xi:include href="../electronics/pc104.xml" />
+    
+        <group name="ETH_BOARD">
+
+        <group name="ETH_BOARD_PROPERTIES">
+            <param name="IpAddress">                10.0.1.1                </param>
+            <param name="IpPort">                   12345                   </param>
+            <param name="Type">                     ems4                    </param>
+            <param name="maxSizeRXpacket">          768                     </param>
+            <param name="maxSizeROP">               384                     </param>
+        </group>
+
+        <group name="ETH_BOARD_SETTINGS">
+            <param name="Name">                     "EB1"                   </param> 
+            <group name="RUNNINGMODE">
+                <param name="period">                   1000                </param>
+                <param name="maxTimeOfRXactivity">      400                 </param>
+                <param name="maxTimeOfDOactivity">      300                 </param>   
+                <param name="maxTimeOfTXactivity">      300                 </param>                
+                <param name="TXrateOfRegularROPs">      3                   </param> 
+            </group>         
+        </group>
+
+        <group name="ETH_BOARD_ACTIONS">
+            <group name="MONITOR_ITS_PRESENCE">
+                <param name="enabled">                  true                </param> 
+                <param name="timeout">                  0.020               </param> 
+                <param name="periodOfMissingReport">    60.0                </param> 
+            </group>
+        </group>
+        
+    </group>  
+
+</params>

--- a/CER02/hardware/electronics/cer_head-mcp10-eln.xml
+++ b/CER02/hardware/electronics/cer_head-mcp10-eln.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER02" build="1">
+
+    <xi:include href="../electronics/pc104.xml" />
+    
+    <group name="ETH_BOARD">
+
+        <group name="ETH_BOARD_PROPERTIES">
+            <param name="IpAddress">                10.0.1.10               </param>
+            <param name="IpPort">                   12345                   </param>
+            <param name="Type">                     mc4plus                 </param>
+            <param name="maxSizeRXpacket">          768                     </param>
+            <param name="maxSizeROP">               384                     </param>
+        </group>
+
+        <group name="ETH_BOARD_SETTINGS">
+            <param name="Name">                     "EB10"                  </param> 
+            <group name="RUNNINGMODE">
+                <param name="period">                   1000                </param>
+                <param name="maxTimeOfRXactivity">      400                 </param>
+                <param name="maxTimeOfDOactivity">      300                 </param>   
+                <param name="maxTimeOfTXactivity">      300                 </param>                
+                <param name="TXrateOfRegularROPs">      5                   </param> 
+            </group>         
+        </group>
+
+        <group name="ETH_BOARD_ACTIONS">
+            <group name="MONITOR_ITS_PRESENCE">
+                <param name="enabled">                  true                </param> 
+                <param name="timeout">                  0.020               </param> 
+                <param name="periodOfMissingReport">    60.0                </param> 
+            </group>
+        </group>        
+        
+    </group>
+    
+</params>

--- a/CER02/hardware/electronics/cer_left_hand-mcp9-eln.xml
+++ b/CER02/hardware/electronics/cer_left_hand-mcp9-eln.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER02" build="1">
+
+    <xi:include href="../electronics/pc104.xml" />
+    
+    <group name="ETH_BOARD">
+
+        <group name="ETH_BOARD_PROPERTIES">
+            <param name="IpAddress">                10.0.1.9                </param>
+            <param name="IpPort">                   12345                   </param>
+            <param name="Type">                     mc2plus                 </param>
+            <param name="maxSizeRXpacket">          768                     </param>
+            <param name="maxSizeROP">               384                     </param>
+        </group>
+
+        <group name="ETH_BOARD_SETTINGS">
+            <param name="Name">                     "EB9"                   </param> 
+            <group name="RUNNINGMODE">
+                <param name="period">                   1000                </param>
+                <param name="maxTimeOfRXactivity">      300                 </param>
+                <param name="maxTimeOfDOactivity">      400                 </param>   
+                <param name="maxTimeOfTXactivity">      300                 </param>                
+                <param name="TXrateOfRegularROPs">      5                   </param> 
+            </group>         
+        </group>
+
+        <group name="ETH_BOARD_ACTIONS">
+            <group name="MONITOR_ITS_PRESENCE">
+                <param name="enabled">                  true                </param> 
+                <param name="timeout">                  0.020               </param> 
+                <param name="periodOfMissingReport">    60.0                </param> 
+            </group>
+        </group>        
+        
+    </group>
+    
+</params>

--- a/CER02/hardware/electronics/cer_left_lower_arm-mcp8-eln.xml
+++ b/CER02/hardware/electronics/cer_left_lower_arm-mcp8-eln.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER02" build="1">
+
+    <xi:include href="../electronics/pc104.xml" />
+    
+    <group name="ETH_BOARD">
+
+        <group name="ETH_BOARD_PROPERTIES">
+            <param name="IpAddress">                10.0.1.8                </param>
+            <param name="IpPort">                   12345                   </param>
+            <param name="Type">                     mc4plus                 </param>
+            <param name="maxSizeRXpacket">          768                     </param>
+            <param name="maxSizeROP">               384                     </param>
+        </group>
+
+        <group name="ETH_BOARD_SETTINGS">
+            <param name="Name">                     "EB8"                   </param> 
+            <group name="RUNNINGMODE">
+                <param name="period">                   1000                </param>
+                <param name="maxTimeOfRXactivity">      400                 </param>
+                <param name="maxTimeOfDOactivity">      300                 </param>   
+                <param name="maxTimeOfTXactivity">      300                 </param>                
+                <param name="TXrateOfRegularROPs">      5                   </param> 
+            </group>         
+        </group>
+
+        <group name="ETH_BOARD_ACTIONS">
+            <group name="MONITOR_ITS_PRESENCE">
+                <param name="enabled">                  true                </param> 
+                <param name="timeout">                  0.020               </param> 
+                <param name="periodOfMissingReport">    60.0                </param> 
+            </group>
+        </group>        
+        
+    </group>
+    
+</params>

--- a/CER02/hardware/electronics/cer_left_shoulder-ems5-eln.xml
+++ b/CER02/hardware/electronics/cer_left_shoulder-ems5-eln.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER02" build="1">
+
+    <xi:include href="../electronics/pc104.xml" />
+    
+    <group name="ETH_BOARD">
+
+        <group name="ETH_BOARD_PROPERTIES">
+            <param name="IpAddress">                10.0.1.5                </param>
+            <param name="IpPort">                   12345                   </param>
+            <param name="Type">                     ems4                    </param>
+            <param name="maxSizeRXpacket">          768                     </param>
+            <param name="maxSizeROP">               384                     </param>
+        </group>
+
+        <group name="ETH_BOARD_SETTINGS">
+            <param name="Name">                     "EB5"                   </param> 
+            <group name="RUNNINGMODE">
+                <param name="period">                   1000                </param>
+                <param name="maxTimeOfRXactivity">      400                 </param>
+                <param name="maxTimeOfDOactivity">      300                 </param>   
+                <param name="maxTimeOfTXactivity">      300                 </param>                
+                <param name="TXrateOfRegularROPs">      5                   </param> 
+            </group>         
+        </group>
+
+        <group name="ETH_BOARD_ACTIONS">
+            <group name="MONITOR_ITS_PRESENCE">
+                <param name="enabled">                  true                </param> 
+                <param name="timeout">                  0.020               </param> 
+                <param name="periodOfMissingReport">    60.0                </param> 
+            </group>
+        </group>        
+        
+    </group>
+    
+</params>

--- a/CER02/hardware/electronics/cer_left_upper_arm-ems12-eln.xml
+++ b/CER02/hardware/electronics/cer_left_upper_arm-ems12-eln.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER02" build="1">
+
+    <xi:include href="../electronics/pc104.xml" />
+    
+    <group name="ETH_BOARD">
+
+        <group name="ETH_BOARD_PROPERTIES">
+            <param name="IpAddress">                10.0.1.12               </param>
+            <param name="IpPort">                   12345                   </param>
+            <param name="Type">                     ems4                    </param>
+            <param name="maxSizeRXpacket">          768                     </param>
+            <param name="maxSizeROP">               384                     </param>
+        </group>
+
+        <group name="ETH_BOARD_SETTINGS">
+            <param name="Name">                     "EB12"                  </param> 
+            <group name="RUNNINGMODE">
+                <param name="period">                   1000                </param>
+                <param name="maxTimeOfRXactivity">      400                 </param>
+                <param name="maxTimeOfDOactivity">      300                 </param>   
+                <param name="maxTimeOfTXactivity">      300                 </param>                
+                <param name="TXrateOfRegularROPs">      5                   </param> 
+            </group>         
+        </group>
+
+        <group name="ETH_BOARD_ACTIONS">
+            <group name="MONITOR_ITS_PRESENCE">
+                <param name="enabled">                  true                </param> 
+                <param name="timeout">                  0.020               </param> 
+                <param name="periodOfMissingReport">    60.0                </param> 
+            </group>
+        </group>        
+        
+    </group>
+    
+</params>

--- a/CER02/hardware/electronics/cer_right_hand-mcp7-eln.xml
+++ b/CER02/hardware/electronics/cer_right_hand-mcp7-eln.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER02" build="1">
+
+    <xi:include href="../electronics/pc104.xml" />
+    
+    <group name="ETH_BOARD">
+
+        <group name="ETH_BOARD_PROPERTIES">
+            <param name="IpAddress">                10.0.1.7                </param>
+            <param name="IpPort">                   12345                   </param>
+            <param name="Type">                     mc2plus                 </param>
+            <param name="maxSizeRXpacket">          768                     </param>
+            <param name="maxSizeROP">               384                     </param>
+        </group>
+
+        <group name="ETH_BOARD_SETTINGS">
+            <param name="Name">                     "EB7"                   </param> 
+            <group name="RUNNINGMODE">
+                <param name="period">                   1000                </param>
+                <param name="maxTimeOfRXactivity">      300                 </param>
+                <param name="maxTimeOfDOactivity">      400                 </param>   
+                <param name="maxTimeOfTXactivity">      300                 </param>                
+                <param name="TXrateOfRegularROPs">      5                   </param> 
+            </group>         
+        </group>
+
+        <group name="ETH_BOARD_ACTIONS">
+            <group name="MONITOR_ITS_PRESENCE">
+                <param name="enabled">                  true                </param> 
+                <param name="timeout">                  0.020               </param> 
+                <param name="periodOfMissingReport">    60.0                </param> 
+            </group>
+        </group>        
+        
+    </group>
+    
+</params>

--- a/CER02/hardware/electronics/cer_right_lower_arm-mcp6-eln.xml
+++ b/CER02/hardware/electronics/cer_right_lower_arm-mcp6-eln.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER02" build="1">
+
+    <xi:include href="../electronics/pc104.xml" />
+    
+    <group name="ETH_BOARD">
+
+        <group name="ETH_BOARD_PROPERTIES">
+            <param name="IpAddress">                10.0.1.6                </param>
+            <param name="IpPort">                   12345                   </param>
+            <param name="Type">                     mc4plus                 </param>
+            <param name="maxSizeRXpacket">          768                     </param>
+            <param name="maxSizeROP">               384                     </param>
+        </group>
+
+        <group name="ETH_BOARD_SETTINGS">
+            <param name="Name">                     "EB6"                   </param> 
+            <group name="RUNNINGMODE">
+                <param name="period">                   1000                </param>
+                <param name="maxTimeOfRXactivity">      400                 </param>
+                <param name="maxTimeOfDOactivity">      300                 </param>   
+                <param name="maxTimeOfTXactivity">      300                 </param>                
+                <param name="TXrateOfRegularROPs">      5                   </param> 
+            </group>         
+        </group>
+
+        <group name="ETH_BOARD_ACTIONS">
+            <group name="MONITOR_ITS_PRESENCE">
+                <param name="enabled">                  true                </param> 
+                <param name="timeout">                  0.020               </param> 
+                <param name="periodOfMissingReport">    60.0                </param> 
+            </group>
+        </group>
+        
+    </group>
+    
+</params>

--- a/CER02/hardware/electronics/cer_right_shoulder-ems4-eln.xml
+++ b/CER02/hardware/electronics/cer_right_shoulder-ems4-eln.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER02" build="1">
+
+    <xi:include href="../electronics/pc104.xml" />
+    
+    <group name="ETH_BOARD">
+
+        <group name="ETH_BOARD_PROPERTIES">
+            <param name="IpAddress">                10.0.1.4                </param>
+            <param name="IpPort">                   12345                   </param>
+            <param name="Type">                     ems4                    </param>
+            <param name="maxSizeRXpacket">          768                     </param>
+            <param name="maxSizeROP">               384                     </param>
+        </group>
+
+        <group name="ETH_BOARD_SETTINGS">
+            <param name="Name">                     "EB4"                   </param> 
+            <group name="RUNNINGMODE">
+                <param name="period">                   1000                </param>
+                <param name="maxTimeOfRXactivity">      400                 </param>
+                <param name="maxTimeOfDOactivity">      300                 </param>   
+                <param name="maxTimeOfTXactivity">      300                 </param>                
+                <param name="TXrateOfRegularROPs">      5                   </param> 
+            </group>         
+        </group>
+
+        <group name="ETH_BOARD_ACTIONS">
+            <group name="MONITOR_ITS_PRESENCE">
+                <param name="enabled">                  true                </param> 
+                <param name="timeout">                  0.020               </param> 
+                <param name="periodOfMissingReport">    60.0                </param> 
+            </group>
+        </group>        
+        
+    </group>
+    
+</params>

--- a/CER02/hardware/electronics/cer_right_upper_arm-ems11-eln.xml
+++ b/CER02/hardware/electronics/cer_right_upper_arm-ems11-eln.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER02" build="1">
+
+    <xi:include href="../electronics/pc104.xml" />
+    
+    <group name="ETH_BOARD">
+
+        <group name="ETH_BOARD_PROPERTIES">
+            <param name="IpAddress">                10.0.1.11               </param>
+            <param name="IpPort">                   12345                   </param>
+            <param name="Type">                     ems4                    </param>
+            <param name="maxSizeRXpacket">          768                     </param>
+            <param name="maxSizeROP">               384                     </param>
+        </group>
+
+        <group name="ETH_BOARD_SETTINGS">
+            <param name="Name">                     "EB11"                  </param> 
+            <group name="RUNNINGMODE">
+                <param name="period">                   1000                </param>
+                <param name="maxTimeOfRXactivity">      400                 </param>
+                <param name="maxTimeOfDOactivity">      300                 </param>   
+                <param name="maxTimeOfTXactivity">      300                 </param>                
+                <param name="TXrateOfRegularROPs">      5                   </param> 
+            </group>         
+        </group>
+
+        <group name="ETH_BOARD_ACTIONS">
+            <group name="MONITOR_ITS_PRESENCE">
+                <param name="enabled">                  true                </param> 
+                <param name="timeout">                  0.020               </param> 
+                <param name="periodOfMissingReport">    60.0                </param> 
+            </group>
+        </group>        
+        
+    </group>
+    
+</params>

--- a/CER02/hardware/electronics/cer_torso-ems3-eln.xml
+++ b/CER02/hardware/electronics/cer_torso-ems3-eln.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER02" build="1">
+
+    <xi:include href="../electronics/pc104.xml" />
+    
+    <group name="ETH_BOARD">
+
+        <group name="ETH_BOARD_PROPERTIES">
+            <param name="IpAddress">                10.0.1.3                </param>
+            <param name="IpPort">                   12345                   </param>
+            <param name="Type">                     ems4                    </param>
+            <param name="maxSizeRXpacket">          768                     </param>
+            <param name="maxSizeROP">               384                     </param>
+        </group>
+
+        <group name="ETH_BOARD_SETTINGS">
+            <param name="Name">                     "EB3"                   </param> 
+            <group name="RUNNINGMODE">
+                <param name="period">                   1000                </param>
+                <param name="maxTimeOfRXactivity">      400                 </param>
+                <param name="maxTimeOfDOactivity">      300                 </param>   
+                <param name="maxTimeOfTXactivity">      300                 </param>                
+                <param name="TXrateOfRegularROPs">      5                   </param> 
+            </group>         
+        </group>
+
+        <group name="ETH_BOARD_ACTIONS">
+            <group name="MONITOR_ITS_PRESENCE">
+                <param name="enabled">                  true                </param> 
+                <param name="timeout">                  0.020               </param> 
+                <param name="periodOfMissingReport">    60.0                </param> 
+            </group>
+        </group>
+        
+    </group>
+    
+</params>

--- a/CER02/hardware/electronics/pc104.xml
+++ b/CER02/hardware/electronics/pc104.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER02" build="1">
+  <group name="PC104">
+     <param name="PC104IpAddress"> 10.0.1.104 </param> 
+     <param name="PC104IpPort">         12345 </param> 
+     <param name="PC104TXrate">	            1 </param> 
+     <param name="PC104RXrate">	            5 </param> 
+  </group>
+</params>

--- a/CER02/hardware/mechanicals/cer_base-ems1-mec.xml
+++ b/CER02/hardware/mechanicals/cer_base-ems1-mec.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER02" build="1">
+    <group name="GENERAL">
+        <param name="MotioncontrolVersion"> 6 </param>
+        <param name="Joints">  2  </param> 
+        <param name="AxisName">          "mobile_base_l_wheel_joint" "mobile_base_r_wheel_joint" </param>
+        <param name="AxisMap">               0           1                 </param>
+        <param name="AxisType">         "revolute"  "revolute"             </param>
+        <param name="Encoder">               182.044     182.044           </param>
+        <param name="fullscalePWM">          32000       32000             </param>
+        <param name="ampsToSensor">          1000.0      1000.0            </param>
+        <param name="Gearbox_M2J">           17          17                </param>
+        <param name="Gearbox_E2J">           1           1                 </param>
+        <param name="useMotorSpeedFbk">      1           1                 </param>
+        
+        <param name="Verbose">   0   </param>
+    </group>
+    
+    <group name="LIMITS">
+        <param name="hardwareJntPosMax">      0          0             </param>
+        <param name="hardwareJntPosMin">      0          0             </param>
+        <param name="rotorPosMin">            0          0             </param>
+        <param name="rotorPosMax">            0          0             </param>
+   </group>
+    
+    
+     <group name="2FOC">
+        <param name="AutoCalibration">       0           0             </param>
+        <param name="Verbose">               0           0             </param>
+        <param name="HasHallSensor">         1           1             </param>
+        <param name="HasTempSensor">         0           0             </param>
+        <param name="HasRotorEncoder">       1           1             </param>
+        <param name="HasRotorEncoderIndex">  0           0             </param>
+        <param name="HasSpeedEncoder">       0           0             </param>
+        <param name="RotorIndexOffset">      0           0             </param>
+        <param name="MotorPoles">            8           8             </param>
+    </group>
+
+ <group name="COUPLINGS"> 
+
+        <param name ="matrixJ2M"> 
+            1.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00
+            0.00    0.00    1.00    0.00
+            0.00    0.00    0.00    1.00   
+        </param>
+               
+        <param name ="matrixM2J"> 
+            1.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00
+            0.00    0.00    1.00    0.00
+            0.00    0.00    0.00    1.00   
+        </param>
+       
+        <param name ="matrixE2J">  
+            1.000   0.000   0.000   0.000   0.000   0.000
+            0.000   1.000   0.000   0.000   0.000   0.000
+            0.000   0.000   1.000   0.000   0.000   0.000
+            0.000   0.000   0.000   1.000   0.000   0.000   
+        </param>
+                
+    </group>   
+
+    <group name="JOINTSET_CFG"> 
+        <param name= "numberofsets"> 2 </param>
+        <group name="JOINTSET_0">
+            <param name="listofjoints">  0            </param>
+            <param name="constraint">    none          </param>
+            <param name="param1">        0             </param>
+            <param name="param2">        0             </param>
+        </group> 
+        <group name="JOINTSET_1">
+            <param name="listofjoints">   1             </param>
+            <param name="constraint">     none          </param>
+            <param name="param1">         0             </param>
+            <param name="param2">         0             </param>
+        </group> 
+    </group>                                       
+    
+</params>

--- a/CER02/hardware/mechanicals/cer_head-mcp10-mec.xml
+++ b/CER02/hardware/mechanicals/cer_head-mcp10-mec.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER02" build="1">
+    <group name="GENERAL">
+        <param name="MotioncontrolVersion"> 6 </param>
+        <param name="Joints">                2  </param> 
+        <param name="AxisName">              "neck_pitch_joint" "neck_yaw_joint" </param>
+        <param name="AxisMap">               0                  1                </param>
+        <param name="AxisType">              "revolute"         "revolute"       </param>
+        <param name="Encoder">               182.044            182.044          </param>
+        <param name="Gearbox_M2J">          -1                  125              </param>
+        <param name="Gearbox_E2J">           1                  1                </param>
+        <param name="fullscalePWM">          3360            3360                </param>
+        <param name="ampsToSensor">          1000.0          1000.0              </param>
+        <param name="MotorType">             "DC"               "DC"             </param>
+        <param name="useMotorSpeedFbk">      1                   1               </param>        
+        <param name="Verbose">               0   </param>
+    </group>
+    
+    <group name="LIMITS">
+        <param name="hardwareJntPosMax">        49.97             57           </param>
+        <param name="hardwareJntPosMin">       -30.04            -57           </param>
+        
+        <param name="rotorPosMin">              0                 0            </param>
+        <param name="rotorPosMax">              0                 0            </param>
+    </group>
+
+    <group name="COUPLINGS"> 
+
+       <param name ="matrixJ2M"> 
+            1.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00
+            0.00    0.00    1.00    0.00
+            0.00    0.00    0.00    1.00   
+        </param>
+               
+        <param name ="matrixM2J"> 
+            1.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00
+            0.00    0.00    1.00    0.00
+            0.00    0.00    0.00    1.00   
+        </param>
+       
+        <param name ="matrixE2J">  
+            1.000   0.000   0.000   0.000   0.000   0.000
+            0.000   1.000   0.000   0.000   0.000   0.000
+            0.000   0.000   1.000   0.000   0.000   0.000
+            0.000   0.000   0.000   1.000   0.000   0.000   
+        </param>
+                
+    </group>   
+
+    <group name="JOINTSET_CFG"> 
+        <param name= "numberofsets"> 2 </param>
+        <group name="JOINTSET_0">
+            <param name="listofjoints">  0            </param>
+            <param name="constraint">    none          </param>
+            <param name="param1">        0             </param>
+            <param name="param2">        0             </param>
+        </group> 
+        <group name="JOINTSET_1">
+            <param name="listofjoints">   1             </param>
+            <param name="constraint">     none          </param>
+            <param name="param1">         0             </param>
+            <param name="param2">         0             </param>
+        </group> 
+    </group>                                       
+    
+</params>

--- a/CER02/hardware/mechanicals/cer_left_hand-mcp9-mec.xml
+++ b/CER02/hardware/mechanicals/cer_left_hand-mcp9-mec.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER02" build="1">
+    <group name="GENERAL">
+        <param name="MotioncontrolVersion"> 6 </param>
+        <param name="Joints">                2  </param> 
+        <param name="AxisName">              "l_palm"           "l_thumb"       </param>
+        <param name="AxisMap">               0                  1               </param>
+        <param name="AxisType">              "revolute"         "revolute"      </param>
+        <param name="Encoder">               182.044            182.044         </param>
+        <param name="Gearbox_M2J">             1                 -1             </param>
+        <param name="Gearbox_E2J">             1                  1             </param>
+         <param name="useMotorSpeedFbk">       0                  0             </param>
+        <param name="MotorType">             "DC"               "DC"            </param>
+       <param name="fullscalePWM">           3360               3360            </param>
+        <param name="ampsToSensor">          1000.0          1000.0             </param>
+        <param name="Verbose">    0   </param>
+    </group>
+
+    <group name="LIMITS">
+        <param name="hardwareJntPosMax">        125               135             </param>
+        <param name="hardwareJntPosMin">         -5                -5             </param>
+        <param name="rotorPosMin">                0                 0             </param>
+        <param name="rotorPosMax">                0                 0             </param>
+    </group>
+    
+    <group name="COUPLINGS"> 
+
+        <param name ="matrixJ2M"> 
+            1.000   0.000   0.000   0.000
+            0.000   1.000   0.000   0.000
+            0.000   0.000   1.000   0.000
+            0.000   0.000   0.000   1.000   
+        </param>
+               
+        <param name ="matrixM2J"> 
+            1.000   0.000   0.000   0.000
+            0.000   1.000   0.000   0.000
+            0.000   0.000   1.000   0.000
+            0.000   0.000   0.000   1.000   
+        </param>
+       
+        <param name ="matrixE2J">  
+           -1.000   1.000   0.000   0.000   0.000   0.000
+            0.000   0.000   0.000   1.000  -1.000   0.000
+            0.000   0.000   0.000   0.000   0.000   0.000
+            0.000   0.000   0.000   0.000   0.000   0.000   
+        </param>
+                
+    </group>   
+
+    <group name="JOINTSET_CFG"> 
+        <param name= "numberofsets"> 2 </param>
+        <group name="JOINTSET_0">
+            <param name="listofjoints">  0             </param>
+            <param name="constraint">    cerhand       </param> <!--NOTE: set deadzone to 400 -->
+            <param name="param1">        0             </param>
+            <param name="param2">        0             </param>
+        </group> 
+        <group name="JOINTSET_1">
+            <param name="listofjoints">   1             </param>
+            <param name="constraint">     cerhand       </param>
+            <param name="param1">         0             </param>
+            <param name="param2">         0             </param>
+        </group> 
+    </group>                                       
+    
+</params>

--- a/CER02/hardware/mechanicals/cer_left_lower_arm-mcp8-mec.xml
+++ b/CER02/hardware/mechanicals/cer_left_lower_arm-mcp8-mec.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER02" build="1">
+    <group name="GENERAL">
+        <param name="MotioncontrolVersion"> 6 </param>
+        <param name="Joints">                4  </param> 
+        <param name="AxisName">              "l_wrist_tripod_0" "l_wrist_tripod_1" "l_wrist_tripod_2" "l_wrist_pronosupination_joint"  </param>
+        <param name="AxisMap">               0                  1                  2                  3                        </param>
+        <param name="AxisType">              "prismatic"        "prismatic"        "prismatic"        "revolute"               </param>
+        <param name="Encoder">               56333.333          56333.333          56333.333          182.044                  </param>
+        <param name="Gearbox_M2J">               1                  1                  1                  1                    </param>
+        <param name="Gearbox_E2J">               1                  1                  1                  64                   </param>
+        <param name="useMotorSpeedFbk">          1                  1                  1                  1                    </param>
+        <param name="fullscalePWM">          3360               3360               3360               3360                     </param>
+        <param name="ampsToSensor">          1000.0             1000.0             1000.0             1000.0                   </param>
+        <param name="MotorType">             "DC"               "DC"               "DC"               "DC"                     </param>
+        <param name="Verbose">               0   </param>
+    </group>
+    
+    <group name="LIMITS">
+        <param name="hardwareJntPosMax">          0.125    0.125   0.125    90     </param>
+        <param name="hardwareJntPosMin">         -0.005   -0.005  -0.005   -90     </param>
+        <param name="rotorPosMin">                0        0       0        0      </param>
+        <param name="rotorPosMax">                0        0       0        0      </param>
+    </group>
+
+   <group name="COUPLINGS"> 
+
+        <!-- 1.625 = 1/alfa = 65/40 -->                  
+        <param name ="matrixJ2M"> 
+            1.000   0.000   0.000   0.000
+            0.000   1.000   0.000   0.000
+            0.000   0.000   1.000   0.000
+            0.000   0.000   0.000   1.000   
+        </param>
+               
+        <!-- 0.615 = alfa = 40/65 --> 
+        <param name ="matrixM2J"> 
+            1.000   0.000   0.000   0.000
+            0.000   1.000   0.000   0.000
+            0.000   0.000   1.000   0.000
+            0.000   0.000   0.000   1.000   
+        </param>
+       
+        <param name ="matrixE2J">  
+            1.000   0.000   0.000   0.000   0.000   0.000
+            0.000   1.000   0.000   0.000   0.000   0.000
+            0.000   0.000   1.000   0.000   0.000   0.000
+            0.000   0.000   0.000   1.000   0.000   0.000   
+        </param>
+                
+    </group>   
+
+    <group name="JOINTSET_CFG"> 
+        <param name= "numberofsets"> 2 </param>
+        <group name="JOINTSET_0">
+            <param name="listofjoints">  0 1 2         </param>
+            <param name="constraint">    trifid        </param>
+            <param name="param1">        835500        </param> <!-- ~31 deg -->
+            <param name="param2">        0             </param>
+        </group> 
+        <group name="JOINTSET_1">
+            <param name="listofjoints">   3             </param>
+            <param name="constraint">     none          </param>
+            <param name="param1">         0             </param>
+            <param name="param2">         0             </param>
+        </group> 
+    </group>                                       
+    
+</params>

--- a/CER02/hardware/mechanicals/cer_left_shoulder-ems5-mec.xml
+++ b/CER02/hardware/mechanicals/cer_left_shoulder-ems5-mec.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER02" build="1">
+    <group name="GENERAL">
+        <param name="MotioncontrolVersion"> 6 </param>
+        <param name="Joints">                   2             </param> 
+        <param name="AxisMap">                  0                            1                          </param>
+        <param name="AxisName">                 "l_shoulder_pitch_joint"     "l_shoulder_roll_joint"    </param>
+        <param name="AxisType">                 "revolute"                   "revolute"                 </param>
+        <param name="Encoder">                  182.044                      182.044                    </param>
+        <param name="Gearbox_M2J">              117.333                     -117.333                    </param>
+        <param name="Gearbox_E2J">              1                            1                          </param>
+        <param name="useMotorSpeedFbk">         1                            1                          </param>
+        <param name="MotorType">                "BLL_MECAP"                  "BLL_MECAP"                </param>
+       <param name="fullscalePWM">              32000                        32000                      </param>
+        <param name="ampsToSensor">             1000.0                       1000.0                     </param>
+        <param name="Verbose">   0      </param>
+    </group>
+
+    <group name="LIMITS">
+        <param name="hardwareJntPosMax">             90            90        </param>
+        <param name="hardwareJntPosMin">            -75             0        </param>
+        <param name="rotorPosMin">                    0             0        </param> 
+        <param name="rotorPosMax">                    0             0        </param>
+    </group>
+    
+    <group name="2FOC">
+        <param name="AutoCalibration">       0             0           </param>
+        <param name="Verbose">               0             0           </param>
+        <param name="HasHallSensor">         1             1           </param>
+        <param name="HasTempSensor">         0             0           </param>
+        <param name="HasRotorEncoder">       1             1           </param>
+        <param name="HasRotorEncoderIndex">  0             0           </param>
+        <param name="HasSpeedEncoder">       0             0           </param>
+        <param name="RotorIndexOffset">      0             0           </param>
+        <param name="MotorPoles">            8             8           </param>
+    </group>
+
+ <group name="COUPLINGS"> 
+
+        <param name ="matrixJ2M"> 
+            1.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00
+            0.00    0.00    1.00    0.00
+            0.00    0.00    0.00    1.00   
+        </param>
+               
+        <param name ="matrixM2J"> 
+            1.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00
+            0.00    0.00    1.00    0.00
+            0.00    0.00    0.00    1.00   
+        </param>
+       
+        <param name ="matrixE2J">  
+            1.000   0.000   0.000   0.000   0.000   0.000
+            0.000   1.000   0.000   0.000   0.000   0.000
+            0.000   0.000   1.000   0.000   0.000   0.000
+            0.000   0.000   0.000   1.000   0.000   0.000   
+        </param>
+                
+    </group>   
+
+    <group name="JOINTSET_CFG"> 
+        <param name= "numberofsets"> 2 </param>
+        <group name="JOINTSET_0">
+            <param name="listofjoints">  0            </param>
+            <param name="constraint">    none          </param>
+            <param name="param1">        0             </param>
+            <param name="param2">        0             </param>
+        </group> 
+        <group name="JOINTSET_1">
+            <param name="listofjoints">   1             </param>
+            <param name="constraint">     none          </param>
+            <param name="param1">         0             </param>
+            <param name="param2">         0             </param>
+        </group> 
+    </group>                                       
+    
+</params>

--- a/CER02/hardware/mechanicals/cer_left_upper_arm-ems12-mec.xml
+++ b/CER02/hardware/mechanicals/cer_left_upper_arm-ems12-mec.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER02" build="1">
+    <group name="GENERAL">
+        <param name="MotioncontrolVersion"> 6 </param>
+        <param name="Joints">                   2                                       </param> 
+        <param name="AxisMap">                  0                       1               </param>
+        <param name="AxisName">                 "l_shoulder_yaw_joint"  "l_elbow_joint" </param>
+        <param name="AxisType">                 "revolute"              "revolute"      </param>
+        <param name="Encoder">                  182.044                 182.044         </param>
+        <param name="Gearbox_M2J">              159.438                 159.438         </param>
+        <param name="Gearbox_E2J">              1                       1               </param>
+        <param name="useMotorSpeedFbk">         1                       1               </param>
+        <param name="MotorType">                "BLL_MECAP"             "BLL_MECAP"     </param>
+       <param name="fullscalePWM">          	32000                   32000           </param>
+        <param name="ampsToSensor">             1000.0                  1000.0          </param>
+        <param name="Verbose">   0      </param>
+    </group>
+
+    <group name="LIMITS">
+        <param name="hardwareJntPosMax">          90       100         </param>
+        <param name="hardwareJntPosMin">         -90         0         </param>
+        <param name="rotorPosMin">                 0         0         </param> 
+        <param name="rotorPosMax">                 0         0         </param>
+    </group>
+    
+    <group name="2FOC">
+		<param name="AutoCalibration">       0             0             </param>
+        <param name="Verbose">               0             0             </param>
+        <param name="HasHallSensor">         1             1             </param>
+        <param name="HasTempSensor">         0             0             </param>
+        <param name="HasRotorEncoder">       1             1             </param>
+        <param name="HasRotorEncoderIndex">  0             0             </param>
+        <param name="HasSpeedEncoder">       0             0             </param>
+        <param name="RotorIndexOffset">      0             0             </param>
+        <param name="MotorPoles">           16            16             </param>
+    </group>
+
+ <group name="COUPLINGS"> 
+
+        <param name ="matrixJ2M"> 
+            1.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00
+            0.00    0.00    1.00    0.00
+            0.00    0.00    0.00    1.00   
+        </param>
+               
+        <param name ="matrixM2J"> 
+            1.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00
+            0.00    0.00    1.00    0.00
+            0.00    0.00    0.00    1.00   
+        </param>
+       
+        <param name ="matrixE2J">  
+            1.000   0.000   0.000   0.000   0.000   0.000
+            0.000   1.000   0.000   0.000   0.000   0.000
+            0.000   0.000   1.000   0.000   0.000   0.000
+            0.000   0.000   0.000   1.000   0.000   0.000   
+        </param>
+                
+    </group>   
+
+    <group name="JOINTSET_CFG"> 
+        <param name= "numberofsets"> 2 </param>
+        <group name="JOINTSET_0">
+            <param name="listofjoints">  0            </param>
+            <param name="constraint">    none          </param>
+            <param name="param1">        0             </param>
+            <param name="param2">        0             </param>
+        </group> 
+        <group name="JOINTSET_1">
+            <param name="listofjoints">   1             </param>
+            <param name="constraint">     none          </param>
+            <param name="param1">         0             </param>
+            <param name="param2">         0             </param>
+        </group> 
+    </group>                                       
+    
+</params>

--- a/CER02/hardware/mechanicals/cer_right_hand-mcp7-mec.xml
+++ b/CER02/hardware/mechanicals/cer_right_hand-mcp7-mec.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER02" build="1">
+    <group name="GENERAL">
+        <param name="MotioncontrolVersion"> 6 </param>
+        <param name="Joints">                2  </param> 
+        <param name="AxisName">              "r_palm"           "r_thumb"       </param>
+        <param name="AxisMap">               0                  1               </param>
+        <param name="AxisType">              "revolute"         "revolute"      </param>
+        <param name="Encoder">               182.044            182.044         </param>
+        <param name="fullscalePWM">          3360               3360            </param>
+        <param name="ampsToSensor">          1000.0             1000.0          </param>
+        <param name="Gearbox_M2J">           -1                  1              </param>
+        <param name="Gearbox_E2J">            1                  1              </param>
+        <param name="useMotorSpeedFbk">       0                  0              </param>
+        <param name="MotorType">             "DC"               "DC"            </param>
+        <param name="Verbose">   0   </param>
+    </group>
+
+    <group name="LIMITS">
+        <param name="hardwareJntPosMax">      125                 135             </param>
+        <param name="hardwareJntPosMin">       -5                  -5             </param>
+        <param name="rotorPosMin">              0                   0             </param>
+        <param name="rotorPosMax">              0                   0             </param>
+    </group>
+    
+    
+    <group name="COUPLINGS"> 
+
+        <param name ="matrixJ2M"> 
+            1.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00
+            0.00    0.00    1.00    0.00
+            0.00    0.00    0.00    1.00   
+        </param>
+               
+        <param name ="matrixM2J"> 
+            1.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00
+            0.00    0.00    1.00    0.00
+            0.00    0.00    0.00    1.00   
+        </param>
+       
+        <param name ="matrixE2J">  
+            1.000  -1.000   0.000   0.000   0.000   0.000
+            0.000   0.000   0.000  -1.000   1.000   0.000
+            0.000   0.000   0.000   0.000   0.000   0.000
+            0.000   0.000   0.000   0.000   0.000   0.000   
+        </param>
+                
+    </group>   
+
+    <group name="JOINTSET_CFG"> 
+        <param name= "numberofsets"> 2 </param>
+        <group name="JOINTSET_0">
+            <param name="listofjoints">  0              </param>
+            <param name="constraint">    cerhand        </param>
+            <param name="param1">        0              </param> 
+            <param name="param2">        0              </param>
+        </group> 
+        <group name="JOINTSET_1">
+            <param name="listofjoints">   1             </param>
+            <param name="constraint">     cerhand       </param>
+            <param name="param1">         0             </param>
+            <param name="param2">         0             </param>
+        </group> 
+    </group>                                       
+    
+</params>
+

--- a/CER02/hardware/mechanicals/cer_right_lower_arm-mcp6-mec.xml
+++ b/CER02/hardware/mechanicals/cer_right_lower_arm-mcp6-mec.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER02" build="1">
+    <group name="GENERAL">
+        <param name="MotioncontrolVersion"> 6 </param>
+        <param name="Joints">                4  </param> 
+        <param name="AxisName">              "r_wrist_tripod_0" "r_wrist_tripod_1" "r_wrist_tripod_2" "r_wrist_pronosupination_joint"</param>
+        <param name="AxisMap">               0                  1                  2                  3                       </param>
+        <param name="AxisType">              "prismatic"        "prismatic"        "prismatic"        "revolute"              </param>
+        <param name="Encoder">               56333.333          56333.333          56333.333          182.044                 </param>
+        <param name="Gearbox_M2J">               1                  1                  1                  1                   </param>
+        <param name="Gearbox_E2J">               1                  1                  1                 64                   </param>
+        <param name="useMotorSpeedFbk">          1                  1                  1                  1                   </param>
+        <param name="fullscalePWM">          3360               3360               3360               3360                    </param>
+        <param name="ampsToSensor">          1000.0             1000.0             1000.0             1000.0                  </param>
+        <param name="MotorType">             "DC"               "DC"               "DC"               "DC"                    </param>
+        <param name="Verbose">               0   </param>
+    </group>
+    
+    <group name="LIMITS">
+        <param name="hardwareJntPosMax">      0.125              0.125                 0.125                90     </param>
+        <param name="hardwareJntPosMin">     -0.005             -0.005                -0.005               -90     </param>
+        <param name="rotorPosMin">            0                  0                     0                    0      </param>
+        <param name="rotorPosMax">            0                  0                     0                    0      </param>
+    </group>
+
+    <group name="COUPLINGS"> 
+
+        <param name ="matrixJ2M"> 
+            1.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00
+            0.00    0.00    1.00    0.00
+            0.00    0.00    0.00    1.00   
+        </param>
+               
+        <param name ="matrixM2J"> 
+            1.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00
+            0.00    0.00    1.00    0.00
+            0.00    0.00    0.00    1.00   
+        </param>
+       
+        <param name ="matrixE2J">  
+            1.000   0.000   0.000   0.000   0.000   0.000
+            0.000   1.000   0.000   0.000   0.000   0.000
+            0.000   0.000   1.000   0.000   0.000   0.000
+            0.000   0.000   0.000   1.000   0.000   0.000   
+        </param>
+                
+    </group>   
+
+    <group name="JOINTSET_CFG"> 
+        <param name= "numberofsets"> 2 </param>
+        <group name="JOINTSET_0">
+            <param name="listofjoints">  0 1 2         </param>
+            <param name="constraint">    trifid        </param>
+            <param name="param1">        835500        </param> <!-- ~31 deg -->
+            <param name="param2">        0             </param>
+        </group> 
+        <group name="JOINTSET_1">
+            <param name="listofjoints">   3             </param>
+            <param name="constraint">     none          </param>
+            <param name="param1">         0             </param>
+            <param name="param2">         0             </param>
+        </group> 
+    </group>                                       
+    
+</params>

--- a/CER02/hardware/mechanicals/cer_right_shoulder-ems4-mec.xml
+++ b/CER02/hardware/mechanicals/cer_right_shoulder-ems4-mec.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER02" build="1">
+    <group name="GENERAL">
+        <param name="MotioncontrolVersion"> 6 </param>
+        <param name="Joints">                   2             </param> 
+        <param name="AxisMap">                  0                             1                                  </param>
+        <param name="AxisName">                 "r_shoulder_pitch_joint"      "r_shoulder_roll_joint"            </param>
+        <param name="AxisType">                 "revolute"                    "revolute"                         </param>
+        <param name="Encoder">                  182.044                       182.044                            </param>
+        <param name="Gearbox_M2J">              117.333                      -117.333                            </param>
+        <param name="Gearbox_E2J">              1                             1                                  </param>
+        <param name="useMotorSpeedFbk">         1                             1                                  </param>
+        <param name="fullscalePWM">             32000                         32000                              </param>
+        <param name="ampsToSensor">             1000.0                        1000.0                             </param>
+        <param name="MotorType">                "BLL_MECAP"                   "BLL_MECAP"                        </param>
+        <param name="Verbose">                  0             </param>
+    </group>
+    
+    <group name="LIMITS">
+        <param name="hardwareJntPosMax">             90            90        </param>
+        <param name="hardwareJntPosMin">            -75             0        </param>
+        <param name="rotorPosMin">                    0             0        </param> 
+        <param name="rotorPosMax">                    0             0        </param>
+    </group>
+
+    <group name="2FOC">
+        <param name="AutoCalibration">       0             0           </param>
+        <param name="Verbose">               0             0           </param>
+        <param name="HasHallSensor">         1             1           </param>
+        <param name="HasTempSensor">         0             0           </param>
+        <param name="HasRotorEncoder">       1             1           </param>
+        <param name="HasRotorEncoderIndex">  0             0           </param>
+        <param name="HasSpeedEncoder">       0             0           </param>
+        <param name="RotorIndexOffset">      0             0           </param>
+        <param name="MotorPoles">            8             8           </param>
+    </group>
+
+ <group name="COUPLINGS"> 
+
+        <param name ="matrixJ2M"> 
+            1.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00
+            0.00    0.00    1.00    0.00
+            0.00    0.00    0.00    1.00   
+        </param>
+               
+        <param name ="matrixM2J"> 
+            1.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00
+            0.00    0.00    1.00    0.00
+            0.00    0.00    0.00    1.00   
+        </param>
+       
+        <param name ="matrixE2J">  
+            1.000   0.000   0.000   0.000   0.000   0.000
+            0.000   1.000   0.000   0.000   0.000   0.000
+            0.000   0.000   1.000   0.000   0.000   0.000
+            0.000   0.000   0.000   1.000   0.000   0.000   
+        </param>
+                
+    </group>   
+
+    <group name="JOINTSET_CFG"> 
+        <param name= "numberofsets"> 2 </param>
+        <group name="JOINTSET_0">
+            <param name="listofjoints">  0            </param>
+            <param name="constraint">    none          </param>
+            <param name="param1">        0             </param>
+            <param name="param2">        0             </param>
+        </group> 
+        <group name="JOINTSET_1">
+            <param name="listofjoints">   1             </param>
+            <param name="constraint">     none          </param>
+            <param name="param1">         0             </param>
+            <param name="param2">         0             </param>
+        </group> 
+    </group>                                       
+    
+</params>

--- a/CER02/hardware/mechanicals/cer_right_upper_arm-ems11-mec.xml
+++ b/CER02/hardware/mechanicals/cer_right_upper_arm-ems11-mec.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER02" build="1">
+    <group name="GENERAL">
+        <param name="MotioncontrolVersion"> 6 </param>
+        <param name="Joints">                   2                                      </param> 
+        <param name="AxisMap">                  0                      1               </param>
+        <param name="AxisName">                 "r_shoulder_yaw_joint" "r_elbow_joint" </param>
+        <param name="AxisType">                 "revolute"             "revolute"      </param>
+        <param name="Encoder">                  182.044                182.044         </param>
+        <param name="Gearbox_M2J">             -159.438                159.438         </param>
+        <param name="Gearbox_E2J">              1                      1               </param>
+        <param name="useMotorSpeedFbk">         1                      1               </param>
+        <param name="fullscalePWM">             32000                  32000           </param>
+        <param name="ampsToSensor">             1000.0                 1000.0          </param>
+        <param name="MotorType">                "BLL_MECAP"            "BLL_MECAP"     </param>
+        <param name="Verbose">                  0             </param>
+    </group>
+    
+    <group name="LIMITS">
+        <param name="hardwareJntPosMax">             90       100       </param>
+        <param name="hardwareJntPosMin">            -90         0       </param>
+        <param name="rotorPosMin">                    0         0       </param> 
+        <param name="rotorPosMax">                    0         0       </param>
+    </group>
+
+    <group name="2FOC">
+        <param name="AutoCalibration">       0             0           </param>
+        <param name="Verbose">               0             0           </param>
+        <param name="HasHallSensor">         1             1             </param>
+        <param name="HasTempSensor">         0             0             </param>
+        <param name="HasRotorEncoder">       1             1             </param>
+        <param name="HasRotorEncoderIndex">  0             0             </param>
+        <param name="HasSpeedEncoder">       0             0             </param>
+        <param name="RotorIndexOffset">      0             0             </param>
+        <param name="MotorPoles">            16            16            </param>
+    </group>
+
+ <group name="COUPLINGS"> 
+
+        <param name ="matrixJ2M"> 
+            1.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00
+            0.00    0.00    1.00    0.00
+            0.00    0.00    0.00    1.00   
+        </param>
+               
+        <param name ="matrixM2J"> 
+            1.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00
+            0.00    0.00    1.00    0.00
+            0.00    0.00    0.00    1.00   
+        </param>
+       
+        <param name ="matrixE2J">  
+            1.000   0.000   0.000   0.000   0.000   0.000
+            0.000   1.000   0.000   0.000   0.000   0.000
+            0.000   0.000   1.000   0.000   0.000   0.000
+            0.000   0.000   0.000   1.000   0.000   0.000   
+        </param>
+                
+    </group>   
+
+    <group name="JOINTSET_CFG"> 
+        <param name= "numberofsets"> 2 </param>
+        <group name="JOINTSET_0">
+            <param name="listofjoints">   0             </param>
+            <param name="constraint">     none          </param>
+            <param name="param1">         0             </param>
+            <param name="param2">         0             </param>
+        </group> 
+        <group name="JOINTSET_1">
+            <param name="listofjoints">   1             </param>
+            <param name="constraint">     none          </param>
+            <param name="param1">         0             </param>
+            <param name="param2">         0             </param>
+        </group> 
+    </group>                                       
+    
+</params>

--- a/CER02/hardware/mechanicals/cer_torso-ems3-mec.xml
+++ b/CER02/hardware/mechanicals/cer_torso-ems3-mec.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER02" build="1">
+    <group name="GENERAL">
+        <param name="MotioncontrolVersion"> 6 </param>
+        <param name="Joints">                4  </param> 
+        <param name="AxisName">              "torso_tripod_0" "torso_tripod_1" "torso_tripod_2" "torso_yaw_joint" </param>
+        <param name="AxisMap">               0            1            2             3             </param>
+        <param name="AxisType">              "prismatic"  "prismatic"  "prismatic"  "revolute"     </param>
+        <param name="Encoder">               10000        10000        10000         182.044       </param>
+        <param name="Gearbox_M2J">           1            1            1             117.333       </param>
+        <param name="Gearbox_E2J">           1            1            1             1             </param>
+        <param name="useMotorSpeedFbk">      1            1            1             1             </param>
+        <param name="MotorType">             "DC"         "DC"         "DC"          "BLL_MECAP"   </param>
+        <param name="fullscalePWM">          32000        32000        32000         32000         </param>
+        <param name="ampsToSensor">          1000.0       1000.0       1000.0        1000.0        </param>
+        <param name="Verbose">               0   </param>
+    </group>
+
+    <group name="LIMITS">
+        <param name="hardwareJntPosMax">        0.155       0.155        0.155          30          </param>
+        <param name="hardwareJntPosMin">       -0.04       -0.04        -0.04          -30          </param>
+        <param name="rotorPosMin">              0           0            0              0           </param>
+        <param name="rotorPosMax">              0           0            0              0           </param>
+    </group>
+    
+    
+    <group name="2FOC">
+        <param name="AutoCalibration">       0            0            0             0             </param>
+        <param name="Verbose">               0            0            0             0             </param>
+        <param name="HasHallSensor">         0            0            0             1             </param>
+        <param name="HasTempSensor">         0            0            0             0             </param>
+        <param name="HasRotorEncoder">       1            1            1             1             </param>
+        <param name="HasRotorEncoderIndex">  0            0            0             0             </param>
+        <param name="HasSpeedEncoder">       0            0            0             0             </param>
+        <param name="RotorIndexOffset">      0            0            0             0             </param>
+        <param name="MotorPoles">            2            2            2             8             </param>
+    </group>
+
+    
+    <group name="COUPLINGS"> 
+
+        <param name ="matrixJ2M"> 
+            1.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00
+            0.00    0.00    1.00    0.00
+            0.00    0.00    0.00    1.00   
+        </param>
+               
+        <param name ="matrixM2J"> 
+            1.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00
+            0.00    0.00    1.00    0.00
+            0.00    0.00    0.00    1.00   
+        </param>
+       
+        <param name ="matrixE2J">  
+            1.000   0.000   0.000   0.000   0.000   0.000
+            0.000   1.000   0.000   0.000   0.000   0.000
+            0.000   0.000   1.000   0.000   0.000   0.000
+            0.000   0.000   0.000   1.000   0.000   0.000   
+        </param>
+                
+    </group>   
+
+    <group name="JOINTSET_CFG"> 
+        <param name= "numberofsets"> 2 </param>
+        <group name="JOINTSET_0">
+            <param name="listofjoints">  0 1 2         </param>
+            <param name="constraint">    trifid        </param>
+            <param name="param1">        658000        </param> <!-- ~31 deg -->
+            <param name="param2">        0             </param>
+        </group> 
+        <group name="JOINTSET_1">
+            <param name="listofjoints">   3             </param>
+            <param name="constraint">     none          </param>
+            <param name="param1">         0             </param>
+            <param name="param2">         0             </param>
+        </group> 
+    </group>                                       
+    
+</params>

--- a/CER02/hardware/motorControl/cer_base-ems1-mc-service.xml
+++ b/CER02/hardware/motorControl/cer_base-ems1-mc-service.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER02" build="1">
+
+    <group name="SERVICE">
+        
+        <param name="type"> eomn_serv_MC_foc </param> 
+    
+        <group name="PROPERTIES">
+        
+            <group name="ETHBOARD">
+                <param name="type">                 ems4        </param> 
+            </group>          
+
+            <group name="CANBOARDS"> 
+                <param name="type">                 foc         </param> 
+                <group name="PROTOCOL">
+                    <param name="major">            1           </param>    
+                    <param name="minor">            6           </param>     
+                </group>                    
+                <group name="FIRMWARE">
+                    <param name="major">            0           </param>    
+                    <param name="minor">            0           </param> 
+                    <param name="build">            0           </param>
+                </group>
+            </group>
+            
+
+            <group name="JOINTMAPPING">
+
+                <group name="ACTUATOR">                
+                    <param name="type">             foc                 foc         </param>
+                    <param name="port">             CAN1:1:0            CAN1:2:0    </param>
+                </group>
+                
+                <group name="ENCODER1">  
+                    <param name="type">             hallmotor           hallmotor   </param>  
+                    <param name="port">             CAN1:4:0            CAN1:2:0    </param>
+                    <param name="position">         atmotor             atmotor     </param> 
+                    <param name="resolution">       14400              -14400       </param>
+                    <param name="tolerance">        0                   0           </param>  
+                </group>        
+                
+                <group name="ENCODER2">
+                    <param name="type">             none                none        </param>
+                    <param name="port">             CONN:none           CONN:none   </param>
+                    <param name="position">         none                none        </param>
+                    <param name="resolution">       0                   0           </param>
+                    <param name="tolerance">        0                   0           </param>  
+                </group> 
+ 
+            </group>    
+
+        </group>
+           
+    </group>
+    
+  
+</params>
+

--- a/CER02/hardware/motorControl/cer_base-ems1-mc.xml
+++ b/CER02/hardware/motorControl/cer_base-ems1-mc.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_mobile_base_mc" type="embObjMotionControl">
+      <xi:include href="../../general.xml" />
+      <xi:include href="../electronics/cer_base-ems1-eln.xml" />
+      <xi:include href="../mechanicals/cer_base-ems1-mec.xml" />
+      <xi:include href="../motorControl/cer_base-ems1-mc-service.xml" />
+
+    <group name="LIMITS">
+        <param name="jntPosMax">                  0       0       </param>
+        <param name="jntPosMin">                  0       0       </param>
+        <param name="jntVelMax">                360     360       </param>
+        <param name="motorOverloadCurrents">  15000   15000       </param>
+        <param name="motorNominalCurrents">   10000   10000       </param>
+        <param name="motorPeakCurrents">      15000   15000       </param>
+        <param name="motorPwmLimit">          10000   10000       </param>  
+   </group>
+   
+   
+    <group name="TIMEOUTS">
+        <param name="velocity">               100       100       </param>
+    </group>
+    
+    <group name="CONTROLS">
+        <param name="positionControl">         JOINT_MINJERK_OUT_VEL_CTRL  JOINT_MINJERK_OUT_VEL_CTRL    </param>
+        <param name="velocityControl">         JOINT_MINJERK_OUT_VEL_CTRL  JOINT_MINJERK_OUT_VEL_CTRL    </param>
+        <param name="mixedControl">            JOINT_MINJERK_OUT_VEL_CTRL  JOINT_MINJERK_OUT_VEL_CTRL    </param>
+        <param name="posDirectControl">        JOINT_DIRECT_OUT_VEL_CTRL   JOINT_DIRECT_OUT_VEL_CTRL     </param>                
+        <param name="velDirectControl">        JOINT_DIRECT_OUT_VEL_CTRL   JOINT_DIRECT_OUT_VEL_CTRL     </param>
+        <param name="torqueControl">           none                        none                          </param>
+                                               
+        <param name="currentPid">              2FOC_CUR_CONTROL            2FOC_CUR_CONTROL              </param>
+        <param name="speedPid">                2FOC_VEL_CONTROL            2FOC_VEL_CONTROL              </param>
+    </group>
+    
+    <group name="JOINT_MINJERK_OUT_VEL_CTRL">
+	    <param name="controlLaw">             minjerk                   </param>
+        <param name="outputType">             velocity                  </param>
+        <param name="fbkControlUnits">        machine_units             </param> 
+        <param name="outputControlUnits">     machine_units             </param>
+        <param name="kff">                        1            1        </param> 
+        <param name="kp">                         5            5        </param>          
+        <param name="kd">                         0            0        </param>                       
+        <param name="maxOutput">              32000        32000        </param>                     
+    </group>
+
+    <group name="JOINT_DIRECT_OUT_VEL_CTRL">
+	    <param name="controlLaw">             direct                    </param>
+        <param name="outputType">             velocity                  </param>
+        <param name="fbkControlUnits">        machine_units             </param> 
+        <param name="outputControlUnits">     machine_units             </param>
+        <param name="kff">                        1            1        </param> 
+        <param name="kp">                         5            5        </param>          
+        <param name="kd">                         0            0        </param>                       
+        <param name="maxOutput">              32000        32000        </param>                     
+    </group>
+    
+    <group name="2FOC_CUR_CONTROL">
+        <param name="controlLaw">          low_lev_current      </param> 
+        <param name="fbkControlUnits">     machine_units        </param> 
+        <param name="outputControlUnits">  machine_units        </param>
+        <param name="kff">                     0         0  </param>
+        <param name="kp">                      8         8  </param>       
+        <param name="kd">                      0         0  </param>       
+        <param name="ki">                      2         2  </param>
+        <param name="shift">                  10        10  </param>
+        <param name="maxOutput">           32000     32000  </param>                 
+        <param name="maxInt">              32000     32000  </param>         
+    </group>
+
+    <group name="2FOC_VEL_CONTROL">
+        <param name="controlLaw">          low_lev_speed        </param> 
+        <param name="fbkControlUnits">     machine_units        </param> 
+        <param name="outputControlUnits">  machine_units        </param>
+        <param name="kff">                 0          0     </param>
+        <param name="kp">                 12         12     </param>       
+        <param name="kd">                  0          0     </param>       
+        <param name="ki">                 16         16     </param>
+        <param name="shift">              10         10     </param>
+        <param name="maxOutput">       32000      32000     </param>                 
+        <param name="maxInt">          32000      32000     </param>        
+    </group>
+
+
+    <group name="IMPEDANCE">
+        <param name="stiffness">       0      0    </param>    
+        <param name="damping">         0      0    </param>    
+    </group>
+
+    <group name="OTHER_CONTROL_PARAMETERS">
+    	<param name="deadZone"> 0.025 0.025 </param>
+    </group>
+
+  </device>
+
+

--- a/CER02/hardware/motorControl/cer_head-mcp10-mc-service.xml
+++ b/CER02/hardware/motorControl/cer_head-mcp10-mc-service.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER02" build="1">
+
+    <group name="SERVICE">
+        
+        <param name="type"> eomn_serv_MC_mc4plus </param> 
+    
+        <group name="PROPERTIES">
+        
+            <group name="ETHBOARD">
+                <param name="type">                 mc4plus        </param> 
+            </group>          
+
+            
+            <group name="JOINTMAPPING">
+
+               <group name="ACTUATOR">                 
+                    <param name="type">             pwm                 pwm                 </param>
+                    <param name="port">             CONN:P5             CONN:P2             </param>
+                </group>
+                
+                <!-- <group name="ENCODER1">  
+                    <param name="type">             eomc_enc_aea        qenc                </param>  
+                    <param name="port">             CONN:P11            CONN:P2             </param>
+                    <param name="position">         eomc_pos_atjoint    atmotor             </param> 
+                    <param name="resolution">       4096                1000                </param>
+                    <param name="numofnoisebits">   3                   0                   </param> 
+                </group> -->       
+
+                <group name="ENCODER1">  
+                    <param name="type">             eomc_enc_aea        aea                 </param>  
+                    <param name="port">             CONN:P11            CONN:P10            </param>
+                    <param name="position">         eomc_pos_atjoint    atjoint             </param> 
+                    <param name="resolution">       4096                4096                </param>
+                    <param name="tolerance">        0.703               0.703               </param>  
+                </group>
+                
+                <group name="ENCODER2">
+                    <param name="type">             eomc_enc_none       none                </param>
+                    <param name="port">             CONN:none           CONN:none           </param>
+                    <param name="position">         eomc_pos_none       none                </param>
+                    <param name="resolution">       0                   0                   </param>
+                    <param name="tolerance">        0                   0                   </param>  
+                </group> 
+ 
+            </group>    
+            
+        </group>
+           
+    </group>
+    
+    <group name="OTHER_CONTROL_PARAMETERS">
+        <param name="deadZone">         0.0495   0.0495   </param>
+    </group>
+    
+  
+</params>

--- a/CER02/hardware/motorControl/cer_head-mcp10-mc.xml
+++ b/CER02/hardware/motorControl/cer_head-mcp10-mc.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+ <!-- Initialization file for EMS 10 - CER head, 2 dof -->
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_head_mc" type="embObjMotionControl">
+      <xi:include href="../../general.xml" />
+      <xi:include href="../electronics/cer_head-mcp10-eln.xml" />
+      <xi:include href="../mechanicals/cer_head-mcp10-mec.xml" />
+      <xi:include href="../motorControl/cer_head-mcp10-mc-service.xml" />
+
+    <group name="LIMITS">
+        <param name="jntPosMax">                48      49           </param>
+        <param name="jntPosMin">               -28     -49           </param>
+        <param name="jntVelMax">                50      50           </param>
+        <param name="motorOverloadCurrents">    5000    5000         </param>
+        <param name="motorNominalCurrents">     8000    8000         </param>
+        <param name="motorPeakCurrents">        8000    8000         </param>
+        <param name="motorPwmLimit">            3360    3360         </param>
+    </group>
+
+    
+    <group name="TIMEOUTS">
+        <param name="velocity">             100           100        </param>
+    </group>
+
+    <group name="CONTROLS">
+        <param name="positionControl">         JOINT_MINJERK_OUT_PWM_CTRL  JOINT_MINJERK_OUT_PWM_CTRL   </param>
+        <param name="velocityControl">         JOINT_MINJERK_OUT_PWM_CTRL  JOINT_MINJERK_OUT_PWM_CTRL   </param>
+        <param name="mixedControl">            JOINT_MINJERK_OUT_PWM_CTRL  JOINT_MINJERK_OUT_PWM_CTRL   </param>
+        <param name="posDirectControl">        JOINT_DIRECT_OUT_PWM_CTRL   JOINT_DIRECT_OUT_PWM_CTRL    </param>                
+        <param name="velDirectControl">        JOINT_DIRECT_OUT_PWM_CTRL   JOINT_DIRECT_OUT_PWM_CTRL    </param>
+        <param name="torqueControl">           none                        none                         </param>
+        
+        <param name="currentPid">              none none </param>
+        <param name="speedPid">                none none </param>
+    </group>
+    
+    <group name="JOINT_MINJERK_OUT_PWM_CTRL">
+	    <param name="controlLaw">             minjerk                   </param>
+        <param name="outputType">             pwm                       </param>
+        <param name="fbkControlUnits">        machine_units             </param> 
+        <param name="outputControlUnits">     machine_units             </param>
+        <param name="kff">                        0            0        </param> 
+        <param name="kp">                         2           -1.5      </param>          
+        <param name="kd">                         0            0        </param>          
+        <param name="ki">                         5           -5        </param>              
+        <param name="maxOutput">               3360         3360        </param>                
+        <param name="maxInt">                  3360         1500        </param>                             
+        <param name="stictionUp">                 0            0        </param>          
+        <param name="stictionDown">                0            0        </param>        
+    </group>
+
+    <group name="JOINT_DIRECT_OUT_PWM_CTRL">
+	    <param name="controlLaw">             direct                    </param>
+        <param name="outputType">             pwm                       </param>
+        <param name="fbkControlUnits">        machine_units             </param> 
+        <param name="outputControlUnits">     machine_units             </param>
+        <param name="kff">                        0            0        </param> 
+        <param name="kp">                         2           -1.5      </param>          
+        <param name="kd">                         0            0        </param>          
+        <param name="ki">                         1           -5        </param>              
+        <param name="maxOutput">               3360         3360        </param>                
+        <param name="maxInt">                  3360         1500        </param>                             
+        <param name="stictionUp">                 0            0        </param>          
+        <param name="stictionDown">                0            0        </param>        
+    </group>
+    
+    <group name="IMPEDANCE">
+        <param name="stiffness">       0      0           </param>
+        <param name="damping">         0      0           </param>
+    </group>
+
+  </device>
+

--- a/CER02/hardware/motorControl/cer_left_hand-mcp9-mc-service.xml
+++ b/CER02/hardware/motorControl/cer_left_hand-mcp9-mc-service.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER02" build="1">
+
+    <group name="SERVICE">
+        
+        <param name="type"> eomn_serv_MC_mc4plus </param> 
+    
+        <group name="PROPERTIES">
+        
+            <group name="ETHBOARD">
+                <param name="type">             mc2plus             </param> 
+            </group>          
+
+
+            <group name="JOINTMAPPING">
+
+                <group name="ACTUATOR">                 
+                    <param name="type">             pwm                 pwm                 </param>
+                    <param name="port">             CONN:P3             CONN:P2             </param>
+                </group>
+                
+                <group name="ENCODER1">  
+                    <param name="type">             spichainof3         spichainof3         </param>  
+                    <param name="port">             CONN:P10            CONN:P11            </param>
+                    <param name="position">         atjoint             atjoint             </param> 
+                    <param name="resolution">       4096               -4096                </param>
+                    <param name="tolerance">        0.703               0.703               </param>  
+                </group>        
+                
+                <group name="ENCODER2">
+                    <param name="type">             qenc                qenc                </param>
+                    <param name="port">             CONN:P3             CONN:P2             </param>
+                    <param name="position">         atmotor             atmotor             </param>
+                    <param name="resolution">       1024                1024                </param>
+                    <param name="tolerance">        0                   0                </param>  
+                </group>  
+            </group>    
+            
+        </group>
+           
+    </group>
+    
+  
+</params>
+

--- a/CER02/hardware/motorControl/cer_left_hand-mcp9-mc.xml
+++ b/CER02/hardware/motorControl/cer_left_hand-mcp9-mc.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+ <!-- Initialization file for EMS 10 - CER hand, 2 dof -->
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_left_hand_mc" type="embObjMotionControl">
+      <xi:include href="../../general.xml" />
+      <xi:include href="../electronics/cer_left_hand-mcp9-eln.xml" />
+      <xi:include href="../mechanicals/cer_left_hand-mcp9-mec.xml" />
+      <xi:include href="../motorControl/cer_left_hand-mcp9-mc-service.xml" />
+
+    <group name="LIMITS">
+        <param name="jntPosMax">                120     130           </param>
+        <param name="jntPosMin">                0       0             </param>
+        <param name="jntVelMax">                150     150           </param>
+        <param name="motorOverloadCurrents">    5000    5000          </param>
+        <param name="motorNominalCurrents">     1500    1500           </param>
+        <param name="motorPeakCurrents">        2500    2500           </param>
+        <param name="motorPwmLimit">            3360    3360          </param>  
+    </group>
+    
+    
+    <group name="TIMEOUTS">
+        <param name="velocity">                 100           100     </param>
+    </group>
+
+
+    <group name="CONTROLS">
+        <param name="positionControl">         JOINT_MINJERK_OUT_PWM_CTRL  JOINT_MINJERK_OUT_PWM_CTRL   </param>
+        <param name="velocityControl">         JOINT_MINJERK_OUT_PWM_CTRL  JOINT_MINJERK_OUT_PWM_CTRL   </param>
+        <param name="mixedControl">            JOINT_MINJERK_OUT_PWM_CTRL  JOINT_MINJERK_OUT_PWM_CTRL   </param>
+        <param name="posDirectControl">        JOINT_DIRECT_OUT_PWM_CTRL   JOINT_DIRECT_OUT_PWM_CTRL    </param>                
+        <param name="velDirectControl">        JOINT_DIRECT_OUT_PWM_CTRL   JOINT_DIRECT_OUT_PWM_CTRL    </param>
+        <param name="torqueControl">           none                        none                         </param>
+        
+        <param name="currentPid">              none none </param>
+        <param name="speedPid">                none none </param>
+    </group>
+    
+    <group name="JOINT_MINJERK_OUT_PWM_CTRL">
+	    <param name="controlLaw">             minjerk                   </param>
+        <param name="outputType">             pwm                       </param>
+        <param name="fbkControlUnits">        machine_units             </param> 
+        <param name="outputControlUnits">     machine_units             </param>
+        <param name="kff">                        0            0        </param> 
+        <param name="kp">                      -200          200        </param>          
+        <param name="kd">                         0            0        </param>          
+        <param name="ki">                      -100          100        </param>              
+        <param name="maxOutput">               3360         3360        </param>                
+        <param name="maxInt">                  1000         1000        </param>                             
+        <param name="stictionUp">                 0            0        </param>          
+        <param name="stictionDown">                0            0        </param>         
+    </group>
+
+    <group name="JOINT_DIRECT_OUT_PWM_CTRL">
+	    <param name="controlLaw">             direct                    </param>
+        <param name="outputType">             pwm                       </param>
+        <param name="fbkControlUnits">        machine_units             </param> 
+        <param name="outputControlUnits">     machine_units             </param>
+        <param name="kff">                        0            0        </param> 
+        <param name="kp">                      -200          200        </param>          
+        <param name="kd">                         0            0        </param>          
+        <param name="ki">                      -100          100        </param>              
+        <param name="maxOutput">               3360         3360        </param>                
+        <param name="maxInt">                  1000         1000        </param>                             
+        <param name="stictionUp">                 0            0        </param>          
+        <param name="stictionDown">                0            0        </param>        
+    </group>
+
+    <group name="IMPEDANCE">
+        <param name="stiffness">       0      0           </param>    
+        <param name="damping">         0      0           </param>    
+    </group>
+    
+    <group name="OTHER_CONTROL_PARAMETERS">
+        <param name="deadZone">        2.20    2.20        </param>
+	</group>
+    
+  </device>
+
+
+        

--- a/CER02/hardware/motorControl/cer_left_lower_arm-mcp8-mc-service.xml
+++ b/CER02/hardware/motorControl/cer_left_lower_arm-mcp8-mc-service.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER02" build="1">
+
+    <group name="SERVICE">
+        
+        <param name="type"> eomn_serv_MC_mc4plus </param> 
+    
+        <group name="PROPERTIES">
+        
+            <group name="ETHBOARD">
+                <param name="type">             mc4plus             </param> 
+            </group>          
+
+
+            <group name="JOINTMAPPING">
+
+                <group name="ACTUATOR">                 
+                    <param name="type">             pwm                 pwm                 pwm                 pwm                     </param>
+                    <param name="port">             CONN:P3             CONN:P2             CONN:P4             CONN:P5                 </param>
+                </group>
+                
+                <group name="ENCODER1">  
+                    <param name="type">             none                none                none                aea                      </param>  
+                    <param name="port">             CONN:none           CONN:none           CONN:none           CONN:P10                 </param>
+                    <param name="position">         none                none                none                atjoint                  </param> 
+                    <param name="resolution">       65535               65535               65535              -4096                     </param>
+                    <param name="tolerance">        0                   0                   0                   0.703                    </param>  
+                </group>        
+                
+                <group name="ENCODER2">
+                    <param name="type">             qenc                qenc                qenc                none                    </param>
+                    <param name="port">             CONN:P3             CONN:P2             CONN:P4             CONN:none               </param>
+                    <param name="position">         atmotor             atmotor             atmotor             none                    </param>
+                    <param name="resolution">       65535               65535               65535               0                       </param>
+                    <param name="tolerance">        0                   0                   0                   0                       </param>  
+                </group>  
+            </group>    
+            
+            
+        </group>
+           
+    </group>
+    
+    <group name="OTHER_CONTROL_PARAMETERS">
+        <param name="deadZone"> 0.00002   0.00002   0.00002   0.0055   </param>
+    </group>
+  
+</params>
+

--- a/CER02/hardware/motorControl/cer_left_lower_arm-mcp8-mc.xml
+++ b/CER02/hardware/motorControl/cer_left_lower_arm-mcp8-mc.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+ <!-- Initialization file for MC4+ 18 - CER left lower arm, 4 dof -->
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_left_lower_arm_mc" type="embObjMotionControl">
+      <xi:include href="../../general.xml" />
+      <xi:include href="../electronics/cer_left_lower_arm-mcp8-eln.xml" />
+      <xi:include href="../mechanicals/cer_left_lower_arm-mcp8-mec.xml" />
+      <xi:include href="../motorControl/cer_left_lower_arm-mcp8-mc-service.xml" />
+
+    <group name="LIMITS">
+        <param name="jntPosMax">                  0.12     0.12    0.12     89     </param>
+        <param name="jntPosMin">                  0        0       0       -89    </param>
+        <param name="jntVelMax">                  0.02     0.02    0.02     3000   </param>
+        <param name="motorOverloadCurrents">      10000    10000   10000    10000   </param>
+        <param name="motorNominalCurrents">       5000     5000    5000     5000   </param>
+        <param name="motorPeakCurrents">          5000     5000    5000     5000   </param>
+        <param name="motorPwmLimit">              3360     3360    3360     3360   </param>  
+    </group>
+
+<group name="TIMEOUTS">
+        <param name="velocity">               100       100           100        100    </param>
+    </group>
+
+
+    <group name="CONTROLS">
+        <param name="positionControl">         JOINT_MINJERK_OUT_PWM_CTRL  JOINT_MINJERK_OUT_PWM_CTRL  JOINT_MINJERK_OUT_PWM_CTRL  JOINT_MINJERK_OUT_PWM_CTRL   </param>
+        <param name="velocityControl">         JOINT_MINJERK_OUT_PWM_CTRL  JOINT_MINJERK_OUT_PWM_CTRL  JOINT_MINJERK_OUT_PWM_CTRL  JOINT_MINJERK_OUT_PWM_CTRL   </param>
+        <param name="mixedControl">            JOINT_MINJERK_OUT_PWM_CTRL  JOINT_MINJERK_OUT_PWM_CTRL  JOINT_MINJERK_OUT_PWM_CTRL  JOINT_MINJERK_OUT_PWM_CTRL   </param>
+        <param name="posDirectControl">        JOINT_DIRECT_OUT_PWM_CTRL   JOINT_DIRECT_OUT_PWM_CTRL   JOINT_DIRECT_OUT_PWM_CTRL   JOINT_DIRECT_OUT_PWM_CTRL    </param>                
+        <param name="velDirectControl">        JOINT_DIRECT_OUT_PWM_CTRL   JOINT_DIRECT_OUT_PWM_CTRL   JOINT_DIRECT_OUT_PWM_CTRL   JOINT_DIRECT_OUT_PWM_CTRL    </param>
+        <param name="torqueControl">           none                        none                        none                        none                         </param>
+    
+        <param name="currentPid">              none none none none </param>
+        <param name="speedPid">                none none none none </param>
+    </group>
+    
+    <group name="JOINT_MINJERK_OUT_PWM_CTRL">
+	    <param name="controlLaw">             minjerk                   </param>
+        <param name="outputType">             pwm                       </param>
+        <param name="fbkControlUnits">        machine_units             </param> 
+        <param name="outputControlUnits">     machine_units             </param>
+        <param name="kff">                        0            0          0        0          </param> 
+        <param name="kp">                       -20          -20        -20        0.7        </param>          
+        <param name="kd">                         0            0          0        0          </param>          
+        <param name="ki">                         0            0          0        0          </param>              
+        <param name="maxOutput">               3000         3000       3000     2000          </param>                
+        <param name="maxInt">                     0            0          0        0          </param>                             
+        <param name="stictionUp">                 0            0          0        0          </param>          
+        <param name="stictionDown">               0            0          0        0          </param>        
+    </group>
+
+    <group name="JOINT_DIRECT_OUT_PWM_CTRL">
+	    <param name="controlLaw">             direct                    </param>
+        <param name="outputType">             pwm                       </param>
+        <param name="fbkControlUnits">        machine_units             </param> 
+        <param name="outputControlUnits">     machine_units             </param>
+        <param name="kff">                        0            0          0        0          </param> 
+        <param name="kp">                       -20          -20        -20        0.7        </param>          
+        <param name="kd">                         0            0          0        0          </param>          
+        <param name="ki">                         0            0          0        0          </param>              
+        <param name="maxOutput">               3000         3000       3000     2000          </param>                
+        <param name="maxInt">                     0            0          0        0          </param>                             
+        <param name="stictionUp">                 0            0          0        0          </param>          
+        <param name="stictionDown">               0            0          0        0          </param>        
+    </group>
+    
+    <group name="IMPEDANCE">
+        <param name="stiffness">       0      0      0      0     </param>    
+        <param name="damping">         0      0      0      0     </param>    
+    </group>
+	
+  </device>
+
+

--- a/CER02/hardware/motorControl/cer_left_shoulder-ems5-mc-service.xml
+++ b/CER02/hardware/motorControl/cer_left_shoulder-ems5-mc-service.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER02" build="1">
+
+    <group name="SERVICE">
+        
+        <param name="type"> eomn_serv_MC_foc </param> 
+    
+        <group name="PROPERTIES">
+        
+            <group name="ETHBOARD">
+                <param name="type">                 ems4        </param> 
+            </group>          
+
+            <group name="CANBOARDS"> 
+                <param name="type">                 foc         </param> 
+                <group name="PROTOCOL">
+                    <param name="major">            1           </param>    
+                    <param name="minor">            6           </param>     
+                </group>                    
+                <group name="FIRMWARE">
+                    <param name="major">            0           </param>    
+                    <param name="minor">            0           </param> 
+                    <param name="build">            0           </param>
+                </group>
+            </group>
+
+            <group name="JOINTMAPPING">
+
+                <group name="ACTUATOR">                
+                    <param name="type">             foc                 foc                </param>
+                    <param name="port">             CAN1:1:0            CAN1:2:0           </param>
+                </group>
+                
+                <group name="ENCODER1">  
+                    <param name="type">             aea                aea                 </param>
+                    <param name="port">             CONN:P8            CONN:P6             </param>
+                    <param name="position">         atjoint            atjoint             </param>
+                    <param name="resolution">       4096              -4096                </param>
+                    <param name="tolerance">        0.703              0.703               </param>
+                </group>        
+                
+                <group name="ENCODER2">
+                    <param name="type">             roie                roie               </param>
+                    <param name="port">             CAN1:1:0            CAN1:2:0           </param>
+                    <param name="position">         atmotor             atmotor            </param>
+                    <param name="resolution">       8192                8192               </param>
+                    <param name="tolerance">        0                   0                  </param>  
+                </group> 
+ 
+            </group>    
+            
+        </group>
+           
+    </group>
+    
+  
+</params>
+

--- a/CER02/hardware/motorControl/cer_left_shoulder-ems5-mc.xml
+++ b/CER02/hardware/motorControl/cer_left_shoulder-ems5-mc.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_left_shoulder_mc" type="embObjMotionControl">
+      <xi:include href="../../general.xml" />
+      <xi:include href="../electronics/cer_left_shoulder-ems5-eln.xml" />
+      <xi:include href="../mechanicals/cer_left_shoulder-ems5-mec.xml" />
+      <xi:include href="../motorControl/cer_left_shoulder-ems5-mc-service.xml" />
+
+    <group name="LIMITS">
+        <param name="jntPosMax">                      85            85      </param>
+        <param name="jntPosMin">                     -70             2      </param>
+        <param name="motorOverloadCurrents">          5000          5000    </param>
+        <param name="motorNominalCurrents">           2500          2500    </param>
+        <param name="motorPeakCurrents">              5000          5000    </param>
+        <param name="jntVelMax">                      50            50      </param>
+        <param name="motorPwmLimit">                  32000         32000   </param>    
+    </group>
+
+    <group name="TIMEOUTS">
+        <param name="velocity">               100       100         </param>
+    </group>
+    
+    
+    <group name="CONTROLS">
+        <param name="positionControl">        JOINT_MINJERK_OUT_WORM_VEL_CTRL    JOINT_MINJERK_OUT_WORM_VEL_CTRL    </param>
+        <param name="velocityControl">        JOINT_MINJERK_OUT_WORM_VEL_CTRL    JOINT_MINJERK_OUT_WORM_VEL_CTRL    </param>
+        <param name="mixedControl">           JOINT_MINJERK_OUT_WORM_VEL_CTRL    JOINT_MINJERK_OUT_WORM_VEL_CTRL    </param>
+        <param name="posDirectControl">       JOINT_DIRECT_OUT_WORM_VEL_CTRL     JOINT_DIRECT_OUT_WORM_VEL_CTRL     </param>                
+        <param name="velDirectControl">       JOINT_DIRECT_OUT_WORM_VEL_CTRL     JOINT_DIRECT_OUT_WORM_VEL_CTRL     </param>
+        <param name="torqueControl">          none                               none                               </param>
+                                            
+        <param name="currentPid">             2FOC_CUR_CONTROL                   2FOC_CUR_CONTROL                   </param>
+        <param name="speedPid">               2FOC_VEL_CONTROL                   2FOC_VEL_CONTROL                   </param>
+    </group>
+    
+    <group name="JOINT_MINJERK_OUT_WORM_VEL_CTRL">
+        <param name="controlLaw">             minjerk                   </param>
+        <param name="outputType">             velocity                  </param>
+        <param name="fbkControlUnits">        machine_units             </param> 
+        <param name="outputControlUnits">     machine_units             </param> 
+        <param name="kff">                        1          1          </param> 
+        <param name="kp">                         5          5          </param>       
+        <param name="kd">                         0          0          </param>             
+        <param name="maxOutput">              32000      32000          </param>                
+    </group>
+    
+    <group name="JOINT_DIRECT_OUT_WORM_VEL_CTRL">
+        <param name="controlLaw">             direct                    </param>
+        <param name="outputType">             velocity                  </param>
+        <param name="fbkControlUnits">        machine_units             </param> 
+        <param name="outputControlUnits">     machine_units             </param> 
+        <param name="kff">                        1          1          </param> 
+        <param name="kp">                         5          5          </param>       
+        <param name="kd">                         0          0          </param>             
+        <param name="maxOutput">              32000      32000          </param>                 
+    </group>
+    
+    <group name="2FOC_CUR_CONTROL">
+        <param name="controlLaw">          low_lev_current      </param> 
+        <param name="fbkControlUnits">     machine_units        </param> 
+        <param name="outputControlUnits">  machine_units        </param>
+        <param name="kff">                     0         0  </param>
+        <param name="kp">                      8         8  </param>       
+        <param name="kd">                      0         0  </param>       
+        <param name="ki">                      2         2  </param>
+        <param name="shift">                  10        10  </param>
+        <param name="maxOutput">           32000     32000  </param>                 
+        <param name="maxInt">              32000     32000  </param>         
+    </group>
+
+    <group name="2FOC_VEL_CONTROL">
+        <param name="controlLaw">          low_lev_speed        </param> 
+        <param name="fbkControlUnits">     machine_units        </param> 
+        <param name="outputControlUnits">  machine_units        </param>
+        <param name="kff">                 0      0         </param>
+        <param name="kp">               1280   1280         </param>       
+        <param name="kd">               6144   6144         </param>       
+        <param name="ki">                  1      1         </param>
+        <param name="shift">              14     14         </param>
+        <param name="maxOutput">       32000  32000         </param>                 
+        <param name="maxInt">          32000  32000         </param>        
+    </group>
+
+    <group name="IMPEDANCE">
+        <param name="stiffness">        0          0         </param>    
+        <param name="damping">          0          0         </param>    
+    </group>
+	
+	
+    <group name="OTHER_CONTROL_PARAMETERS">
+        <param name="deadZone">         0.0495   0.0495   </param>
+    </group>
+	
+  </device>
+

--- a/CER02/hardware/motorControl/cer_left_upper_arm-ems12-mc-service.xml
+++ b/CER02/hardware/motorControl/cer_left_upper_arm-ems12-mc-service.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER02" build="1">
+
+    <group name="SERVICE">
+        
+        <param name="type"> eomn_serv_MC_foc </param> 
+    
+        <group name="PROPERTIES">
+        
+            <group name="ETHBOARD">
+                <param name="type">                 ems4        </param> 
+            </group>          
+
+            <group name="CANBOARDS"> 
+                <param name="type">                 foc         </param> 
+                <group name="PROTOCOL">
+                    <param name="major">            1           </param>    
+                    <param name="minor">            6           </param>     
+                </group>                    
+                <group name="FIRMWARE">
+                    <param name="major">            0           </param>    
+                    <param name="minor">            0           </param> 
+                    <param name="build">            0           </param>
+                </group>
+            </group>
+
+            <group name="JOINTMAPPING">
+
+                <group name="ACTUATOR">                
+                    <param name="type">             foc                 foc                 </param>
+                    <param name="port">             CAN1:1:0            CAN1:2:0            </param>
+                </group>                                                                   
+                                                                                           
+                <group name="ENCODER1">                                                    
+                    <param name="type">             aea                aea                  </param>
+                    <param name="port">             CONN:P8            CONN:P6              </param>
+                    <param name="position">         atjoint            atjoint              </param>
+                    <param name="resolution">      -4096              -4096                 </param>
+                    <param name="tolerance">        0.703              0.703                </param>
+                </group>                                                                   
+                                                                                           
+                <group name="ENCODER2">                                                    
+                    <param name="type">             roie                roie                </param>
+                    <param name="port">             CAN1:1:0            CAN1:2:0            </param>
+                    <param name="position">         atmotor             atmotor             </param>
+                    <param name="resolution">       8192                8192                </param>
+                    <param name="tolerance">        0                   0                   </param>  
+                </group> 
+ 
+            </group>    
+            
+        </group>
+           
+    </group>
+    
+  
+</params>
+

--- a/CER02/hardware/motorControl/cer_left_upper_arm-ems12-mc.xml
+++ b/CER02/hardware/motorControl/cer_left_upper_arm-ems12-mc.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_left_upper_arm_mc" type="embObjMotionControl">
+      <xi:include href="../../general.xml" />
+      <xi:include href="../electronics/cer_left_upper_arm-ems12-eln.xml" />
+      <xi:include href="../mechanicals/cer_left_upper_arm-ems12-mec.xml" />
+      <xi:include href="../motorControl/cer_left_upper_arm-ems12-mc-service.xml" />
+
+    <group name="LIMITS">
+        <param name="jntPosMax">                      85        95         </param>
+        <param name="jntPosMin">                     -85         5         </param>
+        <param name="motorOverloadCurrents">          9000      9000       </param>
+        <param name="motorNominalCurrents">           3000      3000       </param>
+        <param name="motorPeakCurrents">              6000      6000       </param>
+        <param name="jntVelMax">                      90        90         </param>
+        <param name="motorPwmLimit">                  32000     32000      </param>    
+    </group>
+
+    <group name="TIMEOUTS">
+        <param name="velocity">                       100        100    </param>
+    </group>
+    
+    <group name="CONTROLS">
+        <param name="positionControl">        JOINT_MINJERK_OUT_WORM_VEL_CTRL    JOINT_MINJERK_OUT_WORM_VEL_CTRL    </param>
+        <param name="velocityControl">        JOINT_MINJERK_OUT_WORM_VEL_CTRL    JOINT_MINJERK_OUT_WORM_VEL_CTRL    </param>
+        <param name="mixedControl">           JOINT_MINJERK_OUT_WORM_VEL_CTRL    JOINT_MINJERK_OUT_WORM_VEL_CTRL    </param>
+        <param name="posDirectControl">       JOINT_DIRECT_OUT_WORM_VEL_CTRL     JOINT_DIRECT_OUT_WORM_VEL_CTRL     </param>                
+        <param name="velDirectControl">       JOINT_DIRECT_OUT_WORM_VEL_CTRL     JOINT_DIRECT_OUT_WORM_VEL_CTRL     </param>
+        <param name="torqueControl">          none                               none                               </param>
+                                            
+        <param name="currentPid">             2FOC_CUR_CONTROL                   2FOC_CUR_CONTROL                   </param>
+        <param name="speedPid">               2FOC_VEL_CONTROL                   2FOC_VEL_CONTROL                   </param>
+    </group>
+
+    <group name="JOINT_MINJERK_OUT_WORM_VEL_CTRL">
+        <param name="controlLaw">             minjerk                   </param>
+        <param name="outputType">             velocity                  </param>
+        <param name="fbkControlUnits">        machine_units             </param> 
+        <param name="outputControlUnits">     machine_units             </param> 
+        <param name="kff">                        1          1          </param> 
+        <param name="kp">                         5          5          </param>       
+        <param name="kd">                         0          0          </param>             
+        <param name="maxOutput">              32000      32000          </param>                
+    </group>
+    
+    <group name="JOINT_DIRECT_OUT_WORM_VEL_CTRL">
+        <param name="controlLaw">             direct                    </param>
+        <param name="outputType">             velocity                  </param>
+        <param name="fbkControlUnits">        machine_units             </param> 
+        <param name="outputControlUnits">     machine_units             </param> 
+        <param name="kff">                        1          1          </param> 
+        <param name="kp">                         5          5          </param>       
+        <param name="kd">                         0          0          </param>             
+        <param name="maxOutput">              32000      32000          </param>                 
+    </group>
+    
+    <group name="2FOC_CUR_CONTROL">
+        <param name="controlLaw">          low_lev_current      </param> 
+        <param name="fbkControlUnits">     machine_units        </param> 
+        <param name="outputControlUnits">  machine_units        </param>
+        <param name="kff">                     0         0  </param>
+        <param name="kp">                      8         8  </param>       
+        <param name="kd">                      0         0  </param>       
+        <param name="ki">                      2         2  </param>
+        <param name="shift">                  10        10  </param>
+        <param name="maxOutput">           32000     32000  </param>                 
+        <param name="maxInt">              32000     32000  </param>         
+    </group>
+    
+    <group name="2FOC_VEL_CONTROL">
+        <param name="controlLaw">          low_lev_speed        </param> 
+        <param name="fbkControlUnits">     machine_units        </param> 
+        <param name="outputControlUnits">  machine_units        </param>
+        <param name="kff">                 0          0     </param>
+        <param name="kp">                 12         12     </param>       
+        <param name="kd">                  0          0     </param>       
+        <param name="ki">                 16         16     </param>
+        <param name="shift">              10         10     </param>
+        <param name="maxOutput">       32000      32000     </param>                 
+        <param name="maxInt">          32000      32000     </param>        
+    </group>
+        
+    <group name="IMPEDANCE">
+        <param name="stiffness">        0        0       </param>    
+        <param name="damping">          0        0       </param>    
+    </group>
+	
+	<group name="OTHER_CONTROL_PARAMETERS">
+        <param name="deadZone">         0.0495   0.0495   </param>
+    </group>
+	
+  </device>
+

--- a/CER02/hardware/motorControl/cer_left_wrist_equivalent-mc.xml
+++ b/CER02/hardware/motorControl/cer_left_wrist_equivalent-mc.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_left_wrist_equivalent_mc" type="tripodMotionControl">
+      <xi:include href="../../general.xml" />
+
+      <param name="AxisNames">  "l_wrist_heave_eq_joint" "l_wrist_roll_eq_joint" "l_wrist_pitch_eq_joint"  </param>
+
+    <group name="GENERAL">
+      <param name="Joints">      3       </param>
+     <!-- <param name="AxisMap">     0 1 2   </param> -->
+     <!-- <param name="Verbose">     true    </param> -->
+      <param name="Encoder">     1 1 1   </param>
+    </group>
+
+    <group name="TRIPOD">
+      <param name="Radius">      0.018   </param>
+      <param name="Max_el">      0.120  </param>
+      <param name="Min_el">      0.0    </param>
+      <param name="Max_alpha">   30.0   </param>
+
+      <param name="BASE_TRANSFORMATION">   1.0    0.0     0.0    0.0
+                                           0.0    1.0     0.0    0.0
+                                           0.0    0.0     1.0    0.0
+                                           0.0    0.0     0.0    1.0
+      </param>
+    </group>
+
+    <group name="LIMITS">
+        <param name="JntVelocityMax">   0.05  </param>
+    </group>
+
+    <!-- action is alternative to CONNECTION group -->
+    <action phase="startup" level="1" type="attach">
+      <paramlist name="networks">
+          <elem name="FirstSetOfJoints"> cer_left_lower_arm_mc </elem>
+      </paramlist>
+    </action>
+
+    <action phase="shutdown" level="6" type="detach" />
+
+  </device>
+

--- a/CER02/hardware/motorControl/cer_right_hand-mcp7-mc-service.xml
+++ b/CER02/hardware/motorControl/cer_right_hand-mcp7-mc-service.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER02" build="1">
+
+    <group name="SERVICE">
+        
+        <param name="type"> eomn_serv_MC_mc4plus </param> 
+    
+        <group name="PROPERTIES">
+        
+            <group name="ETHBOARD">
+                <param name="type">             mc2plus             </param> 
+            </group>          
+
+
+            <group name="JOINTMAPPING">
+
+                <group name="ACTUATOR">                 
+                    <param name="type">             pwm                 pwm                 </param>
+                    <param name="port">             CONN:P3             CONN:P2             </param>
+                </group>
+                
+                <group name="ENCODER1">  
+                    <param name="type">             spichainof3         spichainof3         </param>  
+                    <param name="port">             CONN:P10            CONN:P11            </param>
+                    <param name="position">         atjoint             atjoint             </param> 
+                    <param name="resolution">      -4096                4096                </param>
+                    <param name="tolerance">        0.703               0.703               </param> 
+                </group>        
+                
+                <group name="ENCODER2">
+                    <param name="type">             qenc                qenc                </param>
+                    <param name="port">             CONN:P3             CONN:P2             </param>
+                    <param name="position">         atmotor             atmotor             </param>
+                    <param name="resolution">       1024                1024                </param>
+                    <param name="tolerance">        0                   0                   </param>
+                </group>  
+            </group>    
+
+        </group>
+           
+    </group>
+    
+  
+</params>
+

--- a/CER02/hardware/motorControl/cer_right_hand-mcp7-mc.xml
+++ b/CER02/hardware/motorControl/cer_right_hand-mcp7-mc.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+ <!-- Initialization file for EMS 10 - CER hand, 2 dof -->
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_right_hand_mc" type="embObjMotionControl">
+      <xi:include href="../../general.xml" />
+      <xi:include href="../electronics/cer_right_hand-mcp7-eln.xml" />
+      <xi:include href="../mechanicals/cer_right_hand-mcp7-mec.xml" />
+      <xi:include href="../motorControl/cer_right_hand-mcp7-mc-service.xml" />
+
+    <group name="LIMITS">
+        <param name="jntPosMax">                120     130           </param>
+        <param name="jntPosMin">                0       0             </param>
+        <param name="jntVelMax">                150     150           </param>
+        <param name="motorOverloadCurrents">    5000    5000          </param>
+        <param name="motorNominalCurrents">     1500    1500          </param>
+        <param name="motorPeakCurrents">        2500    2500          </param>
+        <param name="motorPwmLimit">            3360    3360          </param>  
+    </group>
+
+    
+    <group name="TIMEOUTS">
+        <param name="velocity">               100       100              </param>
+    </group>
+
+
+    <group name="CONTROLS">
+        <param name="positionControl">         JOINT_MINJERK_OUT_PWM_CTRL  JOINT_MINJERK_OUT_PWM_CTRL   </param>
+        <param name="velocityControl">         JOINT_MINJERK_OUT_PWM_CTRL  JOINT_MINJERK_OUT_PWM_CTRL   </param>
+        <param name="mixedControl">            JOINT_MINJERK_OUT_PWM_CTRL  JOINT_MINJERK_OUT_PWM_CTRL   </param>
+        <param name="posDirectControl">        JOINT_DIRECT_OUT_PWM_CTRL   JOINT_DIRECT_OUT_PWM_CTRL    </param>                
+        <param name="velDirectControl">        JOINT_DIRECT_OUT_PWM_CTRL   JOINT_DIRECT_OUT_PWM_CTRL    </param>
+        <param name="torqueControl">           none                        none                         </param>
+        
+        <param name="currentPid">              none none </param>
+        <param name="speedPid">                none none </param>
+    </group>
+    
+    <group name="JOINT_MINJERK_OUT_PWM_CTRL">
+	    <param name="controlLaw">             minjerk                   </param>
+        <param name="outputType">             pwm                       </param>
+        <param name="fbkControlUnits">        machine_units             </param> 
+        <param name="outputControlUnits">     machine_units             </param>
+        <param name="kff">                        0            0        </param> 
+        <param name="kp">                      -200          200        </param>          
+        <param name="kd">                         0            0        </param>          
+        <param name="ki">                      -100          100        </param>              
+        <param name="maxOutput">               3360         3360        </param>                
+        <param name="maxInt">                  1000         1000        </param>                             
+        <param name="stictionUp">                 0            0        </param>          
+        <param name="stictionDown">                0            0        </param>       
+    </group>
+
+    <group name="JOINT_DIRECT_OUT_PWM_CTRL">
+	    <param name="controlLaw">             direct                    </param>
+        <param name="outputType">             pwm                       </param>
+        <param name="fbkControlUnits">        machine_units             </param> 
+        <param name="outputControlUnits">     machine_units             </param>
+        <param name="kff">                        0            0        </param> 
+        <param name="kp">                      -200          200        </param>          
+        <param name="kd">                         0            0        </param>          
+        <param name="ki">                      -100          100        </param>              
+        <param name="maxOutput">               3360         3360        </param>                
+        <param name="maxInt">                  1000         1000        </param>                             
+        <param name="stictionUp">                 0            0        </param>          
+        <param name="stictionDown">                0            0        </param>        
+    </group>
+    
+    <group name="IMPEDANCE">
+        <param name="stiffness">       0      0           </param>    
+        <param name="damping">         0      0           </param>    
+    </group>
+    
+    <group name="OTHER_CONTROL_PARAMETERS">
+        <param name="deadZone">        2.20    2.20        </param>
+	</group>
+	
+  </device>
+
+
+
+

--- a/CER02/hardware/motorControl/cer_right_lower_arm-mcp6-mc-service.xml
+++ b/CER02/hardware/motorControl/cer_right_lower_arm-mcp6-mc-service.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER02" build="1">
+
+    <group name="SERVICE">
+        
+        <param name="type"> eomn_serv_MC_mc4plus </param> 
+    
+        <group name="PROPERTIES">
+        
+            <group name="ETHBOARD">
+                <param name="type">             mc4plus             </param> 
+            </group>          
+
+            
+            <group name="JOINTMAPPING">
+
+                <group name="ACTUATOR">                 
+                    <param name="type">             pwm                 pwm                 pwm                 pwm                  </param>
+                    <param name="port">             CONN:P3             CONN:P2             CONN:P4             CONN:P5              </param>
+                </group>
+                
+                <group name="ENCODER1">  
+                    <param name="type">               none                none                none                aea                </param>  
+                    <param name="port">               CONN:none           CONN:none           CONN:none           CONN:P10           </param>
+                    <param name="position">           none                none                none                atjoint            </param> 
+                    <param name="resolution">         65535               65535               65535               4096               </param>
+                    <param name="tolerance">          0                   0                   0                   0.703              </param>  
+                </group>        
+                
+                <group name="ENCODER2">
+                    <param name="type">             qenc                qenc                qenc                none                 </param> 
+                    <param name="port">             CONN:P3             CONN:P2             CONN:P4             CONN:none            </param>
+                    <param name="position">         atmotor             atmotor             atmotor             none                 </param>
+                    <param name="resolution">       65535               65535               65535               0                    </param>
+                    <param name="tolerance">        0                   0                   0                   0                    </param>  
+                </group>  
+            </group>    
+            
+        </group>
+           
+    </group>
+    
+  
+</params>
+

--- a/CER02/hardware/motorControl/cer_right_lower_arm-mcp6-mc.xml
+++ b/CER02/hardware/motorControl/cer_right_lower_arm-mcp6-mc.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+ <!-- Initialization file for MC4+ 20 - CER right lower arm, 4 dof -->
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_right_lower_arm_mc" type="embObjMotionControl">
+      <xi:include href="../../general.xml" />
+      <xi:include href="../electronics/cer_right_lower_arm-mcp6-eln.xml" />
+      <xi:include href="../mechanicals/cer_right_lower_arm-mcp6-mec.xml" />
+      <xi:include href="../motorControl/cer_right_lower_arm-mcp6-mc-service.xml" />
+
+    <group name="LIMITS">
+        <param name="jntPosMax">                  0.12     0.12    0.12     89     </param>
+        <param name="jntPosMin">                  0        0       0       -89     </param>
+        <param name="jntVelMax">                  0.02     0.02    0.02     3000   </param>
+        <param name="motorOverloadCurrents">      10000    10000   10000    10000  </param>
+        <param name="motorNominalCurrents">       5000     5000    5000     5000   </param>
+        <param name="motorPeakCurrents">          5000     5000    5000     5000   </param>
+        <param name="motorPwmLimit">              3360     3360    3360     3360   </param>  
+    </group>
+    
+    
+    <group name="TIMEOUTS">
+        <param name="velocity">               100       100           100        100    </param>
+    </group>
+
+
+    <group name="CONTROLS">
+        <param name="positionControl">         JOINT_MINJERK_OUT_PWM_CTRL  JOINT_MINJERK_OUT_PWM_CTRL  JOINT_MINJERK_OUT_PWM_CTRL  JOINT_MINJERK_OUT_PWM_CTRL   </param>
+        <param name="velocityControl">         JOINT_MINJERK_OUT_PWM_CTRL  JOINT_MINJERK_OUT_PWM_CTRL  JOINT_MINJERK_OUT_PWM_CTRL  JOINT_MINJERK_OUT_PWM_CTRL   </param>
+        <param name="mixedControl">            JOINT_MINJERK_OUT_PWM_CTRL  JOINT_MINJERK_OUT_PWM_CTRL  JOINT_MINJERK_OUT_PWM_CTRL  JOINT_MINJERK_OUT_PWM_CTRL   </param>
+        <param name="posDirectControl">        JOINT_DIRECT_OUT_PWM_CTRL   JOINT_DIRECT_OUT_PWM_CTRL   JOINT_DIRECT_OUT_PWM_CTRL   JOINT_DIRECT_OUT_PWM_CTRL    </param>                
+        <param name="velDirectControl">        JOINT_DIRECT_OUT_PWM_CTRL   JOINT_DIRECT_OUT_PWM_CTRL   JOINT_DIRECT_OUT_PWM_CTRL   JOINT_DIRECT_OUT_PWM_CTRL    </param>
+        <param name="torqueControl">           none                        none                        none                        none                         </param>
+    
+        <param name="currentPid">              none none none none </param>
+        <param name="speedPid">                none none none none </param>
+    </group>
+    
+    <group name="JOINT_MINJERK_OUT_PWM_CTRL">
+	    <param name="controlLaw">             minjerk                   </param>
+        <param name="outputType">             pwm                       </param>
+        <param name="fbkControlUnits">        machine_units             </param> 
+        <param name="outputControlUnits">     machine_units             </param>
+        <param name="kff">                        0            0          0        0          </param> 
+        <param name="kp">                       -20          -20        -20       -0.7        </param>          
+        <param name="kd">                         0            0          0        0          </param>          
+        <param name="ki">                         0            0          0        0          </param>              
+        <param name="maxOutput">               3000         3000       3000     2000          </param>                
+        <param name="maxInt">                     0            0          0        0          </param>                             
+        <param name="stictionUp">                 0            0          0        0          </param>          
+        <param name="stictionDown">               0            0          0        0          </param>        
+    </group>
+
+    <group name="JOINT_DIRECT_OUT_PWM_CTRL">
+	    <param name="controlLaw">             direct                    </param>
+        <param name="outputType">             pwm                       </param>
+        <param name="fbkControlUnits">        machine_units             </param> 
+        <param name="outputControlUnits">     machine_units             </param>
+        <param name="kff">                        0            0          0        0          </param> 
+        <param name="kp">                       -20          -20        -20       -0.7        </param>          
+        <param name="kd">                         0            0          0        0          </param>          
+        <param name="ki">                         0            0          0        0          </param>              
+        <param name="maxOutput">               3000         3000       3000     2000          </param>                
+        <param name="maxInt">                     0            0          0        0          </param>                             
+        <param name="stictionUp">                 0            0          0        0          </param>          
+        <param name="stictionDown">               0            0          0        0          </param>        
+    </group>
+
+    <group name="IMPEDANCE">
+        <param name="stiffness">       0      0      0      0     </param>    
+        <param name="damping">         0      0      0      0     </param>    
+    </group>
+	
+	<group name="OTHER_CONTROL_PARAMETERS">
+        <param name="deadZone"> 0.00002   0.00002   0.00002   0.0055   </param>
+    </group>
+	
+  </device>
+
+

--- a/CER02/hardware/motorControl/cer_right_shoulder-ems4-mc-service.xml
+++ b/CER02/hardware/motorControl/cer_right_shoulder-ems4-mc-service.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER02" build="1">
+
+    <group name="SERVICE">
+        
+        <param name="type"> eomn_serv_MC_foc </param> 
+    
+        <group name="PROPERTIES">
+        
+            <group name="ETHBOARD">
+                <param name="type">                 ems4        </param> 
+            </group>          
+
+            <group name="CANBOARDS"> 
+                <param name="type">                 foc         </param> 
+                <group name="PROTOCOL">
+                    <param name="major">            1           </param>    
+                    <param name="minor">            6           </param>     
+                </group>                    
+                <group name="FIRMWARE">
+                    <param name="major">            0           </param>    
+                    <param name="minor">            0           </param> 
+                    <param name="build">            0           </param>
+                </group>
+            </group>
+            
+
+            <group name="JOINTMAPPING">
+
+                <group name="ACTUATOR">                
+                    <param name="type">             foc                 foc         </param>
+                    <param name="port">             CAN1:1:0            CAN1:2:0    </param>
+                </group>                                                            
+                                                                                    
+                <group name="ENCODER1">                                             
+                    <param name="type">             aea                aea          </param>  
+                    <param name="port">             CONN:P8            CONN:P6      </param>
+                    <param name="position">         atjoint            atjoint      </param> 
+                    <param name="resolution">      -4096               4096         </param>
+                    <param name="tolerance">        0.703              0.703        </param>  
+                </group>                                                            
+                                                                                    
+                <group name="ENCODER2">                                             
+                    <param name="type">             roie                roie        </param>
+                    <param name="port">             CAN1:1:0            CAN1:2:0    </param>
+                    <param name="position">         atmotor             atmotor     </param>
+                    <param name="resolution">       8192                8192        </param>
+                    <param name="tolerance">        0                   0           </param>  
+                </group>                                                            
+ 
+            </group>    
+            
+        </group>
+           
+    </group>
+    
+  
+</params>
+

--- a/CER02/hardware/motorControl/cer_right_shoulder-ems4-mc.xml
+++ b/CER02/hardware/motorControl/cer_right_shoulder-ems4-mc.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_right_shoulder_mc" type="embObjMotionControl">
+      <xi:include href="../../general.xml" />
+      <xi:include href="../electronics/cer_right_shoulder-ems4-eln.xml" />
+      <xi:include href="../mechanicals/cer_right_shoulder-ems4-mec.xml" />
+      <xi:include href="../motorControl/cer_right_shoulder-ems4-mc-service.xml" />
+
+    <group name="LIMITS">
+        <param name="jntPosMax">                      85            85        </param>
+        <param name="jntPosMin">                     -70             2        </param>
+        <param name="motorOverloadCurrents">          5000          5000      </param>
+        <param name="motorNominalCurrents">           2500          2500      </param>
+        <param name="motorPeakCurrents">              5000          5000      </param>
+        <param name="jntVelMax">                      50            50        </param>
+        <param name="motorPwmLimit">                  32000         32000     </param>    
+    </group>
+    
+    <group name="TIMEOUTS">
+        <param name="velocity">               100       100   </param>
+    </group>
+    
+    <group name="CONTROLS">
+        <param name="positionControl">        JOINT_MINJERK_OUT_WORM_VEL_CTRL    JOINT_MINJERK_OUT_WORM_VEL_CTRL    </param>
+        <param name="velocityControl">        JOINT_MINJERK_OUT_WORM_VEL_CTRL    JOINT_MINJERK_OUT_WORM_VEL_CTRL    </param>
+        <param name="mixedControl">           JOINT_MINJERK_OUT_WORM_VEL_CTRL    JOINT_MINJERK_OUT_WORM_VEL_CTRL    </param>
+        <param name="posDirectControl">       JOINT_DIRECT_OUT_WORM_VEL_CTRL     JOINT_DIRECT_OUT_WORM_VEL_CTRL     </param>                
+        <param name="velDirectControl">       JOINT_DIRECT_OUT_WORM_VEL_CTRL     JOINT_DIRECT_OUT_WORM_VEL_CTRL     </param>
+        <param name="torqueControl">          none                               none                               </param>
+                                            
+        <param name="currentPid">             2FOC_CUR_CONTROL                   2FOC_CUR_CONTROL                   </param>
+        <param name="speedPid">               2FOC_VEL_CONTROL                   2FOC_VEL_CONTROL                   </param>
+    </group>
+    
+    <group name="JOINT_MINJERK_OUT_WORM_VEL_CTRL">
+        <param name="controlLaw">             minjerk                   </param>
+        <param name="outputType">             velocity                  </param>
+        <param name="fbkControlUnits">        machine_units             </param> 
+        <param name="outputControlUnits">     machine_units             </param> 
+        <param name="kff">                        1          1          </param> 
+        <param name="kp">                         5          5          </param>       
+        <param name="kd">                         0          0          </param>             
+        <param name="maxOutput">              32000      32000          </param>                
+    </group>
+    
+    <group name="JOINT_DIRECT_OUT_WORM_VEL_CTRL">
+        <param name="controlLaw">             direct                    </param>
+        <param name="outputType">             velocity                  </param>
+        <param name="fbkControlUnits">        machine_units             </param> 
+        <param name="outputControlUnits">     machine_units             </param> 
+        <param name="kff">                        1          1          </param> 
+        <param name="kp">                         5          5          </param>       
+        <param name="kd">                         0          0          </param>             
+        <param name="maxOutput">              32000      32000          </param>                 
+    </group>
+    
+    <group name="2FOC_CUR_CONTROL">
+        <param name="controlLaw">          low_lev_current      </param> 
+        <param name="fbkControlUnits">     machine_units        </param> 
+        <param name="outputControlUnits">  machine_units        </param>
+        <param name="kff">                     0         0  </param>
+        <param name="kp">                      8         8  </param>       
+        <param name="kd">                      0         0  </param>       
+        <param name="ki">                      2         2  </param>
+        <param name="shift">                  10        10  </param>
+        <param name="maxOutput">           32000     32000  </param>                 
+        <param name="maxInt">              32000     32000  </param>         
+    </group>
+
+    <group name="2FOC_VEL_CONTROL">
+        <param name="controlLaw">          low_lev_speed        </param> 
+        <param name="fbkControlUnits">     machine_units        </param> 
+        <param name="outputControlUnits">  machine_units        </param>
+        <param name="kff">                 0      0         </param>
+        <param name="kp">               1280   1280         </param>       
+        <param name="kd">               6144   6144         </param>       
+        <param name="ki">                  1      1         </param>
+        <param name="shift">              14     14         </param>
+        <param name="maxOutput">       32000  32000         </param>                 
+        <param name="maxInt">          32000  32000         </param>        
+    </group>
+
+    
+    <group name="IMPEDANCE">
+        <param name="stiffness">        0          0     </param>    
+        <param name="damping">          0          0     </param>    
+    </group>
+
+    <group name="OTHER_CONTROL_PARAMETERS">
+        <param name="deadZone">         0.0495   0.0495   </param>
+    </group>
+
+  </device>
+

--- a/CER02/hardware/motorControl/cer_right_upper_arm-ems11-mc-service.xml
+++ b/CER02/hardware/motorControl/cer_right_upper_arm-ems11-mc-service.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER02" build="1">
+
+    <group name="SERVICE">
+        
+        <param name="type"> eomn_serv_MC_foc </param> 
+    
+        <group name="PROPERTIES">
+        
+            <group name="ETHBOARD">
+                <param name="type">                 ems4        </param> 
+            </group>          
+
+            <group name="CANBOARDS"> 
+                <param name="type">                 foc         </param> 
+                <group name="PROTOCOL">
+                    <param name="major">            1           </param>    
+                    <param name="minor">            6           </param>     
+                </group>                    
+                <group name="FIRMWARE">
+                    <param name="major">            0           </param>    
+                    <param name="minor">            0           </param> 
+                    <param name="build">            0           </param>
+                </group>
+            </group>
+            
+
+            <group name="JOINTMAPPING">
+
+                <group name="ACTUATOR">                
+                    <param name="type">             foc                 foc               </param>
+                    <param name="port">             CAN1:1:0            CAN1:2:0          </param>
+                </group>
+                
+                <group name="ENCODER1">  
+                    <param name="type">             aea                 aea               </param>  
+                    <param name="port">             CONN:P8             CONN:P6
+                               </param>
+                    <param name="position">         atjoint             atjoint           </param> 
+                    <param name="resolution">       4096               -4096              </param>
+                    <param name="tolerance">        0.703               0.703             </param>  
+                </group>        
+                
+                <group name="ENCODER2">
+                    <param name="type">             roie                roie              </param>
+                    <param name="port">             CAN1:1:0            CAN1:2:0          </param>
+                    <param name="position">         atmotor             atmotor           </param>
+                    <param name="resolution">       8192                8192              </param>
+                    <param name="tolerance">        0                   0                 </param>  
+                </group> 
+ 
+            </group>    
+            
+        </group>
+           
+    </group>
+    
+  
+</params>
+

--- a/CER02/hardware/motorControl/cer_right_upper_arm-ems11-mc.xml
+++ b/CER02/hardware/motorControl/cer_right_upper_arm-ems11-mc.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_right_upper_arm_mc" type="embObjMotionControl">
+      <xi:include href="../../general.xml" />
+      <xi:include href="../electronics/cer_right_upper_arm-ems11-eln.xml" />
+      <xi:include href="../mechanicals/cer_right_upper_arm-ems11-mec.xml" />
+      <xi:include href="../motorControl/cer_right_upper_arm-ems11-mc-service.xml" />
+
+    <group name="LIMITS">
+        <param name="jntPosMax">                      85            95        </param>
+        <param name="jntPosMin">                     -85             5        </param>
+        <param name="motorOverloadCurrents">          9000          9000      </param>
+        <param name="motorNominalCurrents">           3000          3000      </param>
+        <param name="motorPeakCurrents">              6000          6000      </param>
+        <param name="jntVelMax">                      90            90        </param>
+        <param name="motorPwmLimit">                  32000         32000     </param>    
+    </group>
+    
+    <group name="TIMEOUTS">
+        <param name="velocity">               100       100        </param>
+    </group>
+    
+    <group name="CONTROLS">
+        <param name="positionControl">        JOINT_MINJERK_OUT_WORM_VEL_CTRL    JOINT_MINJERK_OUT_WORM_VEL_CTRL    </param>
+        <param name="velocityControl">        JOINT_MINJERK_OUT_WORM_VEL_CTRL    JOINT_MINJERK_OUT_WORM_VEL_CTRL    </param>
+        <param name="mixedControl">           JOINT_MINJERK_OUT_WORM_VEL_CTRL    JOINT_MINJERK_OUT_WORM_VEL_CTRL    </param>
+        <param name="posDirectControl">       JOINT_DIRECT_OUT_WORM_VEL_CTRL     JOINT_DIRECT_OUT_WORM_VEL_CTRL     </param>                
+        <param name="velDirectControl">       JOINT_DIRECT_OUT_WORM_VEL_CTRL     JOINT_DIRECT_OUT_WORM_VEL_CTRL     </param>
+        <param name="torqueControl">          none                               none                               </param>
+                                            
+        <param name="currentPid">             2FOC_CUR_CONTROL                   2FOC_CUR_CONTROL                   </param>
+        <param name="speedPid">               2FOC_VEL_CONTROL                   2FOC_VEL_CONTROL                   </param>
+    </group>
+
+    <group name="JOINT_MINJERK_OUT_WORM_VEL_CTRL">
+        <param name="controlLaw">             minjerk                   </param>
+        <param name="outputType">             velocity                  </param>
+        <param name="fbkControlUnits">        machine_units             </param> 
+        <param name="outputControlUnits">     machine_units             </param> 
+        <param name="kff">                        1          1          </param> 
+        <param name="kp">                         5          5          </param>       
+        <param name="kd">                         0          0          </param>             
+        <param name="maxOutput">              32000      32000          </param>                
+    </group>
+    
+    <group name="JOINT_DIRECT_OUT_WORM_VEL_CTRL">
+        <param name="controlLaw">             direct                    </param>
+        <param name="outputType">             velocity                  </param>
+        <param name="fbkControlUnits">        machine_units             </param> 
+        <param name="outputControlUnits">     machine_units             </param> 
+        <param name="kff">                        1          1          </param> 
+        <param name="kp">                         5          5          </param>       
+        <param name="kd">                         0          0          </param>             
+        <param name="maxOutput">              32000      32000          </param>                 
+    </group>
+    
+    <group name="2FOC_CUR_CONTROL">
+        <param name="controlLaw">          low_lev_current      </param> 
+        <param name="fbkControlUnits">     machine_units        </param> 
+        <param name="outputControlUnits">  machine_units        </param>
+        <param name="kff">                     0         0  </param>
+        <param name="kp">                      8         8  </param>       
+        <param name="kd">                      0         0  </param>       
+        <param name="ki">                      2         2  </param>
+        <param name="shift">                  10        10  </param>
+        <param name="maxOutput">           32000     32000  </param>                 
+        <param name="maxInt">              32000     32000  </param>         
+    </group>
+    
+    <group name="2FOC_VEL_CONTROL">
+        <param name="controlLaw">          low_lev_speed        </param> 
+        <param name="fbkControlUnits">     machine_units        </param> 
+        <param name="outputControlUnits">  machine_units        </param>
+        <param name="kff">                 0          0     </param>
+        <param name="kp">                 12         12     </param>       
+        <param name="kd">                  0          0     </param>       
+        <param name="ki">                 16         16     </param>
+        <param name="shift">              10         10     </param>
+        <param name="maxOutput">       32000      32000     </param>                 
+        <param name="maxInt">          32000      32000     </param>        
+    </group>
+    
+    <group name="IMPEDANCE">
+        <param name="stiffness">        0          0         </param>    
+        <param name="damping">          0          0         </param>    
+    </group>
+
+	<group name="OTHER_CONTROL_PARAMETERS">
+        <param name="deadZone">         0.0495   0.0495   </param>
+    </group>
+
+  </device>
+

--- a/CER02/hardware/motorControl/cer_right_wrist_equivalent-mc.xml
+++ b/CER02/hardware/motorControl/cer_right_wrist_equivalent-mc.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_right_wrist_equivalent_mc" type="tripodMotionControl">
+      <xi:include href="../../general.xml" />
+
+    <param name="AxisNames">  "r_wrist_heave_eq_joint" "r_wrist_roll_eq_joint" "r_wrist_pitch_eq_joint"  </param>
+
+    <group name="GENERAL">
+      <param name="Joints">    3       </param>
+     <!-- <param name="AxisMap">   0 1 2   </param> -->
+     <!-- <param name="Verbose">   true    </param> -->
+      <param name="Encoder">   1 1 1   </param>
+    </group>
+
+    <group name="TRIPOD">
+      <param name="Radius">      0.018   </param>
+      <param name="Max_el">      0.120  </param>
+      <param name="Min_el">      0.0    </param>
+      <param name="Max_alpha">   30.0   </param>
+
+      <param name="BASE_TRANSFORMATION">   1.0    0.0     0.0    0.0
+                                           0.0    1.0     0.0    0.0
+                                           0.0    0.0     1.0    0.0
+                                           0.0    0.0     0.0    1.0
+      </param>
+    </group>
+
+    <group name="LIMITS">
+        <param name="JntVelocityMax">   0.05  </param>
+    </group>
+
+    <!-- action is alternative to CONNECTION group -->
+    <action phase="startup" level="1" type="attach">
+      <paramlist name="networks">
+          <elem name="FirstSetOfJoints"> cer_right_lower_arm_mc </elem>
+      </paramlist>
+    </action>
+
+    <action phase="shutdown" level="6" type="detach" />
+
+  </device>
+

--- a/CER02/hardware/motorControl/cer_torso-ems3-mc-service.xml
+++ b/CER02/hardware/motorControl/cer_torso-ems3-mc-service.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER02" build="1">
+
+    <group name="SERVICE">
+        
+        <param name="type"> eomn_serv_MC_foc </param> 
+    
+        <group name="PROPERTIES">
+        
+            <group name="ETHBOARD">
+                <param name="type">                 ems4        </param> 
+            </group>          
+
+            <group name="CANBOARDS"> 
+                <param name="type">                 foc         </param> 
+                <group name="PROTOCOL">
+                    <param name="major">            1           </param>    
+                    <param name="minor">            6           </param>     
+                </group>                    
+                <group name="FIRMWARE">
+                    <param name="major">            0           </param>    
+                    <param name="minor">            0           </param> 
+                    <param name="build">            0           </param>
+                </group>
+            </group>
+
+
+            <group name="JOINTMAPPING">
+
+                <group name="ACTUATOR">                
+                    <param name="type">             eomc_act_foc        foc                 foc             foc         </param>
+                    <param name="port">             CAN1:1:0            CAN1:2:0            CAN1:3:0        CAN1:4:0    </param>
+                </group>
+                
+                <group name="ENCODER1">  
+                    <param name="type">             none                none                none             aea         </param>  
+                    <param name="port">             CONN:none           CONN:none           CONN:none        CONN:P8     </param>
+                    <param name="position">         none                none                none             atjoint     </param> 
+                    <param name="resolution">       0                   0                   0               -4096        </param>
+                    <param name="tolerance">        0                   0                   0                0.703       </param> 
+                </group>        
+                
+                <group name="ENCODER2">
+                    <param name="type">             roie                roie                roie            roie         </param>
+                    <param name="port">             CAN1:1:0            CAN1:2:0            CAN1:3:0        CAN1:4:0     </param>
+                    <param name="position">         atmotor             atmotor             atmotor         atmotor      </param>
+                    <param name="resolution">       65535               65535               65535           8192         </param>
+                    <param name="tolerance">            0                   0                   0              0         </param> 
+                </group> 
+ 
+            </group>    
+            
+        </group>
+           
+    </group>
+    
+  
+</params>
+

--- a/CER02/hardware/motorControl/cer_torso-ems3-mc.xml
+++ b/CER02/hardware/motorControl/cer_torso-ems3-mc.xml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+ <!-- Initialization file for EMS 15 - CER torso tripod + yaw, 4 dof -->
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_torso_mc" type="embObjMotionControl">
+      <xi:include href="../../general.xml" />
+      <xi:include href="../electronics/cer_torso-ems3-eln.xml" />
+      <xi:include href="../mechanicals/cer_torso-ems3-mec.xml" />
+      <xi:include href="../motorControl/cer_torso-ems3-mc-service.xml" />
+
+    <group name="LIMITS">
+        <param name="jntPosMax">                0.15    0.15         0.15       30     </param>
+        <param name="jntPosMin">               -0.04   -0.04        -0.04      -30     </param>
+        <param name="jntVelMax">                0.05    0.05         0.05    30000     </param>
+        <param name="motorOverloadCurrents">    5000    5000         5000     5000     </param>
+        <param name="motorNominalCurrents">     2500    2500         2500     2500     </param>
+        <param name="motorPeakCurrents">        5000    5000         5000     5000     </param>
+        <param name="motorPwmLimit">           32000   32000        32000    32000     </param>  
+    </group>
+    
+    
+    <group name="TIMEOUTS">
+        <param name="velocity">               100       100           100        100    </param>
+    </group>
+
+
+    <group name="CONTROLS">
+        <param name="positionControl">         JOINT_MINJERK_OUT_DC_PWM_CTRL  JOINT_MINJERK_OUT_DC_PWM_CTRL  JOINT_MINJERK_OUT_DC_PWM_CTRL  JOINT_MINJERK_OUT_WORM_VEL_CTRL   </param>
+        <param name="velocityControl">         JOINT_MINJERK_OUT_DC_PWM_CTRL  JOINT_MINJERK_OUT_DC_PWM_CTRL  JOINT_MINJERK_OUT_DC_PWM_CTRL  JOINT_MINJERK_OUT_WORM_VEL_CTRL   </param>
+        <param name="mixedControl">            JOINT_MINJERK_OUT_DC_PWM_CTRL  JOINT_MINJERK_OUT_DC_PWM_CTRL  JOINT_MINJERK_OUT_DC_PWM_CTRL  JOINT_MINJERK_OUT_WORM_VEL_CTRL   </param>
+        <param name="posDirectControl">        JOINT_DIRECT_OUT_DC_PWM_CTRL   JOINT_DIRECT_OUT_DC_PWM_CTRL   JOINT_DIRECT_OUT_DC_PWM_CTRL   JOINT_DIRECT_OUT_WORM_VEL_CTRL    </param>                
+        <param name="velDirectControl">        JOINT_DIRECT_OUT_DC_PWM_CTRL   JOINT_DIRECT_OUT_DC_PWM_CTRL   JOINT_DIRECT_OUT_DC_PWM_CTRL   JOINT_DIRECT_OUT_WORM_VEL_CTRL    </param>
+        <param name="torqueControl">           none                           none                           none                           none                              </param>
+                                               
+        <param name="currentPid">              2FOC_CUR_CONTROL               2FOC_CUR_CONTROL               2FOC_CUR_CONTROL               2FOC_CUR_CONTROL                  </param>
+        <param name="speedPid">                2FOC_VEL_CONTROL               2FOC_VEL_CONTROL               2FOC_VEL_CONTROL               2FOC_VEL_CONTROL                  </param>
+    </group>
+    
+    
+    <group name="JOINT_MINJERK_OUT_DC_PWM_CTRL">
+	    <param name="controlLaw">             minjerk                   </param>
+        <param name="outputType">             pwm                       </param>
+        <param name="fbkControlUnits">        machine_units             </param> 
+        <param name="outputControlUnits">     machine_units             </param>
+        <param name="kff">                        0            0           0         0       </param> 
+        <param name="kp">                      3000         3000        3000         0       </param>          
+        <param name="kd">                         0            0           0         0       </param>          
+        <param name="ki">                      5000         5000        5000         0       </param>              
+        <param name="maxOutput">              32000        32000       32000         0       </param>                
+        <param name="maxInt">                  4000         4000        4000         0       </param>                             
+        <param name="stictionUp">                 0            0           0         0       </param>          
+        <param name="stictionDown">               0            0           0         0       </param>        
+    </group>
+
+    <group name="JOINT_DIRECT_OUT_DC_PWM_CTRL">
+	    <param name="controlLaw">             direct                    </param>
+        <param name="outputType">             pwm                       </param>
+        <param name="fbkControlUnits">        machine_units             </param> 
+        <param name="outputControlUnits">     machine_units             </param>
+        <param name="kff">                        0            0           0         0       </param> 
+        <param name="kp">                      3000         3000        3000         0       </param>          
+        <param name="kd">                         0            0           0         0       </param>          
+        <param name="ki">                      5000         5000        5000         0       </param>              
+        <param name="maxOutput">              32000        32000       32000         0       </param>                
+        <param name="maxInt">                  4000         4000        4000         0       </param>                             
+        <param name="stictionUp">                 0            0           0         0       </param>          
+        <param name="stictionDown">               0            0           0         0       </param>        
+    </group>
+    
+    <group name="JOINT_MINJERK_OUT_WORM_VEL_CTRL">
+        <param name="controlLaw">             minjerk                   </param>
+        <param name="outputType">             velocity                  </param>
+        <param name="fbkControlUnits">        machine_units             </param> 
+        <param name="outputControlUnits">     machine_units             </param> 
+        <param name="kff">                    0 0 0           1         </param> 
+        <param name="kp">                     0 0 0           5         </param>       
+        <param name="kd">                     0 0 0           0         </param>             
+        <param name="maxOutput">              0 0 0       32000         </param>                
+    </group>
+    
+    <group name="JOINT_DIRECT_OUT_WORM_VEL_CTRL">
+        <param name="controlLaw">             direct                    </param>
+        <param name="outputType">             velocity                  </param>
+        <param name="fbkControlUnits">        machine_units             </param> 
+        <param name="outputControlUnits">     machine_units             </param> 
+        <param name="kff">                    0 0 0           1         </param> 
+        <param name="kp">                     0 0 0           5         </param>       
+        <param name="kd">                     0 0 0           0         </param>             
+        <param name="maxOutput">              0 0 0       32000         </param>                
+    </group>
+    
+    <group name="2FOC_CUR_CONTROL">
+        <param name="controlLaw">          low_lev_current      </param> 
+        <param name="fbkControlUnits">     machine_units        </param> 
+        <param name="outputControlUnits">  machine_units        </param>
+        <param name="kff">                     0         0         0         0      </param>
+        <param name="kp">                      8         8         8         8      </param>       
+        <param name="kd">                      0         0         0         0      </param>       
+        <param name="ki">                      2         2         2         2      </param>
+        <param name="shift">                  10        10        10        10      </param>
+        <param name="maxOutput">           32000     32000     32000     32000      </param>                 
+        <param name="maxInt">              32000     32000     32000     32000      </param>         
+    </group>
+
+    <group name="2FOC_VEL_CONTROL">
+        <param name="controlLaw">          low_lev_speed        </param> 
+        <param name="fbkControlUnits">     machine_units        </param> 
+        <param name="outputControlUnits">  machine_units        </param>
+        <param name="kff">                 0          0         0         0  </param>
+        <param name="kp">                 12         12        12      1280  </param>       
+        <param name="kd">                  0          0         0      6144  </param>       
+        <param name="ki">                 16         16        16         1  </param>
+        <param name="shift">              10         10        10        14  </param>
+        <param name="maxOutput">       32000      32000     32000     32000  </param>                 
+        <param name="maxInt">          32000      32000     32000     32000  </param>        
+    </group>
+
+    
+    <group name="IMPEDANCE">
+        <param name="stiffness">       0      0      0      0     </param>    
+        <param name="damping">         0      0      0      0     </param>    
+    </group>
+
+    <group name="OTHER_CONTROL_PARAMETERS">
+        <param name="deadZone">        0.0001      0.0001      0.0001   0.0495   </param>
+    </group>
+	
+  </device>
+
+

--- a/CER02/hardware/motorControl/cer_torso_equivalent-mc.xml
+++ b/CER02/hardware/motorControl/cer_torso_equivalent-mc.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_torso_equivalent_mc" type="tripodMotionControl">
+      <xi:include href="../../general.xml" />
+
+    <param name="AxisNames">  "torso_heave_eq_joint"   "torso_pitch_eq_joint"   "torso_roll_eq_joint"  </param>
+
+    <group name="GENERAL">
+      <param name="Joints">    3       </param>
+      <!-- <param name="AxisMap">   0 1 2   </param> -->
+      <!-- <param name="Verbose">   true    </param> -->
+      <param name="Encoder">   1 1 1   </param>
+    </group>
+
+    <group name="TRIPOD">
+      <param name="Radius">      0.09   </param>
+      <param name="Max_el">      0.15   </param>
+      <param name="Min_el">     -0.04   </param>
+      <param name="Max_alpha">   25.0   </param>
+
+      <param name="BASE_TRANSFORMATION">   1.0    0.0     0.0    0.0
+                                           0.0    1.0     0.0    0.0
+                                           0.0    0.0     1.0    0.0
+                                           0.0    0.0     0.0    1.0
+      </param>
+    </group>
+
+    <group name="LIMITS">
+        <param name="JntVelocityMax">   0.05  </param>
+    </group>
+
+
+    <!--
+    <group name="CONNECTION">
+      <param name="local">         /cerGazeboSim/torso_out  </param>
+      <param name="remote">        /cerGazeboSim/torso      </param>
+      <param name="writeStrict">   off                       </param>
+    </group>
+     -->
+
+    <!-- action is alternative to CONNECTION group -->
+    <action phase="startup" level="5" type="attach">
+      <paramlist name="networks">
+          <elem name="FirstSetOfJoints"> cer_torso_mc </elem>
+      </paramlist>
+    </action>
+
+    <action phase="shutdown" level="6" type="detach" />
+
+  </device>
+

--- a/CER02/hardware/rpLidar/laserA2_hw.xml
+++ b/CER02/hardware/rpLidar/laserA2_hw.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" ?>    
+
+<devices>
+    <device name="cerLaser" type="rpLidar2">  
+       <group name="GENERAL">
+            <param name="name">            cer_laser     </param>
+            <param name="clip_max">        7.0          </param>
+            <param name="clip_min">        0.1          </param>
+            <param name="max_angle">       360          </param>
+            <param name="min_angle">       0            </param>
+            <param name="resolution">      0.5           </param>
+            <param name="allow_infinity">  1            </param>
+            <param name="serial_baudrate"> 115200       </param>
+            <param name="serial_port">     /dev/ttyUSB1 </param>
+            <param name="sample_buffer_life">  1        </param>
+        </group>
+        <group name="SKIP">
+            <param name="min">  35     </param>
+            <param name="max">  325    </param>
+        </group> 
+    </device>
+</devices>
+
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 

--- a/CER02/hardware/rpLidar/laserA2_hw_back.xml
+++ b/CER02/hardware/rpLidar/laserA2_hw_back.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>    
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_laser_back_device" type="rpLidar2">  
+       <group name="GENERAL">
+            <param name="name">            cer_laserBack     </param>
+            <param name="clip_max">        7.0          </param>
+            <param name="clip_min">        0.1          </param>
+            <param name="max_angle">       360          </param>
+            <param name="min_angle">       0            </param>
+            <param name="resolution">      0.5           </param>
+            <param name="allow_infinity">  1            </param>
+            <param name="serial_baudrate"> 115200       </param>
+            <param name="serial_port">     /dev/ttyUSB0 </param>
+            <param name="sample_buffer_life">  1        </param>
+        </group>
+        <group name="SKIP">
+            <param name="min">  60     </param>
+            <param name="max">  300    </param>
+        </group> 
+    </device>

--- a/CER02/hardware/rpLidar/laserA2_hw_double.xml
+++ b/CER02/hardware/rpLidar/laserA2_hw_double.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>    
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_double_laser_device" type="cerDoubleLidar">  
+
+	<group name="LASERFRONT-CFG">
+            <param name="sensorName">     L_Front    </param>
+            <param name="pose">        0.070 0.0 0.031 0.0          </param>
+            <param name="file">        laserA2_hw_front.xml         </param>
+        </group>
+        <group name="LASERBACK-CFG">
+            <param name="sensorName">     L_Back     </param>
+            <param name="pose">        -0.070 0.0 0.031 3.14159     </param>
+            <param name="file">        laserA2_hw_back.xml          </param>
+        </group>
+
+      <action phase="startup" level="3" type="attach">
+         <paramlist name="networks">
+            <elem name="L_Front">  cer_laser_front_device </elem>
+            <elem name="L_Back">   cer_laser_back_device </elem>
+         </paramlist>
+      </action>
+      
+      <action phase="shutdown" level="3" type="detach"/>
+
+    </device>
+
+

--- a/CER02/hardware/rpLidar/laserA2_hw_front.xml
+++ b/CER02/hardware/rpLidar/laserA2_hw_front.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>    
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_laser_front_device" type="rpLidar2">  
+       <group name="GENERAL">
+            <param name="name">            cer_laserFront     </param>
+            <param name="clip_max">        7.0          </param>
+            <param name="clip_min">        0.1          </param>
+            <param name="max_angle">       360          </param>
+            <param name="min_angle">       0            </param>
+            <param name="resolution">      0.5          </param>
+            <param name="allow_infinity">  1            </param>
+            <param name="serial_baudrate"> 115200       </param>
+            <param name="serial_port">     /dev/ttyUSB1 </param>
+            <param name="sample_buffer_life">  1        </param>
+        </group>
+        <group name="SKIP">
+            <param name="min">  35     </param>
+            <param name="max">  325    </param>
+        </group> 
+    </device>
+

--- a/CER02/hardware/rpLidar/laser_hw.xml
+++ b/CER02/hardware/rpLidar/laser_hw.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" ?>    
+
+<devices>
+    <device name="cerLaser" type="rpLidar">  
+
+    <group name="GENERAL">
+       <param name="name">      cer_laser        </param>
+       <param name="clip_max">  3.5 </param>
+       <param name="clip_min">  0.1 </param>
+       <param name="max_angle">  359 </param>
+       <param name="min_angle">  0   </param>
+       <param name="resolution">  1   </param>
+       <param name="allow_infinity">  1 </param>
+       <param name="Serial_Configuration">  hardware/rpLidar/serial.ini </param>
+    </group>
+
+    <group name="SKIP">
+       <param name="min">  0  160  </param>
+       <param name="max">  30 360  </param>
+    </group>
+
+    </device>
+</devices>
+
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 

--- a/CER02/hardware/rpLidar/serial.ini
+++ b/CER02/hardware/rpLidar/serial.ini
@@ -1,0 +1,24 @@
+/// configuration file for iKart serial port
+
+verbose 4
+//comport COM4  //windows
+comport /dev/ttyUSB0 //linux
+baudrate 115200
+xonlim 0
+xofflim 0
+readmincharacters 0
+readtimeoutmsec 2
+parityenb 0
+paritymode none
+ctsenb 0
+rtsenb 0
+xinenb 0
+xoutenb 0
+modem 0
+rcvenb 0
+dsrenb 0
+dtrdisable 1
+databits 8
+stopbits 1
+line_terminator_char1 10
+line_terminator_char2 10

--- a/CER02/hardware/skin/left_hand-mc9-skin.xml
+++ b/CER02/hardware/skin/left_hand-mc9-skin.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_hand_skin" type="embObjSkin">
+        <xi:include href="../../general.xml" />
+ 
+        <xi:include href="../electronics/cer_left_hand-mcp9-eln.xml" />
+        <group name="patches">
+            <param name="skinCanAddrsPatch1"> 13 </param> 
+        </group>
+        <xi:include href="./left_hand-mc9-skinSpec.xml" />
+    </device>
+
+  

--- a/CER02/hardware/skin/left_hand-mc9-skinSpec.xml
+++ b/CER02/hardware/skin/left_hand-mc9-skinSpec.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER02" build="1">
+
+        <group name="defaultCfgBoard">
+            <param name="period">        50  </param> 
+            <param name="skinType">      2  </param> <!-- 0 ==> new skin
+                                                              1 ==> palm and fingertips skin
+                                                              2 ==> old skin without temperature compensation -->
+            <param name="noLoad">         0xf0  </param>
+            <param name="diagnostic">    false  </param>     <!-- used to config high level -->
+        </group>
+        
+        
+       <group name="defaultCfgTriangle">
+            <param name="enabled">         true  </param> 
+            <param name="shift">           0  </param>
+            <param name="cdcOffset">       0x2000  </param>
+        </group>
+
+        
+   <!--    <group name="specialCfgTriangles">
+           <param name="numOfSets">            1  </param> 
+     	   <param name="triangleSetCfg1">      2            5        0             6             1              0            0x2000      </param>
+        </group> -->
+        
+</params>

--- a/CER02/hardware/skin/right_hand-mc7-skin.xml
+++ b/CER02/hardware/skin/right_hand-mc7-skin.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_hand_skin" type="embObjSkin">
+        <xi:include href="../../general.xml" />
+ 
+        <xi:include href="../electronics/cer_right_hand-mcp7-eln.xml" />
+        <group name="patches">
+            <param name="skinCanAddrsPatch1"> 13 </param> 
+        </group>
+        <xi:include href="./right_hand-mc7-skinSpec.xml" />
+    </device>
+
+  

--- a/CER02/hardware/skin/right_hand-mc7-skinSpec.xml
+++ b/CER02/hardware/skin/right_hand-mc7-skinSpec.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER02" build="1">
+
+        <group name="defaultCfgBoard">
+            <param name="period">        50  </param> 
+            <param name="skinType">      2  </param> <!-- 0 ==> new skin
+                                                              1 ==> palm and fingertips skin
+                                                              2 ==> old skin without temperature compensation -->
+            <param name="noLoad">         0xf0  </param>
+            <param name="diagnostic">    false  </param>     <!-- used to config high level -->
+        </group>
+        
+        
+       <group name="defaultCfgTriangle">
+            <param name="enabled">         true  </param> 
+            <param name="shift">           0  </param>
+            <param name="cdcOffset">       0x2000  </param>
+        </group>
+
+        
+   <!--    <group name="specialCfgTriangles">
+           <param name="numOfSets">            1  </param> 
+     	   <param name="triangleSetCfg1">      2            5        0             6             1              0            0x2000      </param>
+        </group> -->
+        
+</params>

--- a/CER02/robotStatePublisher.launch
+++ b/CER02/robotStatePublisher.launch
@@ -1,0 +1,9 @@
+<launch>
+
+  <arg name="model" default="./cer.urdf"/>
+
+  <param name="robot_description" command="$(find xacro)/xacro --inorder $(arg model)" />
+
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
+
+</launch>

--- a/CER02/sensors/Orbecc_Astra.ini
+++ b/CER02/sensors/Orbecc_Astra.ini
@@ -1,0 +1,58 @@
+device    RGBDSensorWrapper
+subdevice depthCamera
+name      /depthCamera
+[ROS]
+use_ROS             true
+forceInfoSync       true
+ROS_frame_Id        depth_center
+ROS_nodeName        /YarpRGBDSensor
+ROS_colorTopicName  /yarpColor
+ROS_depthTopicName  /yarpDepth
+ROS_colorInfoTopicName /yarpColor_info
+ROS_depthinfoTopicName /yarpDepth_info
+[SETTINGS]
+
+rgbMirroring false
+depthMirroring false
+
+[HW_DESCRIPTION]
+
+
+[RGB_INTRINSIC_PARAMETERS]
+
+focalLengthX			570.3422241210938
+focalLengthY			570.3422241210938
+principalPointX			314.5
+principalPointY			235.5
+distortionModel 		rgb_distortion
+
+[rgb_distortion]
+name					plumb_bob
+k1						0.0
+k2						0.0
+t1						0.0
+t2						0.0
+k3						0.0
+
+
+[DEPTH_INTRINSIC_PARAMETERS]
+
+focalLengthX			570.3422241210938
+focalLengthY			570.3422241210938
+principalPointX			314.5
+principalPointY			235.5
+distortionModel 		depth_distortion
+
+[depth_distortion]
+name					plumb_bob
+k1						0.0
+k2						0.0
+t1						0.0
+t2						0.0
+k3						0.0
+
+
+[EXTRINSIC_PARAMETERS]
+transformation   (1.0 0.0 0.0 0.0   0.0 1.0 0.0 0.0   0.0 0.0 1.0 0.0  0.0 0.0 0.0 1.0)
+
+

--- a/CER02/sensors/RealSenseStereo_conf.ini
+++ b/CER02/sensors/RealSenseStereo_conf.ini
@@ -1,0 +1,13 @@
+device grabberDual
+subdevice realsense2
+capabilities RAW
+stereoMode true
+split false
+
+[SETTINGS] 
+rgbResolution (640 480) 
+depthResolution (640 480) 
+framerate 30 
+enableEmitter false
+
+[HW_DESCRIPTION]

--- a/CER02/sensors/RealSense_conf.ini
+++ b/CER02/sensors/RealSense_conf.ini
@@ -1,0 +1,14 @@
+
+device       RGBDSensorWrapper
+subdevice    realsense2
+name         /depthCamera
+
+[SETTINGS]
+depthResolution (640 480)    #Note the parentesys
+rgbResolution   (640 480)
+framerate       30
+enableEmitter   true
+alignmentFrame  RGB
+
+[HW_DESCRIPTION]
+clipPlanes (0.2 10.0)

--- a/CER02/sensors/Xtion_depthCamera.ini
+++ b/CER02/sensors/Xtion_depthCamera.ini
@@ -1,0 +1,48 @@
+device       RGBDSensorWrapper
+subdevice    depthCamera
+name         /depthCamera
+
+[SETTINGS]
+accuracy     0.001
+depthResolution (320 240)    #Note the parentesys
+rgbResolution   (320 240)
+#enable mirroring for back compatibility with old driver version
+rgbMirroring    true
+depthMirroring  true
+
+[HW_DESCRIPTION]
+clipPlanes (0.4 4.5)
+
+[RGB_INTRINSIC_PARAMETERS]
+focalLengthX            1.0
+focalLengthY            2.0
+principalPointX         256.0
+principalPointY         128.0
+distortionModel         rgb_distortion
+
+[rgb_distortion]
+name                    plumb_bob
+k1                      1.0
+k2                      2.0
+t1                      3.0
+t2                      4.0
+k3                      5.0
+
+[DEPTH_INTRINSIC_PARAMETERS]
+focalLengthX            1.0
+focalLengthY            2.0
+principalPointX         256.0
+principalPointY         128.0
+distortionModel         depth_distortion
+
+[depth_distortion]
+name                    plumb_bob
+k1                      1.0
+k2                      2.0
+t1                      3.0
+t2                      4.0
+k3                      5.0
+
+[EXTRINSIC_PARAMETERS]
+transformation          (1.0 0.0 0.0 0.0   0.0 1.0 0.0 0.0   0.0 0.0 1.0 0.0  0.0 0.0 0.0 1.0)
+

--- a/CER02/wrappers/FT/cer_left_arm-FT_wrapper.xml
+++ b/CER02/wrappers/FT/cer_left_arm-FT_wrapper.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm_as_wrapper" type="analogServer">
+		<param name="period">   10  				</param>
+		<param name="name">     /cer/left_arm/FT:o  	        </param>
+		
+		<action phase="startup" level="5" type="attach">
+		    <paramlist name="networks">
+		<!-- The param value must match the device name in the corresponding emsX file -->
+		        <elem name="FirstStrain">  left_upper_arm_strain </elem>
+		    </paramlist>
+		</action>
+
+      <group name ="ROS">
+         <param name ="useROS"> true </param>
+         <param name ="ROS_nodeName"> /cer-left_arm_FT </param>
+         <param name ="ROS_topicName"> /left_arm_FT </param>
+         <param name ="frame_id"> /l_clavicle_link  </param>
+         <param name ="ROS_msgType"> geometry_msgs/WrenchStamped </param>
+      </group>
+
+		<action phase="shutdown" level="5" type="detach" />
+	</device>
+

--- a/CER02/wrappers/FT/cer_right_arm-FT_wrapper.xml
+++ b/CER02/wrappers/FT/cer_right_arm-FT_wrapper.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm_as_wrapper" type="analogServer">
+		<param name="period">       10  				</param>
+		<param name="name">     /cer/right_arm/FT:o				</param>
+		
+		<action phase="startup" level="5" type="attach">
+		    <paramlist name="networks">
+		<!-- The param value must match the device name in the corresponding emsX file -->
+		        <elem name="FirstStrain">  right_upper_arm_strain </elem>
+		    </paramlist>
+		</action>
+
+      <group name ="ROS">
+         <param name ="useROS"> true </param>
+         <param name ="ROS_nodeName"> /cer-right_arm_FT </param>
+         <param name ="ROS_topicName"> /right_arm_FT </param>
+         <param name ="frame_id"> /r_clavicle_link  </param>
+         <param name ="ROS_msgType"> geometry_msgs/WrenchStamped </param>
+      </group>
+
+		<action phase="shutdown" level="5" type="detach" />
+	</device>
+

--- a/CER02/wrappers/MAIS/left_hand-mais_wrapper.xml
+++ b/CER02/wrappers/MAIS/left_hand-mais_wrapper.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_hand_as_wrapperMais" type="analogServer">
+        <param name="period">       10                  </param>
+        <param name="name">     /cer/left_hand/analog:o           </param>
+
+        <action phase="startup" level="5" type="attach">
+            <paramlist name="networks">
+                <elem name="left_hand_mais_network">  left_hand_multienc </elem>
+            </paramlist>
+        </action>
+
+        <group name ="ROS">
+           <param name ="useROS"> true </param>
+           <param name ="ROS_nodeName"> /cer-left_hand_MAIS </param>
+           <param name ="ROS_topicName"> /joint_states </param>
+           <param name ="ROS_msgType"> sensor_msgs/JointState </param>
+           <param name ="joint_names"> l_hand_paddle_distal_joint l_hand_paddle_proximal_joint l_dummy_1 l_hand_thumb_proximal_joint l_hand_thumb_distal_joint l_dummy_2 </param>
+        </group>
+      
+        <action phase="shutdown" level="5" type="detach" />
+        </device>
+

--- a/CER02/wrappers/MAIS/right_hand-mais_wrapper.xml
+++ b/CER02/wrappers/MAIS/right_hand-mais_wrapper.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_hand_as_wrapperMais" type="analogServer">
+        <param name="period">       10                  </param>
+        <param name="name">     /cer/right_hand/analog:o          </param>
+
+        <action phase="startup" level="5" type="attach">
+            <paramlist name="networks">
+                <elem name="right_hand_mais_network">  right_hand_multienc </elem>
+            </paramlist>
+        </action>
+
+        <group name ="ROS">
+           <param name ="useROS"> true </param>
+           <param name ="ROS_nodeName"> /cer-right_hand_MAIS </param>
+           <param name ="ROS_topicName"> /joint_states </param>
+           <param name ="ROS_msgType"> sensor_msgs/JointState </param>
+           <param name ="joint_names"> r_hand_paddle_distal_joint r_hand_paddle_proximal_joint r_dummy_1 r_hand_thumb_distal_joint r_hand_thumb_proximal_joint r_dummy_2 </param>
+        </group>
+        
+        <action phase="shutdown" level="5" type="detach" />
+        </device>
+

--- a/CER02/wrappers/VFT/left_arm-VFT_wrapper.xml
+++ b/CER02/wrappers/VFT/left_arm-VFT_wrapper.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<devices robot="CER02" build="1">
+	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm_VFTserver" type="virtualAnalogServer">
+		<param name="period">       10  				</param>
+		<param name="deviceId">     left_arm				</param>
+		
+		 <paramlist name="networks">
+		      <!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+			<elem name="FirstSetOfJoints">  0  3  0  3 </elem> 
+			<elem name="SecondSetOfJoints"> 4  6  0  2 </elem> 	
+		    </paramlist>
+
+		<param name="channels">       7  				</param>
+		<param name="name"> 	     /left_arm				</param>
+
+		<action phase="startup" level="5" type="attach">
+		    <paramlist name="networks">
+			<!-- The param value must match the device name in the corresponding emsX file -->
+			 <elem name="FirstSetOfJoints">  left_upper_arm_mc </elem>	
+	     		 <elem name="SecondSetOfJoints"> left_lower_arm_mc </elem>  
+		    </paramlist>
+		</action>
+
+		<action phase="shutdown" level="5" type="detach" />
+	</device>
+
+
+

--- a/CER02/wrappers/VFT/left_leg-VFT_wrapper.xml
+++ b/CER02/wrappers/VFT/left_leg-VFT_wrapper.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<devices robot="CER02" build="1">
+	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg_VFTserver" type="virtualAnalogServer">
+		<param name="period">       10  				</param>
+		<param name="deviceId">     left_leg				</param>
+		
+		 <paramlist name="networks">
+		      <!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+			<elem name="FirstSetOfJoints">  0  3  0  3 </elem> 
+			<elem name="SecondSetOfJoints"> 4 5  0 1 </elem> 	
+		    </paramlist>
+
+		<param name="channels">       6  				</param>
+		<param name="name"> 	     /left_leg				</param>
+
+		<action phase="startup" level="5" type="attach">
+		    <paramlist name="networks">
+			<!-- The param value must match the device name in the corresponding emsX file -->
+			 <elem name="FirstSetOfJoints">  left_upper_leg_mc </elem>	
+	     		 <elem name="SecondSetOfJoints"> left_lower_leg_mc </elem>  
+		    </paramlist>
+		</action>
+
+		<action phase="shutdown" level="5" type="detach" />
+	</device>
+
+
+

--- a/CER02/wrappers/VFT/right_arm-VFT_wrapper.xml
+++ b/CER02/wrappers/VFT/right_arm-VFT_wrapper.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<devices robot="CER02" build="1">
+	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm_VFTserver" type="virtualAnalogServer">
+		<param name="period">       10  				</param>
+		<param name="deviceId">     right_arm				</param>
+		
+		 <paramlist name="networks">
+		      <!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+			<elem name="FirstSetOfJoints">  0  3  0  3 </elem> 
+			<elem name="SecondSetOfJoints"> 4  6  0  2 </elem> 	
+		    </paramlist>
+
+		<param name="channels">       7  				</param>
+		<param name="name"> 	      /right_arm				</param>
+
+		<action phase="startup" level="5" type="attach">
+		    <paramlist name="networks">
+			<!-- The param value must match the device name in the corresponding emsX file -->
+			 <elem name="FirstSetOfJoints">  right_upper_arm_mc </elem>	
+	     		 <elem name="SecondSetOfJoints"> right_lower_arm_mc </elem>  
+		    </paramlist>
+		</action>
+
+		<action phase="shutdown" level="5" type="detach" />
+	</device>
+
+
+

--- a/CER02/wrappers/VFT/right_leg-VFT_wrapper.xml
+++ b/CER02/wrappers/VFT/right_leg-VFT_wrapper.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<devices robot="CER02" build="1">
+	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg_VFTserver" type="virtualAnalogServer">
+		<param name="period">       10  				</param>
+		<param name="deviceId">     right_leg				</param>
+		
+		 <paramlist name="networks">
+		      <!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+			<elem name="FirstSetOfJoints">  0  3  0  3 </elem> 
+			<elem name="SecondSetOfJoints"> 4  5  0  1 </elem> 	
+		    </paramlist>
+
+		<param name="channels">       6  				</param>
+		<param name="name"> 	      /right_leg				</param>
+
+		<action phase="startup" level="5" type="attach">
+		    <paramlist name="networks">
+			<!-- The param value must match the device name in the corresponding emsX file -->
+			 <elem name="FirstSetOfJoints">  right_upper_leg_mc </elem>	
+	     		 <elem name="SecondSetOfJoints"> right_lower_leg_mc </elem>  
+		    </paramlist>
+		</action>
+
+		<action phase="shutdown" level="5" type="detach" />
+	</device>
+
+
+

--- a/CER02/wrappers/VFT/torso-VFT_wrapper.xml
+++ b/CER02/wrappers/VFT/torso-VFT_wrapper.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<devices robot="CER02" build="1">
+	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="torso_VFTserver" type="virtualAnalogServer">
+		<param name="period">       10  				</param>
+		<param name="deviceId">     torso				</param>
+		
+		 <paramlist name="networks">
+		      <!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+			<elem name="FirstSetOfJoints">  0  2  0  2 </elem> 
+		    </paramlist>
+
+		<param name="channels">       3  				</param>
+		<param name="name"> 	     /torso				</param>
+
+		<action phase="startup" level="5" type="attach">
+		    <paramlist name="networks">
+			<!-- The param value must match the device name in the corresponding emsX file -->
+			 <elem name="FirstSetOfJoints">  torso_mc </elem>	
+		    </paramlist>
+		</action>
+
+		<action phase="shutdown" level="5" type="detach" />
+	</device>
+
+
+

--- a/CER02/wrappers/motorControl/cer_base-mc_wrapper.xml
+++ b/CER02/wrappers/motorControl/cer_base-mc_wrapper.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_mobile_base_mc_wrapper" type="controlboardwrapper2">
+      <paramlist name="networks">
+	<!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+	  <elem name="FirstSetOfJoints"> 0  1  0  1 </elem>
+      </paramlist>
+
+      <param name="period"> 10 </param>
+      <param name="name">   /cer/mobile_base </param>
+      <param name="ports">  mobile_base		 </param>
+      <param name="joints"> 2		     	 </param>
+
+      <action phase="startup" level="5" type="attach">
+	  <paramlist name="networks">
+	  <!-- The param value must match the device name in the corresponding emsX file -->
+	      <elem name="FirstSetOfJoints"> cer_mobile_base_mc </elem>
+	  </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER02/wrappers/motorControl/cer_head-mc_wrapper.xml
+++ b/CER02/wrappers/motorControl/cer_head-mc_wrapper.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_head_mc_wrapper" type="controlboardwrapper2">
+      <paramlist name="networks">
+	<!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+	  <elem name="FirstSetOfJoints"> 0  1  0  1 </elem>
+      </paramlist>
+
+      <param name="period"> 10 </param>
+      <param name="name">   /cer/head	</param>
+      <param name="ports">  head		</param>
+      <param name="joints"> 2			</param>
+
+      <action phase="startup" level="5" type="attach">
+	  <paramlist name="networks">
+	  <!-- The param value must match the device name in the corresponding emsX file -->
+	      <elem name="FirstSetOfJoints"> cer_head_mc </elem>
+	  </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER02/wrappers/motorControl/cer_left_arm-mc_wrapper.xml
+++ b/CER02/wrappers/motorControl/cer_left_arm-mc_wrapper.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_left_arm_mc_wrapper" type="controlboardwrapper2">
+      <paramlist name="networks">
+	<!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+        <elem name="FirstSetOfJoints">  0  3  0  3 </elem>
+        <elem name="YawSetOfJoints">    4  4  3  3 </elem>
+        <elem name="SecondSetOfJoints"> 5  7  0  2 </elem>
+        <elem name="HandSetOfJoints">   8  9  0  1 </elem>
+      </paramlist>
+
+      <param name="period"> 10 </param>
+      <param name="name">   /cer/left_arm	</param>
+      <param name="ports">  left_arm		</param>
+      <param name="joints"> 10			</param>
+
+      <action phase="startup" level="5" type="attach">
+	  <paramlist name="networks">
+	  <!-- The param value must match the device name in the corresponding emsX file -->
+	  <elem name="FirstSetOfJoints">  cer_left_upper_arm_mc</elem>
+          <elem name="SecondSetOfJoints"> cer_left_wrist_equivalent_mc</elem>
+          <elem name="YawSetOfJoints">    cer_left_lower_arm_mc</elem>
+	  <elem name="HandSetOfJoints">   cer_left_hand_mc </elem>
+	  </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER02/wrappers/motorControl/cer_left_arm_no_hand-mc_wrapper.xml
+++ b/CER02/wrappers/motorControl/cer_left_arm_no_hand-mc_wrapper.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_left_arm_no_hand_mc_wrapper" type="controlboardwrapper2">
+      <paramlist name="networks">
+	  <!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+	  <elem name="FirstSetOfJoints">   0  1  0  1 </elem>
+	  <elem name="SecondSetOfJoints">  2  3  0  1 </elem>
+      <elem name="YawSetOfJoints">     4  4  3  3 </elem>
+      <elem name="ThirdSetOfJoints">   5  7  0  2 </elem>
+      <!--  <elem name="HandSetOfJoints">   8  9  0  1 </elem> -->
+      </paramlist>
+
+      <param name="period"> 10              </param>
+      <param name="name">   /cer/left_arm	</param>
+      <param name="ports">  left_arm		</param>
+      <param name="joints"> 8			    </param>
+
+      <action phase="startup" level="5" type="attach">
+	  <paramlist name="networks">
+	  <!-- The param value must match the device name in the corresponding emsX file -->
+	  <elem name="FirstSetOfJoints">  cer_left_shoulder_mc         </elem>
+	  <elem name="SecondSetOfJoints"> cer_left_upper_arm_mc        </elem>
+      <elem name="YawSetOfJoints">    cer_left_lower_arm_mc        </elem>
+      <elem name="ThirdSetOfJoints">  cer_left_wrist_equivalent_mc </elem>
+	  <!--  <elem name="HandSetOfJoints">   cer_left_hand_mc </elem> -->
+	  </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER02/wrappers/motorControl/cer_left_hand-mc_wrapper.xml
+++ b/CER02/wrappers/motorControl/cer_left_hand-mc_wrapper.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_left_hand_mc_wrapper" type="controlboardwrapper2">
+      <paramlist name="networks">
+	<!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+	  <elem name="FirstSetOfJoints"> 0  1  0  1 </elem>
+      </paramlist>
+
+      <param name="period"> 10 </param>
+      <param name="name">   /cer/left_hand	</param>
+      <param name="ports">  left_hand		</param>
+      <param name="joints"> 2	     		</param>
+
+      <action phase="startup" level="5" type="attach">
+	  <paramlist name="networks">
+	  <!-- The param value must match the device name in the corresponding emsX file -->
+	      <elem name="FirstSetOfJoints"> cer_left_hand_mc </elem>
+	  </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER02/wrappers/motorControl/cer_left_shoulder-mc_wrapper.xml
+++ b/CER02/wrappers/motorControl/cer_left_shoulder-mc_wrapper.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_left_shoulder_mc_wrapper" type="controlboardwrapper2">
+      <paramlist name="networks">
+	<!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+        <elem name="FirstSetOfJoints">  0  1  0  1 </elem>
+      </paramlist>
+
+      <param name="period"> 10 </param>
+      <param name="name">   /cer/left_arm	</param>
+      <param name="ports">  left_arm		</param>
+      <param name="joints"> 2			</param>
+
+      <action phase="startup" level="5" type="attach">
+	  <paramlist name="networks">
+	  <!-- The param value must match the device name in the corresponding emsX file -->
+		<elem name="FirstSetOfJoints">  cer_left_shoulder_mc</elem>
+	  </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER02/wrappers/motorControl/cer_left_upper_arm-mc_wrapper.xml
+++ b/CER02/wrappers/motorControl/cer_left_upper_arm-mc_wrapper.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_left_upper_arm_mc_wrapper" type="controlboardwrapper2">
+      <paramlist name="networks">
+	<!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+	  <elem name="FirstSetOfJoints">   0  1  0  1 </elem>
+	  <elem name="SecondSetOfJoints">  2  3  0  1 </elem>
+      </paramlist>
+
+<param name="period"> 10 </param>
+      <param name="name">   /cer/left_arm	</param>
+      <param name="ports">  left_arm	    </param>
+      <param name="joints"> 4			    </param>
+
+      <action phase="startup" level="5" type="attach">
+	  <paramlist name="networks">
+	  <!-- The param value must match the device name in the corresponding emsX file -->
+	      <elem name="FirstSetOfJoints">  cer_left_shoulder_mc  </elem>
+	      <elem name="SecondSetOfJoints"> cer_left_upper_arm_mc </elem>
+	  </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER02/wrappers/motorControl/cer_left_wrist-mc_wrapper.xml
+++ b/CER02/wrappers/motorControl/cer_left_wrist-mc_wrapper.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_left_wrist_mc_wrapper" type="controlboardwrapper2">
+      <param name="period">   10   </param>
+      <paramlist name="networks">
+	  <!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+	  <elem name="FirstSetOfJoints">  0  2  0  2 </elem>
+      </paramlist>
+
+      <param name="name">   /cer/left_wrist  </param>
+      <param name="ports">  left_wrist       </param>
+      <param name="joints"> 3                </param>
+
+      <action phase="startup" level="5" type="attach">
+	  <paramlist name="networks">
+	  <!-- The param value must match the device name in the corresponding emsX file -->
+	      <elem name="FirstSetOfJoints"> cer_left_lower_arm_mc</elem>
+
+	  </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER02/wrappers/motorControl/cer_left_wrist_tripod-mc_wrapper.xml
+++ b/CER02/wrappers/motorControl/cer_left_wrist_tripod-mc_wrapper.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_left_wrist_tripod_mc_wrapper" type="controlboardwrapper2">
+      <param name="period">   10   </param>
+      <paramlist name="networks">
+	  <!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+	  <elem name="FirstSetOfJoints">  0  2  0  2 </elem>
+      </paramlist>
+
+      <param name="name">   /cer/left_wrist_tripod  </param>
+      <param name="ports">  left_wrist_tripod       </param>
+      <param name="joints"> 3                       </param>
+
+      <action phase="startup" level="5" type="attach">
+	  <paramlist name="networks">
+	  <!-- The param value must match the device name in the corresponding emsX file -->
+	      <elem name="FirstSetOfJoints"> cer_left_lower_arm_mc </elem>
+
+	  </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER02/wrappers/motorControl/cer_right_arm-mc_wrapper.xml
+++ b/CER02/wrappers/motorControl/cer_right_arm-mc_wrapper.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_right_arm_mc_wrapper" type="controlboardwrapper2">
+      <paramlist name="networks">
+	<!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+        <elem name="FirstSetOfJoints">  0  3  0  3 </elem>
+        <elem name="YawSetOfJoints">    4  4  3  3 </elem>
+  	<elem name="SecondSetOfJoints"> 5  7  0  2 </elem>
+        <elem name="HandSetOfJoints">   8  9  0  1 </elem>
+      </paramlist>
+
+      <param name="period"> 10 </param>
+      <param name="name">   /cer/right_arm	</param>
+      <param name="ports">  right_arm		</param>
+      <param name="joints"> 10			</param>
+
+      <action phase="startup" level="5" type="attach">
+	  <paramlist name="networks">
+	  <!-- The param value must match the device name in the corresponding emsX file -->
+	  <elem name="FirstSetOfJoints">  cer_right_upper_arm_mc</elem>
+          <elem name="SecondSetOfJoints"> cer_right_wrist_equivalent_mc</elem>
+          <elem name="YawSetOfJoints">    cer_right_lower_arm_mc</elem>
+	  <elem name="HandSetOfJoints">   cer_right_hand_mc </elem>
+	  </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER02/wrappers/motorControl/cer_right_arm_no_hand-mc_wrapper.xml
+++ b/CER02/wrappers/motorControl/cer_right_arm_no_hand-mc_wrapper.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_right_arm_no_hand_mc_wrapper" type="controlboardwrapper2">
+      <paramlist name="networks">
+	  <!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+	  <elem name="FirstSetOfJoints">   0  1  0  1 </elem>
+	  <elem name="SecondSetOfJoints">  2  3  0  1 </elem>
+      <elem name="YawSetOfJoints">     4  4  3  3 </elem>
+  	  <elem name="ThirdSetOfJoints">   5  7  0  2 </elem>
+      <!-- <elem name="HandSetOfJoints">   8  9  0  1 </elem> -->
+      </paramlist>
+
+      <param name="period"> 10              </param>
+      <param name="name">   /cer/right_arm	</param>
+      <param name="ports">  right_arm		</param>
+      <param name="joints"> 8			    </param>
+
+      <action phase="startup" level="5" type="attach">
+	  <paramlist name="networks">
+	  <!-- The param value must match the device name in the corresponding emsX file -->
+	  <elem name="FirstSetOfJoints">  cer_right_shoulder_mc         </elem>
+	  <elem name="SecondSetOfJoints"> cer_right_upper_arm_mc        </elem>  
+      <elem name="YawSetOfJoints">    cer_right_lower_arm_mc        </elem>
+	  <elem name="ThirdSetOfJoints">  cer_right_wrist_equivalent_mc </elem>
+	  <!-- <elem name="HandSetOfJoints">   cer_right_hand_mc </elem> -->
+	  </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER02/wrappers/motorControl/cer_right_hand-mc_wrapper.xml
+++ b/CER02/wrappers/motorControl/cer_right_hand-mc_wrapper.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_right_hand_mc_wrapper" type="controlboardwrapper2">
+      <paramlist name="networks">
+	<!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+	  <elem name="FirstSetOfJoints"> 0  1  0  1 </elem>
+      </paramlist>
+
+      <param name="period"> 10 </param>
+      <param name="name">   /cer/right_hand	</param>
+      <param name="ports">  right_hand		</param>
+      <param name="joints"> 2	     		</param>
+
+      <action phase="startup" level="5" type="attach">
+	  <paramlist name="networks">
+	  <!-- The param value must match the device name in the corresponding emsX file -->
+	      <elem name="FirstSetOfJoints"> cer_right_hand_mc </elem>
+	  </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER02/wrappers/motorControl/cer_right_shoulder-mc_wrapper.xml
+++ b/CER02/wrappers/motorControl/cer_right_shoulder-mc_wrapper.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_right_shoulder_mc_wrapper" type="controlboardwrapper2">
+      <paramlist name="networks">
+	<!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+	  <elem name="FirstSetOfJoints">  0  1  0  1 </elem>
+      </paramlist>
+
+<param name="period"> 10 </param>
+      <param name="name">   /cer/right_arm </param>
+      <param name="ports">  right_arm 	 </param>
+      <param name="joints"> 2			 </param>
+
+      <action phase="startup" level="5" type="attach">
+	  <paramlist name="networks">
+	  <!-- The param value must match the device name in the corresponding emsX file -->
+	      <elem name="FirstSetOfJoints"> cer_right_shoulder_mc</elem>
+	  </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER02/wrappers/motorControl/cer_right_upper_arm-mc_wrapper.xml
+++ b/CER02/wrappers/motorControl/cer_right_upper_arm-mc_wrapper.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_right_upper_arm_mc_wrapper" type="controlboardwrapper2">
+      <paramlist name="networks">
+	<!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+	  <elem name="FirstSetOfJoints">   0  1  0  1 </elem>
+	  <elem name="SecondSetOfJoints">  2  3  0  1 </elem>
+      </paramlist>
+
+<param name="period"> 10 </param>
+      <param name="name">   /cer/right_arm </param>
+      <param name="ports">  right_arm 	   </param>
+      <param name="joints"> 4			   </param>
+
+      <action phase="startup" level="5" type="attach">
+	  <paramlist name="networks">
+	  <!-- The param value must match the device name in the corresponding emsX file -->
+	      <elem name="FirstSetOfJoints">  cer_right_shoulder_mc </elem>
+	      <elem name="SecondSetOfJoints"> cer_right_upper_arm_mc</elem>
+	  </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER02/wrappers/motorControl/cer_right_wrist-mc_wrapper.xml
+++ b/CER02/wrappers/motorControl/cer_right_wrist-mc_wrapper.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_right_wrist_mc_wrapper" type="controlboardwrapper2">
+      <param name="period">   10   </param>
+      <paramlist name="networks">
+	  <!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+	  <elem name="FirstSetOfJoints">  0  2  0  2 </elem>
+      </paramlist>
+
+      <param name="name">   /cer/right_wrist  </param>
+      <param name="ports">  right_wrist       </param>
+      <param name="joints"> 3                       </param>
+
+      <action phase="startup" level="5" type="attach">
+	  <paramlist name="networks">
+	  <!-- The param value must match the device name in the corresponding emsX file -->
+	      <elem name="FirstSetOfJoints"> cer_right_lower_arm_mc </elem>
+
+	  </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER02/wrappers/motorControl/cer_right_wrist_tripod-mc_wrapper.xml
+++ b/CER02/wrappers/motorControl/cer_right_wrist_tripod-mc_wrapper.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_right_wrist_tripod_mc_wrapper" type="controlboardwrapper2">
+      <param name="period">   10   </param>
+      <paramlist name="networks">
+	  <!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+	  <elem name="FirstSetOfJoints">  0  2  0  2 </elem>
+      </paramlist>
+
+      <param name="name">   /cer/right_wrist_tripod  </param>
+      <param name="ports">  right_wrist_tripod       </param>
+      <param name="joints"> 3                       </param>
+
+      <action phase="startup" level="5" type="attach">
+	  <paramlist name="networks">
+	  <!-- The param value must match the device name in the corresponding emsX file -->
+	      <elem name="FirstSetOfJoints"> cer_right_lower_arm_mc  </elem>
+
+	  </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER02/wrappers/motorControl/cer_ros_wrapper.xml
+++ b/CER02/wrappers/motorControl/cer_ros_wrapper.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_all_joints_mc_wrapper" type="controlboardwrapper2">
+
+      <param name="period"> 10 </param>
+      <param name="name">   /cer/all_joints </param>
+      <param name="joints"> 28 </param>
+      
+      <paramlist name="networks">
+
+        <elem name="head">            0  1   0  1 </elem>  <!-- 2 -->
+        <elem name="torso">           2  5   0  3 </elem>  <!-- 4 -->
+        
+        <elem name="right_arm">       6  13  0  7 </elem>  <!-- 8 -->
+        <elem name="left_arm">        14 21  0  7 </elem>  <!-- 8 -->
+        <elem name="right_hand">      22 23  0  1 </elem>  <!-- 2 -->
+        <elem name="left_hand">       24 25  0  1 </elem>  <!-- 2 -->
+        <elem name="base">            26 27  0  1 </elem>  <!-- 2 -->
+
+      </paramlist>
+
+      <group name ="ROS">
+        <param name="useROS"> true </param>
+        <param name="ROS_topicName">  /joint_states </param>
+        <param name="ROS_nodeName">   /cer </param>
+      </group>
+      
+      <action phase="startup" level="5" type="attach">
+        <paramlist name="networks">  
+   
+         <elem name="head">        cer_head_mc_wrapper    </elem>     
+         <elem name="torso">       cer_torso_mc_wrapper   </elem>
+         <elem name="base">            cer_mobile_base_mc_wrapper </elem>
+
+         <elem name="right_arm">       cer_right_arm_no_hand_mc_wrapper </elem>
+         <elem name="right_hand">      cer_right_hand_mc </elem>
+
+         <elem name="left_arm">        cer_left_arm_no_hand_mc_wrapper </elem>
+         <elem name="left_hand">       cer_left_hand_mc </elem>
+
+         </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER02/wrappers/motorControl/cer_ros_wrapper_base_only.xml
+++ b/CER02/wrappers/motorControl/cer_ros_wrapper_base_only.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_all_joints_mc_wrapper" type="controlboardwrapper2">
+
+      <param name="period"> 10 </param>
+      <param name="name">   /cer/all_joints </param>
+      <param name="joints"> 2 </param>
+      
+      <paramlist name="networks">
+       <elem name="base">            0  1  0  1 </elem>
+
+      </paramlist>
+
+      <group name ="ROS">
+        <param name="useROS"> only </param>
+        <param name="ROS_topicName">  /base_joint_states </param>
+        <param name="ROS_nodeName">   /cer </param>
+      </group>
+      
+      <action phase="startup" level="5" type="attach">
+        <paramlist name="networks">
+
+         <elem name="base">            cer_mobile_base_mc_wrapper </elem>
+   
+         </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER02/wrappers/motorControl/cer_ros_wrapper_fix.xml
+++ b/CER02/wrappers/motorControl/cer_ros_wrapper_fix.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_all_joints_mc_wrapper" type="controlboardwrapper2">
+
+      <param name="period"> 10 </param>
+      <param name="name">   /cer/all_joints </param>
+      <param name="joints"> 28 </param>
+      
+      <paramlist name="networks">
+
+        <elem name="head">            0  1   0  1 </elem>  <!-- 2 -->
+        <elem name="torso">           2  5   0  3 </elem>  <!-- 4 -->
+        
+        <elem name="right_arm">       6  13  0  7 </elem>  <!-- 8 -->
+        <elem name="left_arm">        14 21  0  7 </elem>  <!-- 8 -->
+        <elem name="right_hand">      22 23  0  1 </elem>  <!-- 2 -->
+        <elem name="left_hand">       24 25  0  1 </elem>  <!-- 2 -->
+        <elem name="base">            26 27  0  1 </elem>  <!-- 2 -->
+
+      </paramlist>
+
+      <group name ="ROS">
+        <param name="useROS"> true </param>
+        <param name="ROS_topicName">  /joint_states </param>
+        <param name="ROS_nodeName">   /cer </param>
+      </group>
+      
+      <action phase="startup" level="5" type="attach">
+        <paramlist name="networks">  
+   
+         <elem name="head">        cer_head_mc_wrapper    </elem>     
+         <elem name="torso">       cer_torso_mc_wrapper   </elem>
+         <elem name="base">            cer_mobile_base_mc_wrapper </elem>
+
+         <elem name="right_arm">       cer_right_arm_mc_wrapper </elem>
+         <elem name="right_hand">      cer_right_hand_mc </elem>
+
+         <elem name="left_arm">        cer_left_arm_mc_wrapper </elem>
+         <elem name="left_hand">       cer_left_hand_mc </elem>
+
+         </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER02/wrappers/motorControl/cer_torso-mc_wrapper.xml
+++ b/CER02/wrappers/motorControl/cer_torso-mc_wrapper.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_torso_mc_wrapper" type="controlboardwrapper2">
+      <paramlist name="networks">
+	<!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+	<elem name="FirstSetOfJoints"> 0  2  0  2 </elem>
+	<elem name="SecondSetOfJoints"> 3  3  3  3 </elem>
+      </paramlist>
+
+      <param name="period"> 10 </param>
+      <param name="name">   /cer/torso	</param>
+      <param name="ports">  torso		</param>
+      <param name="joints"> 4			</param>
+
+      <action phase="startup" level="5" type="attach">
+	  <paramlist name="networks">
+	  <!-- The param value must match the device name in the corresponding emsX file -->
+	      <elem name="FirstSetOfJoints">  cer_torso_equivalent_mc </elem>
+	      <elem name="SecondSetOfJoints"> cer_torso_mc </elem>
+	  </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER02/wrappers/motorControl/cer_torso_tripod-mc_wrapper.xml
+++ b/CER02/wrappers/motorControl/cer_torso_tripod-mc_wrapper.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_torso_tripod_mc_wrapper" type="controlboardwrapper2">
+      <param name="period">   10   </param>
+      <paramlist name="networks">
+	  <!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+	  <elem name="FirstSetOfJoints">  0  2  0  2 </elem>
+      </paramlist>
+
+      <param name="name">   /cer/torso_tripod  </param>
+      <param name="ports">  torso_tripod       </param>
+      <param name="joints"> 3                  </param>
+
+      <action phase="startup" level="5" type="attach">
+	  <paramlist name="networks">
+	  <!-- The param value must match the device name in the corresponding emsX file -->
+	      <elem name="FirstSetOfJoints"> cer_torso_mc </elem>
+
+	  </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>

--- a/CER02/wrappers/rpLidar/laser_back_wrapper.xml
+++ b/CER02/wrappers/rpLidar/laser_back_wrapper.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cerLaserBackWrapper" type="Rangefinder2DWrapper">
+
+      <param name="period"> 10 </param>
+      <param name="name">   /cer/laser/back:o       </param>
+
+      <action phase="startup" level="5" type="attach">
+         <paramlist name="networks">
+            <elem name="cer_laser">  cer_laser_back_device </elem>
+         </paramlist>
+      </action>
+
+      <group name ="ROS">
+         <param name ="useROS"> true </param>
+         <param name ="ROS_nodeName"> /cer-laserBack </param>
+         <param name ="ROS_topicName"> /laserBack </param>
+         <param name ="frame_id"> /mobile_base_lidar_B </param>>
+
+      </group>
+
+      <action phase="shutdown" level="5" type="detach" />
+  </device>
+

--- a/CER02/wrappers/rpLidar/laser_double_wrapper.xml
+++ b/CER02/wrappers/rpLidar/laser_double_wrapper.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cerDoubleLaserWrapper" type="Rangefinder2DWrapper">
+
+      <param name="period"> 10 </param>
+      <param name="name">   /cer/laser:o       </param>
+
+      <action phase="startup" level="6" type="attach">
+         <paramlist name="networks">
+            <elem name="cer_laser">  cer_double_laser_device </elem>
+         </paramlist>
+      </action>
+
+      <group name ="ROS">
+         <param name ="useROS"> true </param>
+         <param name ="ROS_nodeName"> /cer-laser </param>
+         <param name ="ROS_topicName"> /laser</param>
+         <param name ="frame_id"> /mobile_base_double_lidar </param>
+      </group>
+
+      <action phase="shutdown" level="5" type="detach" />
+  </device>
+

--- a/CER02/wrappers/rpLidar/laser_front_wrapper.xml
+++ b/CER02/wrappers/rpLidar/laser_front_wrapper.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cerLaserFrontWrapper" type="Rangefinder2DWrapper">
+
+      <param name="period"> 10 </param>
+      <param name="name">   /cer/laser/front:o       </param>
+
+      <action phase="startup" level="5" type="attach">
+         <paramlist name="networks">
+            <elem name="cer_laser">  cer_laser_front_device </elem>
+         </paramlist>
+      </action>
+
+      <group name ="ROS">
+         <param name ="useROS"> true </param>
+         <param name ="ROS_nodeName"> /cer-laserFront </param>
+         <param name ="ROS_topicName"> /laserFront </param>
+         <param name ="frame_id"> /mobile_base_lidar_F </param>
+      </group>
+
+      <action phase="shutdown" level="5" type="detach" />
+  </device>
+

--- a/CER02/wrappers/rpLidar/laser_wrapper.xml
+++ b/CER02/wrappers/rpLidar/laser_wrapper.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cerLaserWrapper" type="Rangefinder2DWrapper">
+
+      <param name="period"> 10 </param>
+      <param name="name">   /cer/laser:o       </param>
+
+      <action phase="startup" level="5" type="attach">
+         <paramlist name="networks">
+            <elem name="cer_laser">  cer_laser_front_device </elem>
+         </paramlist>
+      </action>
+
+      <group name ="ROS">
+         <param name ="useROS"> true </param>
+         <param name ="ROS_nodeName"> /cer-laser </param>
+         <param name ="ROS_topicName"> /laser </param>
+         <param name ="frame_id"> /mobile_base_lidar </param>
+      </group>
+
+      <action phase="shutdown" level="5" type="detach" />
+  </device>
+

--- a/CER02/wrappers/skin/left_arm-skin_wrapper.xml
+++ b/CER02/wrappers/skin/left_arm-skin_wrapper.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_hand_skin_wrapper" type="skinWrapper">
+		<param name="period">       20  				</param>
+		<param name="total_taxels"> 156					</param>
+		<param name="device">       skinWrapper				</param>
+		
+		<paramlist name="ports">
+		  <elem name="left_hand_skin"> 	0 155 0 155	</elem>
+		</paramlist>
+		
+		<action phase="startup" level="5" type="attach">
+		    <paramlist name="networks">
+		<!-- The param value must match the device name in the corresponding emsX file -->
+		        <elem name="FirstSetOfSkins"> left_hand_skin </elem>
+		    </paramlist>
+		</action>
+
+		<action phase="shutdown" level="5" type="detach" />
+	</device>
+

--- a/CER02/wrappers/skin/right_arm-skin_wrapper.xml
+++ b/CER02/wrappers/skin/right_arm-skin_wrapper.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_hand_skin_wrapper" type="skinWrapper">
+		<param name="period">       20  				</param>
+		<param name="total_taxels"> 156					</param>
+		<param name="device">       skinWrapper				</param>
+		
+		<paramlist name="ports">
+		  <elem name="right_hand_skin"> 	0 155 0 155	</elem>
+		</paramlist>
+		
+		<action phase="startup" level="5" type="attach">
+		    <paramlist name="networks">
+		<!-- The param value must match the device name in the corresponding emsX file -->
+		        <elem name="FirstSetOfSkins"> right_hand_skin </elem>
+		    </paramlist>
+		</action>
+
+		<action phase="shutdown" level="5" type="detach" />
+	</device>
+

--- a/CER02/yarplaserscannergui.ini
+++ b/CER02/yarplaserscannergui.ini
@@ -1,0 +1,5 @@
+scale            100 
+robot_radius     0.3575 // 715.0 / 2.0 / 1000.0m
+laser_position   0.245  // 245.0 / 1000.0m
+period           50
+sens_port        /cer/laser:o

--- a/CER02/yarpmotorgui.ini
+++ b/CER02/yarpmotorgui.ini
@@ -1,0 +1,4 @@
+name cer
+
+parts (torso torso_tripod mobile_base head left_arm right_arm left_wrist_tripod right_wrist_tripod left_hand right_hand all_joints)
+

--- a/CER02/yarprobotinterface.ini
+++ b/CER02/yarprobotinterface.ini
@@ -1,0 +1,2 @@
+config ./CER.xml
+

--- a/CER03/CER.xml
+++ b/CER03/CER.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<robot name="CER03" build="1" portprefix="cer" xmlns:xi="http://www.w3.org/2001/XInclude">
+<devices>
+ 
+    <!-- LASER -->
+    <xi:include href="hardware/rpLidar/laserA2_hw_back.xml" /> 
+    <xi:include href="wrappers/rpLidar/laser_back_wrapper.xml" /> 
+    <xi:include href="hardware/rpLidar/laserA2_hw_front.xml" /> 
+    <xi:include href="wrappers/rpLidar/laser_front_wrapper.xml" /> 
+    <xi:include href="hardware/rpLidar/laserA2_hw_double.xml" /> 
+    <xi:include href="wrappers/rpLidar/laser_double_wrapper.xml" /> 
+
+    <!-- BASE -->
+    <xi:include href="hardware/motorControl/cer_base-ems1-mc.xml" />
+    <xi:include href="wrappers/motorControl/cer_base-mc_wrapper.xml" />
+
+    <!-- TORSO -->
+    <xi:include href="hardware/motorControl/cer_torso-ems3-mc.xml" />
+    <xi:include href="wrappers/motorControl/cer_torso_tripod-mc_wrapper.xml" />
+    <xi:include href="hardware/motorControl/cer_torso_equivalent-mc.xml" />
+    <xi:include href="wrappers/motorControl/cer_torso-mc_wrapper.xml" />
+    
+    <!-- LEFT ARM -->
+    <xi:include href="hardware/motorControl/cer_left_shoulder-ems5-mc.xml" />
+    <xi:include href="hardware/motorControl/cer_left_upper_arm-ems12-mc.xml" />
+    <xi:include href="hardware/motorControl/cer_left_lower_arm-mcp8-mc.xml" />
+    <xi:include href="hardware/motorControl/cer_left_wrist_equivalent-mc.xml" />
+    <xi:include href="wrappers/motorControl/cer_left_wrist_tripod-mc_wrapper.xml" />
+    <xi:include href="wrappers/motorControl/cer_left_arm_no_hand-mc_wrapper.xml" />
+    
+    <!-- LEFT HAND -->
+    <xi:include href="hardware/motorControl/cer_left_hand-mcp9-mc.xml" />
+    <xi:include href="wrappers/motorControl/cer_left_hand-mc_wrapper.xml" />
+   
+    <!-- RIGHT ARM -->
+    <xi:include href="hardware/motorControl/cer_right_shoulder-ems4-mc.xml" />
+    <xi:include href="hardware/motorControl/cer_right_upper_arm-ems11-mc.xml" />
+    <xi:include href="hardware/motorControl/cer_right_lower_arm-mcp6-mc.xml" />
+    <xi:include href="hardware/motorControl/cer_right_wrist_equivalent-mc.xml" />
+    <xi:include href="wrappers/motorControl/cer_right_wrist_tripod-mc_wrapper.xml" />
+    <xi:include href="wrappers/motorControl/cer_right_arm_no_hand-mc_wrapper.xml" />
+    
+    <!-- RIGHT HAND -->
+    <xi:include href="hardware/motorControl/cer_right_hand-mcp7-mc.xml" />
+    <xi:include href="wrappers/motorControl/cer_right_hand-mc_wrapper.xml" />
+
+    <!-- HEAD -->
+    <xi:include href="hardware/motorControl/cer_head-mcp10-mc.xml" />
+    <xi:include href="wrappers/motorControl/cer_head-mc_wrapper.xml" />
+
+    <!--  CALIBRATORS -->
+    <xi:include href="calibrators/cer_torso-calib.xml" />
+    <xi:include href="calibrators/cer_left_arm_no_hand-calib.xml" />
+    <xi:include href="calibrators/cer_right_arm_no_hand-calib.xml" />
+    <xi:include href="calibrators/cer_head-calib.xml" />
+    <xi:include href="calibrators/cer_base-calib.xml" /> 
+    <xi:include href="calibrators/cer_left_hand-calib.xml" />
+    <xi:include href="calibrators/cer_right_hand-calib.xml" />
+
+    <!-- SKIN-->
+    <!--<xi:include href="hardware/skin/left_hand-mc9-skin.xml" />
+    <xi:include href="wrappers/skin/left_hand-skin_wrapper.xml" />
+    <xi:include href="hardware/skin/right_hand-mc7-skin.xml" />
+    <xi:include href="wrappers/skin/right_hand-skin_wrapper.xml" />
+-->
+    <!-- PSC -->
+    <xi:include href="wrappers/PSC/cer_right_arm-PSC_wrapper.xml" /> 
+    <xi:include href="hardware/PSC/right_hand-psc.xml" />
+    <xi:include href="wrappers/PSC/cer_left_arm-PSC_wrapper.xml" /> 
+    <xi:include href="hardware/PSC/left_hand-psc.xml" />
+
+    <!--  FT -->
+    <xi:include href="hardware/FT/cer_left_shoulder-ems5-strain.xml" />
+    <xi:include href="hardware/FT/cer_right_shoulder-ems4-strain.xml" />
+    <xi:include href="wrappers/FT/cer_left_arm-FT_wrapper.xml" />
+    <xi:include href="wrappers/FT/cer_right_arm-FT_wrapper.xml" /> 
+    
+    <!--  ROS -->
+    <xi:include href="wrappers/motorControl/cer_ros_wrapper.xml" />
+</devices>
+</robot> 

--- a/CER03/CER_hands_only.xml
+++ b/CER03/CER_hands_only.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<robot name="CER03" build="1" portprefix="cer" xmlns:xi="http://www.w3.org/2001/XInclude">
+<devices>
+
+    <!-- DEVICE -->
+    <xi:include href="hardware/motorControl/cer_right_hand-mcp9-mc.xml" />
+    <xi:include href="wrappers/motorControl/cer_right_hand-mc_wrapper.xml" />
+    <xi:include href="hardware/motorControl/cer_left_hand-mcp7-mc.xml" />
+    <xi:include href="wrappers/motorControl/cer_left_hand-mc_wrapper.xml" />
+
+    <!--  CALIBRATORS -->
+    <xi:include href="calibrators/cer_right_hand-calib.xml" />
+    <xi:include href="calibrators/cer_left_hand-calib.xml" />
+</devices>
+</robot> 
+
+

--- a/CER03/CER_mc_no_hands.xml
+++ b/CER03/CER_mc_no_hands.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<robot name="CER03" build="1" portprefix="cer" xmlns:xi="http://www.w3.org/2001/XInclude">
+<devices>
+ 
+    <!-- LASER -->
+    <xi:include href="hardware/rpLidar/laserA2_hw_back.xml" /> 
+    <xi:include href="wrappers/rpLidar/laser_back_wrapper.xml" /> 
+    <xi:include href="hardware/rpLidar/laserA2_hw_front.xml" /> 
+    <xi:include href="wrappers/rpLidar/laser_front_wrapper.xml" /> 
+    <xi:include href="hardware/rpLidar/laserA2_hw_double.xml" /> 
+    <xi:include href="wrappers/rpLidar/laser_double_wrapper.xml" /> 
+
+    <!-- BASE -->
+    <xi:include href="hardware/motorControl/cer_base-ems1-mc.xml" />
+    <xi:include href="wrappers/motorControl/cer_base-mc_wrapper.xml" />
+
+    <!-- TORSO -->
+    <xi:include href="hardware/motorControl/cer_torso-ems3-mc.xml" />
+    <xi:include href="wrappers/motorControl/cer_torso_tripod-mc_wrapper.xml" />
+    <xi:include href="hardware/motorControl/cer_torso_equivalent-mc.xml" />
+    <xi:include href="wrappers/motorControl/cer_torso-mc_wrapper.xml" />
+    
+    <!-- LEFT ARM -->
+    <xi:include href="hardware/motorControl/cer_left_shoulder-ems5-mc.xml" />
+    <xi:include href="hardware/motorControl/cer_left_upper_arm-ems12-mc.xml" />
+    <xi:include href="hardware/motorControl/cer_left_lower_arm-mcp8-mc.xml" />
+    <xi:include href="hardware/motorControl/cer_left_wrist_equivalent-mc.xml" />
+    <xi:include href="wrappers/motorControl/cer_left_wrist_tripod-mc_wrapper.xml" />
+    <xi:include href="wrappers/motorControl/cer_left_arm_no_hand-mc_wrapper.xml" />
+    
+    <!-- LEFT HAND -->
+    <xi:include href="hardware/motorControl/cer_left_hand-mcp9-mc.xml" />
+    <xi:include href="wrappers/motorControl/cer_left_hand-mc_wrapper.xml" />
+   
+    <!-- RIGHT ARM -->
+    <xi:include href="hardware/motorControl/cer_right_shoulder-ems4-mc.xml" />
+    <xi:include href="hardware/motorControl/cer_right_upper_arm-ems11-mc.xml" />
+    <xi:include href="hardware/motorControl/cer_right_lower_arm-mcp6-mc.xml" />
+    <xi:include href="hardware/motorControl/cer_right_wrist_equivalent-mc.xml" />
+    <xi:include href="wrappers/motorControl/cer_right_wrist_tripod-mc_wrapper.xml" />
+    <xi:include href="wrappers/motorControl/cer_right_arm_no_hand-mc_wrapper.xml" />
+    
+    <!-- RIGHT HAND -->
+    <xi:include href="hardware/motorControl/cer_right_hand-mcp7-mc.xml" />
+    <xi:include href="wrappers/motorControl/cer_right_hand-mc_wrapper.xml" />
+
+    <!-- HEAD -->
+    <xi:include href="hardware/motorControl/cer_head-mcp10-mc.xml" />
+    <xi:include href="wrappers/motorControl/cer_head-mc_wrapper.xml" />
+
+    <!--  CALIBRATORS -->
+    <xi:include href="calibrators/cer_torso-calib.xml" />
+    <xi:include href="calibrators/cer_left_arm_no_hand-calib.xml" />
+    <xi:include href="calibrators/cer_right_arm_no_hand-calib.xml" />
+    <xi:include href="calibrators/cer_head-calib.xml" />
+    <xi:include href="calibrators/cer_base-calib.xml" /> 
+    <xi:include href="calibrators/cer_left_hand-calib.xml" />
+    <xi:include href="calibrators/cer_right_hand-calib.xml" />
+
+    <!-- SKIN-->
+    <xi:include href="hardware/skin/left_hand-mc9-skin.xml" />
+    <xi:include href="wrappers/skin/left_hand-skin_wrapper.xml" />
+    <xi:include href="hardware/skin/right_hand-mc7-skin.xml" />
+    <xi:include href="wrappers/skin/right_hand-skin_wrapper.xml" />
+
+    <!-- PSC -->
+    <xi:include href="wrappers/PSC/cer_right_arm-PSC_wrapper.xml" /> 
+    <xi:include href="hardware/PSC/right_hand-psc.xml" />
+    <xi:include href="wrappers/PSC/cer_left_arm-PSC_wrapper.xml" /> 
+    <xi:include href="hardware/PSC/left_hand-psc.xml" />
+
+    <!--  FT -->
+    <xi:include href="hardware/FT/cer_left_shoulder-ems5-strain.xml" />
+    <xi:include href="hardware/FT/cer_right_shoulder-ems4-strain.xml" />
+    <xi:include href="wrappers/FT/cer_left_arm-FT_wrapper.xml" />
+    <xi:include href="wrappers/FT/cer_right_arm-FT_wrapper.xml" /> 
+    
+    <!--  ROS -->
+    <xi:include href="wrappers/motorControl/cer_ros_wrapper.xml" />
+</devices>
+</robot> 

--- a/CER03/CMakeLists.txt
+++ b/CER03/CMakeLists.txt
@@ -1,0 +1,11 @@
+set(appname CER03)
+
+set(scripts CER.xml yarprobotinterface.ini general.xml yarpmotorgui.ini firmwareupdater.ini)
+
+yarp_install(FILES ${scripts} DESTINATION ${ICUBCONTRIB_ROBOTS_INSTALL_DIR}/${appname})
+yarp_install(DIRECTORY calibrators DESTINATION ${ICUBCONTRIB_ROBOTS_INSTALL_DIR}/${appname})
+yarp_install(DIRECTORY wrappers DESTINATION ${ICUBCONTRIB_ROBOTS_INSTALL_DIR}/${appname})
+yarp_install(DIRECTORY hardware DESTINATION ${ICUBCONTRIB_ROBOTS_INSTALL_DIR}/${appname})
+yarp_install(DIRECTORY sensors  DESTINATION ${ICUBCONTRIB_ROBOTS_INSTALL_DIR}/${appname})
+yarp_install(DIRECTORY camera   DESTINATION ${ICUBCONTRIB_ROBOTS_INSTALL_DIR}/${appname})
+

--- a/CER03/calibrators/cer_base-calib.xml
+++ b/CER03/calibrators/cer_base-calib.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="mobile_base_calibrator" type="parametricCalibratorEth">
+        <xi:include href="../general.xml" />
+                
+		<group name="GENERAL">
+		    <param name="joints">  2  </param> <!-- the number of joints of the robot part -->
+		    <param name="deviceName"> Mobile_Base_Calibrator </param>
+		</group>
+
+
+<!-- mobile base does not require parking action -->
+<group name="PARKING_SEQUENCE">
+    <param name= "numberOfSequences">      0    </param>
+ </group>
+
+
+<group name="CALIBRATION">
+<param name="calibrationType">                    3               3        </param>
+<param name="calibration1">                       0               0        </param>
+<param name="calibration2">                       10.0            10.0     </param>
+<param name="calibration3">                       0               0        </param>
+<param name="calibration4">                       0               0        </param>
+<param name="calibration5">                       0               0        </param>
+<param name="calibrationZero">                    0               0        </param>
+<param name="calibrationDelta">                   0.0             0.0      </param>
+<param name="startupPosition">                    0.0             0.0      </param>
+<param name="startupVelocity">                    1.0             1.0      </param>
+<param name="startupMaxPwm">                      5000            5000     </param>
+<param name="startupPosThreshold">                2               2        </param>
+<param name="calibrationTimeout">                 1.0             1.0      </param>
+<param name="startupDisablePosCheck">             1               1        </param>
+</group>
+
+		<param name="CALIB_ORDER">(0 1) </param>
+
+		<action phase="startup" level="10" type="calibrate">
+		    <param name="target">cer_mobile_base_mc_wrapper</param>
+		</action>
+
+		<action phase="interrupt1" level="1" type="park">
+		    <param name="target">cer_mobile_base_mc_wrapper</param>
+		</action>
+
+		<action phase="interrupt3" level="1" type="abort" />
+
+	</device>
+

--- a/CER03/calibrators/cer_head-calib.xml
+++ b/CER03/calibrators/cer_head-calib.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="head_calibrator" type="parametricCalibratorEth">
+        <xi:include href="../general.xml" />
+                
+    <group name="GENERAL">
+        <param name="joints">  2  </param> <!-- the number of joints of the robot part -->
+        <param name="deviceName"> Head_Calibrator </param>
+    </group>
+
+
+    <group name="PARKING_SEQUENCE">
+    <param name= "numberOfSequences">      1    </param>
+
+    <group name="SEQUENCE_0">
+        <param name="position">                       0.00     0.00      </param>
+        <param name="velocity">                       10        10.00    </param>
+    </group>
+ </group>
+
+    <group name="CALIBRATION">                                                    
+        <param name="calibrationType">                    12              12             </param>
+        <param name="calibration1">                       29364           32943          </param>
+        <param name="calibration2">                       0               0              </param>
+        <param name="calibration3">                       0               0              </param> 
+        <param name="calibration4">                       0               0              </param>
+        <param name="calibration5">                       0               0              </param>
+        <param name="calibrationZero">                    0               0              </param>
+        <param name="calibrationDelta">                   0.0             0.0            </param>
+
+        <param name="startupPosition">                    0.0             0.0            </param>
+        <param name="startupVelocity">                    10.0            10.0           </param>
+        <param name="startupMaxPwm">                      2000            1800           </param>
+        <param name="startupPosThreshold">                4               4              </param>
+    </group>
+
+		<param name="CALIB_ORDER">(0 1) </param>
+
+		<action phase="startup" level="10" type="calibrate">
+		    <param name="target">cer_head_mc_wrapper</param>
+		</action>
+
+		<action phase="interrupt1" level="1" type="park">
+		    <param name="target">cer_head_mc_wrapper</param>
+		</action>
+
+		<action phase="interrupt3" level="1" type="abort" />
+
+	</device>
+

--- a/CER03/calibrators/cer_left_arm_no_hand-calib.xml
+++ b/CER03/calibrators/cer_left_arm_no_hand-calib.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm_no_hand_calibrator" type="parametricCalibratorEth">
+        <xi:include href="../general.xml" />
+                
+		<group name="GENERAL">
+		    <param name="joints">  8  </param> <!-- the number of joints of the robot part -->
+		    <param name="deviceName"> Left_Arm_No_Hand_Calibrator </param>
+		</group>
+
+
+<group name="PARKING_SEQUENCE">
+    <param name= "numberOfSequences">      2    </param>
+
+    <group name="SEQUENCE_0">
+        <param name="position">                       25.00     16.00       -9.00     15.00      0.00   0.03       -5.0        0.0           </param>
+        <param name="velocity">                       10        10.00      10.00      10.00      10.00   0.005     10.0       10.0     </param>
+    </group>
+    <group name="SEQUENCE_1">
+        <param name="position">                       0.00       5.00      0.00       0.00      0.00   0.01        -5.0        0.0            </param>
+        <param name="velocity">                      10.00      10.00     10.00      10.00     10.00   0.005       10.0       10.0          </param>
+    </group>
+ </group>
+
+
+
+<group name="CALIBRATION">                                                                                                   
+<param name="calibrationType">                   12         12        12         12        10      8          8          8        </param>
+<param name="calibration1">                      12052     -22591    -3771      -30511     550     1500       1500       1500     </param>
+<param name="calibration2">                      0          0         0          0         0       700        700        700      </param>
+<param name="calibration3">                      0          0         0          0         0       0          0          0        </param>
+<param name="calibration4">                      0          0         0          0         0       0          0          0        </param>
+<param name="calibration5">                      0          0         0          0         0       0          0          0        </param>
+<param name="calibrationZero">                   0          0         0          0         91      0          0          0        </param>
+<param name="calibrationDelta">                  0          0         0          0         0       0          0          0        </param>
+                                                                                          
+<param name="startupPosition">                  -10         20       -10         35        0       0.03       0.0        0.0      </param>
+<param name="startupVelocity">                   10         10        10         10        15.0    0.007      10         10       </param>
+<param name="startupMaxPwm">                     32000      32000     32000      32000     2000    2000       2000       2000     </param>
+<param name="startupPosThreshold">               2          2         2          2         2       0.002      2          2        </param>
+</group>
+
+		<param name="CALIB_ORDER">(0 1 2) (3) (4) (5 6 7)</param> 
+
+		<action phase="startup" level="10" type="calibrate">
+		    <param name="target">cer_left_arm_no_hand_mc_wrapper</param>
+		</action>
+
+		<action phase="interrupt1" level="1" type="park">
+		    <param name="target">cer_left_arm_no_hand_mc_wrapper</param>
+		</action>
+		<action phase="interrupt1" level="2" type="park">
+		    <param name="target">cer_left_arm_no_hand_mc_wrapper</param>
+		</action>
+
+
+		<action phase="interrupt3" level="1" type="abort" />
+
+	</device>
+

--- a/CER03/calibrators/cer_left_hand-calib.xml
+++ b/CER03/calibrators/cer_left_hand-calib.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_hand_calibrator" type="parametricCalibratorEth">
+        <xi:include href="../general.xml" />
+                
+    <group name="GENERAL">
+        <param name="joints">  2  </param> <!-- the number of joints of the robot part -->
+        <param name="deviceName"> Left_Hand_Calibrator </param>
+    </group>
+
+
+    <group name="PARKING_SEQUENCE">
+       <param name= "numberOfSequences">      1    </param>
+
+       <group name="SEQUENCE_0">
+           <param name="position">                       30.00     30.00       </param>
+           <param name="velocity">                       40        40.00       </param>
+       </group>
+    </group>
+
+    <group name="CALIBRATION">                                                    
+        <param name="calibrationType">                       13              13          </param>
+        <param name="calibration1">                      -37574           48751          </param>
+        <param name="calibration2">                      -41962           64735          </param>
+        <param name="calibration3">                      -53576               0          </param>
+        <param name="calibration4">                       55123               0          </param>
+        <param name="calibration5">                       -1500            1500          </param>
+        <param name="calibrationZero">                        0               0          </param>        
+        <param name="calibrationDelta">                       0               0          </param>
+        <param name="startupPosition">                     30.0            30.0          </param>
+        <param name="startupVelocity">                     40.0            40.0          </param>
+        <param name="startupMaxPwm">                       1500            1500          </param>
+        <param name="startupPosThreshold">                   10              10          </param>
+    </group>
+
+		<param name="CALIB_ORDER">(0 1) </param>
+
+		<action phase="startup" level="10" type="calibrate">
+		    <param name="target">cer_left_hand_mc_wrapper</param>
+		</action>
+
+		<action phase="interrupt1" level="1" type="park">
+		    <param name="target">cer_left_hand_mc_wrapper</param>
+		</action>
+
+		<action phase="interrupt3" level="1" type="abort" />
+
+	</device>
+
+

--- a/CER03/calibrators/cer_right_arm_no_hand-calib.xml
+++ b/CER03/calibrators/cer_right_arm_no_hand-calib.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm_no_hand_calibrator" type="parametricCalibratorEth">
+        <xi:include href="../general.xml" />
+                
+		<group name="GENERAL">
+		    <param name="joints">  8  </param> <!-- the number of joints of the robot part -->
+		    <param name="deviceName"> Right_Arm_No_Hand_Calibrator </param>
+		</group>
+
+<group name="PARKING_SEQUENCE">
+    <param name= "numberOfSequences">      2    </param>
+
+    <group name="SEQUENCE_0">
+        <param name="position">                       25.00     16.00       -9.00     15.00      0.00   0.01       -5.0        0.0       </param>
+        <param name="velocity">                       10        10.00      10.00      10.00      10.00   0.005     10.0       10.0       </param>
+    </group>
+    <group name="SEQUENCE_1">
+        <param name="position">                       0.00       5.00      0.00       0.00      0.00   0.01        -5.0        0.0       </param>
+        <param name="velocity">                      10.00      10.00     10.00      10.00     10.00   0.005       10.0       10.0       </param>
+    </group>
+ </group>
+
+
+<group name="CALIBRATION">                                                                                                      
+<param name="calibrationType">                    12         12        12         12         10      8          8          8             </param>
+<param name="calibration1">                      -42713      12431     15827     -5615      -550     1500       1500       1500          </param>
+<param name="calibration2">                       0          0         0          0          0       700        700        700           </param>
+<param name="calibration3">                       0          0         0          0          0       0          0          0             </param>
+<param name="calibration4">                       0          0         0          0          0       0          0          0             </param>
+<param name="calibration5">                       0          0         0          0          0       0          0          0             </param>
+<param name="calibrationZero">                    0          0         0          0          90      0          0          0             </param>
+<param name="calibrationDelta">                   0          0         0          0          0       0          0          0             </param>
+                                                                                           
+<param name="startupPosition">                   -10         20       -10         35         0.0     0.03       0.0        0.0           </param>
+<param name="startupVelocity">                    10         10        10         10         10      0.007      10         10            </param>
+<param name="startupMaxPwm">                      32000      32000     32000      32000      2000    2000       2000       2000          </param>
+<param name="startupPosThreshold">                2          2         2          2          2       0.002      2          2             </param>
+</group>
+
+		<param name="CALIB_ORDER">(0 1 2) (3) (4) (5 6 7)</param> 
+
+		<action phase="startup" level="10" type="calibrate">
+		    <param name="target">cer_right_arm_no_hand_mc_wrapper</param>
+		</action>
+
+		<action phase="interrupt1" level="1" type="park">
+		    <param name="target">cer_right_arm_no_hand_mc_wrapper</param>
+		</action>
+		<action phase="interrupt1" level="2" type="park">
+		    <param name="target">cer_right_arm_no_hand_mc_wrapper</param>
+		</action>
+
+
+		<action phase="interrupt3" level="1" type="abort" />
+
+	</device>
+

--- a/CER03/calibrators/cer_right_hand-calib.xml
+++ b/CER03/calibrators/cer_right_hand-calib.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_hand_calibrator" type="parametricCalibratorEth">
+        <xi:include href="../general.xml" />
+                
+    <group name="GENERAL">
+        <param name="joints">  2  </param> <!-- the number of joints of the robot part -->
+        <param name="deviceName"> Right_Hand_Calibrator </param>
+    </group>
+
+    <group name="PARKING_SEQUENCE">
+       <param name= "numberOfSequences">      1    </param>
+
+       <group name="SEQUENCE_0">
+           <param name="position">                       30.00     30.00       </param>
+           <param name="velocity">                       40        40.00       </param>
+       </group>
+    </group>
+
+    <group name="CALIBRATION">                                                    
+        <param name="calibrationType">                       13              13          </param>
+        <param name="calibration1">                       33514           56288          </param>
+        <param name="calibration2">                       57070           52155          </param>
+        <param name="calibration3">                      -46495               0          </param>
+        <param name="calibration4">                       60147               0          </param>
+        <param name="calibration5">                       -1500            1500          </param>
+        <param name="calibrationZero">                        0               0          </param>        
+        <param name="calibrationDelta">                       0               0          </param>
+        <param name="startupPosition">                     30.0            30.0          </param>
+        <param name="startupVelocity">                     40.0            40.0          </param>
+        <param name="startupMaxPwm">                       1500            1500          </param>
+        <param name="startupPosThreshold">                   10              10          </param>
+    </group>
+
+		<param name="CALIB_ORDER">(0 1) </param>
+
+		<action phase="startup" level="10" type="calibrate">
+		    <param name="target">cer_right_hand_mc_wrapper</param>
+		</action>
+
+		<action phase="interrupt1" level="1" type="park">
+		    <param name="target">cer_right_hand_mc_wrapper</param>
+		</action>
+
+		<action phase="interrupt3" level="1" type="abort" />
+
+	</device>
+
+

--- a/CER03/calibrators/cer_torso-calib.xml
+++ b/CER03/calibrators/cer_torso-calib.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="torso_calibrator" type="parametricCalibratorEth">
+        <xi:include href="../general.xml" />
+                
+		<group name="GENERAL">
+		    <param name="joints">  4  </param> <!-- the number of joints of the robot part -->
+		    <param name="deviceName"> Torso_Calibrator </param>
+		</group>
+
+<group name="PARKING_SEQUENCE">
+    <param name= "numberOfSequences">      2    </param>
+ 
+    <group name="SEQUENCE_0">
+        <param name="position">                       0.14       0.00       0.00       0.00            </param>
+        <param name="velocity">                       0.01      10.00      10.00      10.00           </param>
+    </group>
+    <group name="SEQUENCE_1">
+        <param name="position">                       0.05       0.00       0.00       0.00            </param>
+        <param name="velocity">                       0.01      10.00      10.00      10.00            </param>
+    </group>
+ </group>
+
+
+<group name="CALIBRATION">
+<param name="calibrationType">                    9               9           9         12            </param>
+<param name="calibration1">                       15000           15000       15000    -49007         </param>
+<param name="calibration2">                       280             280         280       0             </param>
+<param name="calibration3">                       0               0           0         0             </param>
+<param name="calibration4">                       0               0           0         0             </param>
+<param name="calibration5">                       0               0           0         0             </param>
+<param name="calibrationZero">                    1500            1500        1500      0             </param>
+<param name="calibrationDelta">                   0.0             0.0         0.0       0.0           </param>
+
+<param name="startupPosition">                    0.12            0.0         0.0       0.0           </param>
+<param name="startupVelocity">                    0.01            10          10        10.0          </param>
+<param name="startupTimeout">                     30              30          30        20            </param>
+<param name="startupMaxPwm">                      20000           20000       20000     5000          </param>
+<param name="startupPosThreshold">                0.005           2           2         2             </param>
+</group>
+
+		<param name="CALIB_ORDER">(0 1 2 3) </param>
+
+		<action phase="startup" level="10" type="calibrate">
+		    <param name="target">cer_torso_mc_wrapper</param>
+		</action>
+
+		<action phase="interrupt1" level="1" type="park">
+		    <param name="target">cer_torso_mc_wrapper</param>
+		</action>
+		<action phase="interrupt1" level="2" type="park">
+		    <param name="target">cer_torso_mc_wrapper</param>
+		</action>
+
+
+		<action phase="interrupt3" level="1" type="abort" />
+
+	</device>
+

--- a/CER03/camera/ServerGrabberDual.ini
+++ b/CER03/camera/ServerGrabberDual.ini
@@ -1,0 +1,8 @@
+device grabberDual
+subdevice usbCamera
+capabilities COLOR
+name /cer/cam
+d /dev/video0
+width  1280
+height 480
+

--- a/CER03/cer.urdf
+++ b/CER03/cer.urdf
@@ -1,0 +1,1540 @@
+
+<robot name="SIM_CER_ROBOT">
+  <link name="mobile_base_body_link">
+    <inertial>
+      <origin xyz="0.00353188 0 0.062803" rpy="0 0 0"/>
+      <mass value="14.0"/>
+      <inertia ixx="0.342401" ixy="0.0" ixz="-0.0396992" iyy="0.362542" iyz="0.0" izz="0.168981"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 -0.16" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_mobilebase_body.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="green">
+        <color rgba="0 1 0 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 -0.16" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_mobilebase_body.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <link name="base_link"/>
+  <joint name="base_link_fixed_joint" type="fixed">
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+    <parent link="mobile_base_body_link"/>
+    <child link="base_link"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="mobile_base_lidar_F"/>
+  <joint name="mobile_base_lidar_F_fixed_joint" type="fixed">
+    <origin xyz="0.07 0 0.031" rpy="0 0 0"/>
+    <parent link="mobile_base_body_link"/>
+    <child link="mobile_base_lidar_F"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="mobile_base_lidar_B"/>
+  <joint name="mobile_base_lidar_B_fixed_joint" type="fixed">
+    <origin xyz="-0.085 0 0.031" rpy="0 0 3.14"/>
+    <parent link="mobile_base_body_link"/>
+    <child link="mobile_base_lidar_B"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="mobile_base_double_lidar"/>
+  <joint name="mobile_base_double_lidar_fixed_joint" type="fixed">
+    <origin xyz="0.0 0 0.031" rpy="0 0 0"/>
+    <parent link="mobile_base_body_link"/>
+    <child link="mobile_base_double_lidar"/>
+    <dynamics damping="0.1"/>
+  </joint>
+
+  <link name="torso_slider_eq_link">
+    <inertial>
+      <origin xyz="0.015175 2.80975e-06 0.244533" rpy="0 0 0"/>
+      <mass value="7.5"/>
+      <inertia ixx="0.0978792" ixy="-1.83466e-06" ixz="0.00625726" iyy="0.0969511" iyz="0.0" izz="0.0746114"/>
+    </inertial>
+    <visual>
+      <origin xyz="-0.044 0 -0.231" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_torso_slider_eq.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="black">
+        <color rgba="0 0 0 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="-0.044 0 -0.231" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_torso_slider_eq.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="torso_heave_eq_joint" type="prismatic">
+    <origin xyz="0.044 0 0.071" rpy="0 0 0"/>
+    <axis xyz="0.0 0.0 1.0"/>
+    <parent link="mobile_base_body_link"/>
+    <child link="torso_slider_eq_link"/>
+    <limit effort="1200.0" lower="0.0" upper="0.17" velocity="0.5"/>
+    <dynamics damping="1000.0"/>
+  </joint>
+  <link name="torso_pin_eq_link">
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="1.5"/>
+      <inertia ixx="0.000379688" ixy="0.0" ixz="0.0" iyy="0.00143984" iyz="0.0" izz="0.00143984"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_torso_pin_eq.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="red">
+        <color rgba="1 0 0 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_torso_pin_eq.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="torso_roll_eq_joint" type="revolute">
+    <origin xyz="0 0 0.399" rpy="3.14159265359 0 0"/>
+    <axis xyz="1.0 0.0 0.0"/>
+    <parent link="torso_slider_eq_link"/>
+    <child link="torso_pin_eq_link"/>
+    <limit effort="50.0" lower="-0.523598775598" upper="0.523598775598" velocity="3.14"/>
+    <dynamics damping="100.0"/>
+  </joint>
+  <link name="torso_platform_link">
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="1.5"/>
+      <inertia ixx="0.00153125" ixy="0.0" ixz="0.0" iyy="0.00153125" iyz="0.0" izz="0.0030375"/>
+    </inertial>
+    <visual>
+      <origin xyz="-0.044 0 -0.63" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_torso_platform.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="blue">
+        <color rgba="0 0 1 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="-0.044 0 -0.63" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_torso_platform.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="torso_pitch_eq_joint" type="revolute">
+    <origin xyz="0 0 0" rpy="3.14159265359 0 0"/>
+    <axis xyz="0.0 1.0 0.0"/>
+    <parent link="torso_pin_eq_link"/>
+    <child link="torso_platform_link"/>
+    <limit effort="50.0" lower="-0.523598775598" upper="0.523598775598" velocity="3.14"/>
+    <dynamics damping="100.0"/>
+  </joint>
+  <link name="torso_tripod_root"/>
+  <joint name="torso_tripod_root_fixed_joint" type="fixed">
+    <origin xyz="0 0 0" rpy="0 0 3.14159265359"/>
+    <parent link="torso_platform_link"/>
+    <child link="torso_tripod_root"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="chest_link">
+    <inertial>
+      <origin xyz="-0.0330305 0 0.220198" rpy="0 0 0"/>
+      <mass value="13.0"/>
+      <inertia ixx="0.275816" ixy="0.0" ixz="0.0564476" iyy="0.253579" iyz="0.0" izz="0.127156"/>
+    </inertial>
+    <visual>
+      <origin xyz="-0.044 0 -0.63" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_chest.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="yellow">
+        <color rgba="1 1 0 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="-0.044 0 -0.63" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_chest.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="torso_yaw_joint" type="revolute">
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+    <axis xyz="0.0 0.0 1.0"/>
+    <parent link="torso_platform_link"/>
+    <child link="chest_link"/>
+    <limit effort="30.0" lower="-1.0471975512" upper="1.0471975512" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="torso"/>
+  <joint name="torso_fixed_joint" type="fixed">
+    <origin xyz="-0.042 0 0.185" rpy="0 0 0"/>
+    <parent link="chest_link"/>
+    <child link="torso"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_clavicle_link">
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="0.2"/>
+      <inertia ixx="0.000288" ixy="0.0" ixz="0.0" iyy="0.000288" iyz="0.0" izz="0.000288"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 0.177 -1.0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_clavicle.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="pink">
+        <color rgba="1 0 1 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.04 0.177 -1.0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_clavicle.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_shoulder_pitch_joint" type="revolute">
+    <origin xyz="-0.084 -0.177 0.37" rpy="0 0 0"/>
+    <axis xyz="0.0 -0.970296 0.241922"/>
+    <parent link="chest_link"/>
+    <child link="r_clavicle_link"/>
+    <limit effort="30.0" lower="-0.523598775598" upper="1.57079632679" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="r_shoulder_link">
+    <inertial>
+      <origin xyz="1.5e-06 -0.042148 -0.06332" rpy="0 0 0"/>
+      <mass value="0.5"/>
+      <inertia ixx="0.00076143" ixy="0.0" ixz="-2.84508e-08" iyy="0.000819748" iyz="0.000135828" izz="0.000588486"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 0.177 -1.0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_shoulder.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="cyan">
+        <color rgba="0 1 1 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.04 0.177 -1.0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_shoulder.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_shoulder_roll_joint" type="revolute">
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+    <axis xyz="-1.0 0.0 0.0"/>
+    <parent link="r_clavicle_link"/>
+    <child link="r_shoulder_link"/>
+    <limit effort="30.0" lower="-0.174532925199" upper="1.308996939" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="r_upperarm_FT_sensor_link">
+    <inertial>
+      <origin xyz="0 0 -0.014527" rpy="0 0 0"/>
+      <mass value="0.3"/>
+      <inertia ixx="6.00899e-05" ixy="0.0" ixz="0.0" iyy="6.00898e-05" iyz="0.0" izz="7.59375e-05"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 0.211 -0.89" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_upperarm_sensor.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="green"/>
+    </visual>
+    <collision>
+      <origin xyz="0.04 0.211 -0.89" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_upperarm_sensor.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_shoulder_yaw_joint" type="revolute">
+    <origin xyz="0 -0.034 -0.11" rpy="0 0 0"/>
+    <axis xyz="0.0 0.0 -1.0"/>
+    <parent link="r_shoulder_link"/>
+    <child link="r_upperarm_FT_sensor_link"/>
+    <limit effort="15.0" lower="-1.57079632679" upper="1.57079632679" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="r_upperarm_FT_sensor_frame"/>
+  <joint name="r_upperarm_FT_sensor_frame_fixed_joint" type="fixed">
+    <origin xyz="0 0 -0.0294" rpy="3.14159265359 0 1.57079632679"/>
+    <parent link="r_upperarm_FT_sensor_link"/>
+    <child link="r_upperarm_FT_sensor_frame"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_upperarm_link">
+    <inertial>
+      <origin xyz="0.000197 -0.001254 0.030305" rpy="3.14159265359 0 1.57079632679"/>
+      <mass value="0.5"/>
+      <inertia ixx="0.000849608" ixy="0.0" ixz="-3.39184e-05" iyy="0.000841002" iyz="-4.47567e-07" izz="0.000581528"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.211 0.04 0.8606" rpy="3.14159265359 0 1.57079632679"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_upperarm.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="white">
+        <color rgba="1 1 1 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.211 0.04 0.8606" rpy="3.14159265359 0 1.57079632679"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_upperarm.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_upperarm_FT_sensor" type="fixed">
+    <origin xyz="0 0 -0.0294" rpy="3.14159265359 0 1.57079632679"/>
+    <parent link="r_upperarm_FT_sensor_link"/>
+    <child link="r_upperarm_link"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_elbow_sphere_link">
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="0.2"/>
+      <inertia ixx="0.000128" ixy="0.0" ixz="0.0" iyy="0.000128" iyz="0.0" izz="0.000128"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 0.211 -0.749" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_elbow_sphere.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="dblue">
+        <color rgba="0 0 0.8 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.04 0.211 -0.749" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_elbow_sphere.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_elbow_joint" type="revolute">
+    <origin xyz="0 0 0.1116" rpy="3.14159265359 0 1.57079632679"/>
+    <axis xyz="0.0 -1.0 0.0"/>
+    <parent link="r_upperarm_link"/>
+    <child link="r_elbow_sphere_link"/>
+    <limit effort="20.0" lower="0.0" upper="1.74532925199" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="r_forearm_link">
+    <inertial>
+      <origin xyz="-0.0005116 0.000175 -0.072511" rpy="0 0 0"/>
+      <mass value="0.6"/>
+      <inertia ixx="0.00283352" ixy="0.0" ixz="3.15449e-05" iyy="0.00282953" iyz="-1.03787e-07" izz="0.000436673"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 0.211 -0.678" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_forearm.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="r_forearm_link_color">
+        <color rgba="0.929 0.933 0.91 1.0"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.04 0.211 -0.678" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_forearm.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_wrist_pronosupination_joint" type="revolute">
+    <origin xyz="0 0 -0.071" rpy="0 0 0"/>
+    <axis xyz="0.0 0.0 -1.0"/>
+    <parent link="r_elbow_sphere_link"/>
+    <child link="r_forearm_link"/>
+    <limit effort="10.0" lower="-1.57079632679" upper="1.57079632679" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="r_wrist_tripod_root"/>
+  <joint name="r_wrist_tripod_root_fixed_joint" type="fixed">
+    <origin xyz="0 0 -0.22" rpy="3.14159265359 0 1.57079632679"/>
+    <parent link="r_forearm_link"/>
+    <child link="r_wrist_tripod_root"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_wrist_slider_eq_link">
+    <inertial>
+      <origin xyz="0 5.9e-05 -0.225759" rpy="0 0 0"/>
+      <mass value="0.3"/>
+      <inertia ixx="0.00094001" ixy="0.0" ixz="0.0" iyy="0.000940012" iyz="0.0" izz="0.00022094"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 0.211 -0.749" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_wrist_slider.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="dgreen">
+        <color rgba="0.1 0.8 0.1 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.04 0.211 -0.749" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_wrist_slider.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_wrist_heave_eq_joint" type="prismatic">
+    <origin xyz="0 0 0.071" rpy="0 0 0"/>
+    <axis xyz="0.0 0.0 -1.0"/>
+    <parent link="r_forearm_link"/>
+    <child link="r_wrist_slider_eq_link"/>
+    <limit effort="200.0" lower="0.0" upper="0.13" velocity="0.25"/>
+    <dynamics damping="100.0"/>
+  </joint>
+  <link name="r_wrist_cup_eq_link">
+    <inertial>
+      <origin xyz="-1.1e-05 -0.0319409 -0.018146" rpy="0 0 0"/>
+      <mass value="0.2"/>
+      <inertia ixx="0.000102239" ixy="0.0" ixz="3.78925e-08" iyy="0.000102239" iyz="0.0" izz="0.000163555"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 0.179 -0.458" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_wrist_cup_eq.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="r_wrist_cup_eq_link_color">
+        <color rgba="0.776 0.8 0.769 1.0"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.04 0.179 -0.458" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_wrist_cup_eq.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_wrist_roll_eq_joint" type="revolute">
+    <origin xyz="-0.032 0 -0.291" rpy="0 0 1.57079632679"/>
+    <axis xyz="0.0 1.0 0.0"/>
+    <parent link="r_wrist_slider_eq_link"/>
+    <child link="r_wrist_cup_eq_link"/>
+    <limit effort="10.0" lower="-0.523598775598" upper="0.523598775598" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="r_hand_root_link">
+    <inertial>
+      <origin xyz="0.0001906 0.013614 -0.06234" rpy="0 0 0"/>
+      <mass value="0.3"/>
+      <inertia ixx="0.000294522" ixy="-1.41036e-06" ixz="6.91732e-08" iyy="0.000297774" iyz="2.11461e-05" izz="0.000189897"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 0.211 -0.458" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_hand_root.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="gray">
+        <color rgba="0.5 0.5 0.5 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.04 0.211 -0.458" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_hand_root.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_wrist_pitch_eq_joint" type="revolute">
+    <origin xyz="0 -0.032 0" rpy="0 0 -1.57079632679"/>
+    <axis xyz="0.0 -1.0 0.0"/>
+    <parent link="r_wrist_cup_eq_link"/>
+    <child link="r_hand_root_link"/>
+    <limit effort="10.0" lower="-0.523598775598" upper="0.523598775598" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="r_wrist"/>
+  <joint name="r_wrist_fixed_joint" type="fixed">
+    <origin xyz="0 0 0" rpy="3.14159265359 0 1.57079632679"/>
+    <parent link="r_hand_root_link"/>
+    <child link="r_wrist"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_gripper"/>
+  <joint name="r_gripper_fixed_joint" type="fixed">
+    <origin xyz="0 0.026917 -0.100456" rpy="0 1.30899714732 1.57079632679"/>
+    <parent link="r_hand_root_link"/>
+    <child link="r_gripper"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_hand_paddle_proximal_link">
+    <inertial>
+      <origin xyz="-9.65e-05 -0.010867 -0.022258" rpy="0 0 0"/>
+      <mass value="0.05"/>
+      <inertia ixx="0.0001" ixy="6.93652e-09" ixz="1.75564e-08" iyy="0.0001" iyz="-1.81901e-06" izz="0.0001"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 0.198143 -0.345494" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_hand_paddle_proximal.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="green"/>
+    </visual>
+    <collision>
+      <origin xyz="0.04 0.198143 -0.345494" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_hand_paddle_proximal.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_hand_paddle_proximal_joint" type="revolute">
+    <origin xyz="0 0.012857 -0.112506" rpy="0 0 0"/>
+    <axis xyz="1.0 0.0 0.0"/>
+    <parent link="r_hand_root_link"/>
+    <child link="r_hand_paddle_proximal_link"/>
+    <limit effort="5.0" lower="0.0" upper="1.2217304764" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="r_hand_paddle_distal_link">
+    <inertial>
+      <origin xyz="0.0013214 -0.005592 -0.020601" rpy="0 0 0"/>
+      <mass value="0.05"/>
+      <inertia ixx="0.0001" ixy="1.94983e-07" ixz="9.0126e-07" iyy="0.0001" iyz="-6.79853e-07" izz="0.0001"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 0.214471 -0.306748" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_hand_paddle_distal.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="black"/>
+    </visual>
+    <collision>
+      <origin xyz="0.04 0.214471 -0.306748" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_hand_paddle_distal.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_hand_paddle_distal_joint" type="revolute">
+    <origin xyz="0 -0.016328 -0.038746" rpy="0 0 0"/>
+    <axis xyz="1.0 0.0 0.0"/>
+    <parent link="r_hand_paddle_proximal_link"/>
+    <child link="r_hand_paddle_distal_link"/>
+    <limit effort="5.0" lower="0.0" upper="1.2217304764" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="r_hand_paddle_tip"/>
+  <joint name="r_hand_paddle_tip_fixed_joint" type="fixed">
+    <origin xyz="0 -0.008959 -0.044226" rpy="0 1.30899714732 1.57079632679"/>
+    <parent link="r_hand_paddle_distal_link"/>
+    <child link="r_hand_paddle_tip"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_hand_thumb_proximal_link">
+    <inertial>
+      <origin xyz="0.002515 0.017936 -0.003159" rpy="0 0 0"/>
+      <mass value="0.05"/>
+      <inertia ixx="0.0001" ixy="1.49367e-09" ixz="3.12525e-10" iyy="0.0001" iyz="2.63475e-06" izz="0.0001"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 0.171352 -0.382282" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_hand_thumb_proximal.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="red"/>
+    </visual>
+    <collision>
+      <origin xyz="0.04 0.171352 -0.382282" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_hand_thumb_proximal.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_hand_thumb_proximal_joint" type="revolute">
+    <origin xyz="0 0.039648 -0.075718" rpy="0 0 0"/>
+    <axis xyz="-1.0 0.0 0.0"/>
+    <parent link="r_hand_root_link"/>
+    <child link="r_hand_thumb_proximal_link"/>
+    <limit effort="5.0" lower="0.0" upper="1.0471975512" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="r_hand_thumb_distal_link">
+    <inertial>
+      <origin xyz="0.0024483 0.014529 -0.005865" rpy="0 0 0"/>
+      <mass value="0.05"/>
+      <inertia ixx="3.85163e-06" ixy="-1.50194e-10" ixz="4.04682e-10" iyy="7.40388e-06" iyz="9.14021e-07" izz="8.52416e-06"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 0.130827 -0.371296" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_hand_thumb_distal.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="blue"/>
+    </visual>
+    <collision>
+      <origin xyz="0.04 0.130827 -0.371296" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_r_hand_thumb_distal.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_hand_thumb_distal_joint" type="revolute">
+    <origin xyz="0 0.040525 -0.010986" rpy="0 0 0"/>
+    <axis xyz="-1.0 0.0 0.0"/>
+    <parent link="r_hand_thumb_proximal_link"/>
+    <child link="r_hand_thumb_distal_link"/>
+    <limit effort="5.0" lower="0.0" upper="1.2217304764" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="r_hand_thumb_tip"/>
+  <joint name="r_hand_thumb_tip_fixed_joint" type="fixed">
+    <origin xyz="0 0.028617 -0.014073" rpy="0 1.30899714732 1.57079632679"/>
+    <parent link="r_hand_thumb_distal_link"/>
+    <child link="r_hand_thumb_tip"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_clavicle_link">
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="0.2"/>
+      <inertia ixx="0.000288" ixy="0.0" ixz="0.0" iyy="0.000288" iyz="0.0" izz="0.000288"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 -0.177 -1.0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_clavicle.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="yellow"/>
+    </visual>
+    <collision>
+      <origin xyz="0.04 -0.177 -1.0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_clavicle.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_shoulder_pitch_joint" type="revolute">
+    <origin xyz="-0.084 0.177 0.37" rpy="0 0 0"/>
+    <axis xyz="0.0 -0.970296 -0.241922"/>
+    <parent link="chest_link"/>
+    <child link="l_clavicle_link"/>
+    <limit effort="30.0" lower="-0.523598775598" upper="1.57079632679" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="l_shoulder_link">
+    <inertial>
+      <origin xyz="1.5e-06 0.042148 -0.06332" rpy="0 0 0"/>
+      <mass value="0.5"/>
+      <inertia ixx="0.00076143" ixy="0.0" ixz="-2.84061e-08" iyy="0.000819748" iyz="-0.000135828" izz="0.000588486"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 -0.177 -1.0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_shoulder.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="pink"/>
+    </visual>
+    <collision>
+      <origin xyz="0.04 -0.177 -1.0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_shoulder.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_shoulder_roll_joint" type="revolute">
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+    <axis xyz="1.0 0.0 0.0"/>
+    <parent link="l_clavicle_link"/>
+    <child link="l_shoulder_link"/>
+    <limit effort="30.0" lower="-0.174532925199" upper="1.308996939" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="l_upperarm_FT_sensor_link">
+    <inertial>
+      <origin xyz="0 0 -0.014527" rpy="0 0 0"/>
+      <mass value="0.3"/>
+      <inertia ixx="6.00899e-05" ixy="0.0" ixz="0.0" iyy="6.00898e-05" iyz="0.0" izz="7.59375e-05"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 -0.211 -0.89" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_upperarm_sensor.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="cyan"/>
+    </visual>
+    <collision>
+      <origin xyz="0.04 -0.211 -0.89" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_upperarm_sensor.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_shoulder_yaw_joint" type="revolute">
+    <origin xyz="0 0.034 -0.11" rpy="0 0 0"/>
+    <axis xyz="0.0 0.0 1.0"/>
+    <parent link="l_shoulder_link"/>
+    <child link="l_upperarm_FT_sensor_link"/>
+    <limit effort="15.0" lower="-1.57079632679" upper="1.57079632679" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="l_upperarm_FT_sensor_frame"/>
+  <joint name="l_upperarm_FT_sensor_frame_fixed_joint" type="fixed">
+    <origin xyz="0 0 -0.0294" rpy="3.14159265359 0 1.57079632679"/>
+    <parent link="l_upperarm_FT_sensor_link"/>
+    <child link="l_upperarm_FT_sensor_frame"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_upperarm_link">
+    <inertial>
+      <origin xyz="-0.000197 -0.001254 0.030305" rpy="3.14159265359 0 1.57079632679"/>
+      <mass value="0.5"/>
+      <inertia ixx="0.000849607" ixy="0.0" ixz="-3.39183e-05" iyy="0.000841001" iyz="4.47458e-07" izz="0.000581528"/>
+    </inertial>
+    <visual>
+      <origin xyz="-0.211 0.04 0.8606" rpy="3.14159265359 0 1.57079632679"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_upperarm.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="green"/>
+    </visual>
+    <collision>
+      <origin xyz="-0.211 0.04 0.8606" rpy="3.14159265359 0 1.57079632679"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_upperarm.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_upperarm_FT_sensor" type="fixed">
+    <origin xyz="0 0 -0.0294" rpy="3.14159265359 0 1.57079632679"/>
+    <parent link="l_upperarm_FT_sensor_link"/>
+    <child link="l_upperarm_link"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_elbow_sphere_link">
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="0.2"/>
+      <inertia ixx="0.000128" ixy="0.0" ixz="0.0" iyy="0.000128" iyz="0.0" izz="0.000128"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 -0.211 -0.749" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_elbow_sphere.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="white"/>
+    </visual>
+    <collision>
+      <origin xyz="0.04 -0.211 -0.749" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_elbow_sphere.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_elbow_joint" type="revolute">
+    <origin xyz="0 0 0.1116" rpy="3.14159265359 0 1.57079632679"/>
+    <axis xyz="0.0 -1.0 0.0"/>
+    <parent link="l_upperarm_link"/>
+    <child link="l_elbow_sphere_link"/>
+    <limit effort="20.0" lower="0.0" upper="1.74532925199" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="l_forearm_link">
+    <inertial>
+      <origin xyz="-0.0005116 -0.000175 -0.072511" rpy="0 0 0"/>
+      <mass value="0.6"/>
+      <inertia ixx="0.00283352" ixy="0.0" ixz="3.15449e-05" iyy="0.00282953" iyz="1.0379e-07" izz="0.000436673"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 -0.211 -0.678" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_forearm.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="l_forearm_link_color">
+        <color rgba="0.929 0.933 0.91 1.0"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.04 -0.211 -0.678" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_forearm.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_wrist_pronosupination_joint" type="revolute">
+    <origin xyz="0 0 -0.071" rpy="0 0 0"/>
+    <axis xyz="0.0 0.0 1.0"/>
+    <parent link="l_elbow_sphere_link"/>
+    <child link="l_forearm_link"/>
+    <limit effort="10.0" lower="-1.57079632679" upper="1.57079632679" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="l_wrist_tripod_root"/>
+  <joint name="l_wrist_tripod_root_fixed_joint" type="fixed">
+    <origin xyz="0 0 -0.22" rpy="3.14159265359 0 -1.57079632679"/>
+    <parent link="l_forearm_link"/>
+    <child link="l_wrist_tripod_root"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_wrist_slider_eq_link">
+    <inertial>
+      <origin xyz="0 -5.9e-05 -0.225761" rpy="0 0 0"/>
+      <mass value="0.3"/>
+      <inertia ixx="0.000939997" ixy="0.0" ixz="0.0" iyy="0.00094" iyz="4.18243e-09" izz="0.000220942"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 -0.211 -0.749" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_wrist_slider.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="dblue"/>
+    </visual>
+    <collision>
+      <origin xyz="0.04 -0.211 -0.749" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_wrist_slider.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_wrist_heave_eq_joint" type="prismatic">
+    <origin xyz="0 0 0.071" rpy="0 0 0"/>
+    <axis xyz="0.0 0.0 -1.0"/>
+    <parent link="l_forearm_link"/>
+    <child link="l_wrist_slider_eq_link"/>
+    <limit effort="200.0" lower="0.0" upper="0.13" velocity="0.25"/>
+    <dynamics damping="100.0"/>
+  </joint>
+  <link name="l_wrist_cup_eq_link">
+    <inertial>
+      <origin xyz="0.0319892 -5.9e-05 -0.018146" rpy="0 0 0"/>
+      <mass value="0.2"/>
+      <inertia ixx="0.000102239" ixy="0.0" ixz="3.78925e-08" iyy="0.000102239" iyz="0.0" izz="0.000163555"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.072 -0.211 -0.458" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_wrist_cup_eq.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="l_wrist_cup_eq_link_color">
+        <color rgba="0.776 0.8 0.769 1.0"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.072 -0.211 -0.458" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_wrist_cup_eq.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_wrist_roll_eq_joint" type="revolute">
+    <origin xyz="-0.032 0 -0.291" rpy="0 0 0"/>
+    <axis xyz="1.0 0.0 0.0"/>
+    <parent link="l_wrist_slider_eq_link"/>
+    <child link="l_wrist_cup_eq_link"/>
+    <limit effort="10.0" lower="-0.523598775598" upper="0.523598775598" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="l_hand_root_link">
+    <inertial>
+      <origin xyz="0.0001906 -0.013614 -0.06234" rpy="0 0 0"/>
+      <mass value="0.3"/>
+      <inertia ixx="0.000294522" ixy="1.41029e-06" ixz="6.92026e-08" iyy="0.000297775" iyz="-2.11461e-05" izz="0.000189897"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 -0.211 -0.458" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_hand_root.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="dgreen"/>
+    </visual>
+    <collision>
+      <origin xyz="0.04 -0.211 -0.458" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_hand_root.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_wrist_pitch_eq_joint" type="revolute">
+    <origin xyz="0.032 0 0" rpy="0 0 0"/>
+    <axis xyz="0.0 -1.0 0.0"/>
+    <parent link="l_wrist_cup_eq_link"/>
+    <child link="l_hand_root_link"/>
+    <limit effort="10.0" lower="-0.523598775598" upper="0.523598775598" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="l_wrist"/>
+  <joint name="l_wrist_fixed_joint" type="fixed">
+    <origin xyz="0 0 0" rpy="3.14159265359 0 -1.57079632679"/>
+    <parent link="l_hand_root_link"/>
+    <child link="l_wrist"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_gripper"/>
+  <joint name="l_gripper_fixed_joint" type="fixed">
+    <origin xyz="0 -0.026917 -0.100456" rpy="3.14159265359 1.30899714732 -1.57079632679"/>
+    <parent link="l_hand_root_link"/>
+    <child link="l_gripper"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_hand_paddle_proximal_link">
+    <inertial>
+      <origin xyz="-9.65e-05 0.010867 -0.022259" rpy="0 0 0"/>
+      <mass value="0.05"/>
+      <inertia ixx="0.0001" ixy="-6.9439e-09" ixz="1.7549e-08" iyy="0.0001" iyz="1.81902e-06" izz="0.0001"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 -0.198143 -0.345494" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_hand_paddle_proximal.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="gray"/>
+    </visual>
+    <collision>
+      <origin xyz="0.04 -0.198143 -0.345494" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_hand_paddle_proximal.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_hand_paddle_proximal_joint" type="revolute">
+    <origin xyz="0 -0.012857 -0.112506" rpy="0 0 0"/>
+    <axis xyz="-1.0 0.0 0.0"/>
+    <parent link="l_hand_root_link"/>
+    <child link="l_hand_paddle_proximal_link"/>
+    <limit effort="5.0" lower="0.0" upper="1.2217304764" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="l_hand_paddle_distal_link">
+    <inertial>
+      <origin xyz="0.0013214 0.005592 -0.020601" rpy="0 0 0"/>
+      <mass value="0.05"/>
+      <inertia ixx="0.0001" ixy="-1.94983e-07" ixz="9.01259e-07" iyy="0.0001" iyz="6.79853e-07" izz="0.0001"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 -0.214471 -0.306748" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_hand_paddle_distal.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="green"/>
+    </visual>
+    <collision>
+      <origin xyz="0.04 -0.214471 -0.306748" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_hand_paddle_distal.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_hand_paddle_distal_joint" type="revolute">
+    <origin xyz="0 0.016328 -0.038746" rpy="0 0 0"/>
+    <axis xyz="-1.0 0.0 0.0"/>
+    <parent link="l_hand_paddle_proximal_link"/>
+    <child link="l_hand_paddle_distal_link"/>
+    <limit effort="5.0" lower="0.0" upper="1.2217304764" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="l_hand_paddle_tip"/>
+  <joint name="l_hand_paddle_tip_fixed_joint" type="fixed">
+    <origin xyz="0 0.008959 -0.044226" rpy="3.14159265359 1.30899714732 -1.57079632679"/>
+    <parent link="l_hand_paddle_distal_link"/>
+    <child link="l_hand_paddle_tip"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_hand_thumb_proximal_link">
+    <inertial>
+      <origin xyz="0.002515 -0.017936 -0.003159" rpy="0 0 0"/>
+      <mass value="0.05"/>
+      <inertia ixx="0.0001" ixy="-1.50858e-09" ixz="3.04948e-10" iyy="0.0001" iyz="-2.63475e-06" izz="0.0001"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.04 -0.171352 -0.382282" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_hand_thumb_proximal.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="black"/>
+    </visual>
+    <collision>
+      <origin xyz="0.04 -0.171352 -0.382282" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_hand_thumb_proximal.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_hand_thumb_proximal_joint" type="revolute">
+    <origin xyz="0 -0.039648 -0.075718" rpy="0 0 0"/>
+    <axis xyz="1.0 0.0 0.0"/>
+    <parent link="l_hand_root_link"/>
+    <child link="l_hand_thumb_proximal_link"/>
+    <limit effort="5.0" lower="0.0" upper="1.0471975512" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="l_hand_thumb_distal_link">
+    <inertial>
+      <origin xyz="0.0021933 -0.014529 -0.005865" rpy="0 0 0"/>
+      <mass value="0.05"/>
+      <inertia ixx="0.0001" ixy="1.50893e-10" ixz="4.0488e-10" iyy="0.0001" iyz="-9.14021e-07" izz="0.0001"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.039745 -0.130827 -0.371296" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_hand_thumb_distal.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="red"/>
+    </visual>
+    <collision>
+      <origin xyz="0.039745 -0.130827 -0.371296" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_l_hand_thumb_distal.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_hand_thumb_distal_joint" type="revolute">
+    <origin xyz="0.000255 -0.040525 -0.010986" rpy="0 0 0"/>
+    <axis xyz="1.0 0.0 0.0"/>
+    <parent link="l_hand_thumb_proximal_link"/>
+    <child link="l_hand_thumb_distal_link"/>
+    <limit effort="5.0" lower="0.0" upper="1.2217304764" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="l_hand_thumb_tip"/>
+  <joint name="l_hand_thumb_tip_fixed_joint" type="fixed">
+    <origin xyz="-0.000255 -0.028617 -0.014073" rpy="3.14159265359 1.30899714732 -1.57079632679"/>
+    <parent link="l_hand_thumb_distal_link"/>
+    <child link="l_hand_thumb_tip"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="neck_link">
+    <inertial>
+      <origin xyz="-0.0003217 0 0.07756" rpy="0 0 0"/>
+      <mass value="1.4"/>
+      <inertia ixx="0.00429793" ixy="0.0" ixz="-0.000592817" iyy="0.00443784" iyz="-6.85477e-08" izz="0.000419904"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.05 0 -1.03" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_neck.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="blue"/>
+    </visual>
+    <collision>
+      <origin xyz="0.05 0 -1.03" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_neck.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="neck_pitch_joint" type="revolute">
+    <origin xyz="-0.094 0 0.4" rpy="0 0 0"/>
+    <axis xyz="0.0 1.0 0.0"/>
+    <parent link="chest_link"/>
+    <child link="neck_link"/>
+    <limit effort="10.0" lower="-0.523598775598" upper="0.872664625997" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="head_link">
+    <inertial>
+      <origin xyz="0.0301486 -1.57202e-06 -0.00035" rpy="0 0 0"/>
+      <mass value="2.0"/>
+      <inertia ixx="0.0106536" ixy="-7.34817e-08" ixz="0.000274098" iyy="0.00398482" iyz="1.64063e-07" izz="0.00944369"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.0383205 0 -1.18838" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_head.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="head_link_color">
+        <color rgba="0.368932 0.368932 0.368932 1.0"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.0383205 0 -1.18838" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_head.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="neck_yaw_joint" type="revolute">
+    <origin xyz="0.0116795 0 0.15838" rpy="0 0 0"/>
+    <axis xyz="0.173648 0.0 0.984808"/>
+    <parent link="neck_link"/>
+    <child link="head_link"/>
+    <limit effort="10.0" lower="-1.3962634016" upper="1.3962634016" velocity="3.14"/>
+    <dynamics damping="10.0"/>
+  </joint>
+  <link name="depth_rgb"/>
+  <joint name="depth_rgb_fixed_joint" type="fixed">
+    <origin xyz="0.0598814 0.0184871 0.04402" rpy="-1.57079632679 0 -1.57079632679"/>
+    <parent link="head_link"/>
+    <child link="depth_rgb"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="head_leopard_cyclopic"/>
+  <joint name="head_leopard_cyclopic_fixed_joint" type="fixed">
+    <origin xyz="0.0521666 0 -0.06748" rpy="-1.57079632679 0 -1.57079632679"/>
+    <parent link="head_link"/>
+    <child link="head_leopard_cyclopic"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="gaze"/>
+  <joint name="gaze_fixed_joint" type="fixed">
+    <origin xyz="0.0494817 0 -0.01388" rpy="-1.57079632679 0 -1.57079632679"/>
+    <parent link="head_link"/>
+    <child link="gaze"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="head_leopard_right"/>
+  <joint name="head_leopard_right_fixed_joint" type="fixed">
+    <origin xyz="0.0521666 -0.0335105 -0.06748" rpy="-1.57079632679 0 -1.57079632679"/>
+    <parent link="head_link"/>
+    <child link="head_leopard_right"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="head_leopard_left"/>
+  <joint name="head_leopard_left_fixed_joint" type="fixed">
+    <origin xyz="0.0521666 0.0335105 -0.06748" rpy="-1.57079632679 0 -1.57079632679"/>
+    <parent link="head_link"/>
+    <child link="head_leopard_left"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="depth"/>
+  <joint name="depth_fixed_joint" type="fixed">
+    <origin xyz="0.0598814 0.0444871 0.04402" rpy="-1.57079632679 0 -1.57079632679"/>
+    <parent link="head_link"/>
+    <child link="depth"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="depth_center"/>
+  <joint name="depth_center_fixed_joint" type="fixed">
+    <origin xyz="0.0598756 0 0.04402" rpy="-1.57079632679 0 -1.57079632679"/>
+    <parent link="head_link"/>
+    <child link="depth_center"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="mobile_base_r_tyre_link">
+    <inertial>
+      <origin xyz="0 -0.034425 8.99999999998e-06" rpy="0 0 0"/>
+      <mass value="3.0"/>
+      <inertia ixx="0.0200196" ixy="0.0" ixz="0.0" iyy="0.0376169" iyz="8.28101e-07" izz="0.0200156"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0.139 -0.16" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_mobilebase_r_tyre.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="yellow"/>
+    </visual>
+    <collision>
+      <origin xyz="0.0 -0.03 0.0" rpy="1.57079632679 0.0 0.0"/>
+      <geometry>
+        <cylinder radius="0.16" length="0.005"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="mobile_base_r_wheel_joint" type="continuous">
+    <origin xyz="0 -0.139 0" rpy="0 0 0"/>
+    <axis xyz="0.0 1.0 0.0"/>
+    <parent link="mobile_base_body_link"/>
+    <child link="mobile_base_r_tyre_link"/>
+    <limit effort="100.0" velocity="30.0"/>
+    <dynamics damping="0.5"/>
+  </joint>
+  <link name="mobile_base_l_tyre_link">
+    <inertial>
+      <origin xyz="0 0.034425 8.99999999998e-06" rpy="0 0 0"/>
+      <mass value="3.0"/>
+      <inertia ixx="0.0200196" ixy="0.0" ixz="0.0" iyy="0.0376169" iyz="-8.28446e-07" izz="0.0200156"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 -0.139 -0.16" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://cer/meshes/dae/sim_cer_mobilebase_l_tyre.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="pink"/>
+    </visual>
+    <collision>
+      <origin xyz="0.0 0.03 0.0" rpy="1.57079632679 0.0 0.0"/>
+      <geometry>
+        <cylinder radius="0.16" length="0.005"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="mobile_base_l_wheel_joint" type="continuous">
+    <origin xyz="0 0.139 0" rpy="0 0 0"/>
+    <axis xyz="0.0 1.0 0.0"/>
+    <parent link="mobile_base_body_link"/>
+    <child link="mobile_base_l_tyre_link"/>
+    <limit effort="100.0" velocity="30.0"/>
+    <dynamics damping="0.5"/>
+  </joint>
+  <gazebo reference="l_upperarm_FT_sensor">
+    <sensor name="l_upperarm_FT_sensor" type="force_torque">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <force_torque>
+        <frame>child</frame>
+        <measure_direction>child_to_parent</measure_direction>
+      </force_torque>
+    </sensor>
+  </gazebo>
+  <sensor name="l_upperarm_FT_sensor" type="force_torque">
+    <parent joint="l_upperarm_FT_sensor"/>
+    <force_torque>
+      <frame>child</frame>
+      <measure_direction>child_to_parent</measure_direction>
+    </force_torque>
+  </sensor>
+  <gazebo reference="r_upperarm_FT_sensor">
+    <sensor name="r_upperarm_FT_sensor" type="force_torque">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <force_torque>
+        <frame>child</frame>
+        <measure_direction>child_to_parent</measure_direction>
+      </force_torque>
+    </sensor>
+  </gazebo>
+  <sensor name="r_upperarm_FT_sensor" type="force_torque">
+    <parent joint="r_upperarm_FT_sensor"/>
+    <force_torque>
+      <frame>child</frame>
+      <measure_direction>child_to_parent</measure_direction>
+    </force_torque>
+  </sensor>
+  <gazebo reference="mobile_base_body_link">
+    <sensor name="base_laser" type="ray">
+      <always_on>1</always_on>
+      <update_rate>40</update_rate>
+      <pose>0.07 0.0 0.031 0.0 -0.0 0.0</pose>
+      <ray>
+ <scan>
+  <horizontal>
+   <samples>360</samples>
+   <resolution>1</resolution>
+   <min_angle>-3.14</min_angle>
+   <max_angle>3.14</max_angle>
+  </horizontal>
+ </scan>
+ <range>
+  <min>0.10</min>
+  <max>5.0</max>
+  <resolution>0.01</resolution>
+ </range>
+ <noise>
+  <type>gaussian</type>
+  <mean>0.0</mean>
+  <stddev>0.005</stddev>
+ </noise>
+</ray>
+      <plugin name="laser_sensor" filename="libgazebo_yarp_lasersensor.so">
+    <yarpConfigurationFile>package://cer/conf/gazebo_cer_laser_sensor.ini</yarpConfigurationFile>
+</plugin>
+    </sensor>
+  </gazebo>
+  <sensor name="base_laser" type="ray">
+    <parent link="mobile_base_body_link"/>
+    <origin rpy="0.0 -0.0 0.0" xyz="0.07 0.0 0.031"/>
+  </sensor>
+  <gazebo reference="head_link">
+    <sensor name="multicamera_sensor" type="multicamera">
+      <always_on>1</always_on>
+      <update_rate>30</update_rate>
+      <pose>0.0521666 0.0 -0.06748 -1.57079632679 -0.0 -1.57079632679</pose>
+      <camera name="left_camera">
+  <pose>-0.0325 0 0 -1.57079 -1.57079 3.14159</pose>
+  <horizontal_fov>1.5708</horizontal_fov>
+  <image>
+     <width>640</width>
+     <height>480</height>
+  </image>
+  <clip>
+     <near>0.1</near>
+     <far>100</far>
+  </clip>
+</camera>
+      <camera name="right_camera">
+  <pose>0.0325 0 0 -1.57079 -1.57079 3.14159</pose>
+  <horizontal_fov>1.5708</horizontal_fov>
+  <image>
+    <width>640</width>
+    <height>480</height>
+  </image>
+  <clip>
+    <near>0.1</near>
+    <far>100</far>
+  </clip>
+</camera>
+      <plugin name="multicamera_plugin" filename="libgazebo_yarp_multicamera.so">
+    <yarpConfigurationFile>package://cer/conf/gazebo_cer_multicamera.ini</yarpConfigurationFile>
+</plugin>
+    </sensor>
+  </gazebo>
+  <sensor name="multicamera_sensor" type="multicamera">
+    <parent link="head_link"/>
+    <origin rpy="-1.57079632679 -0.0 -1.57079632679" xyz="0.0521666 0.0 -0.06748"/>
+  </sensor>
+  <gazebo reference="head_link">
+    <sensor name="asus_xtion_depth" type="depth">
+      <always_on>1</always_on>
+      <update_rate>30</update_rate>
+      <pose>0.0598814 0.0444871 0.04402 -1.57079632679 -0.0 -1.57079632679</pose>
+      <camera name="asus_xtion_depth_camera">
+    <pose frame="">0 0 0 -1.57079 -1.57079 3.14159</pose>
+    <horizontal_fov>1.02259</horizontal_fov>
+    <distortion>
+        <k1>0</k1>
+        <k2>0</k2>
+        <k3>0</k3>
+        <p1>0</p1>
+        <p2>0</p2>
+        <center>319.5 239.5</center>
+    </distortion>
+    <image>
+        <width>640</width>
+        <height>480</height>
+        <format>R8G8B8</format>
+    </image>
+    <clip>
+        <near>0.02</near>
+        <far>3000</far>
+    </clip>
+</camera>
+      <plugin filename="libgazebo_yarp_depthCamera.so" name="depth_camera_plugin">
+    <yarpConfigurationFile>package://cer/conf/gazebo_cer_depthCamera.ini</yarpConfigurationFile>
+</plugin>
+    </sensor>
+  </gazebo>
+  <sensor name="asus_xtion_depth" type="depth">
+    <parent link="head_link"/>
+    <origin rpy="-1.57079632679 -0.0 -1.57079632679" xyz="0.0598814 0.0444871 0.04402"/>
+  </sensor>
+  <gazebo reference="head_link">
+    <sensor name="asus_xtion_rgb" type="camera">
+      <always_on>1</always_on>
+      <update_rate>30</update_rate>
+      <pose>0.0598814 0.0184871 0.04402 -1.57079632679 -0.0 -1.57079632679</pose>
+      <camera name="asus_xtion_rgb_camera">
+    <pose frame="">0 0 0 -1.57079 -1.57079 3.14159</pose>
+    <horizontal_fov>1.02259</horizontal_fov>
+    <distortion>
+        <k1>0</k1>
+        <k2>0</k2>
+        <k3>0</k3>
+        <p1>0</p1>
+        <p2>0</p2>
+        <center>319.5 239.5</center>
+    </distortion>
+    <image>
+        <width>640</width>
+        <height>480</height>
+        <format>R8G8B8</format>
+    </image>
+    <clip>
+        <near>0.02</near>
+        <far>3000</far>
+    </clip>
+</camera>
+      <plugin filename="libgazebo_yarp_camera.so" name="xtion_camera_rgb_plugin">
+    <yarpConfigurationFile>package://cer/conf/gazebo_cer_xtion_camera_rgb.ini</yarpConfigurationFile>
+</plugin>
+    </sensor>
+  </gazebo>
+  <sensor name="asus_xtion_rgb" type="camera">
+    <parent link="head_link"/>
+    <origin rpy="-1.57079632679 -0.0 -1.57079632679" xyz="0.0598814 0.0184871 0.04402"/>
+  </sensor>
+  <gazebo>
+<!-- TORSO user view -->
+<plugin name="controlboard_torso" filename="libgazebo_yarp_controlboard.so">
+  <yarpConfigurationFile>package://cer/conf/gazebo_cer_torso.ini</yarpConfigurationFile>
+</plugin>
+<!-- TORSO low level view -->
+<plugin name="controlboard_torso_tripod" filename="libgazeboTripod.so">
+  <yarpConfigurationFile>package://cer/conf/gazebo_cer_torso_tripod.ini</yarpConfigurationFile>
+</plugin>
+
+<plugin name="controlboard_left_upper_arm" filename="libgazebo_yarp_controlboard.so">
+  <yarpConfigurationFile>package://cer/conf/gazebo_cer_left_upper_arm.ini</yarpConfigurationFile>
+</plugin>
+<!-- LEFT WRIST user view -->  
+<plugin name="controlboard_left_wrist" filename="libgazebo_yarp_controlboard.so">
+  <yarpConfigurationFile>package://cer/conf/gazebo_cer_left_wrist.ini</yarpConfigurationFile>
+</plugin>
+<!-- LEFT WRIST low level view -->
+<plugin name="controlboard_left_wrist_tripod" filename="libgazeboTripod.so">
+  <yarpConfigurationFile>package://cer/conf/gazebo_cer_left_wrist_tripod.ini</yarpConfigurationFile>
+</plugin>
+
+<plugin name="controlboard_right_upper_arm" filename="libgazebo_yarp_controlboard.so">
+  <yarpConfigurationFile>package://cer/conf/gazebo_cer_right_upper_arm.ini</yarpConfigurationFile>
+</plugin>
+<!-- RIGHT WRIST user view -->
+<plugin name="controlboard_right_wrist" filename="libgazebo_yarp_controlboard.so">
+  <yarpConfigurationFile>package://cer/conf/gazebo_cer_right_wrist.ini</yarpConfigurationFile>
+</plugin>
+<!-- RIGHT WRIST low level view -->
+<plugin name="controlboard_right_wrist_tripod" filename="libgazeboTripod.so">
+  <yarpConfigurationFile>package://cer/conf/gazebo_cer_right_wrist_tripod.ini</yarpConfigurationFile>
+</plugin>
+
+<plugin name="controlboard_right_arm" filename="libgazebo_yarp_controlboard.so">
+  <yarpConfigurationFile>package://cer/conf/gazebo_cer_right_arm.ini</yarpConfigurationFile>
+</plugin>
+<plugin name="controlboard_left_arm" filename="libgazebo_yarp_controlboard.so">
+  <yarpConfigurationFile>package://cer/conf/gazebo_cer_left_arm.ini</yarpConfigurationFile>
+</plugin>
+
+<plugin name="controlboard_head" filename="libgazebo_yarp_controlboard.so">
+  <yarpConfigurationFile>package://cer/conf/gazebo_cer_head.ini</yarpConfigurationFile>
+</plugin>
+
+<plugin name="controlboard_left_hand" filename="libgazebo_yarp_controlboard.so">
+  <yarpConfigurationFile>package://cer/conf/gazebo_cer_left_hand.ini</yarpConfigurationFile>
+</plugin>
+
+<plugin name="controlboard_right_hand" filename="libgazebo_yarp_controlboard.so">
+  <yarpConfigurationFile>package://cer/conf/gazebo_cer_right_hand.ini</yarpConfigurationFile>
+</plugin> 
+
+<plugin name="mais_left_hand" filename="libgazebo_yarp_maissensor.so">
+  <yarpConfigurationFile>package://cer/conf/gazebo_cer_left_hand_mais.ini</yarpConfigurationFile>
+</plugin>
+<plugin name="mais_right_hand" filename="libgazebo_yarp_maissensor.so">
+  <yarpConfigurationFile>package://cer/conf/gazebo_cer_right_hand_mais.ini</yarpConfigurationFile>
+</plugin>
+
+<plugin name="controlboard_mobile_base" filename="libgazebo_yarp_controlboard.so">
+  <yarpConfigurationFile>package://cer/conf/gazebo_cer_mobile_base.ini</yarpConfigurationFile>
+</plugin>
+<plugin name="controlboard_all" filename="libgazebo_yarp_controlboard.so">
+  <yarpConfigurationFile>package://cer/conf/gazebo_cer_all.ini</yarpConfigurationFile>
+</plugin>
+<plugin name="world_interface" filename="libgazebo_yarp_worldinterface.so">
+  <yarpConfigurationFile>package://cer/conf/worldInterface.ini</yarpConfigurationFile>
+</plugin>
+</gazebo>
+  <gazebo reference="mobile_base_body_link">
+    <collision>
+      <surface>
+        <contact>
+          <ode/>
+        </contact>
+        <friction>
+          <ode>
+            <mu>0.0</mu>
+            <mu2>0.0</mu2>
+          </ode>
+        </friction>
+      </surface>
+    </collision>
+</gazebo>
+  <gazebo>
+  <pose>0 0 0.16 0 0 0</pose>
+</gazebo>
+  <gazebo reference="mobile_base_l_wheel_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="mobile_base_r_wheel_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="torso_heave_eq_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="torso_roll_eq_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="torso_pitch_eq_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="torso_yaw_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="neck_pitch_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="neck_yaw_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="l_shoulder_pitch_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="l_shoulder_roll_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="l_shoulder_yaw_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="l_elbow_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="l_wrist_pronosupination_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="l_wrist_heave_eq_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="l_wrist_roll_eq_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="l_wrist_pitch_eq_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="l_hand_paddle_proximal_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="l_hand_paddle_distal_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="l_hand_thumb_proximal_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="l_hand_thumb_distal_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="r_shoulder_pitch_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="r_shoulder_roll_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="r_shoulder_yaw_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="r_elbow_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="r_wrist_pronosupination_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="r_wrist_heave_eq_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="r_wrist_roll_eq_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="r_wrist_pitch_eq_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="r_hand_paddle_proximal_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="r_hand_paddle_distal_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="r_hand_thumb_proximal_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="r_hand_thumb_distal_joint">
+  <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+</robot>
+

--- a/CER03/firmwareupdater.ini
+++ b/CER03/firmwareupdater.ini
@@ -1,0 +1,2 @@
+[DRIVERS]
+ETH "eth"

--- a/CER03/general.xml
+++ b/CER03/general.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER03" build="1">
+  
+  <group name="GENERAL">
+      <param name="skipCalibration">    false  </param>
+      <param name="useRawEncoderData">  false  </param>
+      <param name="useLimitedPWM">      false  </param>
+      <param name="verbose">            false  </param>
+  </group>
+</params>

--- a/CER03/hardware/FT/cer_left_shoulder-ems5-strain.xml
+++ b/CER03/hardware/FT/cer_left_shoulder-ems5-strain.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_left_arm-eb5-strain" type="embObjStrain">
+    
+      <xi:include href="../../general.xml" />
+      <xi:include href="../electronics/cer_left_shoulder-ems5-eln.xml" />
+
+        <group name="SERVICE">
+            
+            <param name="type"> eomn_serv_AS_strain </param>
+        
+            <group name="PROPERTIES">
+  
+                <group name="CANBOARDS">
+                    <param name="type">                 eobrd_strain            </param>
+
+                    <group name="PROTOCOL">
+                        <param name="major">            1                       </param>    
+                        <param name="minor">            0                       </param>     
+                    </group>                    
+                    <group name="FIRMWARE">
+                        <param name="major">            0                       </param>    
+                        <param name="minor">            0                       </param> 
+                        <param name="build">            0                       </param>
+                    </group>
+                </group>
+                
+                <group name="SENSORS">
+                    <param name="id">                   id_l_upper_arm_strain   </param>
+                    <param name="type">                 eoas_strain             </param>
+                    <param name="location">             CAN2:13                 </param>
+                </group>                
+            
+            </group>
+
+            <group name="SETTINGS">        
+                <param name="acquisitionRate">          10                      </param>
+                <param name="enabledSensors">           id_l_upper_arm_strain   </param>                
+            </group>
+            
+            <group name="STRAIN_SETTINGS">        
+                <param name="useCalibration">           true                    </param>          
+            </group>            
+            
+        </group>
+    
+</device>
+
+

--- a/CER03/hardware/FT/cer_right_shoulder-ems4-strain.xml
+++ b/CER03/hardware/FT/cer_right_shoulder-ems4-strain.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_right_arm-eb4-strain" type="embObjStrain">
+    
+      <xi:include href="../../general.xml" />
+      <xi:include href="../electronics/cer_right_shoulder-ems4-eln.xml" />
+
+        <group name="SERVICE">
+            
+            <param name="type"> eomn_serv_AS_strain </param>
+        
+            <group name="PROPERTIES">
+  
+                <group name="CANBOARDS">
+                    <param name="type">                 eobrd_strain            </param>
+
+                    <group name="PROTOCOL">
+                        <param name="major">            1                       </param>    
+                        <param name="minor">            0                       </param>     
+                    </group>                    
+                    <group name="FIRMWARE">
+                        <param name="major">            0                       </param>    
+                        <param name="minor">            0                       </param> 
+                        <param name="build">            0                       </param>
+                    </group>
+                </group>
+                
+                <group name="SENSORS">
+                    <param name="id">                   id_r_upper_arm_strain   </param>
+                    <param name="type">                 eoas_strain             </param>
+                    <param name="location">             CAN2:13                 </param>
+                </group>                
+            
+            </group>
+
+            <group name="SETTINGS">        
+                <param name="acquisitionRate">          10                      </param>
+                <param name="enabledSensors">           id_r_upper_arm_strain   </param>                
+            </group>
+            
+            <group name="STRAIN_SETTINGS">        
+                <param name="useCalibration">           true                    </param>          
+            </group>            
+            
+        </group>
+    
+</device>
+
+

--- a/CER03/hardware/MAIS/left_hand-multi_enc.xml
+++ b/CER03/hardware/MAIS/left_hand-multi_enc.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_hand_multienc" type="embObjMultiEnc"> 
+        <xi:include href="general.xml" />
+        <xi:include href="hardware/electronics/cer_left_hand-mcp7-eln.xml" />
+        <group name="JOINTS">
+            <param name="listofjoints"> 0 1 </param>
+            <param name="encoderConversionFactor"> -182.044 182.044 1.0 -182.044 182.044 1.0 </param>
+        </group>
+    </device> 
+    
+
+

--- a/CER03/hardware/MAIS/right_hand-multi_enc.xml
+++ b/CER03/hardware/MAIS/right_hand-multi_enc.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_hand_multienc" type="embObjMultiEnc">
+        <xi:include href="general.xml" />
+        <xi:include href="hardware/electronics/cer_right_hand-mcp7-eln.xml" />
+        <group name="JOINTS">
+            <param name="listofjoints"> 0 1 </param>
+            <param name="encoderConversionFactor"> -182.044 182.044 1.0 -182.044 182.044 1.0 </param>
+        </group>
+    </device> 
+    
+
+

--- a/CER03/hardware/PSC/left_hand-psc.xml
+++ b/CER03/hardware/PSC/left_hand-psc.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+  
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_hand-psc" type="embObjPSC">
+	    <xi:include href="../../general.xml" />
+ 
+	    <xi:include href="../../hardware/electronics/cer_left_hand-mcp9-eln.xml" />
+        
+        <group name="SERVICE">
+            
+		<param name="type"> eomn_serv_AS_psc	</param>
+        
+            <group name="PROPERTIES">
+  
+                <group name="CANBOARDS">
+                    <param name="type">                 eobrd_psc            </param>
+
+                    <group name="PROTOCOL">
+                        <param name="major">            2                       </param>    
+                        <param name="minor">            0                       </param>     
+                    </group>                    
+                    <group name="FIRMWARE">
+                        <param name="major">            0                       </param>    
+                        <param name="minor">            0                       </param> 
+                        <param name="build">            0                       </param>
+                    </group>
+                </group>
+                
+                <group name="SENSORS">
+                    <param name="id">                   id_left_hand1       id_left_hand2   id_left_hand3       </param>
+                    <param name="type">                 eoas_psc_angle      eoas_psc_angle  eoas_psc_angle      </param>
+                    <param name="location">             CAN1:1              CAN1:2          CAN1:3              </param>
+                </group>                
+            
+            </group>
+
+            <group name="SETTINGS">        
+                <param name="acquisitionRate">          50                                          </param>
+                <param name="enabledSensors">           id_left_hand1 id_left_hand2 id_left_hand3   </param>                
+            </group>
+                   
+            
+        </group>
+    
+  </device>
+  
+  
+
+
+

--- a/CER03/hardware/PSC/right_hand-psc.xml
+++ b/CER03/hardware/PSC/right_hand-psc.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+  
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_hand-psc" type="embObjPSC">
+        <xi:include href="../../general.xml" />
+ 
+	<xi:include href="../../hardware/electronics/cer_right_hand-mcp7-eln.xml" />
+        
+        <group name="SERVICE">
+            
+		<param name="type"> eomn_serv_AS_psc	</param>
+        
+            <group name="PROPERTIES">
+  
+                <group name="CANBOARDS">
+                    <param name="type">                 eobrd_psc            </param>
+
+                    <group name="PROTOCOL">
+                        <param name="major">            2                       </param>    
+                        <param name="minor">            0                       </param>     
+                    </group>                    
+                    <group name="FIRMWARE">
+                        <param name="major">            0                       </param>    
+                        <param name="minor">            0                       </param> 
+                        <param name="build">            0                       </param>
+                    </group>
+                </group>
+                
+                <group name="SENSORS">
+                    <param name="id">                   id_right_hand1      id_right_hand2   id_right_hand3       </param>
+                    <param name="type">                 eoas_psc_angle      eoas_psc_angle  eoas_psc_angle      </param>
+                    <param name="location">             CAN1:1              CAN1:2          CAN1:3              </param>
+                </group>                
+            
+            </group>
+
+            <group name="SETTINGS">        
+                <param name="acquisitionRate">          50                                          </param>
+                <param name="enabledSensors">           id_right_hand1 id_right_hand2 id_right_hand3   </param>                
+            </group>
+                   
+            
+        </group>
+    
+  </device>
+  
+  
+
+
+

--- a/CER03/hardware/electronics/cer_base-ems1-eln.xml
+++ b/CER03/hardware/electronics/cer_base-ems1-eln.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER03" build="1">
+    <xi:include href="../electronics/pc104.xml" />
+    
+        <group name="ETH_BOARD">
+
+        <group name="ETH_BOARD_PROPERTIES">
+            <param name="IpAddress">                10.0.1.1                </param>
+            <param name="IpPort">                   12345                   </param>
+            <param name="Type">                     ems4                    </param>
+            <param name="maxSizeRXpacket">          768                     </param>
+            <param name="maxSizeROP">               384                     </param>
+        </group>
+
+        <group name="ETH_BOARD_SETTINGS">
+            <param name="Name">                     "EB1"                   </param> 
+            <group name="RUNNINGMODE">
+                <param name="period">                   1000                </param>
+                <param name="maxTimeOfRXactivity">      400                 </param>
+                <param name="maxTimeOfDOactivity">      300                 </param>   
+                <param name="maxTimeOfTXactivity">      300                 </param>                
+                <param name="TXrateOfRegularROPs">      3                   </param> 
+            </group>         
+        </group>
+
+        <group name="ETH_BOARD_ACTIONS">
+            <group name="MONITOR_ITS_PRESENCE">
+                <param name="enabled">                  true                </param> 
+                <param name="timeout">                  0.020               </param> 
+                <param name="periodOfMissingReport">    60.0                </param> 
+            </group>
+        </group>
+        
+    </group>  
+
+</params>

--- a/CER03/hardware/electronics/cer_head-mcp10-eln.xml
+++ b/CER03/hardware/electronics/cer_head-mcp10-eln.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER03" build="1">
+
+    <xi:include href="../electronics/pc104.xml" />
+    
+    <group name="ETH_BOARD">
+
+        <group name="ETH_BOARD_PROPERTIES">
+            <param name="IpAddress">                10.0.1.10               </param>
+            <param name="IpPort">                   12345                   </param>
+            <param name="Type">                     mc4plus                 </param>
+            <param name="maxSizeRXpacket">          768                     </param>
+            <param name="maxSizeROP">               384                     </param>
+        </group>
+
+        <group name="ETH_BOARD_SETTINGS">
+            <param name="Name">                     "EB10"                  </param> 
+            <group name="RUNNINGMODE">
+                <param name="period">                   1000                </param>
+                <param name="maxTimeOfRXactivity">      400                 </param>
+                <param name="maxTimeOfDOactivity">      300                 </param>   
+                <param name="maxTimeOfTXactivity">      300                 </param>                
+                <param name="TXrateOfRegularROPs">      5                   </param> 
+            </group>         
+        </group>
+
+        <group name="ETH_BOARD_ACTIONS">
+            <group name="MONITOR_ITS_PRESENCE">
+                <param name="enabled">                  true                </param> 
+                <param name="timeout">                  0.020               </param> 
+                <param name="periodOfMissingReport">    60.0                </param> 
+            </group>
+        </group>        
+        
+    </group>
+    
+</params>

--- a/CER03/hardware/electronics/cer_left_hand-mcp9-eln.xml
+++ b/CER03/hardware/electronics/cer_left_hand-mcp9-eln.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER03" build="1">
+
+    <xi:include href="../electronics/pc104.xml" />
+    
+    <group name="ETH_BOARD">
+
+        <group name="ETH_BOARD_PROPERTIES">
+            <param name="IpAddress">                10.0.1.9                </param>
+            <param name="IpPort">                   12345                   </param>
+            <param name="Type">                     mc2plus                 </param>
+            <param name="maxSizeRXpacket">          768                     </param>
+            <param name="maxSizeROP">               384                     </param>
+        </group>
+
+        <group name="ETH_BOARD_SETTINGS">
+            <param name="Name">                     "EB9"                   </param> 
+            <group name="RUNNINGMODE">
+                <param name="period">                   1000                </param>
+                <param name="maxTimeOfRXactivity">      300                 </param>
+                <param name="maxTimeOfDOactivity">      400                 </param>   
+                <param name="maxTimeOfTXactivity">      300                 </param>                
+                <param name="TXrateOfRegularROPs">      5                   </param> 
+            </group>         
+        </group>
+
+        <group name="ETH_BOARD_ACTIONS">
+            <group name="MONITOR_ITS_PRESENCE">
+                <param name="enabled">                  true                </param> 
+                <param name="timeout">                  0.020               </param> 
+                <param name="periodOfMissingReport">    60.0                </param> 
+            </group>
+        </group>        
+        
+    </group>
+    
+</params>

--- a/CER03/hardware/electronics/cer_left_lower_arm-mcp8-eln.xml
+++ b/CER03/hardware/electronics/cer_left_lower_arm-mcp8-eln.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER03" build="1">
+
+    <xi:include href="../electronics/pc104.xml" />
+    
+    <group name="ETH_BOARD">
+
+        <group name="ETH_BOARD_PROPERTIES">
+            <param name="IpAddress">                10.0.1.8                </param>
+            <param name="IpPort">                   12345                   </param>
+            <param name="Type">                     mc4plus                 </param>
+            <param name="maxSizeRXpacket">          768                     </param>
+            <param name="maxSizeROP">               384                     </param>
+        </group>
+
+        <group name="ETH_BOARD_SETTINGS">
+            <param name="Name">                     "EB8"                   </param> 
+            <group name="RUNNINGMODE">
+                <param name="period">                   1000                </param>
+                <param name="maxTimeOfRXactivity">      400                 </param>
+                <param name="maxTimeOfDOactivity">      300                 </param>   
+                <param name="maxTimeOfTXactivity">      300                 </param>                
+                <param name="TXrateOfRegularROPs">      5                   </param> 
+            </group>         
+        </group>
+
+        <group name="ETH_BOARD_ACTIONS">
+            <group name="MONITOR_ITS_PRESENCE">
+                <param name="enabled">                  true                </param> 
+                <param name="timeout">                  0.020               </param> 
+                <param name="periodOfMissingReport">    60.0                </param> 
+            </group>
+        </group>        
+        
+    </group>
+    
+</params>

--- a/CER03/hardware/electronics/cer_left_shoulder-ems5-eln.xml
+++ b/CER03/hardware/electronics/cer_left_shoulder-ems5-eln.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER03" build="1">
+
+    <xi:include href="../electronics/pc104.xml" />
+    
+    <group name="ETH_BOARD">
+
+        <group name="ETH_BOARD_PROPERTIES">
+            <param name="IpAddress">                10.0.1.5                </param>
+            <param name="IpPort">                   12345                   </param>
+            <param name="Type">                     ems4                    </param>
+            <param name="maxSizeRXpacket">          768                     </param>
+            <param name="maxSizeROP">               384                     </param>
+        </group>
+
+        <group name="ETH_BOARD_SETTINGS">
+            <param name="Name">                     "EB5"                   </param> 
+            <group name="RUNNINGMODE">
+                <param name="period">                   1000                </param>
+                <param name="maxTimeOfRXactivity">      400                 </param>
+                <param name="maxTimeOfDOactivity">      300                 </param>   
+                <param name="maxTimeOfTXactivity">      300                 </param>                
+                <param name="TXrateOfRegularROPs">      5                   </param> 
+            </group>         
+        </group>
+
+        <group name="ETH_BOARD_ACTIONS">
+            <group name="MONITOR_ITS_PRESENCE">
+                <param name="enabled">                  true                </param> 
+                <param name="timeout">                  0.020               </param> 
+                <param name="periodOfMissingReport">    60.0                </param> 
+            </group>
+        </group>        
+        
+    </group>
+    
+</params>

--- a/CER03/hardware/electronics/cer_left_upper_arm-ems12-eln.xml
+++ b/CER03/hardware/electronics/cer_left_upper_arm-ems12-eln.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER03" build="1">
+
+    <xi:include href="../electronics/pc104.xml" />
+    
+    <group name="ETH_BOARD">
+
+        <group name="ETH_BOARD_PROPERTIES">
+            <param name="IpAddress">                10.0.1.12               </param>
+            <param name="IpPort">                   12345                   </param>
+            <param name="Type">                     ems4                    </param>
+            <param name="maxSizeRXpacket">          768                     </param>
+            <param name="maxSizeROP">               384                     </param>
+        </group>
+
+        <group name="ETH_BOARD_SETTINGS">
+            <param name="Name">                     "EB12"                  </param> 
+            <group name="RUNNINGMODE">
+                <param name="period">                   1000                </param>
+                <param name="maxTimeOfRXactivity">      400                 </param>
+                <param name="maxTimeOfDOactivity">      300                 </param>   
+                <param name="maxTimeOfTXactivity">      300                 </param>                
+                <param name="TXrateOfRegularROPs">      5                   </param> 
+            </group>         
+        </group>
+
+        <group name="ETH_BOARD_ACTIONS">
+            <group name="MONITOR_ITS_PRESENCE">
+                <param name="enabled">                  true                </param> 
+                <param name="timeout">                  0.020               </param> 
+                <param name="periodOfMissingReport">    60.0                </param> 
+            </group>
+        </group>        
+        
+    </group>
+    
+</params>

--- a/CER03/hardware/electronics/cer_right_hand-mcp7-eln.xml
+++ b/CER03/hardware/electronics/cer_right_hand-mcp7-eln.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER03" build="1">
+
+    <xi:include href="../electronics/pc104.xml" />
+    
+    <group name="ETH_BOARD">
+
+        <group name="ETH_BOARD_PROPERTIES">
+            <param name="IpAddress">                10.0.1.7                </param>
+            <param name="IpPort">                   12345                   </param>
+            <param name="Type">                     mc2plus                 </param>
+            <param name="maxSizeRXpacket">          768                     </param>
+            <param name="maxSizeROP">               384                     </param>
+        </group>
+
+        <group name="ETH_BOARD_SETTINGS">
+            <param name="Name">                     "EB7"                   </param> 
+            <group name="RUNNINGMODE">
+                <param name="period">                   1000                </param>
+                <param name="maxTimeOfRXactivity">      300                 </param>
+                <param name="maxTimeOfDOactivity">      400                 </param>   
+                <param name="maxTimeOfTXactivity">      300                 </param>                
+                <param name="TXrateOfRegularROPs">      5                   </param> 
+            </group>         
+        </group>
+
+        <group name="ETH_BOARD_ACTIONS">
+            <group name="MONITOR_ITS_PRESENCE">
+                <param name="enabled">                  true                </param> 
+                <param name="timeout">                  0.020               </param> 
+                <param name="periodOfMissingReport">    60.0                </param> 
+            </group>
+        </group>        
+        
+    </group>
+    
+</params>

--- a/CER03/hardware/electronics/cer_right_lower_arm-mcp6-eln.xml
+++ b/CER03/hardware/electronics/cer_right_lower_arm-mcp6-eln.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER03" build="1">
+
+    <xi:include href="../electronics/pc104.xml" />
+    
+    <group name="ETH_BOARD">
+
+        <group name="ETH_BOARD_PROPERTIES">
+            <param name="IpAddress">                10.0.1.6                </param>
+            <param name="IpPort">                   12345                   </param>
+            <param name="Type">                     mc4plus                 </param>
+            <param name="maxSizeRXpacket">          768                     </param>
+            <param name="maxSizeROP">               384                     </param>
+        </group>
+
+        <group name="ETH_BOARD_SETTINGS">
+            <param name="Name">                     "EB6"                   </param> 
+            <group name="RUNNINGMODE">
+                <param name="period">                   1000                </param>
+                <param name="maxTimeOfRXactivity">      400                 </param>
+                <param name="maxTimeOfDOactivity">      300                 </param>   
+                <param name="maxTimeOfTXactivity">      300                 </param>                
+                <param name="TXrateOfRegularROPs">      5                   </param> 
+            </group>         
+        </group>
+
+        <group name="ETH_BOARD_ACTIONS">
+            <group name="MONITOR_ITS_PRESENCE">
+                <param name="enabled">                  true                </param> 
+                <param name="timeout">                  0.020               </param> 
+                <param name="periodOfMissingReport">    60.0                </param> 
+            </group>
+        </group>
+        
+    </group>
+    
+</params>

--- a/CER03/hardware/electronics/cer_right_shoulder-ems4-eln.xml
+++ b/CER03/hardware/electronics/cer_right_shoulder-ems4-eln.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER03" build="1">
+
+    <xi:include href="../electronics/pc104.xml" />
+    
+    <group name="ETH_BOARD">
+
+        <group name="ETH_BOARD_PROPERTIES">
+            <param name="IpAddress">                10.0.1.4                </param>
+            <param name="IpPort">                   12345                   </param>
+            <param name="Type">                     ems4                    </param>
+            <param name="maxSizeRXpacket">          768                     </param>
+            <param name="maxSizeROP">               384                     </param>
+        </group>
+
+        <group name="ETH_BOARD_SETTINGS">
+            <param name="Name">                     "EB4"                   </param> 
+            <group name="RUNNINGMODE">
+                <param name="period">                   1000                </param>
+                <param name="maxTimeOfRXactivity">      400                 </param>
+                <param name="maxTimeOfDOactivity">      300                 </param>   
+                <param name="maxTimeOfTXactivity">      300                 </param>                
+                <param name="TXrateOfRegularROPs">      5                   </param> 
+            </group>         
+        </group>
+
+        <group name="ETH_BOARD_ACTIONS">
+            <group name="MONITOR_ITS_PRESENCE">
+                <param name="enabled">                  true                </param> 
+                <param name="timeout">                  0.020               </param> 
+                <param name="periodOfMissingReport">    60.0                </param> 
+            </group>
+        </group>        
+        
+    </group>
+    
+</params>

--- a/CER03/hardware/electronics/cer_right_upper_arm-ems11-eln.xml
+++ b/CER03/hardware/electronics/cer_right_upper_arm-ems11-eln.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER03" build="1">
+
+    <xi:include href="../electronics/pc104.xml" />
+    
+    <group name="ETH_BOARD">
+
+        <group name="ETH_BOARD_PROPERTIES">
+            <param name="IpAddress">                10.0.1.11               </param>
+            <param name="IpPort">                   12345                   </param>
+            <param name="Type">                     ems4                    </param>
+            <param name="maxSizeRXpacket">          768                     </param>
+            <param name="maxSizeROP">               384                     </param>
+        </group>
+
+        <group name="ETH_BOARD_SETTINGS">
+            <param name="Name">                     "EB11"                  </param> 
+            <group name="RUNNINGMODE">
+                <param name="period">                   1000                </param>
+                <param name="maxTimeOfRXactivity">      400                 </param>
+                <param name="maxTimeOfDOactivity">      300                 </param>   
+                <param name="maxTimeOfTXactivity">      300                 </param>                
+                <param name="TXrateOfRegularROPs">      5                   </param> 
+            </group>         
+        </group>
+
+        <group name="ETH_BOARD_ACTIONS">
+            <group name="MONITOR_ITS_PRESENCE">
+                <param name="enabled">                  true                </param> 
+                <param name="timeout">                  0.020               </param> 
+                <param name="periodOfMissingReport">    60.0                </param> 
+            </group>
+        </group>        
+        
+    </group>
+    
+</params>

--- a/CER03/hardware/electronics/cer_torso-ems3-eln.xml
+++ b/CER03/hardware/electronics/cer_torso-ems3-eln.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER03" build="1">
+
+    <xi:include href="../electronics/pc104.xml" />
+    
+    <group name="ETH_BOARD">
+
+        <group name="ETH_BOARD_PROPERTIES">
+            <param name="IpAddress">                10.0.1.3                </param>
+            <param name="IpPort">                   12345                   </param>
+            <param name="Type">                     ems4                    </param>
+            <param name="maxSizeRXpacket">          768                     </param>
+            <param name="maxSizeROP">               384                     </param>
+        </group>
+
+        <group name="ETH_BOARD_SETTINGS">
+            <param name="Name">                     "EB3"                   </param> 
+            <group name="RUNNINGMODE">
+                <param name="period">                   1000                </param>
+                <param name="maxTimeOfRXactivity">      400                 </param>
+                <param name="maxTimeOfDOactivity">      300                 </param>   
+                <param name="maxTimeOfTXactivity">      300                 </param>                
+                <param name="TXrateOfRegularROPs">      5                   </param> 
+            </group>         
+        </group>
+
+        <group name="ETH_BOARD_ACTIONS">
+            <group name="MONITOR_ITS_PRESENCE">
+                <param name="enabled">                  true                </param> 
+                <param name="timeout">                  0.020               </param> 
+                <param name="periodOfMissingReport">    60.0                </param> 
+            </group>
+        </group>
+        
+    </group>
+    
+</params>

--- a/CER03/hardware/electronics/pc104.xml
+++ b/CER03/hardware/electronics/pc104.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER03" build="1">
+  <group name="PC104">
+     <param name="PC104IpAddress"> 10.0.1.104 </param> 
+     <param name="PC104IpPort">         12345 </param> 
+     <param name="PC104TXrate">	            1 </param> 
+     <param name="PC104RXrate">	            5 </param> 
+  </group>
+</params>

--- a/CER03/hardware/mechanicals/cer_base-ems1-mec.xml
+++ b/CER03/hardware/mechanicals/cer_base-ems1-mec.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER03" build="1">
+    <group name="GENERAL">
+        <param name="MotioncontrolVersion">  5 </param>
+        <param name="Joints">  2  </param> 
+        <param name="AxisName">          "mobile_base_l_wheel_joint" "mobile_base_r_wheel_joint" </param>
+        <param name="AxisMap">               0           1                 </param>
+        <param name="AxisType">         "revolute"  "revolute"             </param>
+        <param name="Encoder">               182.044     182.044           </param>
+        <param name="fullscalePWM">          32000       32000             </param>
+        <param name="ampsToSensor">          1000.0      1000.0            </param>
+        <param name="Gearbox_M2J">           17          17                </param>
+        <param name="Gearbox_E2J">           1           1                 </param>
+        <param name="useMotorSpeedFbk">      1           1                 </param>
+        
+        <param name="Verbose">   0   </param>
+    </group>
+    
+    <group name="LIMITS">
+        <param name="hardwareJntPosMax">      0          0             </param>
+        <param name="hardwareJntPosMin">      0          0             </param>
+        <param name="rotorPosMin">            0          0             </param>
+        <param name="rotorPosMax">            0          0             </param>
+   </group>
+    
+    
+     <group name="2FOC">
+        <param name="AutoCalibration">       0           0             </param>
+        <param name="Verbose">               0           0             </param>
+        <param name="HasHallSensor">         1           1             </param>
+        <param name="HasTempSensor">         0           0             </param>
+        <param name="HasRotorEncoder">       1           1             </param>
+        <param name="HasRotorEncoderIndex">  0           0             </param>
+        <param name="HasSpeedEncoder">       0           0             </param>
+        <param name="RotorIndexOffset">      0           0             </param>
+        <param name="MotorPoles">            8           8             </param>
+    </group>
+
+ <group name="COUPLINGS"> 
+
+        <param name ="matrixJ2M"> 
+            1.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00
+            0.00    0.00    1.00    0.00
+            0.00    0.00    0.00    1.00   
+        </param>
+               
+        <param name ="matrixM2J"> 
+            1.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00
+            0.00    0.00    1.00    0.00
+            0.00    0.00    0.00    1.00   
+        </param>
+       
+        <param name ="matrixE2J">  
+            1.000   0.000   0.000   0.000   0.000   0.000
+            0.000   1.000   0.000   0.000   0.000   0.000
+            0.000   0.000   1.000   0.000   0.000   0.000
+            0.000   0.000   0.000   1.000   0.000   0.000   
+        </param>
+                
+    </group>   
+
+    <group name="JOINTSET_CFG"> 
+        <param name= "numberofsets"> 2 </param>
+        <group name="JOINTSET_0">
+            <param name="listofjoints">  0            </param>
+            <param name="constraint">    none          </param>
+            <param name="param1">        0             </param>
+            <param name="param2">        0             </param>
+        </group> 
+        <group name="JOINTSET_1">
+            <param name="listofjoints">   1             </param>
+            <param name="constraint">     none          </param>
+            <param name="param1">         0             </param>
+            <param name="param2">         0             </param>
+        </group> 
+    </group>                                       
+    
+</params>

--- a/CER03/hardware/mechanicals/cer_head-mcp10-mec.xml
+++ b/CER03/hardware/mechanicals/cer_head-mcp10-mec.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER03" build="1">
+    <group name="GENERAL">
+        <param name="MotioncontrolVersion">  5 </param>
+        <param name="Joints">                2  </param> 
+        <param name="AxisName">              "neck_pitch_joint" "neck_yaw_joint" </param>
+        <param name="AxisMap">               0                  1                </param>
+        <param name="AxisType">              "revolute"         "revolute"       </param>
+        <param name="Encoder">               182.044            182.044          </param>
+        <param name="Gearbox_M2J">          -1                  125              </param>
+        <param name="Gearbox_E2J">           1                  1                </param>
+        <param name="fullscalePWM">          3360            3360                </param>
+        <param name="ampsToSensor">          1000.0          1000.0              </param>
+        <param name="MotorType">             "DC"               "DC"             </param>
+        <param name="useMotorSpeedFbk">      1                   1               </param>        
+        <param name="Verbose">               0   </param>
+    </group>
+    
+    <group name="LIMITS">
+        <param name="hardwareJntPosMax">        40               51           </param>
+        <param name="hardwareJntPosMin">       -30.0            -51           </param>
+        
+        <param name="rotorPosMin">              0                 0            </param>
+        <param name="rotorPosMax">              0                 0            </param>
+    </group>
+
+    <group name="COUPLINGS"> 
+
+       <param name ="matrixJ2M"> 
+            1.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00
+            0.00    0.00    1.00    0.00
+            0.00    0.00    0.00    1.00   
+        </param>
+               
+        <param name ="matrixM2J"> 
+            1.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00
+            0.00    0.00    1.00    0.00
+            0.00    0.00    0.00    1.00   
+        </param>
+       
+        <param name ="matrixE2J">  
+            1.000   0.000   0.000   0.000   0.000   0.000
+            0.000   1.000   0.000   0.000   0.000   0.000
+            0.000   0.000   1.000   0.000   0.000   0.000
+            0.000   0.000   0.000   1.000   0.000   0.000   
+        </param>
+                
+    </group>   
+
+    <group name="JOINTSET_CFG"> 
+        <param name= "numberofsets"> 2 </param>
+        <group name="JOINTSET_0">
+            <param name="listofjoints">  0            </param>
+            <param name="constraint">    none          </param>
+            <param name="param1">        0             </param>
+            <param name="param2">        0             </param>
+        </group> 
+        <group name="JOINTSET_1">
+            <param name="listofjoints">   1             </param>
+            <param name="constraint">     none          </param>
+            <param name="param1">         0             </param>
+            <param name="param2">         0             </param>
+        </group> 
+    </group>                                       
+    
+</params>

--- a/CER03/hardware/mechanicals/cer_left_hand-mcp9-mec.xml
+++ b/CER03/hardware/mechanicals/cer_left_hand-mcp9-mec.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CERSN002" build="1">
+    <group name="GENERAL">
+        <param name="MotioncontrolVersion">  5 </param>
+        <param name="Joints">                2  </param> 
+        <param name="AxisName">              "l_palm"           "l_thumb"       </param>
+        <param name="AxisMap">               0                  1               </param>
+        <param name="AxisType">              "revolute"         "revolute"      </param>
+        <param name="Encoder">               182.044            182.044         </param>
+        <param name="Gearbox_M2J">             1                 -1             </param>
+        <param name="Gearbox_E2J">             1                  1             </param>
+         <param name="useMotorSpeedFbk">       0                  0             </param>
+        <param name="MotorType">             "DC"               "DC"            </param>
+       <param name="fullscalePWM">           3360               3360            </param>
+        <param name="ampsToSensor">          1000.0          1000.0             </param>
+        <param name="Verbose">    0   </param>
+    </group>
+
+    <group name="LIMITS">
+        <param name="hardwareJntPosMax">        145               135             </param>
+        <param name="hardwareJntPosMin">         -5                -5             </param>
+        <param name="rotorPosMin">                0                 0             </param>
+        <param name="rotorPosMax">                0                 0             </param>
+    </group>
+    
+    <group name="COUPLINGS"> 
+
+        <param name ="matrixJ2M"> 
+            1.000   0.000   0.000   0.000
+            0.000   1.000   0.000   0.000
+            0.000   0.000   1.000   0.000
+            0.000   0.000   0.000   1.000   
+        </param>
+               
+        <param name ="matrixM2J"> 
+            1.000   0.000   0.000   0.000
+            0.000   1.000   0.000   0.000
+            0.000   0.000   1.000   0.000
+            0.000   0.000   0.000   1.000   
+        </param>
+        
+        <param name ="matrixE2J">  
+           -0.5     0.5     0.5    -0.5     0.000   0.000
+            0.000   0.000   0.000   0.000  -1.000   1.000
+            0.000   0.000   0.000   0.000   0.000   0.000
+            0.000   0.000   0.000   0.000   0.000   0.000   
+        </param>
+		<!--
+        <param name ="matrixE2J">  
+            0.0     0.0     0.0     1.0     0.000   0.000
+            0.000   0.000   0.000   0.000  -1.000   1.000
+            0.000   0.000   0.000   0.000   0.000   0.000
+            0.000   0.000   0.000   0.000   0.000   0.000   
+        </param>
+        -->                 
+    </group>   
+
+    <group name="JOINTSET_CFG"> 
+        <param name= "numberofsets"> 2 </param>
+        <group name="JOINTSET_0">
+            <param name="listofjoints">  0             </param>
+            <param name="constraint">    cerhand2      </param> <!--NOTE: set deadzone to 400 -->
+            <param name="param1">        0             </param>
+            <param name="param2">        0             </param>
+        </group> 
+        <group name="JOINTSET_1">
+            <param name="listofjoints">   1             </param>
+            <param name="constraint">     cerhand2      </param>
+            <param name="param1">         0             </param>
+            <param name="param2">         0             </param>
+        </group> 
+    </group>                                       
+    
+</params>

--- a/CER03/hardware/mechanicals/cer_left_lower_arm-mcp8-mec.xml
+++ b/CER03/hardware/mechanicals/cer_left_lower_arm-mcp8-mec.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER03" build="1">
+    <group name="GENERAL">
+        <param name="MotioncontrolVersion">  5 </param>
+        <param name="Joints">                4  </param> 
+        <param name="AxisName">              "l_wrist_tripod_0" "l_wrist_tripod_1" "l_wrist_tripod_2" "l_wrist_pronosupination_joint"  </param>
+        <param name="AxisMap">               0                  1                  2                  3                        </param>
+        <param name="AxisType">              "prismatic"        "prismatic"        "prismatic"        "revolute"               </param>
+        <param name="Encoder">               56333.333          56333.333          56333.333          182.044                  </param>
+        <param name="Gearbox_M2J">               1                  1                  1                  1                    </param>
+        <param name="Gearbox_E2J">               1                  1                  1                  64                   </param>
+        <param name="useMotorSpeedFbk">          1                  1                  1                  1                    </param>
+        <param name="fullscalePWM">          3360               3360               3360               3360                     </param>
+        <param name="ampsToSensor">          1000.0             1000.0             1000.0             1000.0                   </param>
+        <param name="MotorType">             "DC"               "DC"               "DC"               "DC"                     </param>
+        <param name="Verbose">               0   </param>
+    </group>
+    
+    <group name="LIMITS">
+        <param name="hardwareJntPosMax">          0.125    0.125   0.125    90     </param>
+        <param name="hardwareJntPosMin">         -0.005   -0.005  -0.005   -90     </param>
+        <param name="rotorPosMin">                0        0       0        0      </param>
+        <param name="rotorPosMax">                0        0       0        0      </param>
+    </group>
+
+   <group name="COUPLINGS"> 
+
+        <!-- 1.625 = 1/alfa = 65/40 -->                  
+        <param name ="matrixJ2M"> 
+            1.000   0.000   0.000   0.000
+            0.000   1.000   0.000   0.000
+            0.000   0.000   1.000   0.000
+            0.000   0.000   0.000   1.000   
+        </param>
+               
+        <!-- 0.615 = alfa = 40/65 --> 
+        <param name ="matrixM2J"> 
+            1.000   0.000   0.000   0.000
+            0.000   1.000   0.000   0.000
+            0.000   0.000   1.000   0.000
+            0.000   0.000   0.000   1.000   
+        </param>
+       
+        <param name ="matrixE2J">  
+            1.000   0.000   0.000   0.000   0.000   0.000
+            0.000   1.000   0.000   0.000   0.000   0.000
+            0.000   0.000   1.000   0.000   0.000   0.000
+            0.000   0.000   0.000   1.000   0.000   0.000   
+        </param>
+                
+    </group>   
+
+    <group name="JOINTSET_CFG"> 
+        <param name= "numberofsets"> 2 </param>
+        <group name="JOINTSET_0">
+            <param name="listofjoints">  0 1 2         </param>
+            <param name="constraint">    trifid        </param>
+<!--        <param name="param1">        835500        </param> <!-- ~31 deg -->
+            <param name="param1">        244236        </param> <!-- ~17 deg -->
+            <param name="param2">        0             </param>
+        </group> 
+        <group name="JOINTSET_1">
+            <param name="listofjoints">   3             </param>
+            <param name="constraint">     none          </param>
+            <param name="param1">         0             </param>
+            <param name="param2">         0             </param>
+        </group> 
+    </group>                                       
+    
+</params>

--- a/CER03/hardware/mechanicals/cer_left_shoulder-ems5-mec.xml
+++ b/CER03/hardware/mechanicals/cer_left_shoulder-ems5-mec.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER03" build="1">
+    <group name="GENERAL">
+        <param name="MotioncontrolVersion">     5             </param>
+        <param name="Joints">                   2             </param> 
+        <param name="AxisMap">                  0                            1                          </param>
+        <param name="AxisName">                 "l_shoulder_pitch_joint"     "l_shoulder_roll_joint"    </param>
+        <param name="AxisType">                 "revolute"                   "revolute"                 </param>
+        <param name="Encoder">                  182.044                      182.044                    </param>
+        <param name="Gearbox_M2J">              117.333                     -117.333                    </param>
+        <param name="Gearbox_E2J">              1                            1                          </param>
+        <param name="useMotorSpeedFbk">         1                            1                          </param>
+        <param name="MotorType">                "BLL_MECAP"                  "BLL_MECAP"                </param>
+       <param name="fullscalePWM">              32000                        32000                      </param>
+        <param name="ampsToSensor">             1000.0                       1000.0                     </param>
+        <param name="Verbose">   0      </param>
+    </group>
+
+    <group name="LIMITS">
+        <param name="hardwareJntPosMax">             90            90        </param>
+        <param name="hardwareJntPosMin">            -75             0        </param>
+        <param name="rotorPosMin">                    0             0        </param> 
+        <param name="rotorPosMax">                    0             0        </param>
+    </group>
+    
+    <group name="2FOC">
+        <param name="AutoCalibration">       0             0           </param>
+        <param name="Verbose">               0             0           </param>
+        <param name="HasHallSensor">         1             1           </param>
+        <param name="HasTempSensor">         0             0           </param>
+        <param name="HasRotorEncoder">       1             1           </param>
+        <param name="HasRotorEncoderIndex">  0             0           </param>
+        <param name="HasSpeedEncoder">       0             0           </param>
+        <param name="RotorIndexOffset">      0             0           </param>
+        <param name="MotorPoles">            8             8           </param>
+    </group>
+
+ <group name="COUPLINGS"> 
+
+        <param name ="matrixJ2M"> 
+            1.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00
+            0.00    0.00    1.00    0.00
+            0.00    0.00    0.00    1.00   
+        </param>
+               
+        <param name ="matrixM2J"> 
+            1.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00
+            0.00    0.00    1.00    0.00
+            0.00    0.00    0.00    1.00   
+        </param>
+       
+        <param name ="matrixE2J">  
+            1.000   0.000   0.000   0.000   0.000   0.000
+            0.000   1.000   0.000   0.000   0.000   0.000
+            0.000   0.000   1.000   0.000   0.000   0.000
+            0.000   0.000   0.000   1.000   0.000   0.000   
+        </param>
+                
+    </group>   
+
+    <group name="JOINTSET_CFG"> 
+        <param name= "numberofsets"> 2 </param>
+        <group name="JOINTSET_0">
+            <param name="listofjoints">  0            </param>
+            <param name="constraint">    none          </param>
+            <param name="param1">        0             </param>
+            <param name="param2">        0             </param>
+        </group> 
+        <group name="JOINTSET_1">
+            <param name="listofjoints">   1             </param>
+            <param name="constraint">     none          </param>
+            <param name="param1">         0             </param>
+            <param name="param2">         0             </param>
+        </group> 
+    </group>                                       
+    
+</params>

--- a/CER03/hardware/mechanicals/cer_left_upper_arm-ems12-mec.xml
+++ b/CER03/hardware/mechanicals/cer_left_upper_arm-ems12-mec.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER03" build="1">
+    <group name="GENERAL">
+        <param name="MotioncontrolVersion">     5                                       </param>
+        <param name="Joints">                   2                                       </param> 
+        <param name="AxisMap">                  0                       1               </param>
+        <param name="AxisName">                 "l_shoulder_yaw_joint"  "l_elbow_joint" </param>
+        <param name="AxisType">                 "revolute"              "revolute"      </param>
+        <param name="Encoder">                  182.044                 182.044         </param>
+        <param name="Gearbox_M2J">              159.438                 159.438         </param>
+        <param name="Gearbox_E2J">              1                       1               </param>
+        <param name="useMotorSpeedFbk">         1                       1               </param>
+        <param name="MotorType">                "BLL_MECAP"             "BLL_MECAP"     </param>
+       <param name="fullscalePWM">          	32000                   32000           </param>
+        <param name="ampsToSensor">             1000.0                  1000.0          </param>
+        <param name="Verbose">   0      </param>
+    </group>
+
+    <group name="LIMITS">
+        <param name="hardwareJntPosMax">          92       100         </param>
+        <param name="hardwareJntPosMin">         -92         0         </param>
+        <param name="rotorPosMin">                 0         0         </param> 
+        <param name="rotorPosMax">                 0         0         </param>
+    </group>
+    
+    <group name="2FOC">
+		<param name="AutoCalibration">       0             0             </param>
+        <param name="Verbose">               0             0             </param>
+        <param name="HasHallSensor">         1             1             </param>
+        <param name="HasTempSensor">         0             0             </param>
+        <param name="HasRotorEncoder">       1             1             </param>
+        <param name="HasRotorEncoderIndex">  0             0             </param>
+        <param name="HasSpeedEncoder">       0             0             </param>
+        <param name="RotorIndexOffset">      0             0             </param>
+        <param name="MotorPoles">           16            16             </param>
+    </group>
+
+ <group name="COUPLINGS"> 
+
+        <param name ="matrixJ2M"> 
+            1.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00
+            0.00    0.00    1.00    0.00
+            0.00    0.00    0.00    1.00   
+        </param>
+               
+        <param name ="matrixM2J"> 
+            1.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00
+            0.00    0.00    1.00    0.00
+            0.00    0.00    0.00    1.00   
+        </param>
+       
+        <param name ="matrixE2J">  
+            1.000   0.000   0.000   0.000   0.000   0.000
+            0.000   1.000   0.000   0.000   0.000   0.000
+            0.000   0.000   1.000   0.000   0.000   0.000
+            0.000   0.000   0.000   1.000   0.000   0.000   
+        </param>
+                
+    </group>   
+
+    <group name="JOINTSET_CFG"> 
+        <param name= "numberofsets"> 2 </param>
+        <group name="JOINTSET_0">
+            <param name="listofjoints">  0            </param>
+            <param name="constraint">    none          </param>
+            <param name="param1">        0             </param>
+            <param name="param2">        0             </param>
+        </group> 
+        <group name="JOINTSET_1">
+            <param name="listofjoints">   1             </param>
+            <param name="constraint">     none          </param>
+            <param name="param1">         0             </param>
+            <param name="param2">         0             </param>
+        </group> 
+    </group>                                       
+    
+</params>

--- a/CER03/hardware/mechanicals/cer_right_hand-mcp7-mec.xml
+++ b/CER03/hardware/mechanicals/cer_right_hand-mcp7-mec.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CERSN002" build="1">
+    <group name="GENERAL">
+        <param name="MotioncontrolVersion">  5 </param>
+        <param name="Joints">                2  </param> 
+        <param name="AxisName">              "l_palm"           "l_thumb"       </param>
+        <param name="AxisMap">               0                  1               </param>
+        <param name="AxisType">              "revolute"         "revolute"      </param>
+        <param name="Encoder">                 182.044            182.044       </param>
+        <param name="Gearbox_M2J">             1                 -1             </param>
+        <param name="Gearbox_E2J">             1                  1             </param>
+         <param name="useMotorSpeedFbk">       0                  0             </param>
+        <param name="MotorType">             "DC"               "DC"            </param>
+       <param name="fullscalePWM">           3360               3360            </param>
+        <param name="ampsToSensor">          1000.0          1000.0             </param>
+        <param name="Verbose">    0   </param>
+    </group>
+
+    <group name="LIMITS">
+        <param name="hardwareJntPosMax">        145               135             </param>
+        <param name="hardwareJntPosMin">         -5                -5             </param>
+        <param name="rotorPosMin">                0                 0             </param>
+        <param name="rotorPosMax">                0                 0             </param>
+    </group>
+    
+    <group name="COUPLINGS"> 
+
+        <param name ="matrixJ2M"> 
+            1.000   0.000   0.000   0.000
+            0.000   1.000   0.000   0.000
+            0.000   0.000   1.000   0.000
+            0.000   0.000   0.000   1.000   
+        </param>
+               
+        <param name ="matrixM2J"> 
+            1.000   0.000   0.000   0.000
+            0.000   1.000   0.000   0.000
+            0.000   0.000   1.000   0.000
+            0.000   0.000   0.000   1.000   
+        </param>
+
+        <param name ="matrixE2J">  
+            0.5    -0.5    -0.5     0.5     0.000   0.000
+            0.000   0.000   0.000   0.000   1.0    -1.0
+            0.000   0.000   0.000   0.000   0.000   0.000
+            0.000   0.000   0.000   0.000   0.000   0.000   
+        </param> 
+    </group>   
+
+    <group name="JOINTSET_CFG"> 
+        <param name= "numberofsets"> 2 </param>
+        <group name="JOINTSET_0">
+            <param name="listofjoints">  0             </param>
+            <param name="constraint">    cerhand2      </param> <!--NOTE: set deadzone to 400 -->
+            <param name="param1">        0             </param>
+            <param name="param2">        0             </param>
+        </group> 
+        <group name="JOINTSET_1">
+            <param name="listofjoints">   1             </param>
+            <param name="constraint">     cerhand2      </param>
+            <param name="param1">         0             </param>
+            <param name="param2">         0             </param>
+        </group> 
+    </group>                                       
+    
+</params>

--- a/CER03/hardware/mechanicals/cer_right_lower_arm-mcp6-mec.xml
+++ b/CER03/hardware/mechanicals/cer_right_lower_arm-mcp6-mec.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER03" build="1">
+    <group name="GENERAL">
+        <param name="MotioncontrolVersion">  5 </param>
+        <param name="Joints">                4  </param> 
+        <param name="AxisName">              "r_wrist_tripod_0" "r_wrist_tripod_1" "r_wrist_tripod_2" "r_wrist_pronosupination_joint"</param>
+        <param name="AxisMap">               0                  1                  2                  3                       </param>
+        <param name="AxisType">              "prismatic"        "prismatic"        "prismatic"        "revolute"              </param>
+        <param name="Encoder">               56333.333          56333.333          56333.333          182.044                 </param>
+        <param name="Gearbox_M2J">               1                  1                  1                  1                   </param>
+        <param name="Gearbox_E2J">               1                  1                  1                 64                   </param>
+        <param name="useMotorSpeedFbk">          1                  1                  1                  1                   </param>
+        <param name="fullscalePWM">          3360               3360               3360               3360                    </param>
+        <param name="ampsToSensor">          1000.0             1000.0             1000.0             1000.0                  </param>
+        <param name="MotorType">             "DC"               "DC"               "DC"               "DC"                    </param>
+        <param name="Verbose">               0   </param>
+    </group>
+    
+    <group name="LIMITS">
+        <param name="hardwareJntPosMax">      0.125              0.125                 0.125                90     </param>
+        <param name="hardwareJntPosMin">     -0.005             -0.005                -0.005               -90     </param>
+        <param name="rotorPosMin">            0                  0                     0                    0      </param>
+        <param name="rotorPosMax">            0                  0                     0                    0      </param>
+    </group>
+
+    <group name="COUPLINGS"> 
+
+        <param name ="matrixJ2M"> 
+            1.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00
+            0.00    0.00    1.00    0.00
+            0.00    0.00    0.00    1.00   
+        </param>
+               
+        <param name ="matrixM2J"> 
+            1.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00
+            0.00    0.00    1.00    0.00
+            0.00    0.00    0.00    1.00   
+        </param>
+       
+        <param name ="matrixE2J">  
+            1.000   0.000   0.000   0.000   0.000   0.000
+            0.000   1.000   0.000   0.000   0.000   0.000
+            0.000   0.000   1.000   0.000   0.000   0.000
+            0.000   0.000   0.000   1.000   0.000   0.000   
+        </param>
+                
+    </group>   
+
+    <group name="JOINTSET_CFG"> 
+        <param name= "numberofsets"> 2 </param>
+        <group name="JOINTSET_0">
+            <param name="listofjoints">  0 1 2         </param>
+            <param name="constraint">    trifid        </param>
+<!--           <param name="param1">        835500        </param> <!-- ~31 deg -->
+            <param name="param1">        244236        </param> <!-- ~17 deg -->
+            <param name="param2">        0             </param>
+        </group> 
+        <group name="JOINTSET_1">
+            <param name="listofjoints">   3             </param>
+            <param name="constraint">     none          </param>
+            <param name="param1">         0             </param>
+            <param name="param2">         0             </param>
+        </group> 
+    </group>                                       
+    
+</params>

--- a/CER03/hardware/mechanicals/cer_right_shoulder-ems4-mec.xml
+++ b/CER03/hardware/mechanicals/cer_right_shoulder-ems4-mec.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER03" build="1">
+    <group name="GENERAL">
+        <param name="MotioncontrolVersion">     5             </param>
+        <param name="Joints">                   2             </param> 
+        <param name="AxisMap">                  0                             1                                  </param>
+        <param name="AxisName">                 "r_shoulder_pitch_joint"      "r_shoulder_roll_joint"            </param>
+        <param name="AxisType">                 "revolute"                    "revolute"                         </param>
+        <param name="Encoder">                  182.044                       182.044                            </param>
+        <param name="Gearbox_M2J">              117.333                      -117.333                            </param>
+        <param name="Gearbox_E2J">              1                             1                                  </param>
+        <param name="useMotorSpeedFbk">         1                             1                                  </param>
+        <param name="fullscalePWM">             32000                         32000                              </param>
+        <param name="ampsToSensor">             1000.0                        1000.0                             </param>
+        <param name="MotorType">                "BLL_MECAP"                   "BLL_MECAP"                        </param>
+        <param name="Verbose">                  0             </param>
+    </group>
+    
+    <group name="LIMITS">
+        <param name="hardwareJntPosMax">             90            90        </param>
+        <param name="hardwareJntPosMin">            -75             0        </param>
+        <param name="rotorPosMin">                    0             0        </param> 
+        <param name="rotorPosMax">                    0             0        </param>
+    </group>
+
+    <group name="2FOC">
+        <param name="AutoCalibration">       0             0           </param>
+        <param name="Verbose">               0             0           </param>
+        <param name="HasHallSensor">         1             1           </param>
+        <param name="HasTempSensor">         0             0           </param>
+        <param name="HasRotorEncoder">       1             1           </param>
+        <param name="HasRotorEncoderIndex">  0             0           </param>
+        <param name="HasSpeedEncoder">       0             0           </param>
+        <param name="RotorIndexOffset">      0             0           </param>
+        <param name="MotorPoles">            8             8           </param>
+    </group>
+
+ <group name="COUPLINGS"> 
+
+        <param name ="matrixJ2M"> 
+            1.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00
+            0.00    0.00    1.00    0.00
+            0.00    0.00    0.00    1.00   
+        </param>
+               
+        <param name ="matrixM2J"> 
+            1.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00
+            0.00    0.00    1.00    0.00
+            0.00    0.00    0.00    1.00   
+        </param>
+       
+        <param name ="matrixE2J">  
+            1.000   0.000   0.000   0.000   0.000   0.000
+            0.000   1.000   0.000   0.000   0.000   0.000
+            0.000   0.000   1.000   0.000   0.000   0.000
+            0.000   0.000   0.000   1.000   0.000   0.000   
+        </param>
+                
+    </group>   
+
+    <group name="JOINTSET_CFG"> 
+        <param name= "numberofsets"> 2 </param>
+        <group name="JOINTSET_0">
+            <param name="listofjoints">  0            </param>
+            <param name="constraint">    none          </param>
+            <param name="param1">        0             </param>
+            <param name="param2">        0             </param>
+        </group> 
+        <group name="JOINTSET_1">
+            <param name="listofjoints">   1             </param>
+            <param name="constraint">     none          </param>
+            <param name="param1">         0             </param>
+            <param name="param2">         0             </param>
+        </group> 
+    </group>                                       
+    
+</params>

--- a/CER03/hardware/mechanicals/cer_right_upper_arm-ems11-mec.xml
+++ b/CER03/hardware/mechanicals/cer_right_upper_arm-ems11-mec.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER03" build="1">
+    <group name="GENERAL">
+        <param name="MotioncontrolVersion">     5                                      </param>
+        <param name="Joints">                   2                                      </param> 
+        <param name="AxisMap">                  0                      1               </param>
+        <param name="AxisName">                 "r_shoulder_yaw_joint" "r_elbow_joint" </param>
+        <param name="AxisType">                 "revolute"             "revolute"      </param>
+        <param name="Encoder">                  182.044                182.044         </param>
+        <param name="Gearbox_M2J">             -159.438                159.438         </param>
+        <param name="Gearbox_E2J">              1                      1               </param>
+        <param name="useMotorSpeedFbk">         1                      1               </param>
+        <param name="fullscalePWM">             32000                  32000           </param>
+        <param name="ampsToSensor">             1000.0                 1000.0          </param>
+        <param name="MotorType">                "BLL_MECAP"            "BLL_MECAP"     </param>
+        <param name="Verbose">                  0             </param>
+    </group>
+    
+    <group name="LIMITS">
+        <param name="hardwareJntPosMax">             92       100       </param>
+        <param name="hardwareJntPosMin">            -92         0       </param>
+        <param name="rotorPosMin">                    0         0       </param> 
+        <param name="rotorPosMax">                    0         0       </param>
+    </group>
+
+    <group name="2FOC">
+        <param name="AutoCalibration">       0             0           </param>
+        <param name="Verbose">               0             0           </param>
+        <param name="HasHallSensor">         1             1             </param>
+        <param name="HasTempSensor">         0             0             </param>
+        <param name="HasRotorEncoder">       1             1             </param>
+        <param name="HasRotorEncoderIndex">  0             0             </param>
+        <param name="HasSpeedEncoder">       0             0             </param>
+        <param name="RotorIndexOffset">      0             0             </param>
+        <param name="MotorPoles">            16            16            </param>
+    </group>
+
+ <group name="COUPLINGS"> 
+
+        <param name ="matrixJ2M"> 
+            1.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00
+            0.00    0.00    1.00    0.00
+            0.00    0.00    0.00    1.00   
+        </param>
+               
+        <param name ="matrixM2J"> 
+            1.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00
+            0.00    0.00    1.00    0.00
+            0.00    0.00    0.00    1.00   
+        </param>
+       
+        <param name ="matrixE2J">  
+            1.000   0.000   0.000   0.000   0.000   0.000
+            0.000   1.000   0.000   0.000   0.000   0.000
+            0.000   0.000   1.000   0.000   0.000   0.000
+            0.000   0.000   0.000   1.000   0.000   0.000   
+        </param>
+                
+    </group>   
+
+    <group name="JOINTSET_CFG"> 
+        <param name= "numberofsets"> 2 </param>
+        <group name="JOINTSET_0">
+            <param name="listofjoints">   0             </param>
+            <param name="constraint">     none          </param>
+            <param name="param1">         0             </param>
+            <param name="param2">         0             </param>
+        </group> 
+        <group name="JOINTSET_1">
+            <param name="listofjoints">   1             </param>
+            <param name="constraint">     none          </param>
+            <param name="param1">         0             </param>
+            <param name="param2">         0             </param>
+        </group> 
+    </group>                                       
+    
+</params>

--- a/CER03/hardware/mechanicals/cer_torso-ems3-mec.xml
+++ b/CER03/hardware/mechanicals/cer_torso-ems3-mec.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER03" build="1">
+    <group name="GENERAL">
+        <param name="MotioncontrolVersion">  5 </param>
+        <param name="Joints">                4  </param> 
+        <param name="AxisName">              "torso_tripod_0" "torso_tripod_1" "torso_tripod_2" "torso_yaw_joint" </param>
+        <param name="AxisMap">               0            1            2             3             </param>
+        <param name="AxisType">              "prismatic"  "prismatic"  "prismatic"  "revolute"     </param>
+        <param name="Encoder">               10000        10000        10000         182.044       </param>
+        <param name="Gearbox_M2J">           1            1            1             117.333       </param>
+        <param name="Gearbox_E2J">           1            1            1             1             </param>
+        <param name="useMotorSpeedFbk">      1            1            1             1             </param>
+        <param name="MotorType">             "DC"         "DC"         "DC"          "BLL_MECAP"   </param>
+        <param name="fullscalePWM">          32000        32000        32000         32000         </param>
+        <param name="ampsToSensor">          1000.0       1000.0       1000.0        1000.0        </param>
+        <param name="Verbose">               0   </param>
+    </group>
+
+    <group name="LIMITS">
+        <param name="hardwareJntPosMax">        0.155       0.155        0.155          31          </param>
+        <param name="hardwareJntPosMin">       -0.04       -0.04        -0.04          -31          </param>
+        <param name="rotorPosMin">              0           0            0              0           </param>
+        <param name="rotorPosMax">              0           0            0              0           </param>
+    </group>
+    
+    
+    <group name="2FOC">
+        <param name="AutoCalibration">       0            0            0             0             </param>
+        <param name="Verbose">               0            0            0             0             </param>
+        <param name="HasHallSensor">         0            0            0             1             </param>
+        <param name="HasTempSensor">         0            0            0             0             </param>
+        <param name="HasRotorEncoder">       1            1            1             1             </param>
+        <param name="HasRotorEncoderIndex">  0            0            0             0             </param>
+        <param name="HasSpeedEncoder">       0            0            0             0             </param>
+        <param name="RotorIndexOffset">      0            0            0             0             </param>
+        <param name="MotorPoles">            2            2            2             8             </param>
+    </group>
+
+    
+    <group name="COUPLINGS"> 
+
+        <param name ="matrixJ2M"> 
+            1.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00
+            0.00    0.00    1.00    0.00
+            0.00    0.00    0.00    1.00   
+        </param>
+               
+        <param name ="matrixM2J"> 
+            1.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00
+            0.00    0.00    1.00    0.00
+            0.00    0.00    0.00    1.00   
+        </param>
+       
+        <param name ="matrixE2J">  
+            1.000   0.000   0.000   0.000   0.000   0.000
+            0.000   1.000   0.000   0.000   0.000   0.000
+            0.000   0.000   1.000   0.000   0.000   0.000
+            0.000   0.000   0.000   1.000   0.000   0.000   
+        </param>
+                
+    </group>   
+
+    <group name="JOINTSET_CFG"> 
+        <param name= "numberofsets"> 2 </param>
+        <group name="JOINTSET_0">
+            <param name="listofjoints">  0 1 2         </param>
+            <param name="constraint">    trifid        </param>
+            <param name="param1">        658000        </param> <!-- ~31 deg -->
+            <param name="param2">        0             </param>
+        </group> 
+        <group name="JOINTSET_1">
+            <param name="listofjoints">   3             </param>
+            <param name="constraint">     none          </param>
+            <param name="param1">         0             </param>
+            <param name="param2">         0             </param>
+        </group> 
+    </group>                                       
+    
+</params>

--- a/CER03/hardware/motorControl/cer_base-ems1-mc-service.xml
+++ b/CER03/hardware/motorControl/cer_base-ems1-mc-service.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER03" build="1">
+
+    <group name="SERVICE">
+        
+        <param name="type"> eomn_serv_MC_foc </param> 
+    
+        <group name="PROPERTIES">
+        
+            <group name="ETHBOARD">
+                <param name="type">                 ems4        </param> 
+            </group>          
+
+            <group name="CANBOARDS"> 
+                <param name="type">                 foc         </param> 
+                <group name="PROTOCOL">
+                    <param name="major">            1           </param>    
+                    <param name="minor">            6           </param>     
+                </group>                    
+                <group name="FIRMWARE">
+                    <param name="major">            0           </param>    
+                    <param name="minor">            0           </param> 
+                    <param name="build">            0           </param>
+                </group>
+            </group>
+            
+
+            <group name="JOINTMAPPING">
+
+                <group name="ACTUATOR">                
+                    <param name="type">             foc                 foc         </param>
+                    <param name="port">             CAN1:1:0            CAN1:2:0    </param>
+                </group>
+                
+                <group name="ENCODER1">  
+                    <param name="type">             hallmotor           hallmotor   </param>  
+                    <param name="port">             CAN1:4:0            CAN1:2:0    </param>
+                    <param name="position">         atmotor             atmotor     </param> 
+                    <param name="resolution">       14400              -14400       </param>
+                    <param name="tolerance">        0                   0           </param>  
+                </group>        
+                
+                <group name="ENCODER2">
+                    <param name="type">             none                none        </param>
+                    <param name="port">             CONN:none           CONN:none   </param>
+                    <param name="position">         none                none        </param>
+                    <param name="resolution">       0                   0           </param>
+                    <param name="tolerance">        0                   0           </param>  
+                </group> 
+ 
+            </group>    
+
+        </group>
+           
+    </group>
+    
+  
+</params>
+

--- a/CER03/hardware/motorControl/cer_base-ems1-mc.xml
+++ b/CER03/hardware/motorControl/cer_base-ems1-mc.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_mobile_base_mc" type="embObjMotionControl">
+      <xi:include href="../../general.xml" />
+      <xi:include href="../electronics/cer_base-ems1-eln.xml" />
+      <xi:include href="../mechanicals/cer_base-ems1-mec.xml" />
+      <xi:include href="../motorControl/cer_base-ems1-mc-service.xml" />
+
+    <group name="LIMITS">
+        <param name="jntPosMax">                  0       0       </param>
+        <param name="jntPosMin">                  0       0       </param>
+        <param name="jntVelMax">                360     360       </param>
+        <param name="motorOverloadCurrents">  15000   15000       </param>
+        <param name="motorNominalCurrents">   10000   10000       </param>
+        <param name="motorPeakCurrents">      15000   15000       </param>
+        <param name="motorPwmLimit">          10000   10000       </param>  
+   </group>
+   
+   
+    <group name="TIMEOUTS">
+        <param name="velocity">               100       100       </param>
+    </group>
+
+
+    <group name="CONTROLS">
+       
+       <param name="positionControl">  JOINT_POS_VEL_CTRL     JOINT_POS_VEL_CTRL    </param> 
+       <param name="velocityControl">  none                   none                  </param> 
+       <param name="torqueControl">    none                   none                  </param>
+       <param name="currentPid">       2FOC_CURRENT_CONTROL   2FOC_CURRENT_CONTROL  </param> 
+    </group>
+
+
+    <group name="JOINT_POS_VEL_CTRL">
+        <param name="controlLaw">    PidPos_withInnerVelPid    </param> 
+        <param name="fbkControlUnits">     machine_units             </param> 
+        <param name="outputControlUnits">  machine_units             </param>
+        <param name="pos_kp">               5           5      </param>       
+        <param name="pos_kd">               0           0      </param>       
+        <param name="pos_ki">               0           0      </param>      
+        <param name="pos_maxOutput">    32000       32000      </param>    
+        <param name="pos_maxInt">           0           0      </param>   
+        <param name="pos_shift">            0           0      </param>   
+        <param name="pos_ko">               0           0      </param>   
+        <param name="pos_stictionUp">       0           0      </param>   
+        <param name="pos_stictionDwn">      0           0      </param>   
+        <param name="pos_kff">              1           1      </param>   
+        <param name="vel_kp">              12          12      </param>       
+        <param name="vel_kd">               0           0      </param>       
+        <param name="vel_ki">              16          16      </param>     
+        <param name="vel_limOutput">        0           0      </param>   
+        <param name="vel_maxOutput">        0           0      </param>   
+        <param name="vel_maxInt">           0           0      </param>   
+        <param name="vel_shift">           10          10      </param>   
+        <param name="vel_ko">               0           0      </param>   
+        <param name="vel_stictionUp">       0           0      </param>   
+        <param name="vel_stictionDwn">      0           0      </param>   
+        <param name="vel_kff">              0           0      </param>   
+    </group>
+
+
+    <group name="IMPEDANCE">
+        <param name="stiffness">       0      0    </param>    
+        <param name="damping">         0      0    </param>    
+    </group>
+    
+    <group name="2FOC_CURRENT_CONTROL">
+        <param name="controlLaw">       limitscurrent            </param> 
+        <param name="fbkControlUnits">        machine_units  </param>
+        <param name="outputControlUnits">     machine_units  </param>
+        <param name="cur_kp">                  8           8     </param>       
+        <param name="cur_kd">                  0           0     </param>       
+        <param name="cur_ki">                  2           2     </param>
+        <param name="cur_shift">              10          10     </param>
+        <param name="cur_maxOutput">       32000       32000     </param>                 
+        <param name="cur_maxInt">          32000       32000     </param> 
+        <param name="cur_ko">                  0           0     </param>       
+        <param name="cur_stictionUp">          0           0     </param>       
+        <param name="cur_stictionDwn">         0           0     </param>   
+        <param name="cur_kff">                 0           0     </param>            
+    </group>
+
+    <group name="OTHER_CONTROL_PARAMETERS">
+    	<param name="deadZone"> 0.025 0.025 </param>
+    </group>
+
+  </device>
+
+

--- a/CER03/hardware/motorControl/cer_head-mcp10-mc-service.xml
+++ b/CER03/hardware/motorControl/cer_head-mcp10-mc-service.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER03" build="1">
+
+    <group name="SERVICE">
+        
+        <param name="type"> eomn_serv_MC_mc4plus </param> 
+    
+        <group name="PROPERTIES">
+        
+            <group name="ETHBOARD">
+                <param name="type">                 mc4plus        </param> 
+            </group>          
+
+            
+            <group name="JOINTMAPPING">
+
+               <group name="ACTUATOR">                 
+                    <param name="type">             pwm                 pwm                 </param>
+                    <param name="port">             CONN:P5             CONN:P2             </param>
+                </group>
+                
+                <!-- <group name="ENCODER1">  
+                    <param name="type">             eomc_enc_aea        qenc                </param>  
+                    <param name="port">             CONN:P11            CONN:P2             </param>
+                    <param name="position">         eomc_pos_atjoint    atmotor             </param> 
+                    <param name="resolution">       4096                1000                </param>
+                    <param name="numofnoisebits">   3                   0                   </param> 
+                </group> -->       
+
+                <group name="ENCODER1">  
+                    <param name="type">             eomc_enc_aea        aea                 </param>  
+                    <param name="port">             CONN:P11            CONN:P10            </param>
+                    <param name="position">         eomc_pos_atjoint    atjoint             </param> 
+                    <param name="resolution">       4096                4096                </param>
+                    <param name="tolerance">        0.703               0.703               </param>  
+                </group>
+                
+                <group name="ENCODER2">
+                    <param name="type">             eomc_enc_none       none                </param>
+                    <param name="port">             CONN:none           CONN:none           </param>
+                    <param name="position">         eomc_pos_none       none                </param>
+                    <param name="resolution">       0                   0                   </param>
+                    <param name="tolerance">        0                   0                   </param>  
+                </group> 
+ 
+            </group>    
+            
+        </group>
+           
+    </group>
+    
+    <group name="OTHER_CONTROL_PARAMETERS">
+        <param name="deadZone">         0.0495   0.0495   </param>
+    </group>
+    
+  
+</params>

--- a/CER03/hardware/motorControl/cer_head-mcp10-mc.xml
+++ b/CER03/hardware/motorControl/cer_head-mcp10-mc.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+ <!-- Initialization file for EMS 10 - CER head, 2 dof -->
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_head_mc" type="embObjMotionControl">
+      <xi:include href="../../general.xml" />
+      <xi:include href="../electronics/cer_head-mcp10-eln.xml" />
+      <xi:include href="../mechanicals/cer_head-mcp10-mec.xml" />
+      <xi:include href="../motorControl/cer_head-mcp10-mc-service.xml" />
+
+    <group name="LIMITS">
+        <param name="jntPosMax">                38      49           </param>
+        <param name="jntPosMin">               -28     -49           </param>
+        <param name="jntVelMax">                50      50           </param>
+        <param name="motorOverloadCurrents">    5000    5000         </param>
+        <param name="motorNominalCurrents">     8000    8000         </param>
+        <param name="motorPeakCurrents">        8000    8000         </param>
+        <param name="motorPwmLimit">            3360    3360         </param>
+    </group>
+
+    
+     <group name="TIMEOUTS">
+        <param name="velocity">             100           100        </param>
+    </group>
+
+
+    <group name="CONTROLS">
+       <param name="positionControl">  JOINT_PID_V1           JOINT_PID_V1         </param> 
+       <param name="velocityControl">  VEL_CONTROL            VEL_CONTROL          </param> 
+       <param name="torqueControl">    none                   none                 </param>
+        <param name="currentPid">      none                   none                 </param> 
+    </group>
+    
+    
+    
+    <group name="JOINT_PID_V1">
+	    <param name="controlLaw">    Pid_inPos_outPwm            </param> 
+        <param name="fbkControlUnits">     machine_units             </param> 
+        <param name="outputControlUnits">  machine_units             </param>
+	    <param name="pos_kp">               2          -1.5      </param>
+        <param name="pos_kd">               0           0        </param>
+        <param name="pos_ki">               1          -5        </param>
+        <param name="pos_maxOutput">     3360        3360        </param>
+        <param name="pos_maxInt">        1000        1500        </param>
+        <param name="pos_shift">            0           0        </param>
+        <param name="pos_ko">               0           0        </param>
+        <param name="pos_stictionUp">       0           0        </param>
+        <param name="pos_stictionDwn">      0           0        </param>
+        <param name="pos_kff">              0           0        </param>
+    </group>
+
+    <group name="VEL_CONTROL">
+	    <param name="controlLaw">    Pid_inVel_outPwm            </param>
+        <param name="fbkControlUnits">     machine_units         </param> 
+        <param name="outputControlUnits">  machine_units         </param>
+        <param name="vel_kp">              -5           5        </param>
+        <param name="vel_kd">              -0           0        </param>
+        <param name="vel_ki">              -5          50        </param>
+        <param name="vel_maxOutput">     3000        3000        </param>
+        <param name="vel_maxInt">        3000        3000        </param>
+        <param name="vel_shift">            0           0        </param>
+        <param name="vel_ko">               0           0        </param>
+        <param name="vel_stictionUp">       0           0        </param>
+        <param name="vel_stictionDwn">      0           0        </param>
+        <param name="vel_kff">              0           0        </param>
+    </group>
+
+    
+
+    <group name="IMPEDANCE">
+        <param name="stiffness">       0      0           </param>
+        <param name="damping">         0      0           </param>
+    </group>
+
+  </device>
+

--- a/CER03/hardware/motorControl/cer_left_hand-mcp9-mc-service.xml
+++ b/CER03/hardware/motorControl/cer_left_hand-mcp9-mc-service.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CERSN002" build="1">
+
+    <group name="SERVICE">
+        
+        <param name="type"> eomn_serv_MC_mc2pluspsc </param> 
+    
+        <group name="PROPERTIES">
+        
+            <group name="ETHBOARD">
+                <param name="type">             mc2plus             </param> 
+            </group>          
+
+            <group name="CANBOARDS"> 
+                <param name="type">                 psc              </param> 
+                <group name="PROTOCOL">                    
+                    <param name="major">            2                  </param>    
+                    <param name="minor">            0                  </param>     
+                </group>                                   
+                <group name="FIRMWARE">                    
+                    <param name="major">            0                  </param>    
+                    <param name="minor">            0                  </param> 
+                    <param name="build">            0                  </param>
+                </group>
+            </group>
+            
+            <group name="PSC"> 
+                <param name="location">             CAN1:1  CAN1:2   CAN1:3        </param> 
+            </group>                      
+            
+           
+
+            <group name="JOINTMAPPING">
+
+                <group name="ACTUATOR">                 
+                    <param name="type">             pwm                 pwm                 </param>
+                    <param name="port">             CONN:P2             CONN:P3             </param>
+                </group>
+                
+                <group name="ENCODER1">  
+                    <param name="type">             psc                psc                 </param>  
+                    <param name="port">             finger0            finger1             </param>
+                    <param name="position">         atjoint            atjoint             </param> 
+                    <param name="resolution">       65535              65535               </param> <!-- 65535:this value will change by fw during calibration (type 6 or 7) --> 
+                    <param name="tolerance">        5                  5                   </param>  
+                </group>        
+                
+                <group name="ENCODER2">
+                    <param name="type">             qenc                qenc                </param>
+                    <param name="port">             CONN:P2             CONN:P3             </param>
+                    <param name="position">         atmotor             atmotor             </param>
+                    <param name="resolution">       1024                1024                </param>
+                    <param name="tolerance">        0                   0                   </param>  
+                </group>  
+            </group>    
+            
+           
+        </group>
+           
+    </group>
+    
+  
+</params>
+

--- a/CER03/hardware/motorControl/cer_left_hand-mcp9-mc.xml
+++ b/CER03/hardware/motorControl/cer_left_hand-mcp9-mc.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+ <!-- Initialization file for EMS 10 - CER hand, 2 dof -->
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_left_hand_mc" type="embObjMotionControl">
+      <xi:include href="../../general.xml" />
+      <xi:include href="../electronics/cer_left_hand-mcp9-eln.xml" />
+      <xi:include href="../mechanicals/cer_left_hand-mcp9-mec.xml" />
+      <xi:include href="../motorControl/cer_left_hand-mcp9-mc-service.xml" />
+
+    <group name="LIMITS">
+        <param name="jntPosMax">                140     130           </param>
+        <param name="jntPosMin">                0       0             </param>
+        <param name="jntVelMax">                150     150           </param>
+        <param name="motorOverloadCurrents">    5000    5000          </param>
+        <param name="motorNominalCurrents">     1500    1500           </param>
+        <param name="motorPeakCurrents">        2500    2500           </param>
+        <param name="motorPwmLimit">            3360    3360          </param>  
+    </group>
+    
+    
+    <group name="TIMEOUTS">
+        <param name="velocity">                 100           100     </param>
+    </group>
+
+
+     <group name="CONTROLS">
+       <param name="positionControl">  JOINT_PID_V1           JOINT_PID_V1          </param> 
+       <param name="velocityControl">  none                   none                  </param> 
+       <param name="torqueControl">    none                   none                  </param> 
+        <param name="currentPid">      none                   none                  </param> 
+    </group>
+
+	<group name="JOINT_PID_V1">
+    <param name="controlLaw">    Pid_inPos_outPwm </param> 
+        <param name="fbkControlUnits">     metric_units              </param> 
+        <param name="outputControlUnits">  machine_units             </param> 
+        <param name="pos_kp">              100         100        </param>       
+        <param name="pos_kd">                0           0        </param>       
+        <param name="pos_ki">              300         300        </param>         
+        <param name="pos_maxOutput">       800         800        </param>          
+        <param name="pos_maxInt">          800         800        </param>       
+        <param name="pos_shift">             0           0        </param>       
+        <param name="pos_ko">                0           0        </param>       
+        <param name="pos_stictionUp">        0           0        </param>       
+        <param name="pos_stictionDwn">       0           0        </param>     
+        <param name="pos_kff">               0           0        </param>   
+    </group>
+
+
+    <group name="IMPEDANCE">
+        <param name="stiffness">       0      0           </param>    
+        <param name="damping">         0      0           </param>    
+    </group>
+    
+    <group name="OTHER_CONTROL_PARAMETERS">
+        <param name="deadZone">        4.20    4.20        </param>
+	</group>
+    
+  </device>
+
+
+        

--- a/CER03/hardware/motorControl/cer_left_lower_arm-mcp8-mc-service.xml
+++ b/CER03/hardware/motorControl/cer_left_lower_arm-mcp8-mc-service.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER03" build="1">
+
+    <group name="SERVICE">
+        
+        <param name="type"> eomn_serv_MC_mc4plus </param> 
+    
+        <group name="PROPERTIES">
+        
+            <group name="ETHBOARD">
+                <param name="type">             mc4plus             </param> 
+            </group>          
+
+
+            <group name="JOINTMAPPING">
+
+                <group name="ACTUATOR">                 
+                    <param name="type">             pwm                 pwm                 pwm                 pwm                     </param>
+                    <param name="port">             CONN:P3             CONN:P2             CONN:P4             CONN:P5                 </param>
+                </group>
+                
+                <group name="ENCODER1">  
+                    <param name="type">             none                none                none                aea                      </param>  
+                    <param name="port">             CONN:none           CONN:none           CONN:none           CONN:P10                 </param>
+                    <param name="position">         none                none                none                atjoint                  </param> 
+                    <param name="resolution">       65535               65535               65535              -4096                     </param>
+                    <param name="tolerance">        0                   0                   0                   0.703                    </param>  
+                </group>        
+                
+                <group name="ENCODER2">
+                    <param name="type">             qenc                qenc                qenc                none                    </param>
+                    <param name="port">             CONN:P3             CONN:P2             CONN:P4             CONN:none               </param>
+                    <param name="position">         atmotor             atmotor             atmotor             none                    </param>
+                    <param name="resolution">       65535               65535               65535               0                       </param>
+                    <param name="tolerance">        0                   0                   0                   0                       </param>  
+                </group>  
+            </group>    
+            
+            
+        </group>
+           
+    </group>
+    
+    <group name="OTHER_CONTROL_PARAMETERS">
+        <param name="deadZone"> 0.00002   0.00002   0.00002   0.0055   </param>
+    </group>
+  
+</params>
+

--- a/CER03/hardware/motorControl/cer_left_lower_arm-mcp8-mc.xml
+++ b/CER03/hardware/motorControl/cer_left_lower_arm-mcp8-mc.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+ <!-- Initialization file for MC4+ 18 - CER left lower arm, 4 dof -->
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_left_lower_arm_mc" type="embObjMotionControl">
+      <xi:include href="../../general.xml" />
+      <xi:include href="../electronics/cer_left_lower_arm-mcp8-eln.xml" />
+      <xi:include href="../mechanicals/cer_left_lower_arm-mcp8-mec.xml" />
+      <xi:include href="../motorControl/cer_left_lower_arm-mcp8-mc-service.xml" />
+
+    <group name="LIMITS">
+        <param name="jntPosMax">                  0.12     0.12    0.12     89     </param>
+        <param name="jntPosMin">                  0        0       0       -89    </param>
+        <param name="jntVelMax">                  0.02     0.02    0.02     3000   </param>
+        <param name="motorOverloadCurrents">      10000    10000   10000    10000   </param>
+        <param name="motorNominalCurrents">       5000     5000    5000     5000   </param>
+        <param name="motorPeakCurrents">          5000     5000    5000     5000   </param>
+        <param name="motorPwmLimit">              3360     3360    3360     3360   </param>  
+    </group>
+
+<group name="TIMEOUTS">
+        <param name="velocity">               100       100           100        100    </param>
+    </group>
+
+
+<group name="CONTROLS">
+       <param name="positionControl">  JOINT_PID_V1         JOINT_PID_V1          JOINT_PID_V1         JOINT_PID_V1                 </param>
+       <param name="velocityControl">  VEL_CTRL              VEL_CTRL             VEL_CTRL             VEL_CTRL                     </param>
+       <param name="torqueControl">    none                  none                  none                MOTOR_PID_WITH_FRICTION_V1   </param>
+        <param name="currentPid">      none                  none                  none                none                         </param>
+    </group>
+    
+
+    <group name="JOINT_PID_V1">
+        <param name="controlLaw">    Pid_inPos_outPwm </param> 
+        <param name="fbkControlUnits">     machine_units             </param> 
+        <param name="outputControlUnits">  machine_units             </param> 
+        <param name="pos_kp">                   -20        -20        -20       0.7    </param>       
+        <param name="pos_kd">                    0          0          0        0      </param>       
+        <param name="pos_ki">                    0          0          0        0      </param>       
+        <param name="pos_maxOutput">             3000       3000       3000     2000   </param>          
+        <param name="pos_maxInt">                0          0          0        0      </param>       
+        <param name="pos_shift">                 0          0          0        0      </param>       
+        <param name="pos_ko">                    0          0          0        0      </param>       
+        <param name="pos_stictionUp">            0          0          0        0      </param>       
+        <param name="pos_stictionDwn">           0          0          0        0      </param>     
+        <param name="pos_kff">                   0          0          0        0      </param>  
+    </group>
+
+   <group name="VEL_CTRL">
+        <param name="controlLaw">    Pid_inVel_outPwm </param>
+        <param name="fbkControlUnits">     machine_units             </param> 
+        <param name="outputControlUnits">  machine_units             </param>
+        <param name="pos_kp">                   -20        -20        -20       0.7    </param>       
+        <param name="pos_kd">                    0          0          0        0      </param>       
+        <param name="pos_ki">                    0          0          0        0      </param>       
+        <param name="pos_maxOutput">             3000       3000       3000     2000   </param>          
+        <param name="pos_maxInt">                0          0          0        0      </param>       
+        <param name="pos_shift">                 0          0          0        0      </param>       
+        <param name="pos_ko">                    0          0          0        0      </param>       
+        <param name="pos_stictionUp">            0          0          0        0      </param>       
+        <param name="pos_stictionDwn">           0          0          0        0      </param>     
+        <param name="pos_kff">                   0          0          0        0      </param>
+        <param name="vel_kp">                   -20        -20        -20       0.7    </param>       
+        <param name="vel_kd">                    0          0          0        0      </param>       
+        <param name="vel_ki">                    0          0          0        0      </param>       
+        <param name="vel_maxOutput">             3000       3000       3000     2000   </param>          
+        <param name="vel_maxInt">                0          0          0        0      </param>       
+        <param name="vel_shift">                 0          0          0        0      </param>       
+        <param name="vel_ko">                    0          0          0        0      </param>       
+        <param name="vel_stictionUp">            0          0          0        0      </param>       
+        <param name="vel_stictionDwn">           0          0          0        0      </param>     
+        <param name="vel_kff">                   0          0          0        0      </param>     
+    </group>
+
+    <group name="MOTOR_PID_WITH_FRICTION_V1">
+        <param name="controlLaw">             Pid_inTrq_outPwm          </param>
+        <param name="fbkControlUnits">        metric_units              </param>
+        <param name="outputControlUnits">     machine_units             </param>
+        <param name="trq_kp">              0          0          0          0     </param>       
+        <param name="trq_kd">              0          0          0          0     </param>       
+        <param name="trq_ki">              0          0          0          0     </param>       
+        <param name="trq_maxOutput">       0          0          0          0     </param>       
+        <param name="trq_maxInt">          0          0          0          0     </param>       
+        <param name="trq_shift">           0          0          0          0     </param>       
+        <param name="trq_ko">              0          0          0          0     </param>       
+        <param name="trq_stictionUp">      0          0          0          0     </param>       
+        <param name="trq_stictionDwn">     0          0          0          0     </param>       
+        <param name="trq_kff">             0          0          0          0     </param>  
+        <param name="trq_kbemf">           0          0          0          0     </param>            
+        <param name="trq_filterType">      0          0          0          0     </param>     
+        <param name="trq_ktau">            0          0          0          0     </param>
+    </group>
+
+    <group name="IMPEDANCE">
+        <param name="stiffness">       0      0      0      0     </param>    
+        <param name="damping">         0      0      0      0     </param>    
+    </group>
+	
+  </device>
+
+

--- a/CER03/hardware/motorControl/cer_left_shoulder-ems5-mc-service.xml
+++ b/CER03/hardware/motorControl/cer_left_shoulder-ems5-mc-service.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER03" build="1">
+
+    <group name="SERVICE">
+        
+        <param name="type"> eomn_serv_MC_foc </param> 
+    
+        <group name="PROPERTIES">
+        
+            <group name="ETHBOARD">
+                <param name="type">                 ems4        </param> 
+            </group>          
+
+            <group name="CANBOARDS"> 
+                <param name="type">                 foc         </param> 
+                <group name="PROTOCOL">
+                    <param name="major">            1           </param>    
+                    <param name="minor">            6           </param>     
+                </group>                    
+                <group name="FIRMWARE">
+                    <param name="major">            0           </param>    
+                    <param name="minor">            0           </param> 
+                    <param name="build">            0           </param>
+                </group>
+            </group>
+
+            <group name="JOINTMAPPING">
+
+                <group name="ACTUATOR">                
+                    <param name="type">             foc                 foc                </param>
+                    <param name="port">             CAN1:1:0            CAN1:2:0           </param>
+                </group>
+                
+                <group name="ENCODER1">  
+                    <param name="type">             aea                aea                 </param>
+                    <param name="port">             CONN:P8            CONN:P6             </param>
+                    <param name="position">         atjoint            atjoint             </param>
+                    <param name="resolution">       4096              -4096                </param>
+                    <param name="tolerance">        0.703              0.703               </param>
+                </group>        
+                
+                <group name="ENCODER2">
+                    <param name="type">             roie                roie               </param>
+                    <param name="port">             CAN1:1:0            CAN1:2:0           </param>
+                    <param name="position">         atmotor             atmotor            </param>
+                    <param name="resolution">       8192                8192               </param>
+                    <param name="tolerance">        0                   0                  </param>  
+                </group> 
+ 
+            </group>    
+            
+        </group>
+           
+    </group>
+    
+  
+</params>
+

--- a/CER03/hardware/motorControl/cer_left_shoulder-ems5-mc.xml
+++ b/CER03/hardware/motorControl/cer_left_shoulder-ems5-mc.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_left_shoulder_mc" type="embObjMotionControl">
+      <xi:include href="../../general.xml" />
+      <xi:include href="../electronics/cer_left_shoulder-ems5-eln.xml" />
+      <xi:include href="../mechanicals/cer_left_shoulder-ems5-mec.xml" />
+      <xi:include href="../motorControl/cer_left_shoulder-ems5-mc-service.xml" />
+
+    <group name="LIMITS">
+        <param name="jntPosMax">                      85            85      </param>
+        <param name="jntPosMin">                     -70             2      </param>
+        <param name="motorOverloadCurrents">          5000          5000    </param>
+        <param name="motorNominalCurrents">           2500          2500    </param>
+        <param name="motorPeakCurrents">              5000          5000    </param>
+        <param name="jntVelMax">                      50            50      </param>
+        <param name="motorPwmLimit">                  32000         32000   </param>    
+    </group>
+
+    <group name="TIMEOUTS">
+        <param name="velocity">               100       100         </param>
+    </group>
+    
+    <group name="CONTROLS">
+       
+       <param name="positionControl">  JOINT_POS_VEL_CTRL     JOINT_POS_VEL_CTRL   </param> 
+       <param name="velocityControl">  none                   none                 </param> 
+<!--   <param name="torqueControl">    JOINT_TRQ_VEL_CTRL     JOINT_TRQ_VEL_CTRL   </param> -->
+       <param name="torqueControl">    none                   none                 </param>
+       <param name="currentPid">       2FOC_CURRENT_CONTROL   2FOC_CURRENT_CONTROL </param> 
+    </group>
+
+    
+    <group name="JOINT_POS_VEL_CTRL">
+        <param name="controlLaw">       PidPos_withInnerVelPid           </param> 
+        <param name="fbkControlUnits">     machine_units             </param> 
+        <param name="outputControlUnits">  machine_units             </param> 
+        <param name="pos_kp">               5           5          </param>       
+        <param name="pos_kd">               0           0          </param>       
+        <param name="pos_ki">               0           0          </param>       
+        <param name="pos_limPwm">           15000       15000      </param>
+        <param name="pos_maxOutput">        32000       32000      </param>      
+        <param name="pos_maxInt">           0           0          </param>       
+        <param name="pos_shift">            0           0          </param>       
+        <param name="pos_ko">               0           0          </param>       
+        <param name="pos_stictionUp">       0           0          </param>       
+        <param name="pos_stictionDwn">      0           0          </param>     
+        <param name="pos_kff">              1           1          </param>   
+        <param name="vel_kp">               1280        1280       </param>       
+        <param name="vel_kd">               6144        6144       </param>       
+        <param name="vel_ki">               1           1          </param>       
+        <param name="vel_limPwm">           0           0          </param>
+        <param name="vel_maxOutput">        0           0          </param>                 
+        <param name="vel_maxInt">           0           0          </param>       
+        <param name="vel_shift">            14          14         </param>       
+        <param name="vel_ko">               0           0          </param>       
+        <param name="vel_stictionUp">       0           0          </param>       
+        <param name="vel_stictionDwn">      0           0          </param>     
+        <param name="vel_kff">              0           0          </param>   
+    </group>
+    
+     <group name="JOINT_TRQ_VEL_CTRL">
+        <param name="controlLaw">       PidTrq_withInnerVelPid      </param> 
+        <param name="fbkControlUnits">        metric_units              </param>
+        <param name="outputControlUnits">     machine_units             </param>       
+        <param name="trq_kp">               1          1         </param>       
+        <param name="trq_kd">               0          0         </param>       
+        <param name="trq_ki">               0          0         </param> 
+        <param name="trq_limPwm">           2500       2500      </param>        
+        <param name="trq_maxOutput">        1500       1500      </param>       
+        <param name="trq_maxInt">           0          0         </param>       
+        <param name="trq_shift">            0          0         </param>       
+        <param name="trq_ko">               0          0         </param>       
+        <param name="trq_stictionUp">       0          0         </param>       
+        <param name="trq_stictionDwn">      0          0         </param>       
+        <param name="trq_kff">              0          0         </param>  
+        <param name="trq_kbemf">            0          0         </param>            
+        <param name="trq_filterType">       0          0         </param>     
+        <param name="trq_ktau">             0          0         </param>
+        <param name="vel_kp">               1280        1280     </param>       
+        <param name="vel_kd">               6144        6144     </param>       
+        <param name="vel_ki">               1           1        </param>       
+        <param name="vel_limPwm">           0           0        </param>
+        <param name="vel_maxOutput">        0           0        </param>                 
+        <param name="vel_maxInt">           0           0        </param>       
+        <param name="vel_shift">            14          14       </param>       
+        <param name="vel_ko">               0           0        </param>       
+        <param name="vel_stictionUp">       0           0        </param>       
+        <param name="vel_stictionDwn">      0           0        </param>     
+        <param name="vel_kff">              0           0        </param>   
+    </group>
+
+    <group name="2FOC_CURRENT_CONTROL">
+        <param name="controlLaw">       limitscurrent            </param> 
+        <param name="fbkControlUnits">        machine_units  </param>
+        <param name="outputControlUnits">     machine_units  </param>
+        <param name="cur_kp">              8           8         </param>       
+        <param name="cur_kd">              0           0         </param>       
+        <param name="cur_ki">              2           2         </param>
+        <param name="cur_shift">           10          10        </param>
+        <param name="cur_maxOutput">       32000       32000     </param>                 
+        <param name="cur_maxInt">          32000       32000     </param> 
+        <param name="cur_ko">              0           0         </param>       
+        <param name="cur_stictionUp">      0           0         </param>       
+        <param name="cur_stictionDwn">     0           0         </param>   
+        <param name="cur_kff">             0           0         </param>            
+    </group>
+
+    <group name="IMPEDANCE">
+        <param name="stiffness">        0          0         </param>    
+        <param name="damping">          0          0         </param>    
+    </group>
+	
+	
+    <group name="OTHER_CONTROL_PARAMETERS">
+        <param name="deadZone">         0.0495   0.0495   </param>
+    </group>
+	
+  </device>
+

--- a/CER03/hardware/motorControl/cer_left_upper_arm-ems12-mc-service.xml
+++ b/CER03/hardware/motorControl/cer_left_upper_arm-ems12-mc-service.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER03" build="1">
+
+    <group name="SERVICE">
+        
+        <param name="type"> eomn_serv_MC_foc </param> 
+    
+        <group name="PROPERTIES">
+        
+            <group name="ETHBOARD">
+                <param name="type">                 ems4        </param> 
+            </group>          
+
+            <group name="CANBOARDS"> 
+                <param name="type">                 foc         </param> 
+                <group name="PROTOCOL">
+                    <param name="major">            1           </param>    
+                    <param name="minor">            6           </param>     
+                </group>                    
+                <group name="FIRMWARE">
+                    <param name="major">            0           </param>    
+                    <param name="minor">            0           </param> 
+                    <param name="build">            0           </param>
+                </group>
+            </group>
+
+            <group name="JOINTMAPPING">
+
+                <group name="ACTUATOR">                
+                    <param name="type">             foc                 foc                 </param>
+                    <param name="port">             CAN1:1:0            CAN1:2:0            </param>
+                </group>                                                                   
+                                                                                           
+                <group name="ENCODER1">                                                    
+                    <param name="type">             aea                aea                  </param>
+                    <param name="port">             CONN:P8            CONN:P6              </param>
+                    <param name="position">         atjoint            atjoint              </param>
+                    <param name="resolution">      -4096              -4096                 </param>
+                    <param name="tolerance">        0.703              0.703                </param>
+                </group>                                                                   
+                                                                                           
+                <group name="ENCODER2">                                                    
+                    <param name="type">             roie                roie                </param>
+                    <param name="port">             CAN1:1:0            CAN1:2:0            </param>
+                    <param name="position">         atmotor             atmotor             </param>
+                    <param name="resolution">       8192                8192                </param>
+                    <param name="tolerance">        0                   0                   </param>  
+                </group> 
+ 
+            </group>    
+            
+        </group>
+           
+    </group>
+    
+  
+</params>
+

--- a/CER03/hardware/motorControl/cer_left_upper_arm-ems12-mc.xml
+++ b/CER03/hardware/motorControl/cer_left_upper_arm-ems12-mc.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_left_upper_arm_mc" type="embObjMotionControl">
+      <xi:include href="../../general.xml" />
+      <xi:include href="../electronics/cer_left_upper_arm-ems12-eln.xml" />
+      <xi:include href="../mechanicals/cer_left_upper_arm-ems12-mec.xml" />
+      <xi:include href="../motorControl/cer_left_upper_arm-ems12-mc-service.xml" />
+
+    <group name="LIMITS">
+        <param name="jntPosMax">                      90        95         </param>
+        <param name="jntPosMin">                     -90         2         </param>
+        <param name="motorOverloadCurrents">          9000      9000       </param>
+        <param name="motorNominalCurrents">           3000      3000       </param>
+        <param name="motorPeakCurrents">              6000      6000       </param>
+        <param name="jntVelMax">                      90        90         </param>
+        <param name="motorPwmLimit">                  32000     32000      </param>    
+    </group>
+
+    <group name="TIMEOUTS">
+        <param name="velocity">                       100        100    </param>
+    </group>
+    
+    <group name="CONTROLS">
+       
+       <param name="positionControl">  JOINT_POS_VEL_CTRL    JOINT_POS_VEL_CTRL    </param> 
+       <param name="velocityControl">  none                  none                  </param> 
+<!--    <param name="torqueControl">   JOINT_TRQ_VEL_CTRL    JOINT_TRQ_VEL_CTRL    </param> -->
+       <param name="torqueControl">    none                  none                  </param>
+       <param name="currentPid">       2FOC_CURRENT_CONTROL  2FOC_CURRENT_CONTROL  </param> 
+    </group>
+
+    
+    <group name="JOINT_POS_VEL_CTRL">
+        <param name="controlLaw">       PidPos_withInnerVelPid           </param> 
+        <param name="fbkControlUnits">     machine_units             </param> 
+        <param name="outputControlUnits">  machine_units             </param>
+        <param name="pos_kp">               5         5      </param>       
+        <param name="pos_kd">               0         0      </param>       
+        <param name="pos_ki">               0         0      </param>       
+        <param name="pos_maxOutput">        32000     32000  </param>      
+        <param name="pos_maxInt">           0         0      </param>       
+        <param name="pos_shift">            0         0      </param>       
+        <param name="pos_ko">               0         0      </param>       
+        <param name="pos_stictionUp">       0         0      </param>       
+        <param name="pos_stictionDwn">      0         0      </param>     
+        <param name="pos_kff">              1         1      </param>   
+        <param name="vel_kp">               12        12     </param>       
+        <param name="vel_kd">               0         0      </param>       
+        <param name="vel_ki">               16        16     </param>       
+        <param name="vel_maxOutput">        0         0      </param>                 
+        <param name="vel_maxInt">           0         0      </param>       
+        <param name="vel_shift">            10        10     </param>       
+        <param name="vel_ko">               0         0      </param>       
+        <param name="vel_stictionUp">       0         0      </param>       
+        <param name="vel_stictionDwn">      0         0      </param>     
+        <param name="vel_kff">              0         0      </param>   
+    </group>
+    
+     <group name="JOINT_TRQ_VEL_CTRL">
+        <param name="controlLaw">       PidTrq_withInnerVelPid      </param> 
+        <param name="fbkControlUnits">        metric_units              </param>
+        <param name="outputControlUnits">     machine_units             </param>        
+        <param name="trq_kp">               1        1       </param>       
+        <param name="trq_kd">               0        0       </param>       
+        <param name="trq_ki">               0        0       </param> 
+        <param name="trq_limPwm">           2500     2500    </param>        
+        <param name="trq_maxOutput">        1500     1500    </param>       
+        <param name="trq_maxInt">           0        0       </param>       
+        <param name="trq_shift">            0        0       </param>       
+        <param name="trq_ko">               0        0       </param>       
+        <param name="trq_stictionUp">       0        0       </param>       
+        <param name="trq_stictionDwn">      0        0       </param>       
+        <param name="trq_kff">              0        0       </param>  
+        <param name="trq_kbemf">            0        0       </param>            
+        <param name="trq_filterType">       0        0       </param>     
+        <param name="trq_ktau">             0        0       </param>
+        <param name="vel_kp">               1280      1280   </param>       
+        <param name="vel_kd">               6144      6144   </param>       
+        <param name="vel_ki">               1         1      </param>       
+        <param name="vel_maxOutput">        0         0      </param>                 
+        <param name="vel_maxInt">           0         0      </param>       
+        <param name="vel_shift">            14        14     </param>       
+        <param name="vel_ko">               0         0      </param>       
+        <param name="vel_stictionUp">       0         0      </param>       
+        <param name="vel_stictionDwn">      0         0      </param>     
+        <param name="vel_kff">              0         0      </param>   
+    </group>
+
+    <group name="2FOC_CURRENT_CONTROL">
+        <param name="controlLaw">       limitscurrent                               </param> 
+        <param name="fbkControlUnits">        machine_units  </param>
+        <param name="outputControlUnits">     machine_units  </param>
+        <param name="cur_kp">              8           8      </param>       
+        <param name="cur_kd">              0           0      </param>       
+        <param name="cur_ki">              2           2      </param>
+        <param name="cur_shift">           10          10     </param>
+        <param name="cur_maxOutput">       32000       32000  </param>                 
+        <param name="cur_maxInt">          32000       32000  </param> 
+        <param name="cur_ko">              0            0     </param>       
+        <param name="cur_stictionUp">      0            0     </param>       
+        <param name="cur_stictionDwn">     0            0     </param>   
+        <param name="cur_kff">             0            0     </param>            
+    </group>
+
+    <group name="IMPEDANCE">
+        <param name="stiffness">        0        0       </param>    
+        <param name="damping">          0        0       </param>    
+    </group>
+	
+	<group name="OTHER_CONTROL_PARAMETERS">
+        <param name="deadZone">         0.0495   0.0495   </param>
+    </group>
+	
+  </device>
+

--- a/CER03/hardware/motorControl/cer_left_wrist_equivalent-mc.xml
+++ b/CER03/hardware/motorControl/cer_left_wrist_equivalent-mc.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_left_wrist_equivalent_mc" type="tripodMotionControl">
+      <xi:include href="../../general.xml" />
+
+      <param name="AxisNames">  "l_wrist_heave_eq_joint" "l_wrist_roll_eq_joint" "l_wrist_pitch_eq_joint"  </param>
+
+    <group name="GENERAL">
+      <param name="Joints">      3       </param>
+     <!-- <param name="AxisMap">     0 1 2   </param> -->
+     <!-- <param name="Verbose">     true    </param> -->
+      <param name="Encoder">     1 1 1   </param>
+    </group>
+
+    <group name="TRIPOD">
+      <param name="Radius">      0.018   </param>
+      <param name="Max_el">      0.120  </param>
+      <param name="Min_el">      0.0    </param>
+      <param name="Max_alpha">   17.0   </param>
+
+      <param name="BASE_TRANSFORMATION">   1.0    0.0     0.0    0.0
+                                           0.0    1.0     0.0    0.0
+                                           0.0    0.0     1.0    0.0
+                                           0.0    0.0     0.0    1.0
+      </param>
+    </group>
+
+    <group name="LIMITS">
+        <param name="JntVelocityMax">   0.05  </param>
+    </group>
+
+    <!-- action is alternative to CONNECTION group -->
+    <action phase="startup" level="1" type="attach">
+      <paramlist name="networks">
+          <elem name="FirstSetOfJoints"> cer_left_lower_arm_mc </elem>
+      </paramlist>
+    </action>
+
+    <action phase="shutdown" level="6" type="detach" />
+
+  </device>
+

--- a/CER03/hardware/motorControl/cer_right_hand-mcp7-mc-service.xml
+++ b/CER03/hardware/motorControl/cer_right_hand-mcp7-mc-service.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CERSN002" build="1">
+
+    <group name="SERVICE">
+        
+        <param name="type"> eomn_serv_MC_mc2pluspsc </param> 
+    
+        <group name="PROPERTIES">
+        
+            <group name="ETHBOARD">
+                <param name="type">             mc2plus             </param> 
+            </group>          
+
+            <group name="CANBOARDS"> 
+                <param name="type">                 psc              </param> 
+                <group name="PROTOCOL">                    
+                    <param name="major">            2                  </param>    
+                    <param name="minor">            0                  </param>     
+                </group>                                   
+                <group name="FIRMWARE">                    
+                    <param name="major">            0                  </param>    
+                    <param name="minor">            0                  </param> 
+                    <param name="build">            0                  </param>
+                </group>
+            </group>
+            
+            <group name="PSC"> 
+                <param name="location">             CAN1:1  CAN1:2   CAN1:3        </param> 
+            </group>                      
+            
+           
+
+            <group name="JOINTMAPPING">
+
+                <group name="ACTUATOR">                 
+                    <param name="type">              pwm                 pwm                    </param>
+                    <param name="port">              CONN:P2             CONN:P3                </param>
+                </group>
+                
+                <group name="ENCODER1">  
+                    <param name="type">                psc                psc                    </param>  
+                    <param name="port">                finger0            finger1                 </param>
+                    <param name="position">            atjoint             atjoint               </param>
+                    <param name="resolution">          65535               65535                 </param> <!-- 65535:this value will change by fw during calibration (type 6 or 7) --> 
+                    <param name="tolerance">           5                  5                      </param>  
+                </group>        
+                
+                <group name="ENCODER2">
+                    <param name="type">                qenc                qenc                 </param>
+                    <param name="port">                CONN:P2             CONN:P3              </param>
+                    <param name="position">            atmotor             atmotor              </param>
+                    <param name="resolution">          1024                1024                 </param>
+                    <param name="tolerance">           0                   0                    </param>  
+                </group>  
+            </group>    
+            
+           
+       </group>
+             
+    </group>
+    
+  
+</params>
+

--- a/CER03/hardware/motorControl/cer_right_hand-mcp7-mc.xml
+++ b/CER03/hardware/motorControl/cer_right_hand-mcp7-mc.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+ <!-- Initialization file for EMS 10 - CER hand, 2 dof -->
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_right_hand_mc" type="embObjMotionControl">
+      <xi:include href="../../general.xml" />
+      <xi:include href="../electronics/cer_right_hand-mcp7-eln.xml" />
+      <xi:include href="../mechanicals/cer_right_hand-mcp7-mec.xml" />
+      <xi:include href="../motorControl/cer_right_hand-mcp7-mc-service.xml" />
+
+    <group name="LIMITS">
+        <param name="jntPosMax">                140     130           </param>
+        <param name="jntPosMin">                0       0             </param>
+        <param name="jntVelMax">                150     150           </param>
+        <param name="motorOverloadCurrents">    5000    5000          </param>
+        <param name="motorNominalCurrents">     1500    1500          </param>
+        <param name="motorPeakCurrents">        2500    2500          </param>
+        <param name="motorPwmLimit">            3360    3360          </param>  
+    </group>
+    
+    
+    <group name="TIMEOUTS">
+        <param name="velocity">                 100           100     </param>
+    </group>
+
+
+     <group name="CONTROLS"> 
+       <param name="positionControl">  JOINT_PID_V1           JOINT_PID_V1          </param> 
+       <param name="velocityControl">  none                   none                  </param> 
+       <param name="torqueControl">    none                   none                  </param> 
+        <param name="currentPid">      none                   none                  </param> 
+    </group>
+
+	<group name="JOINT_PID_V1">
+    <param name="controlLaw">    Pid_inPos_outPwm </param> 
+        <param name="fbkControlUnits">     metric_units              </param> 
+        <param name="outputControlUnits">  machine_units             </param> 
+        <param name="pos_kp">             -100        -100        </param>       
+        <param name="pos_kd">                0           0        </param>       
+        <param name="pos_ki">             -300        -300        </param>         
+        <param name="pos_maxOutput">       800         800        </param>          
+        <param name="pos_maxInt">          800         800        </param>       
+        <param name="pos_shift">             0           0        </param>       
+        <param name="pos_ko">                0           0        </param>       
+        <param name="pos_stictionUp">        0           0        </param>       
+        <param name="pos_stictionDwn">       0           0        </param>     
+        <param name="pos_kff">               0           0        </param>   
+    </group>
+
+
+    <group name="IMPEDANCE">
+        <param name="stiffness">       0      0           </param>    
+        <param name="damping">         0      0           </param>    
+    </group>
+    
+    <group name="OTHER_CONTROL_PARAMETERS">
+        <param name="deadZone">        4.20    4.20        </param>
+	</group>
+    
+  </device>
+
+
+        

--- a/CER03/hardware/motorControl/cer_right_lower_arm-mcp6-mc-service.xml
+++ b/CER03/hardware/motorControl/cer_right_lower_arm-mcp6-mc-service.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER03" build="1">
+
+    <group name="SERVICE">
+        
+        <param name="type"> eomn_serv_MC_mc4plus </param> 
+    
+        <group name="PROPERTIES">
+        
+            <group name="ETHBOARD">
+                <param name="type">             mc4plus             </param> 
+            </group>          
+
+            
+            <group name="JOINTMAPPING">
+
+                <group name="ACTUATOR">                 
+                    <param name="type">             pwm                 pwm                 pwm                 pwm                  </param>
+                    <param name="port">             CONN:P3             CONN:P2             CONN:P4             CONN:P5              </param>
+                </group>
+                
+                <group name="ENCODER1">  
+                    <param name="type">               none                none                none                aea                </param>  
+                    <param name="port">               CONN:none           CONN:none           CONN:none           CONN:P10           </param>
+                    <param name="position">           none                none                none                atjoint            </param> 
+                    <param name="resolution">         65535               65535               65535               4096               </param>
+                    <param name="tolerance">          0                   0                   0                   0.703              </param>  
+                </group>        
+                
+                <group name="ENCODER2">
+                    <param name="type">             qenc                qenc                qenc                none                 </param> 
+                    <param name="port">             CONN:P3             CONN:P2             CONN:P4             CONN:none            </param>
+                    <param name="position">         atmotor             atmotor             atmotor             none                 </param>
+                    <param name="resolution">       65535               65535               65535               0                    </param>
+                    <param name="tolerance">        0                   0                   0                   0                    </param>  
+                </group>  
+            </group>    
+            
+        </group>
+           
+    </group>
+    
+  
+</params>
+

--- a/CER03/hardware/motorControl/cer_right_lower_arm-mcp6-mc.xml
+++ b/CER03/hardware/motorControl/cer_right_lower_arm-mcp6-mc.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+ <!-- Initialization file for MC4+ 20 - CER right lower arm, 4 dof -->
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_right_lower_arm_mc" type="embObjMotionControl">
+      <xi:include href="../../general.xml" />
+      <xi:include href="../electronics/cer_right_lower_arm-mcp6-eln.xml" />
+      <xi:include href="../mechanicals/cer_right_lower_arm-mcp6-mec.xml" />
+      <xi:include href="../motorControl/cer_right_lower_arm-mcp6-mc-service.xml" />
+
+    <group name="LIMITS">
+        <param name="jntPosMax">                  0.12     0.12    0.12     89     </param>
+        <param name="jntPosMin">                  0        0       0       -89     </param>
+        <param name="jntVelMax">                  0.02     0.02    0.02     3000   </param>
+        <param name="motorOverloadCurrents">      10000    10000   10000    10000  </param>
+        <param name="motorNominalCurrents">       5000     5000    5000     5000   </param>
+        <param name="motorPeakCurrents">          5000     5000    5000     5000   </param>
+        <param name="motorPwmLimit">              3360     3360    3360     3360   </param>  
+    </group>
+    
+    
+    <group name="TIMEOUTS">
+        <param name="velocity">               100       100           100        100    </param>
+    </group>
+
+
+    <group name="CONTROLS">
+       <param name="positionControl">  JOINT_PID_V1         JOINT_PID_V1          JOINT_PID_V1         JOINT_PID_V1                 </param> 
+       <param name="velocityControl">  VEL_CTRL              VEL_CTRL             VEL_CTRL             VEL_CTRL                     </param> 
+       <param name="torqueControl">    none                  none                  none                MOTOR_PID_WITH_FRICTION_V1   </param>
+        <param name="currentPid">      none                  none                  none                none                         </param> 
+    </group>
+
+
+    <group name="JOINT_PID_V1">
+        <param name="controlLaw">    Pid_inPos_outPwm </param> 
+        <param name="fbkControlUnits">     machine_units             </param> 
+        <param name="outputControlUnits">  machine_units             </param>
+        <param name="pos_kp">              -20        -20        -20      -0.7    </param>       
+        <param name="pos_kd">               0          0          0        0      </param>       
+        <param name="pos_ki">               0          0          0        0      </param>       
+        <param name="pos_maxOutput">        3000       3000       3000     2000   </param>          
+        <param name="pos_maxInt">           0          0          0        0      </param>       
+        <param name="pos_shift">            0          0          0        0      </param>       
+        <param name="pos_ko">               0          0          0        0      </param>       
+        <param name="pos_stictionUp">       0          0          0        0      </param>       
+        <param name="pos_stictionDwn">      0          0          0        0      </param>     
+        <param name="pos_kff">              0          0          0        0      </param>   
+    </group>
+
+    <group name="VEL_CTRL">
+        <param name="controlLaw">    Pid_inVel_outPwm </param> 
+        <param name="fbkControlUnits">     machine_units             </param> 
+        <param name="outputControlUnits">  machine_units             </param>  
+        <param name="pos_kp">              -20        -20        -20      -0.7    </param>       
+        <param name="pos_kd">               0          0          0        0      </param>       
+        <param name="pos_ki">               0          0          0        0      </param>       
+        <param name="pos_maxOutput">        3000       3000       3000     2000   </param>          
+        <param name="pos_maxInt">           0          0          0        0      </param>       
+        <param name="pos_shift">            0          0          0        0      </param>       
+        <param name="pos_ko">               0          0          0        0      </param>       
+        <param name="pos_stictionUp">       0          0          0        0      </param>       
+        <param name="pos_stictionDwn">      0          0          0        0      </param>     
+        <param name="pos_kff">              0          0          0        0      </param>
+        <param name="vel_kp">              -20        -20        -20      -0.7    </param>       
+        <param name="vel_kd">               0          0          0        0      </param>       
+        <param name="vel_ki">               0          0          0        0      </param>       
+        <param name="vel_maxOutput">        3000       3000       3000     2000   </param>          
+        <param name="vel_maxInt">           0          0          0        0      </param>       
+        <param name="vel_shift">            0          0          0        0      </param>       
+        <param name="vel_ko">               0          0          0        0      </param>       
+        <param name="vel_stictionUp">       0          0          0        0      </param>       
+        <param name="vel_stictionDwn">      0          0          0        0      </param>     
+        <param name="vel_kff">              0          0          0        0      </param>      
+    </group>
+
+    <group name="MOTOR_PID_WITH_FRICTION_V1">
+        <param name="controlLaw">    Pid_inTrq_outPwm               </param> 
+        <param name="fbkControlUnits">        metric_units              </param>
+        <param name="outputControlUnits">     machine_units             </param>         
+        <param name="trq_kp">              0          0          0          0     </param>       
+        <param name="trq_kd">              0          0          0          0     </param>       
+        <param name="trq_ki">              0          0          0          0     </param>       
+        <param name="trq_maxOutput">       0          0          0          0     </param>       
+        <param name="trq_maxInt">          0          0          0          0     </param>       
+        <param name="trq_shift">           0          0          0          0     </param>       
+        <param name="trq_ko">              0          0          0          0     </param>       
+        <param name="trq_stictionUp">      0          0          0          0     </param>       
+        <param name="trq_stictionDwn">     0          0          0          0     </param>       
+        <param name="trq_kff">             0          0          0          0     </param>  
+        <param name="trq_kbemf">           0          0          0          0     </param>            
+        <param name="trq_filterType">      0          0          0          0     </param>     
+        <param name="trq_ktau">            0          0          0          0     </param>
+    </group>
+
+    <group name="IMPEDANCE">
+        <param name="stiffness">       0      0      0      0     </param>    
+        <param name="damping">         0      0      0      0     </param>    
+    </group>
+	
+	<group name="OTHER_CONTROL_PARAMETERS">
+        <param name="deadZone"> 0.00002   0.00002   0.00002   0.0055   </param>
+    </group>
+	
+  </device>
+
+

--- a/CER03/hardware/motorControl/cer_right_shoulder-ems4-mc-service.xml
+++ b/CER03/hardware/motorControl/cer_right_shoulder-ems4-mc-service.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER03" build="1">
+
+    <group name="SERVICE">
+        
+        <param name="type"> eomn_serv_MC_foc </param> 
+    
+        <group name="PROPERTIES">
+        
+            <group name="ETHBOARD">
+                <param name="type">                 ems4        </param> 
+            </group>          
+
+            <group name="CANBOARDS"> 
+                <param name="type">                 foc         </param> 
+                <group name="PROTOCOL">
+                    <param name="major">            1           </param>    
+                    <param name="minor">            6           </param>     
+                </group>                    
+                <group name="FIRMWARE">
+                    <param name="major">            0           </param>    
+                    <param name="minor">            0           </param> 
+                    <param name="build">            0           </param>
+                </group>
+            </group>
+            
+
+            <group name="JOINTMAPPING">
+
+                <group name="ACTUATOR">                
+                    <param name="type">             foc                 foc         </param>
+                    <param name="port">             CAN1:1:0            CAN1:2:0    </param>
+                </group>                                                            
+                                                                                    
+                <group name="ENCODER1">                                             
+                    <param name="type">             aea                aea          </param>  
+                    <param name="port">             CONN:P8            CONN:P6      </param>
+                    <param name="position">         atjoint            atjoint      </param> 
+                    <param name="resolution">      -4096               4096         </param>
+                    <param name="tolerance">        0.703              0.703        </param>  
+                </group>                                                            
+                                                                                    
+                <group name="ENCODER2">                                             
+                    <param name="type">             roie                roie        </param>
+                    <param name="port">             CAN1:1:0            CAN1:2:0    </param>
+                    <param name="position">         atmotor             atmotor     </param>
+                    <param name="resolution">       8192                8192        </param>
+                    <param name="tolerance">        0                   0           </param>  
+                </group>                                                            
+ 
+            </group>    
+            
+        </group>
+           
+    </group>
+    
+  
+</params>
+

--- a/CER03/hardware/motorControl/cer_right_shoulder-ems4-mc.xml
+++ b/CER03/hardware/motorControl/cer_right_shoulder-ems4-mc.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_right_shoulder_mc" type="embObjMotionControl">
+      <xi:include href="../../general.xml" />
+      <xi:include href="../electronics/cer_right_shoulder-ems4-eln.xml" />
+      <xi:include href="../mechanicals/cer_right_shoulder-ems4-mec.xml" />
+      <xi:include href="../motorControl/cer_right_shoulder-ems4-mc-service.xml" />
+
+    <group name="LIMITS">
+        <param name="jntPosMax">                      85            85        </param>
+        <param name="jntPosMin">                     -70             2        </param>
+        <param name="motorOverloadCurrents">          5000          5000      </param>
+        <param name="motorNominalCurrents">           2500          2500      </param>
+        <param name="motorPeakCurrents">              5000          5000      </param>
+        <param name="jntVelMax">                      50            50        </param>
+        <param name="motorPwmLimit">                  32000         32000     </param>    
+    </group>
+    
+    <group name="TIMEOUTS">
+        <param name="velocity">               100       100   </param>
+    </group>
+
+    <group name="CONTROLS">
+       
+       <param name="positionControl">  JOINT_POS_VEL_CTRL     JOINT_POS_VEL_CTRL   </param> 
+       <param name="velocityControl">  none                   none                 </param> 
+<!--   <param name="torqueControl">    JOINT_TRQ_VEL_CTRL     JOINT_TRQ_VEL_CTRL   </param> -->
+       <param name="torqueControl">    none                   none                 </param>
+       <param name="currentPid">       2FOC_CURRENT_CONTROL   2FOC_CURRENT_CONTROL </param> 
+    </group>
+
+    
+    <group name="JOINT_POS_VEL_CTRL">
+        <param name="controlLaw">       PidPos_withInnerVelPid           </param> 
+        <param name="fbkControlUnits">     machine_units             </param> 
+        <param name="outputControlUnits">  machine_units             </param>  
+        <param name="pos_kp">               5           5       </param>       
+        <param name="pos_kd">               0           0       </param>       
+        <param name="pos_ki">               0           0       </param>       
+        <param name="pos_limPwm">           15000       15000   </param>
+        <param name="pos_maxOutput">        32000       32000   </param>                 
+        <param name="pos_maxInt">           0           0       </param>       
+        <param name="pos_shift">            0           0       </param>       
+        <param name="pos_ko">               0           0       </param>       
+        <param name="pos_stictionUp">       0           0       </param>       
+        <param name="pos_stictionDwn">      0           0       </param>     
+        <param name="pos_kff">              1           1       </param>   
+        <param name="vel_kp">               1280        1280    </param>       
+        <param name="vel_kd">               6144        6144    </param>       
+        <param name="vel_ki">               1           1       </param>       
+        <param name="vel_limOutput">        0           0       </param>
+        <param name="vel_maxOutput">        0           0       </param>                 
+        <param name="vel_maxInt">           0           0       </param>       
+        <param name="vel_shift">            14          14      </param>       
+        <param name="vel_ko">               0           0       </param>       
+        <param name="vel_stictionUp">       0           0       </param>       
+        <param name="vel_stictionDwn">      0           0       </param>     
+        <param name="vel_kff">              0           0       </param>   
+    </group>
+    
+
+    
+    <group name="JOINT_TRQ_VEL_CTRL">
+        <param name="controlLaw">       PidTrq_withInnerVelPid      </param> 
+        <param name="fbkControlUnits">        metric_units              </param>
+        <param name="outputControlUnits">     machine_units             </param>        
+        <param name="trq_kp">               1          1       </param>       
+        <param name="trq_kd">               0          0       </param>       
+        <param name="trq_ki">               0          0       </param> 
+        <param name="trq_limPwm">           2500       2500    </param>        
+        <param name="trq_maxOutput">        1500       1500    </param>       
+        <param name="trq_maxInt">           0          0       </param>       
+        <param name="trq_shift">            0          0       </param>       
+        <param name="trq_ko">               0          0       </param>       
+        <param name="trq_stictionUp">       0          0       </param>       
+        <param name="trq_stictionDwn">      0          0       </param>       
+        <param name="trq_kff">              0          0       </param>  
+        <param name="trq_kbemf">            0          0       </param>            
+        <param name="trq_filterType">       0          0       </param>     
+        <param name="trq_ktau">             0          0       </param>
+        <param name="vel_kp">               1280       1280    </param>       
+        <param name="vel_kd">               6144       6144    </param>       
+        <param name="vel_ki">               1          1       </param>       
+        <param name="vel_limOutput">        0          0       </param>
+        <param name="vel_maxOutput">        0          0       </param>                 
+        <param name="vel_maxInt">           0          0       </param>       
+        <param name="vel_shift">            14         14      </param>       
+        <param name="vel_ko">               0          0       </param>       
+        <param name="vel_stictionUp">       0          0       </param>       
+        <param name="vel_stictionDwn">      0          0       </param>     
+        <param name="vel_kff">              0          0       </param>   
+    </group>
+
+    <group name="2FOC_CURRENT_CONTROL">
+        <param name="controlLaw">       limitscurrent            </param> 
+        <param name="fbkControlUnits">        machine_units  </param>
+        <param name="outputControlUnits">     machine_units  </param>
+        <param name="cur_kp">              8           8         </param>       
+        <param name="cur_kd">              0           0         </param>       
+        <param name="cur_ki">              2           2         </param>
+        <param name="cur_shift">           10          10        </param>
+        <param name="cur_maxOutput">       32000       32000     </param>                 
+        <param name="cur_maxInt">          32000       32000     </param> 
+        <param name="cur_ko">              0           0         </param>       
+        <param name="cur_stictionUp">      0           0         </param>       
+        <param name="cur_stictionDwn">     0           0         </param>   
+        <param name="cur_kff">             0           0         </param>            
+    </group>
+    
+    <group name="IMPEDANCE">
+        <param name="stiffness">        0          0     </param>    
+        <param name="damping">          0          0     </param>    
+    </group>
+
+    <group name="OTHER_CONTROL_PARAMETERS">
+        <param name="deadZone">         0.0495   0.0495   </param>
+    </group>
+
+  </device>
+

--- a/CER03/hardware/motorControl/cer_right_upper_arm-ems11-mc-service.xml
+++ b/CER03/hardware/motorControl/cer_right_upper_arm-ems11-mc-service.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER03" build="1">
+
+    <group name="SERVICE">
+        
+        <param name="type"> eomn_serv_MC_foc </param> 
+    
+        <group name="PROPERTIES">
+        
+            <group name="ETHBOARD">
+                <param name="type">                 ems4        </param> 
+            </group>          
+
+            <group name="CANBOARDS"> 
+                <param name="type">                 foc         </param> 
+                <group name="PROTOCOL">
+                    <param name="major">            1           </param>    
+                    <param name="minor">            6           </param>     
+                </group>                    
+                <group name="FIRMWARE">
+                    <param name="major">            0           </param>    
+                    <param name="minor">            0           </param> 
+                    <param name="build">            0           </param>
+                </group>
+            </group>
+            
+
+            <group name="JOINTMAPPING">
+
+                <group name="ACTUATOR">                
+                    <param name="type">             foc                 foc               </param>
+                    <param name="port">             CAN1:1:0            CAN1:2:0          </param>
+                </group>
+                
+                <group name="ENCODER1">  
+                    <param name="type">             aea                 aea               </param>  
+                    <param name="port">             CONN:P8             CONN:P6
+                               </param>
+                    <param name="position">         atjoint             atjoint           </param> 
+                    <param name="resolution">       4096               -4096              </param>
+                    <param name="tolerance">        0.703               0.703             </param>  
+                </group>        
+                
+                <group name="ENCODER2">
+                    <param name="type">             roie                roie              </param>
+                    <param name="port">             CAN1:1:0            CAN1:2:0          </param>
+                    <param name="position">         atmotor             atmotor           </param>
+                    <param name="resolution">       8192                8192              </param>
+                    <param name="tolerance">        0                   0                 </param>  
+                </group> 
+ 
+            </group>    
+            
+        </group>
+           
+    </group>
+    
+  
+</params>
+

--- a/CER03/hardware/motorControl/cer_right_upper_arm-ems11-mc.xml
+++ b/CER03/hardware/motorControl/cer_right_upper_arm-ems11-mc.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_right_upper_arm_mc" type="embObjMotionControl">
+      <xi:include href="../../general.xml" />
+      <xi:include href="../electronics/cer_right_upper_arm-ems11-eln.xml" />
+      <xi:include href="../mechanicals/cer_right_upper_arm-ems11-mec.xml" />
+      <xi:include href="../motorControl/cer_right_upper_arm-ems11-mc-service.xml" />
+
+    <group name="LIMITS">
+        <param name="jntPosMax">                      90            95        </param>
+        <param name="jntPosMin">                     -90             2        </param>
+        <param name="motorOverloadCurrents">          9000          9000      </param>
+        <param name="motorNominalCurrents">           3500          3000      </param>
+        <param name="motorPeakCurrents">              8000          6000      </param>
+        <param name="jntVelMax">                      90            90        </param>
+        <param name="motorPwmLimit">                  32000         32000     </param>    
+    </group>
+    
+    <group name="TIMEOUTS">
+        <param name="velocity">               100       100        </param>
+    </group>
+
+    <group name="CONTROLS">
+       
+       <param name="positionControl">  JOINT_POS_VEL_CTRL     JOINT_POS_VEL_CTRL     </param> 
+       <param name="velocityControl">  none                   none                   </param> 
+<!--   <param name="torqueControl">    JOINT_TRQ_VEL_CTRL     JOINT_TRQ_VEL_CTRL     </param> -->
+       <param name="torqueControl">    none                   none                   </param>
+       <param name="currentPid">       2FOC_CURRENT_CONTROL   2FOC_CURRENT_CONTROL   </param> 
+    </group>
+
+    
+    <group name="JOINT_POS_VEL_CTRL">
+        <param name="controlLaw">       PidPos_withInnerVelPid                      </param> 
+        <param name="fbkControlUnits">     machine_units             </param> 
+        <param name="outputControlUnits">  machine_units             </param>  
+        <param name="pos_kp">               5           5        </param>       
+        <param name="pos_kd">               0           0        </param>       
+        <param name="pos_ki">               0           0        </param>       
+        <param name="pos_maxOutput">        32000       32000    </param>                 
+        <param name="pos_maxInt">           32000       32000    </param>       
+        <param name="pos_shift">            0           0        </param>       
+        <param name="pos_ko">               0           0        </param>       
+        <param name="pos_stictionUp">       0           0        </param>       
+        <param name="pos_stictionDwn">      0           0        </param>     
+        <param name="pos_kff">              1           1        </param>   
+        <param name="vel_kp">               12          12       </param>       
+        <param name="vel_kd">               0           0        </param>       
+        <param name="vel_ki">               16          16       </param>       
+        <param name="vel_limOutput">        0           0        </param>
+        <param name="vel_maxOutput">        0           0        </param>                 
+        <param name="vel_maxInt">           0           0        </param>       
+        <param name="vel_shift">            10          10       </param>       
+        <param name="vel_ko">               0           0        </param>       
+        <param name="vel_stictionUp">       0           0        </param>       
+        <param name="vel_stictionDwn">      0           0        </param>     
+        <param name="vel_kff">              0           0        </param>   
+    </group>
+    
+
+    
+    <group name="JOINT_TRQ_VEL_CTRL">
+        <param name="controlLaw">       PidTrq_withInnerVelPid      </param> 
+        <param name="fbkControlUnits">        metric_units              </param>
+        <param name="outputControlUnits">     machine_units             </param>         
+        <param name="trq_kp">               1          1       </param>       
+        <param name="trq_kd">               0          0       </param>       
+        <param name="trq_ki">               0          0       </param>        
+        <param name="trq_maxOutput">        1500       1500    </param>       
+        <param name="trq_maxInt">           0          0       </param>       
+        <param name="trq_shift">            0          0       </param>       
+        <param name="trq_ko">               0          0       </param>       
+        <param name="trq_stictionUp">       0          0       </param>       
+        <param name="trq_stictionDwn">      0          0       </param>       
+        <param name="trq_kff">              0          0       </param>  
+        <param name="trq_kbemf">            0          0       </param>            
+        <param name="trq_filterType">       0          0       </param>     
+        <param name="trq_ktau">             0          0       </param>
+        <param name="vel_kp">               1280        1280   </param>       
+        <param name="vel_kd">               6144        6144   </param>       
+        <param name="vel_ki">               1           1      </param>       
+        <param name="vel_maxOutput">        0           0      </param>                 
+        <param name="vel_maxInt">           0           0      </param>       
+        <param name="vel_shift">            14          14     </param>       
+        <param name="vel_ko">               0           0      </param>       
+        <param name="vel_stictionUp">       0           0      </param>       
+        <param name="vel_stictionDwn">      0           0      </param>     
+        <param name="vel_kff">              0           0      </param>   
+    </group>
+
+    <group name="2FOC_CURRENT_CONTROL">
+        <param name="controlLaw">       limitscurrent         </param> 
+        <param name="fbkControlUnits">        machine_units   </param>
+        <param name="outputControlUnits">     machine_units   </param>
+        <param name="cur_kp">              8           8      </param>       
+        <param name="cur_kd">              0           0      </param>       
+        <param name="cur_ki">              2           2      </param>
+        <param name="cur_shift">           10          10     </param>
+        <param name="cur_maxOutput">       32000       32000  </param>                 
+        <param name="cur_maxInt">          32000       32000  </param> 
+        <param name="cur_ko">              0           0      </param>       
+        <param name="cur_stictionUp">      0           0      </param>       
+        <param name="cur_stictionDwn">     0           0      </param>   
+        <param name="cur_kff">             0           0      </param>            
+    </group>
+    
+    <group name="IMPEDANCE">
+        <param name="stiffness">        0          0         </param>    
+        <param name="damping">          0          0         </param>    
+    </group>
+
+	<group name="OTHER_CONTROL_PARAMETERS">
+        <param name="deadZone">         0.0495   0.0495   </param>
+    </group>
+
+  </device>
+

--- a/CER03/hardware/motorControl/cer_right_wrist_equivalent-mc.xml
+++ b/CER03/hardware/motorControl/cer_right_wrist_equivalent-mc.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_right_wrist_equivalent_mc" type="tripodMotionControl">
+      <xi:include href="../../general.xml" />
+
+    <param name="AxisNames">  "r_wrist_heave_eq_joint" "r_wrist_roll_eq_joint" "r_wrist_pitch_eq_joint"  </param>
+
+    <group name="GENERAL">
+      <param name="Joints">    3       </param>
+     <!-- <param name="AxisMap">   0 1 2   </param> -->
+     <!-- <param name="Verbose">   true    </param> -->
+      <param name="Encoder">   1 1 1   </param>
+    </group>
+
+    <group name="TRIPOD">
+      <param name="Radius">      0.018   </param>
+      <param name="Max_el">      0.120  </param>
+      <param name="Min_el">      0.0    </param>
+      <param name="Max_alpha">   17.0   </param>
+
+      <param name="BASE_TRANSFORMATION">   1.0    0.0     0.0    0.0
+                                           0.0    1.0     0.0    0.0
+                                           0.0    0.0     1.0    0.0
+                                           0.0    0.0     0.0    1.0
+      </param>
+    </group>
+
+    <group name="LIMITS">
+        <param name="JntVelocityMax">   0.05  </param>
+    </group>
+
+    <!-- action is alternative to CONNECTION group -->
+    <action phase="startup" level="1" type="attach">
+      <paramlist name="networks">
+          <elem name="FirstSetOfJoints"> cer_right_lower_arm_mc </elem>
+      </paramlist>
+    </action>
+
+    <action phase="shutdown" level="6" type="detach" />
+
+  </device>
+

--- a/CER03/hardware/motorControl/cer_torso-ems3-mc-service.xml
+++ b/CER03/hardware/motorControl/cer_torso-ems3-mc-service.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER03" build="1">
+
+    <group name="SERVICE">
+        
+        <param name="type"> eomn_serv_MC_foc </param> 
+    
+        <group name="PROPERTIES">
+        
+            <group name="ETHBOARD">
+                <param name="type">                 ems4        </param> 
+            </group>          
+
+            <group name="CANBOARDS"> 
+                <param name="type">                 foc         </param> 
+                <group name="PROTOCOL">
+                    <param name="major">            1           </param>    
+                    <param name="minor">            6           </param>     
+                </group>                    
+                <group name="FIRMWARE">
+                    <param name="major">            0           </param>    
+                    <param name="minor">            0           </param> 
+                    <param name="build">            0           </param>
+                </group>
+            </group>
+
+
+            <group name="JOINTMAPPING">
+
+                <group name="ACTUATOR">                
+                    <param name="type">             eomc_act_foc        foc                 foc             foc         </param>
+                    <param name="port">             CAN1:1:0            CAN1:2:0            CAN1:3:0        CAN1:4:0    </param>
+                </group>
+                
+                <group name="ENCODER1">  
+                    <param name="type">             none                none                none             aea         </param>  
+                    <param name="port">             CONN:none           CONN:none           CONN:none        CONN:P8     </param>
+                    <param name="position">         none                none                none             atjoint     </param> 
+                    <param name="resolution">       0                   0                   0               -4096        </param>
+                    <param name="tolerance">        0                   0                   0                0.703       </param> 
+                </group>        
+                
+                <group name="ENCODER2">
+                    <param name="type">             roie                roie                roie            roie         </param>
+                    <param name="port">             CAN1:1:0            CAN1:2:0            CAN1:3:0        CAN1:4:0     </param>
+                    <param name="position">         atmotor             atmotor             atmotor         atmotor      </param>
+                    <param name="resolution">       65535               65535               65535           8192         </param>
+                    <param name="tolerance">            0                   0                   0              0         </param> 
+                </group> 
+ 
+            </group>    
+            
+        </group>
+           
+    </group>
+    
+  
+</params>
+

--- a/CER03/hardware/motorControl/cer_torso-ems3-mc.xml
+++ b/CER03/hardware/motorControl/cer_torso-ems3-mc.xml
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+ <!-- Initialization file for EMS 15 - CER torso tripod + yaw, 4 dof -->
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_torso_mc" type="embObjMotionControl">
+      <xi:include href="../../general.xml" />
+      <xi:include href="../electronics/cer_torso-ems3-eln.xml" />
+      <xi:include href="../mechanicals/cer_torso-ems3-mec.xml" />
+      <xi:include href="../motorControl/cer_torso-ems3-mc-service.xml" />
+
+    <group name="LIMITS">
+        <param name="jntPosMax">                0.15    0.15         0.15       30     </param>
+        <param name="jntPosMin">               -0.04   -0.04        -0.04      -30     </param>
+        <param name="jntVelMax">                0.05    0.05         0.05    30000     </param>
+        <param name="motorOverloadCurrents">    5000    5000         5000     5000     </param>
+        <param name="motorNominalCurrents">     2500    2500         2500     2500     </param>
+        <param name="motorPeakCurrents">        5000    5000         5000     5000     </param>
+        <param name="motorPwmLimit">           32000   32000        32000    32000     </param>  
+    </group>
+    
+    
+    <group name="TIMEOUTS">
+        <param name="velocity">               100       100           100        100    </param>
+    </group>
+
+
+    <group name="CONTROLS">
+       <param name="positionControl">  JOINT_PID_V1         JOINT_PID_V1         JOINT_PID_V1         JOINT_POS_VEL_CTRL           </param> 
+       <param name="velocityControl">  VEL_CTRL             VEL_CTRL             VEL_CTRL             VEL_CTRL                     </param> 
+       <param name="torqueControl">    none                 none                 none                 none                         </param>
+       <param name="currentPid">       2FOC_CURRENT_CONTROL 2FOC_CURRENT_CONTROL 2FOC_CURRENT_CONTROL 2FOC_CURRENT_CONTROL         </param> 
+    </group>
+    
+    
+
+    <group name="JOINT_PID_V1">
+    <param name="controlLaw">    Pid_inPos_outPwm </param> 
+        <param name="fbkControlUnits">     machine_units             </param> 
+        <param name="outputControlUnits">  machine_units             </param> 
+        <param name="pos_kp">            3000        3000       3000          0     </param>       
+        <param name="pos_kd">               0           0          0          0     </param>       
+        <param name="pos_ki">            5000        5000       5000          0     </param>       
+        <param name="pos_maxOutput">    32000       32000      32000          0     </param>          
+        <param name="pos_maxInt">        4000        4000       4000          0     </param>       
+        <param name="pos_shift">            0           0          0          0     </param>       
+        <param name="pos_ko">               0           0          0          0     </param>       
+        <param name="pos_stictionUp">       0           0          0          0     </param>       
+        <param name="pos_stictionDwn">      0           0          0          0     </param>     
+        <param name="pos_kff">              0           0          0          0     </param>   
+    </group>
+    
+    
+    
+    <group name="JOINT_POS_VEL_CTRL">
+	<param name="controlLaw">    PidPos_withInnerVelPid </param> 
+        <param name="fbkControlUnits">     machine_units             </param> 
+        <param name="outputControlUnits">  machine_units             </param>  
+        <param name="pos_kp">               0           0          0          5     </param>       
+        <param name="pos_kd">               0           0          0          0     </param>       
+        <param name="pos_ki">               0           0          0          0     </param>       
+        <param name="pos_maxOutput">        0           0          0          32000 </param>          
+        <param name="pos_maxInt">           0           0          0          0     </param>       
+        <param name="pos_shift">            0           0          0          0     </param>       
+        <param name="pos_ko">               0           0          0          0     </param>       
+        <param name="pos_stictionUp">       0           0          0          0     </param>       
+        <param name="pos_stictionDwn">      0           0          0          0     </param>     
+        <param name="pos_kff">              0           0          0          1     </param>   
+        <param name="vel_kp">               0           0          0          1280  </param>       
+        <param name="vel_kd">               0           0          0          6144  </param>       
+        <param name="vel_ki">               0           0          0          1     </param>       
+        <param name="vel_maxOutput">        0           0          0          0     </param>          
+        <param name="vel_maxInt">           0           0          0          0     </param>       
+        <param name="vel_shift">            0           0          0          14    </param>       
+        <param name="vel_ko">               0           0          0          0     </param>       
+        <param name="vel_stictionUp">       0           0          0          0     </param>       
+        <param name="vel_stictionDwn">      0           0          0          0     </param>     
+        <param name="vel_kff">              0           0          0          0     </param>   
+    </group>
+
+
+    <group name="VEL_CTRL">
+	<param name="controlLaw">    Pid_inVel_outPwm  </param> 
+        <param name="fbkControlUnits">     machine_units             </param> 
+        <param name="outputControlUnits">  machine_units             </param>  
+        <param name="vel_kp">           3000        3000       3000       1280     </param>       
+        <param name="vel_kd">              0           0          0       6144     </param>       
+        <param name="vel_ki">           5000        5000       5000          1     </param>       
+        <param name="vel_maxOutput">   32000       32000      32000          0     </param>          
+        <param name="vel_maxInt">       4000        4000       4000          0     </param>       
+        <param name="vel_shift">           0           0          0         14     </param>       
+        <param name="vel_ko">              0           0          0          0     </param>       
+        <param name="vel_stictionUp">      0           0          0          0     </param>       
+        <param name="vel_stictionDwn">     0           0          0          0     </param>     
+        <param name="vel_kff">             0           0          0          0     </param>   
+    </group>
+    
+    <group name="JOINT_TRQ_VEL_CTRL">
+        <param name="controlLaw">    PidTrq_withInnerVelPid </param> 
+        <param name="fbkControlUnits">        metric_units              </param>
+        <param name="outputControlUnits">     machine_units             </param>         
+        <param name="trq_kp">              0          0          0          0     </param>       
+        <param name="trq_kd">              0          0          0          0     </param>       
+        <param name="trq_ki">              0          0          0          0     </param>       
+        <param name="trq_maxOutput">       0          0          0          0     </param>       
+        <param name="trq_maxInt">          0          0          0          0     </param>       
+        <param name="trq_shift">           0          0          0          0     </param>       
+        <param name="trq_ko">              0          0          0          0     </param>       
+        <param name="trq_stictionUp">      0          0          0          0     </param>       
+        <param name="trq_stictionDwn">     0          0          0          0     </param>       
+        <param name="trq_kff">             0          0          0          0     </param>  
+        <param name="trq_kbemf">           0          0          0          0     </param>            
+        <param name="trq_filterType">      0          0          0          0     </param>     
+        <param name="trq_ktau">            0          0          0          0     </param>
+        <param name="vel_kp">              0          0          0       1280     </param>       
+        <param name="vel_kd">              0          0          0       6144     </param>       
+        <param name="vel_ki">              0          0          0          1     </param>       
+        <param name="vel_maxOutput">       0          0          0          0     </param>          
+        <param name="vel_maxInt">          0          0          0          0     </param>       
+        <param name="vel_shift">           0          0          0         14     </param>       
+        <param name="vel_ko">              0          0          0          0     </param>       
+        <param name="vel_stictionUp">      0          0          0          0     </param>       
+        <param name="vel_stictionDwn">     0          0          0          0     </param>     
+        <param name="vel_kff">             0          0          0          0     </param>   
+    </group>
+
+    <group name="2FOC_CURRENT_CONTROL">
+        <param name="controlLaw">       limitscurrent </param>  
+        <param name="fbkControlUnits">        machine_units  </param>
+        <param name="outputControlUnits">     machine_units  </param>
+        <param name="cur_kp">              8           8           8           8      </param>       
+        <param name="cur_kd">              0           0           0           0      </param>       
+        <param name="cur_ki">              2           2           2           2      </param>
+        <param name="cur_shift">          10          10          10          10      </param>
+        <param name="cur_maxOutput">   32000       32000       32000       32000      </param>                 
+        <param name="cur_maxInt">      32000       32000       32000       32000      </param> 
+        <param name="cur_ko">              0           0           0           0      </param>       
+        <param name="cur_stictionUp">      0           0           0           0      </param>       
+        <param name="cur_stictionDwn">     0           0           0           0      </param>   
+        <param name="cur_kff">             0           0           0           0      </param>            
+    </group>
+    
+    <group name="IMPEDANCE">
+        <param name="stiffness">       0      0      0      0     </param>    
+        <param name="damping">         0      0      0      0     </param>    
+    </group>
+
+    <group name="OTHER_CONTROL_PARAMETERS">
+        <param name="deadZone">        0.0001      0.0001      0.0001   0.0495   </param>
+    </group>
+	
+  </device>
+
+

--- a/CER03/hardware/motorControl/cer_torso_equivalent-mc.xml
+++ b/CER03/hardware/motorControl/cer_torso_equivalent-mc.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_torso_equivalent_mc" type="tripodMotionControl">
+      <xi:include href="../../general.xml" />
+
+    <param name="AxisNames">  "torso_heave_eq_joint"   "torso_pitch_eq_joint"   "torso_roll_eq_joint"  </param>
+
+    <group name="GENERAL">
+      <param name="Joints">    3       </param>
+      <!-- <param name="AxisMap">   0 1 2   </param> -->
+      <!-- <param name="Verbose">   true    </param> -->
+      <param name="Encoder">   1 1 1   </param>
+    </group>
+
+    <group name="TRIPOD">
+      <param name="Radius">      0.09   </param>
+      <param name="Max_el">      0.15   </param>
+      <param name="Min_el">     -0.04   </param>
+      <param name="Max_alpha">   25.0   </param>
+
+      <param name="BASE_TRANSFORMATION">   1.0    0.0     0.0    0.0
+                                           0.0    1.0     0.0    0.0
+                                           0.0    0.0     1.0    0.0
+                                           0.0    0.0     0.0    1.0
+      </param>
+    </group>
+
+    <group name="LIMITS">
+        <param name="JntVelocityMax">   0.05  </param>
+    </group>
+
+
+    <!--
+    <group name="CONNECTION">
+      <param name="local">         /cerGazeboSim/torso_out  </param>
+      <param name="remote">        /cerGazeboSim/torso      </param>
+      <param name="writeStrict">   off                       </param>
+    </group>
+     -->
+
+    <!-- action is alternative to CONNECTION group -->
+    <action phase="startup" level="5" type="attach">
+      <paramlist name="networks">
+          <elem name="FirstSetOfJoints"> cer_torso_mc </elem>
+      </paramlist>
+    </action>
+
+    <action phase="shutdown" level="6" type="detach" />
+
+  </device>
+

--- a/CER03/hardware/rpLidar/laserA2_hw_back.xml
+++ b/CER03/hardware/rpLidar/laserA2_hw_back.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>    
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_laser_back_device" type="rpLidar2">  
+       <group name="GENERAL">
+            <param name="name">            cer_laserBack     </param>
+            <param name="clip_max">        7.0          </param>
+            <param name="clip_min">        0.1          </param>
+            <param name="max_angle">       360          </param>
+            <param name="min_angle">       0            </param>
+            <param name="resolution">      0.5           </param>
+            <param name="allow_infinity">  1            </param>
+            <param name="serial_baudrate"> 115200       </param>
+            <param name="serial_port">     /dev/ttyUSB1 </param>
+            <param name="sample_buffer_life">  1        </param>
+        </group>
+        <group name="SKIP">
+            <param name="min">  60     </param>
+            <param name="max">  300    </param>
+        </group> 
+    </device>

--- a/CER03/hardware/rpLidar/laserA2_hw_double.xml
+++ b/CER03/hardware/rpLidar/laserA2_hw_double.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>    
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_double_laser_device" type="cerDoubleLidar">  
+
+	<group name="LASERFRONT-CFG">
+            <param name="sensorName">     L_Front    </param>
+            <param name="pose">        0.070 0.0 0.031 0.0          </param>
+	        <param name="file">        laserA2_hw_front.xml         </param>
+        </group>
+        <group name="LASERBACK-CFG">
+            <param name="sensorName">     L_Back     </param>
+            <param name="pose">        -0.070 0.0 0.031 3.14159     </param>
+	        <param name="file">        laserA2_hw_back.xml          </param>
+        </group>
+
+      <action phase="startup" level="3" type="attach">
+         <paramlist name="networks">
+            <elem name="L_Front">  cer_laser_front_device </elem>
+            <elem name="L_Back">   cer_laser_back_device </elem>
+         </paramlist>
+      </action>
+
+      <action phase="shutdown" level="3" type="detach"/>
+  </device>
+
+

--- a/CER03/hardware/rpLidar/laserA2_hw_front.xml
+++ b/CER03/hardware/rpLidar/laserA2_hw_front.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>    
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_laser_front_device" type="rpLidar2">  
+       <group name="GENERAL">
+            <param name="name">            cer_laserFront  </param>
+            <param name="clip_max">        7.0          </param>
+            <param name="clip_min">        0.1          </param>
+            <param name="max_angle">       360          </param>
+            <param name="min_angle">       0            </param>
+            <param name="resolution">      0.5           </param>
+            <param name="allow_infinity">  1            </param>
+            <param name="serial_baudrate"> 115200       </param>
+            <param name="serial_port">     /dev/ttyUSB0 </param>
+            <param name="sample_buffer_life">  1        </param>
+        </group>
+        <group name="SKIP">
+            <param name="min">  35     </param>
+            <param name="max">  325    </param>
+        </group> 
+    </device>
+

--- a/CER03/hardware/skin/left_hand-mc9-skin.xml
+++ b/CER03/hardware/skin/left_hand-mc9-skin.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_hand_skin" type="embObjSkin">
+        <xi:include href="../../general.xml" />
+ 
+        <xi:include href="../electronics/cer_left_hand-mcp9-eln.xml" />
+
+        <group name="SERVICE">
+        
+            <param name="type"> eomn_serv_SK_skin </param>
+
+            <group name="PROPERTIES">
+            
+                <group name="CANBOARDS">
+                    <param name="type">                 psc                 </param>
+
+                    <group name="PROTOCOL">
+                        <param name="major">            2                   </param>    
+                        <param name="minor">            0                   </param>     
+                    </group>                    
+                    <group name="FIRMWARE">
+                        <param name="major">            0                   </param>    
+                        <param name="minor">            0                   </param> 
+                        <param name="build">            0                   </param>
+                    </group>
+                </group>
+           
+            </group>  
+
+        </group>
+
+        <group name="patches">
+            <param name="skinCanAddrsPatch1"> 1 2 3 </param> 
+        </group>
+        <xi:include href="../skin/left_hand-mc9-skinSpec.xml" />
+    </device>
+
+  

--- a/CER03/hardware/skin/left_hand-mc9-skinSpec.xml
+++ b/CER03/hardware/skin/left_hand-mc9-skinSpec.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER03" build="1">
+
+        <group name="defaultCfgBoard">
+            <param name="period">         50        </param>
+            <param name="skinType">       0         </param>    <!--    0 ==> new skin
+                                                                        1 ==> palm and fingertips skin
+                                                                        2 ==> old skin without temperature compensation -->
+            <param name="noLoad">         0xf0      </param>
+            <param name="diagnostic">     false     </param>     <!-- used to config high level -->
+        </group>
+
+
+       <group name="defaultCfgTriangle">
+            <param name="enabled">        true      </param>
+            <param name="shift">          2         </param>
+            <param name="cdcOffset">      0x0000    </param>
+        </group>
+
+        <!-- marco.accame: for test now we allow tx of all the 16 triangles in each psc board.
+             however we have only some triangles attached to the psc boards:
+             left hand
+             psc @ CAN1:1 -> {[patch, jx, trg, taxels]} = { [index_proxy, j2, trg = 8 9, taxels = 24], [index_distal, j1, trg = 0 1, taxels = 24]}
+             psc @ CAN1:2 -> {[patch, jx, trg, taxels]} = { [paddle_proxy, j1, trg = 0 1 2 3, taxels = 48], [paddle_distal, j2, trg = 8 9 10 11, taxels = 48]}
+             psc @ CAN1:3 -> {[patch, jx, trg, taxels]} = { [thumb_proxy, j2, trg = 8 9, taxels = 24], [thumb_distal, j1, trg = 0 1 2, taxels = 36]}
+          -->
+
+
+   <!--    <group name="specialCfgTriangles">
+           <param name="numOfSets">            1  </param>
+     	   <param name="triangleSetCfg1">      2            5        0             6             1              0            0x2000      </param>
+        </group> -->
+
+</params>

--- a/CER03/hardware/skin/right_hand-mc7-skin.xml
+++ b/CER03/hardware/skin/right_hand-mc7-skin.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_hand_skin" type="embObjSkin">
+        <xi:include href="../../general.xml" />
+ 
+        <xi:include href="../electronics/cer_right_hand-mcp7-eln.xml" />
+
+        <group name="SERVICE">
+        
+            <param name="type"> eomn_serv_SK_skin </param>
+
+            <group name="PROPERTIES">
+
+                <group name="CANBOARDS">
+                    <param name="type">                 psc                 </param>
+
+                    <group name="PROTOCOL">
+                        <param name="major">            2                   </param>
+                        <param name="minor">            0                   </param>
+                    </group>
+                    <group name="FIRMWARE">
+                        <param name="major">            0                   </param>
+                        <param name="minor">            0                   </param>
+                        <param name="build">            0                   </param>
+                    </group>
+                </group>
+
+            </group>
+
+        </group>
+
+        <group name="patches">
+            <param name="skinCanAddrsPatch1"> 1 2 3 </param>
+        </group>
+        <xi:include href="../skin/right_hand-mc7-skinSpec.xml" />
+    </device>
+
+  

--- a/CER03/hardware/skin/right_hand-mc7-skinSpec.xml
+++ b/CER03/hardware/skin/right_hand-mc7-skinSpec.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER03" build="1">
+
+        <group name="defaultCfgBoard">
+            <param name="period">         50        </param> 
+            <param name="skinType">       0         </param>    <!--    0 ==> new skin
+                                                                        1 ==> palm and fingertips skin
+                                                                        2 ==> old skin without temperature compensation -->
+            <param name="noLoad">         0xf0      </param>
+            <param name="diagnostic">     false     </param>     <!-- used to config high level -->
+        </group>
+        
+        
+       <group name="defaultCfgTriangle">
+            <param name="enabled">        true      </param> 
+            <param name="shift">          2         </param>
+            <param name="cdcOffset">      0x0000    </param>
+        </group>
+
+        <!-- marco.accame: for test now we allow tx of all the 16 triangles in each psc board.
+             however we have only some triangles attached to the psc boards:
+             right hand
+             psc @ CAN1:1 -> {[patch, jx, trg, taxels]} = { [index_proxy, j1, trg = 0 1, taxels = 24], [index_distal, j2, trg = 8 9, taxels = 24]}
+             psc @ CAN1:2 -> {[patch, jx, trg, taxels]} = { [paddle_proxy, j2, trg = 8 9 10 11, taxels = 48], [paddle_distal, j1, trg = 0 1 2 3, taxels = 48]}
+             psc @ CAN1:3 -> {[patch, jx, trg, taxels]} = { [thumb_proxy, j1, trg = 0 1, taxels = 24], [thumb_distal, j2, trg = 8 9 10, taxels = 36]}
+          -->
+          
+        
+   <!--    <group name="specialCfgTriangles">
+           <param name="numOfSets">            1  </param> 
+     	   <param name="triangleSetCfg1">      2            5        0             6             1              0            0x2000      </param>
+        </group> -->
+        
+</params>

--- a/CER03/robotStatePublisher.launch
+++ b/CER03/robotStatePublisher.launch
@@ -1,0 +1,9 @@
+<launch>
+
+  <arg name="model" default="./cer.urdf"/>
+
+  <param name="robot_description" command="$(find xacro)/xacro --inorder $(arg model)" />
+
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
+
+</launch>

--- a/CER03/sensors/Orbecc_Astra.ini
+++ b/CER03/sensors/Orbecc_Astra.ini
@@ -1,0 +1,58 @@
+device    RGBDSensorWrapper
+subdevice depthCamera
+name      /depthCamera
+[ROS]
+use_ROS             true
+forceInfoSync       true
+ROS_frame_Id        depth_center
+ROS_nodeName        /YarpRGBDSensor
+ROS_colorTopicName  /yarpColor
+ROS_depthTopicName  /yarpDepth
+ROS_colorInfoTopicName /yarpColor_info
+ROS_depthinfoTopicName /yarpDepth_info
+[SETTINGS]
+
+rgbMirroring false
+depthMirroring false
+
+[HW_DESCRIPTION]
+
+
+[RGB_INTRINSIC_PARAMETERS]
+
+focalLengthX			570.3422241210938
+focalLengthY			570.3422241210938
+principalPointX			314.5
+principalPointY			235.5
+distortionModel 		rgb_distortion
+
+[rgb_distortion]
+name					plumb_bob
+k1						0.0
+k2						0.0
+t1						0.0
+t2						0.0
+k3						0.0
+
+
+[DEPTH_INTRINSIC_PARAMETERS]
+
+focalLengthX			570.3422241210938
+focalLengthY			570.3422241210938
+principalPointX			314.5
+principalPointY			235.5
+distortionModel 		depth_distortion
+
+[depth_distortion]
+name					plumb_bob
+k1						0.0
+k2						0.0
+t1						0.0
+t2						0.0
+k3						0.0
+
+
+[EXTRINSIC_PARAMETERS]
+transformation   (1.0 0.0 0.0 0.0   0.0 1.0 0.0 0.0   0.0 0.0 1.0 0.0  0.0 0.0 0.0 1.0)
+
+

--- a/CER03/sensors/RealSenseStereo_conf.ini
+++ b/CER03/sensors/RealSenseStereo_conf.ini
@@ -1,0 +1,13 @@
+device grabberDual
+subdevice realsense2
+capabilities RAW
+stereoMode true
+split false
+
+[SETTINGS] 
+rgbResolution (640 480) 
+depthResolution (640 480) 
+framerate 30 
+enableEmitter false
+
+[HW_DESCRIPTION]

--- a/CER03/sensors/RealSense_conf.ini
+++ b/CER03/sensors/RealSense_conf.ini
@@ -1,0 +1,14 @@
+
+device       RGBDSensorWrapper
+subdevice    realsense2
+name         /depthCamera
+
+[SETTINGS]
+depthResolution (640 480)    #Note the parentesys
+rgbResolution   (640 480)
+framerate       30
+enableEmitter   true
+alignmentFrame  RGB
+
+[HW_DESCRIPTION]
+clipPlanes (0.2 10.0)

--- a/CER03/sensors/Xtion_depthCamera.ini
+++ b/CER03/sensors/Xtion_depthCamera.ini
@@ -1,0 +1,48 @@
+device       RGBDSensorWrapper
+subdevice    depthCamera
+name         /depthCamera
+
+[SETTINGS]
+accuracy     0.001
+depthResolution (320 240)    #Note the parentesys
+rgbResolution   (320 240)
+#enable mirroring for back compatibility with old driver version
+rgbMirroring    true
+depthMirroring  true
+
+[HW_DESCRIPTION]
+clipPlanes (0.4 4.5)
+
+[RGB_INTRINSIC_PARAMETERS]
+focalLengthX            1.0
+focalLengthY            2.0
+principalPointX         256.0
+principalPointY         128.0
+distortionModel         rgb_distortion
+
+[rgb_distortion]
+name                    plumb_bob
+k1                      1.0
+k2                      2.0
+t1                      3.0
+t2                      4.0
+k3                      5.0
+
+[DEPTH_INTRINSIC_PARAMETERS]
+focalLengthX            1.0
+focalLengthY            2.0
+principalPointX         256.0
+principalPointY         128.0
+distortionModel         depth_distortion
+
+[depth_distortion]
+name                    plumb_bob
+k1                      1.0
+k2                      2.0
+t1                      3.0
+t2                      4.0
+k3                      5.0
+
+[EXTRINSIC_PARAMETERS]
+transformation          (1.0 0.0 0.0 0.0   0.0 1.0 0.0 0.0   0.0 0.0 1.0 0.0  0.0 0.0 0.0 1.0)
+

--- a/CER03/wrappers/FT/cer_left_arm-FT_wrapper.xml
+++ b/CER03/wrappers/FT/cer_left_arm-FT_wrapper.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm_as_wrapper" type="analogServer">
+		<param name="period">   10  				</param>
+		<param name="name">     /cer/left_arm/FT:o  	        </param>
+		
+		<action phase="startup" level="5" type="attach">
+		    <paramlist name="networks">
+		<!-- The param value must match the device name in the corresponding emsX file -->
+		        <elem name="FirstStrain"> cer_left_arm-eb5-strain </elem>
+		    </paramlist>
+		</action>
+
+<!-- <group name ="ROS">
+         <param name ="useROS"> true </param>
+         <param name ="ROS_nodeName"> /cer-left_arm_FT </param>
+         <param name ="ROS_topicName"> /left_arm_FT </param>
+         <param name ="frame_id"> /l_clavicle_link  </param>
+         <param name ="ROS_msgType"> geometry_msgs/WrenchStamped </param>
+      </group> -->
+
+		<action phase="shutdown" level="5" type="detach" />
+	</device>
+

--- a/CER03/wrappers/FT/cer_right_arm-FT_wrapper.xml
+++ b/CER03/wrappers/FT/cer_right_arm-FT_wrapper.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm_as_wrapper" type="analogServer">
+		<param name="period">       10  				</param>
+		<param name="name">     /cer/right_arm/FT:o				</param>
+		
+		<action phase="startup" level="5" type="attach">
+		    <paramlist name="networks">
+		<!-- The param value must match the device name in the corresponding emsX file -->
+		        <elem name="FirstStrain"> cer_right_arm-eb4-strain </elem>
+		    </paramlist>
+		</action>
+
+      <!-- TO BE DONE 	       
+       <group name ="ROS">
+         <param name ="useROS"> true </param>
+         <param name ="ROS_nodeName"> /cer-right_arm_FT </param>
+         <param name ="ROS_topicName"> /right_arm_FT </param>
+         <param name ="frame_id"> /r_clavicle_link  </param>
+         <param name ="ROS_msgType"> geometry_msgs/WrenchStamped </param>
+      </group>
+      -->
+
+		<action phase="shutdown" level="5" type="detach" />
+	</device>
+

--- a/CER03/wrappers/MAIS/left_hand-mais_wrapper.xml
+++ b/CER03/wrappers/MAIS/left_hand-mais_wrapper.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_hand_as_wrapperMais" type="analogServer">
+        <param name="period">       10                  </param>
+        <param name="name">     /cer/left_hand/analog:o           </param>
+
+        <action phase="startup" level="5" type="attach">
+            <paramlist name="networks">
+                <elem name="left_hand_mais_network">  left_hand_multienc </elem>
+            </paramlist>
+        </action>
+
+        <group name ="ROS">
+           <param name ="useROS"> true </param>
+           <param name ="ROS_nodeName"> /cer-left_hand_MAIS </param>
+           <param name ="ROS_topicName"> /joint_states </param>
+           <param name ="ROS_msgType"> sensor_msgs/JointState </param>
+           <param name ="joint_names"> l_hand_paddle_distal_joint l_hand_paddle_proximal_joint l_dummy_1 l_hand_thumb_proximal_joint l_hand_thumb_distal_joint l_dummy_2 </param>
+        </group>
+      
+        <action phase="shutdown" level="5" type="detach" />
+        </device>
+

--- a/CER03/wrappers/MAIS/right_hand-mais_wrapper.xml
+++ b/CER03/wrappers/MAIS/right_hand-mais_wrapper.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_hand_as_wrapperMais" type="analogServer">
+        <param name="period">       10                  </param>
+        <param name="name">     /cer/right_hand/analog:o          </param>
+
+        <action phase="startup" level="5" type="attach">
+            <paramlist name="networks">
+                <elem name="right_hand_mais_network">  right_hand_multienc </elem>
+            </paramlist>
+        </action>
+
+        <group name ="ROS">
+           <param name ="useROS"> true </param>
+           <param name ="ROS_nodeName"> /cer-right_hand_MAIS </param>
+           <param name ="ROS_topicName"> /joint_states </param>
+           <param name ="ROS_msgType"> sensor_msgs/JointState </param>
+           <param name ="joint_names"> r_hand_paddle_distal_joint r_hand_paddle_proximal_joint r_dummy_1 r_hand_thumb_distal_joint r_hand_thumb_proximal_joint r_dummy_2 </param>
+        </group>
+        
+        <action phase="shutdown" level="5" type="detach" />
+        </device>
+

--- a/CER03/wrappers/PSC/cer_left_arm-PSC_wrapper.xml
+++ b/CER03/wrappers/PSC/cer_left_arm-PSC_wrapper.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_hand_as_wrapper" type="analogServer">
+		<param name="period">   10  				</param>
+		<param name="name">     /cer/left_hand/PSC:o  	        </param>
+		
+		<action phase="startup" level="5" type="attach">
+		    <paramlist name="networks">
+		<!-- The param value must match the device name in the corresponding emsX file -->
+		        <elem name="pscBoardsLeftHand">  left_hand-psc </elem>
+		    </paramlist>
+		</action>
+
+		<action phase="shutdown" level="5" type="detach" />
+	</device>
+

--- a/CER03/wrappers/PSC/cer_right_arm-PSC_wrapper.xml
+++ b/CER03/wrappers/PSC/cer_right_arm-PSC_wrapper.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_hand_as_wrapper" type="analogServer">
+		<param name="period">   10  				</param>
+		<param name="name">     /cer/right_hand/PSC:o  	        </param>
+		
+		<action phase="startup" level="5" type="attach">
+		    <paramlist name="networks">
+		<!-- The param value must match the device name in the corresponding emsX file -->
+		        <elem name="pscBoardsRightHand">  right_hand-psc </elem>
+		    </paramlist>
+		</action>
+
+		<action phase="shutdown" level="5" type="detach" />
+	</device>
+

--- a/CER03/wrappers/VFT/left_arm-VFT_wrapper.xml
+++ b/CER03/wrappers/VFT/left_arm-VFT_wrapper.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<devices robot="CER03" build="1">
+	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm_VFTserver" type="virtualAnalogServer">
+		<param name="period">       10  				</param>
+		<param name="deviceId">     left_arm				</param>
+		
+		 <paramlist name="networks">
+		      <!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+			<elem name="FirstSetOfJoints">  0  3  0  3 </elem> 
+			<elem name="SecondSetOfJoints"> 4  6  0  2 </elem> 	
+		    </paramlist>
+
+		<param name="channels">       7  				</param>
+		<param name="name"> 	     /left_arm				</param>
+
+		<action phase="startup" level="5" type="attach">
+		    <paramlist name="networks">
+			<!-- The param value must match the device name in the corresponding emsX file -->
+			 <elem name="FirstSetOfJoints">  left_upper_arm_mc </elem>	
+	     		 <elem name="SecondSetOfJoints"> left_lower_arm_mc </elem>  
+		    </paramlist>
+		</action>
+
+		<action phase="shutdown" level="5" type="detach" />
+	</device>
+
+
+

--- a/CER03/wrappers/VFT/left_leg-VFT_wrapper.xml
+++ b/CER03/wrappers/VFT/left_leg-VFT_wrapper.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<devices robot="CER03" build="1">
+	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg_VFTserver" type="virtualAnalogServer">
+		<param name="period">       10  				</param>
+		<param name="deviceId">     left_leg				</param>
+		
+		 <paramlist name="networks">
+		      <!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+			<elem name="FirstSetOfJoints">  0  3  0  3 </elem> 
+			<elem name="SecondSetOfJoints"> 4 5  0 1 </elem> 	
+		    </paramlist>
+
+		<param name="channels">       6  				</param>
+		<param name="name"> 	     /left_leg				</param>
+
+		<action phase="startup" level="5" type="attach">
+		    <paramlist name="networks">
+			<!-- The param value must match the device name in the corresponding emsX file -->
+			 <elem name="FirstSetOfJoints">  left_upper_leg_mc </elem>	
+	     		 <elem name="SecondSetOfJoints"> left_lower_leg_mc </elem>  
+		    </paramlist>
+		</action>
+
+		<action phase="shutdown" level="5" type="detach" />
+	</device>
+
+
+

--- a/CER03/wrappers/VFT/right_arm-VFT_wrapper.xml
+++ b/CER03/wrappers/VFT/right_arm-VFT_wrapper.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<devices robot="CER03" build="1">
+	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm_VFTserver" type="virtualAnalogServer">
+		<param name="period">       10  				</param>
+		<param name="deviceId">     right_arm				</param>
+		
+		 <paramlist name="networks">
+		      <!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+			<elem name="FirstSetOfJoints">  0  3  0  3 </elem> 
+			<elem name="SecondSetOfJoints"> 4  6  0  2 </elem> 	
+		    </paramlist>
+
+		<param name="channels">       7  				</param>
+		<param name="name"> 	      /right_arm				</param>
+
+		<action phase="startup" level="5" type="attach">
+		    <paramlist name="networks">
+			<!-- The param value must match the device name in the corresponding emsX file -->
+			 <elem name="FirstSetOfJoints">  right_upper_arm_mc </elem>	
+	     		 <elem name="SecondSetOfJoints"> right_lower_arm_mc </elem>  
+		    </paramlist>
+		</action>
+
+		<action phase="shutdown" level="5" type="detach" />
+	</device>
+
+
+

--- a/CER03/wrappers/VFT/right_leg-VFT_wrapper.xml
+++ b/CER03/wrappers/VFT/right_leg-VFT_wrapper.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<devices robot="CER03" build="1">
+	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg_VFTserver" type="virtualAnalogServer">
+		<param name="period">       10  				</param>
+		<param name="deviceId">     right_leg				</param>
+		
+		 <paramlist name="networks">
+		      <!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+			<elem name="FirstSetOfJoints">  0  3  0  3 </elem> 
+			<elem name="SecondSetOfJoints"> 4  5  0  1 </elem> 	
+		    </paramlist>
+
+		<param name="channels">       6  				</param>
+		<param name="name"> 	      /right_leg				</param>
+
+		<action phase="startup" level="5" type="attach">
+		    <paramlist name="networks">
+			<!-- The param value must match the device name in the corresponding emsX file -->
+			 <elem name="FirstSetOfJoints">  right_upper_leg_mc </elem>	
+	     		 <elem name="SecondSetOfJoints"> right_lower_leg_mc </elem>  
+		    </paramlist>
+		</action>
+
+		<action phase="shutdown" level="5" type="detach" />
+	</device>
+
+
+

--- a/CER03/wrappers/VFT/torso-VFT_wrapper.xml
+++ b/CER03/wrappers/VFT/torso-VFT_wrapper.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<devices robot="CER03" build="1">
+	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="torso_VFTserver" type="virtualAnalogServer">
+		<param name="period">       10  				</param>
+		<param name="deviceId">     torso				</param>
+		
+		 <paramlist name="networks">
+		      <!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+			<elem name="FirstSetOfJoints">  0  2  0  2 </elem> 
+		    </paramlist>
+
+		<param name="channels">       3  				</param>
+		<param name="name"> 	     /torso				</param>
+
+		<action phase="startup" level="5" type="attach">
+		    <paramlist name="networks">
+			<!-- The param value must match the device name in the corresponding emsX file -->
+			 <elem name="FirstSetOfJoints">  torso_mc </elem>	
+		    </paramlist>
+		</action>
+
+		<action phase="shutdown" level="5" type="detach" />
+	</device>
+
+
+

--- a/CER03/wrappers/motorControl/cer_base-mc_wrapper.xml
+++ b/CER03/wrappers/motorControl/cer_base-mc_wrapper.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_mobile_base_mc_wrapper" type="controlboardwrapper2">
+      <paramlist name="networks">
+	<!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+	  <elem name="FirstSetOfJoints"> 0  1  0  1 </elem>
+      </paramlist>
+
+      <param name="period"> 10 </param>
+      <param name="name">   /cer/mobile_base </param>
+      <param name="ports">  mobile_base		 </param>
+      <param name="joints"> 2		     	 </param>
+
+      <action phase="startup" level="5" type="attach">
+	  <paramlist name="networks">
+	  <!-- The param value must match the device name in the corresponding emsX file -->
+	      <elem name="FirstSetOfJoints"> cer_mobile_base_mc </elem>
+	  </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER03/wrappers/motorControl/cer_head-mc_wrapper.xml
+++ b/CER03/wrappers/motorControl/cer_head-mc_wrapper.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_head_mc_wrapper" type="controlboardwrapper2">
+      <paramlist name="networks">
+	<!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+	  <elem name="FirstSetOfJoints"> 0  1  0  1 </elem>
+      </paramlist>
+
+      <param name="period"> 10 </param>
+      <param name="name">   /cer/head	</param>
+      <param name="ports">  head		</param>
+      <param name="joints"> 2			</param>
+
+      <action phase="startup" level="5" type="attach">
+	  <paramlist name="networks">
+	  <!-- The param value must match the device name in the corresponding emsX file -->
+	      <elem name="FirstSetOfJoints"> cer_head_mc </elem>
+	  </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER03/wrappers/motorControl/cer_left_arm-mc_wrapper.xml
+++ b/CER03/wrappers/motorControl/cer_left_arm-mc_wrapper.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_left_arm_mc_wrapper" type="controlboardwrapper2">
+      <paramlist name="networks">
+	<!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+        <elem name="FirstSetOfJoints">  0  3  0  3 </elem>
+        <elem name="YawSetOfJoints">    4  4  3  3 </elem>
+        <elem name="SecondSetOfJoints"> 5  7  0  2 </elem>
+        <elem name="HandSetOfJoints">   8  9  0  1 </elem>
+      </paramlist>
+
+      <param name="period"> 10 </param>
+      <param name="name">   /cer/left_arm	</param>
+      <param name="ports">  left_arm		</param>
+      <param name="joints"> 10			</param>
+
+      <action phase="startup" level="5" type="attach">
+	  <paramlist name="networks">
+	  <!-- The param value must match the device name in the corresponding emsX file -->
+	  <elem name="FirstSetOfJoints">  cer_left_upper_arm_mc</elem>
+          <elem name="SecondSetOfJoints"> cer_left_wrist_equivalent_mc</elem>
+          <elem name="YawSetOfJoints">    cer_left_lower_arm_mc</elem>
+	  <elem name="HandSetOfJoints">   cer_left_hand_mc </elem>
+	  </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER03/wrappers/motorControl/cer_left_arm_no_hand-mc_wrapper.xml
+++ b/CER03/wrappers/motorControl/cer_left_arm_no_hand-mc_wrapper.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_left_arm_no_hand_mc_wrapper" type="controlboardwrapper2">
+      <paramlist name="networks">
+	  <!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+	  <elem name="FirstSetOfJoints">   0  1  0  1 </elem>
+	  <elem name="SecondSetOfJoints">  2  3  0  1 </elem>
+      <elem name="YawSetOfJoints">     4  4  3  3 </elem>
+      <elem name="ThirdSetOfJoints">   5  7  0  2 </elem>
+      <!--  <elem name="HandSetOfJoints">   8  9  0  1 </elem> -->
+      </paramlist>
+
+      <param name="period"> 10              </param>
+      <param name="name">   /cer/left_arm	</param>
+      <param name="ports">  left_arm		</param>
+      <param name="joints"> 8			    </param>
+
+      <action phase="startup" level="5" type="attach">
+	  <paramlist name="networks">
+	  <!-- The param value must match the device name in the corresponding emsX file -->
+	  <elem name="FirstSetOfJoints">  cer_left_shoulder_mc         </elem>
+	  <elem name="SecondSetOfJoints"> cer_left_upper_arm_mc        </elem>
+      <elem name="YawSetOfJoints">    cer_left_lower_arm_mc        </elem>
+      <elem name="ThirdSetOfJoints">  cer_left_wrist_equivalent_mc </elem>
+	  <!--  <elem name="HandSetOfJoints">   cer_left_hand_mc </elem> -->
+	  </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER03/wrappers/motorControl/cer_left_hand-mc_wrapper.xml
+++ b/CER03/wrappers/motorControl/cer_left_hand-mc_wrapper.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_left_hand_mc_wrapper" type="controlboardwrapper2">
+      <paramlist name="networks">
+	<!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+	  <elem name="FirstSetOfJoints"> 0  1  0  1 </elem>
+      </paramlist>
+
+      <param name="period"> 10 </param>
+      <param name="name">   /cer/left_hand	</param>
+      <param name="ports">  left_hand		</param>
+      <param name="joints"> 2	     		</param>
+
+      <action phase="startup" level="5" type="attach">
+	  <paramlist name="networks">
+	  <!-- The param value must match the device name in the corresponding emsX file -->
+	      <elem name="FirstSetOfJoints"> cer_left_hand_mc </elem>
+	  </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER03/wrappers/motorControl/cer_left_shoulder-mc_wrapper.xml
+++ b/CER03/wrappers/motorControl/cer_left_shoulder-mc_wrapper.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_left_shoulder_mc_wrapper" type="controlboardwrapper2">
+      <paramlist name="networks">
+	<!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+        <elem name="FirstSetOfJoints">  0  1  0  1 </elem>
+      </paramlist>
+
+      <param name="period"> 10 </param>
+      <param name="name">   /cer/left_arm	</param>
+      <param name="ports">  left_arm		</param>
+      <param name="joints"> 2			</param>
+
+      <action phase="startup" level="5" type="attach">
+	  <paramlist name="networks">
+	  <!-- The param value must match the device name in the corresponding emsX file -->
+		<elem name="FirstSetOfJoints">  cer_left_shoulder_mc</elem>
+	  </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER03/wrappers/motorControl/cer_left_upper_arm-mc_wrapper.xml
+++ b/CER03/wrappers/motorControl/cer_left_upper_arm-mc_wrapper.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_left_upper_arm_mc_wrapper" type="controlboardwrapper2">
+      <paramlist name="networks">
+	<!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+	  <elem name="FirstSetOfJoints">   0  1  0  1 </elem>
+	  <elem name="SecondSetOfJoints">  2  3  0  1 </elem>
+      </paramlist>
+
+<param name="period"> 10 </param>
+      <param name="name">   /cer/left_arm	</param>
+      <param name="ports">  left_arm	    </param>
+      <param name="joints"> 4			    </param>
+
+      <action phase="startup" level="5" type="attach">
+	  <paramlist name="networks">
+	  <!-- The param value must match the device name in the corresponding emsX file -->
+	      <elem name="FirstSetOfJoints">  cer_left_shoulder_mc  </elem>
+	      <elem name="SecondSetOfJoints"> cer_left_upper_arm_mc </elem>
+	  </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER03/wrappers/motorControl/cer_left_wrist-mc_wrapper.xml
+++ b/CER03/wrappers/motorControl/cer_left_wrist-mc_wrapper.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_left_wrist_mc_wrapper" type="controlboardwrapper2">
+      <param name="period">   10   </param>
+      <paramlist name="networks">
+	  <!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+	  <elem name="FirstSetOfJoints">  0  2  0  2 </elem>
+      </paramlist>
+
+      <param name="name">   /cer/left_wrist  </param>
+      <param name="ports">  left_wrist       </param>
+      <param name="joints"> 3                </param>
+
+      <action phase="startup" level="5" type="attach">
+	  <paramlist name="networks">
+	  <!-- The param value must match the device name in the corresponding emsX file -->
+	      <elem name="FirstSetOfJoints"> cer_left_lower_arm_mc</elem>
+
+	  </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER03/wrappers/motorControl/cer_left_wrist_tripod-mc_wrapper.xml
+++ b/CER03/wrappers/motorControl/cer_left_wrist_tripod-mc_wrapper.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_left_wrist_tripod_mc_wrapper" type="controlboardwrapper2">
+      <param name="period">   10   </param>
+      <paramlist name="networks">
+	  <!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+	  <elem name="FirstSetOfJoints">  0  2  0  2 </elem>
+      </paramlist>
+
+      <param name="name">   /cer/left_wrist_tripod  </param>
+      <param name="ports">  left_wrist_tripod       </param>
+      <param name="joints"> 3                       </param>
+
+      <action phase="startup" level="5" type="attach">
+	  <paramlist name="networks">
+	  <!-- The param value must match the device name in the corresponding emsX file -->
+	      <elem name="FirstSetOfJoints"> cer_left_lower_arm_mc </elem>
+
+	  </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER03/wrappers/motorControl/cer_right_arm-mc_wrapper.xml
+++ b/CER03/wrappers/motorControl/cer_right_arm-mc_wrapper.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_right_arm_mc_wrapper" type="controlboardwrapper2">
+      <paramlist name="networks">
+	<!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+        <elem name="FirstSetOfJoints">  0  3  0  3 </elem>
+        <elem name="YawSetOfJoints">    4  4  3  3 </elem>
+  	<elem name="SecondSetOfJoints"> 5  7  0  2 </elem>
+        <elem name="HandSetOfJoints">   8  9  0  1 </elem>
+      </paramlist>
+
+      <param name="period"> 10 </param>
+      <param name="name">   /cer/right_arm	</param>
+      <param name="ports">  right_arm		</param>
+      <param name="joints"> 10			</param>
+
+      <action phase="startup" level="5" type="attach">
+	  <paramlist name="networks">
+	  <!-- The param value must match the device name in the corresponding emsX file -->
+	  <elem name="FirstSetOfJoints">  cer_right_upper_arm_mc</elem>
+          <elem name="SecondSetOfJoints"> cer_right_wrist_equivalent_mc</elem>
+          <elem name="YawSetOfJoints">    cer_right_lower_arm_mc</elem>
+	  <elem name="HandSetOfJoints">   cer_right_hand_mc </elem>
+	  </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER03/wrappers/motorControl/cer_right_arm_no_hand-mc_wrapper.xml
+++ b/CER03/wrappers/motorControl/cer_right_arm_no_hand-mc_wrapper.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_right_arm_no_hand_mc_wrapper" type="controlboardwrapper2">
+      <paramlist name="networks">
+	  <!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+	  <elem name="FirstSetOfJoints">   0  1  0  1 </elem>
+	  <elem name="SecondSetOfJoints">  2  3  0  1 </elem>
+      <elem name="YawSetOfJoints">     4  4  3  3 </elem>
+  	  <elem name="ThirdSetOfJoints">   5  7  0  2 </elem>
+      <!-- <elem name="HandSetOfJoints">   8  9  0  1 </elem> -->
+      </paramlist>
+
+      <param name="period"> 10              </param>
+      <param name="name">   /cer/right_arm	</param>
+      <param name="ports">  right_arm		</param>
+      <param name="joints"> 8			    </param>
+
+      <action phase="startup" level="5" type="attach">
+	  <paramlist name="networks">
+	  <!-- The param value must match the device name in the corresponding emsX file -->
+	  <elem name="FirstSetOfJoints">  cer_right_shoulder_mc         </elem>
+	  <elem name="SecondSetOfJoints"> cer_right_upper_arm_mc        </elem>  
+      <elem name="YawSetOfJoints">    cer_right_lower_arm_mc        </elem>
+	  <elem name="ThirdSetOfJoints">  cer_right_wrist_equivalent_mc </elem>
+	  <!-- <elem name="HandSetOfJoints">   cer_right_hand_mc </elem> -->
+	  </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER03/wrappers/motorControl/cer_right_hand-mc_wrapper.xml
+++ b/CER03/wrappers/motorControl/cer_right_hand-mc_wrapper.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_right_hand_mc_wrapper" type="controlboardwrapper2">
+      <paramlist name="networks">
+	<!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+	  <elem name="FirstSetOfJoints"> 0  1  0  1 </elem>
+      </paramlist>
+
+      <param name="period"> 10 </param>
+      <param name="name">   /cer/right_hand	</param>
+      <param name="ports">  right_hand		</param>
+      <param name="joints"> 2	     		</param>
+
+      <action phase="startup" level="5" type="attach">
+	  <paramlist name="networks">
+	  <!-- The param value must match the device name in the corresponding emsX file -->
+	      <elem name="FirstSetOfJoints"> cer_right_hand_mc </elem>
+	  </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER03/wrappers/motorControl/cer_right_shoulder-mc_wrapper.xml
+++ b/CER03/wrappers/motorControl/cer_right_shoulder-mc_wrapper.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_right_shoulder_mc_wrapper" type="controlboardwrapper2">
+      <paramlist name="networks">
+	<!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+	  <elem name="FirstSetOfJoints">  0  1  0  1 </elem>
+      </paramlist>
+
+<param name="period"> 10 </param>
+      <param name="name">   /cer/right_arm </param>
+      <param name="ports">  right_arm 	 </param>
+      <param name="joints"> 2			 </param>
+
+      <action phase="startup" level="5" type="attach">
+	  <paramlist name="networks">
+	  <!-- The param value must match the device name in the corresponding emsX file -->
+	      <elem name="FirstSetOfJoints"> cer_right_shoulder_mc</elem>
+	  </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER03/wrappers/motorControl/cer_right_upper_arm-mc_wrapper.xml
+++ b/CER03/wrappers/motorControl/cer_right_upper_arm-mc_wrapper.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_right_upper_arm_mc_wrapper" type="controlboardwrapper2">
+      <paramlist name="networks">
+	<!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+	  <elem name="FirstSetOfJoints">   0  1  0  1 </elem>
+	  <elem name="SecondSetOfJoints">  2  3  0  1 </elem>
+      </paramlist>
+
+<param name="period"> 10 </param>
+      <param name="name">   /cer/right_arm </param>
+      <param name="ports">  right_arm 	   </param>
+      <param name="joints"> 4			   </param>
+
+      <action phase="startup" level="5" type="attach">
+	  <paramlist name="networks">
+	  <!-- The param value must match the device name in the corresponding emsX file -->
+	      <elem name="FirstSetOfJoints">  cer_right_shoulder_mc </elem>
+	      <elem name="SecondSetOfJoints"> cer_right_upper_arm_mc</elem>
+	  </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER03/wrappers/motorControl/cer_right_wrist-mc_wrapper.xml
+++ b/CER03/wrappers/motorControl/cer_right_wrist-mc_wrapper.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_right_wrist_mc_wrapper" type="controlboardwrapper2">
+      <param name="period">   10   </param>
+      <paramlist name="networks">
+	  <!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+	  <elem name="FirstSetOfJoints">  0  2  0  2 </elem>
+      </paramlist>
+
+      <param name="name">   /cer/right_wrist  </param>
+      <param name="ports">  right_wrist       </param>
+      <param name="joints"> 3                       </param>
+
+      <action phase="startup" level="5" type="attach">
+	  <paramlist name="networks">
+	  <!-- The param value must match the device name in the corresponding emsX file -->
+	      <elem name="FirstSetOfJoints"> cer_right_lower_arm_mc </elem>
+
+	  </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER03/wrappers/motorControl/cer_right_wrist_tripod-mc_wrapper.xml
+++ b/CER03/wrappers/motorControl/cer_right_wrist_tripod-mc_wrapper.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_right_wrist_tripod_mc_wrapper" type="controlboardwrapper2">
+      <param name="period">   10   </param>
+      <paramlist name="networks">
+	  <!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+	  <elem name="FirstSetOfJoints">  0  2  0  2 </elem>
+      </paramlist>
+
+      <param name="name">   /cer/right_wrist_tripod  </param>
+      <param name="ports">  right_wrist_tripod       </param>
+      <param name="joints"> 3                       </param>
+
+      <action phase="startup" level="5" type="attach">
+	  <paramlist name="networks">
+	  <!-- The param value must match the device name in the corresponding emsX file -->
+	      <elem name="FirstSetOfJoints"> cer_right_lower_arm_mc  </elem>
+
+	  </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER03/wrappers/motorControl/cer_ros_wrapper.xml
+++ b/CER03/wrappers/motorControl/cer_ros_wrapper.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_all_joints_mc_wrapper" type="controlboardwrapper2">
+
+      <param name="period"> 10 </param>
+      <param name="name">   /cer/all_joints </param>
+      <param name="joints"> 28 </param>
+      
+      <paramlist name="networks">
+
+        <elem name="head">            0  1   0  1 </elem>  <!-- 2 -->
+        <elem name="torso">           2  5   0  3 </elem>  <!-- 4 -->
+        
+        <elem name="right_arm">       6  13  0  7 </elem>  <!-- 8 -->
+        <elem name="left_arm">        14 21  0  7 </elem>  <!-- 8 -->
+        <elem name="right_hand">      22 23  0  1 </elem>  <!-- 2 -->
+        <elem name="left_hand">       24 25  0  1 </elem>  <!-- 2 -->
+        <elem name="base">            26 27  0  1 </elem>  <!-- 2 -->
+
+      </paramlist>
+
+      <group name ="ROS">
+        <param name="useROS"> true </param>
+        <param name="ROS_topicName">  /joint_states </param>
+        <param name="ROS_nodeName">   /cer </param>
+      </group>
+      
+      <action phase="startup" level="5" type="attach">
+        <paramlist name="networks">  
+   
+         <elem name="head">        cer_head_mc_wrapper    </elem>     
+         <elem name="torso">       cer_torso_mc_wrapper   </elem>
+         <elem name="base">            cer_mobile_base_mc_wrapper </elem>
+
+         <elem name="right_arm">       cer_right_arm_no_hand_mc_wrapper </elem>
+         <elem name="right_hand">      cer_right_hand_mc </elem>
+
+         <elem name="left_arm">        cer_left_arm_no_hand_mc_wrapper </elem>
+         <elem name="left_hand">       cer_left_hand_mc </elem>
+
+         </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER03/wrappers/motorControl/cer_ros_wrapper_base_only.xml
+++ b/CER03/wrappers/motorControl/cer_ros_wrapper_base_only.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_all_joints_mc_wrapper" type="controlboardwrapper2">
+
+      <param name="period"> 10 </param>
+      <param name="name">   /cer/all_joints </param>
+      <param name="joints"> 2 </param>
+      
+      <paramlist name="networks">
+       <elem name="base">            0  1  0  1 </elem>
+
+      </paramlist>
+
+      <group name ="ROS">
+        <param name="useROS"> only </param>
+        <param name="ROS_topicName">  /base_joint_states </param>
+        <param name="ROS_nodeName">   /cer </param>
+      </group>
+      
+      <action phase="startup" level="5" type="attach">
+        <paramlist name="networks">
+
+         <elem name="base">            cer_mobile_base_mc_wrapper </elem>
+   
+         </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER03/wrappers/motorControl/cer_ros_wrapper_fix.xml
+++ b/CER03/wrappers/motorControl/cer_ros_wrapper_fix.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_all_joints_mc_wrapper" type="controlboardwrapper2">
+
+      <param name="period"> 10 </param>
+      <param name="name">   /cer/all_joints </param>
+      <param name="joints"> 28 </param>
+      
+      <paramlist name="networks">
+
+        <elem name="head">            0  1   0  1 </elem>  <!-- 2 -->
+        <elem name="torso">           2  5   0  3 </elem>  <!-- 4 -->
+        
+        <elem name="right_arm">       6  13  0  7 </elem>  <!-- 8 -->
+        <elem name="left_arm">        14 21  0  7 </elem>  <!-- 8 -->
+        <elem name="right_hand">      22 23  0  1 </elem>  <!-- 2 -->
+        <elem name="left_hand">       24 25  0  1 </elem>  <!-- 2 -->
+        <elem name="base">            26 27  0  1 </elem>  <!-- 2 -->
+
+      </paramlist>
+
+      <group name ="ROS">
+        <param name="useROS"> true </param>
+        <param name="ROS_topicName">  /joint_states </param>
+        <param name="ROS_nodeName">   /cer </param>
+      </group>
+      
+      <action phase="startup" level="5" type="attach">
+        <paramlist name="networks">  
+   
+         <elem name="head">        cer_head_mc_wrapper    </elem>     
+         <elem name="torso">       cer_torso_mc_wrapper   </elem>
+         <elem name="base">            cer_mobile_base_mc_wrapper </elem>
+
+         <elem name="right_arm">       cer_right_arm_mc_wrapper </elem>
+         <elem name="right_hand">      cer_right_hand_mc </elem>
+
+         <elem name="left_arm">        cer_left_arm_mc_wrapper </elem>
+         <elem name="left_hand">       cer_left_hand_mc </elem>
+
+         </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER03/wrappers/motorControl/cer_torso-mc_wrapper.xml
+++ b/CER03/wrappers/motorControl/cer_torso-mc_wrapper.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_torso_mc_wrapper" type="controlboardwrapper2">
+      <paramlist name="networks">
+	<!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+	<elem name="FirstSetOfJoints"> 0  2  0  2 </elem>
+	<elem name="SecondSetOfJoints"> 3  3  3  3 </elem>
+      </paramlist>
+
+      <param name="period"> 10 </param>
+      <param name="name">   /cer/torso	</param>
+      <param name="ports">  torso		</param>
+      <param name="joints"> 4			</param>
+
+      <action phase="startup" level="5" type="attach">
+	  <paramlist name="networks">
+	  <!-- The param value must match the device name in the corresponding emsX file -->
+	      <elem name="FirstSetOfJoints">  cer_torso_equivalent_mc </elem>
+	      <elem name="SecondSetOfJoints"> cer_torso_mc </elem>
+	  </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>
+

--- a/CER03/wrappers/motorControl/cer_torso_tripod-mc_wrapper.xml
+++ b/CER03/wrappers/motorControl/cer_torso_tripod-mc_wrapper.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_torso_tripod_mc_wrapper" type="controlboardwrapper2">
+      <param name="period">   10   </param>
+      <paramlist name="networks">
+	  <!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
+	  <elem name="FirstSetOfJoints">  0  2  0  2 </elem>
+      </paramlist>
+
+      <param name="name">   /cer/torso_tripod  </param>
+      <param name="ports">  torso_tripod       </param>
+      <param name="joints"> 3                  </param>
+
+      <action phase="startup" level="5" type="attach">
+	  <paramlist name="networks">
+	  <!-- The param value must match the device name in the corresponding emsX file -->
+	      <elem name="FirstSetOfJoints"> cer_torso_mc </elem>
+
+	  </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+
+  </device>

--- a/CER03/wrappers/rpLidar/laser_back_wrapper.xml
+++ b/CER03/wrappers/rpLidar/laser_back_wrapper.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cerLaserBackWrapper" type="Rangefinder2DWrapper">
+
+      <param name="period"> 10 </param>
+      <param name="name">   /cer/laser/back:o       </param>
+
+      <action phase="startup" level="5" type="attach">
+         <paramlist name="networks">
+            <elem name="cer_laser">  cer_laser_back_device </elem>
+         </paramlist>
+      </action>
+
+      <group name ="ROS">
+         <param name ="useROS"> true </param>
+         <param name ="ROS_nodeName"> /cer-laserBack </param>
+         <param name ="ROS_topicName"> /laserBack </param>
+         <param name ="frame_id"> /mobile_base_lidar_B </param>>
+
+      </group>
+
+      <action phase="shutdown" level="5" type="detach" />
+  </device>
+

--- a/CER03/wrappers/rpLidar/laser_double_wrapper.xml
+++ b/CER03/wrappers/rpLidar/laser_double_wrapper.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cerDoubleLaserWrapper" type="Rangefinder2DWrapper">
+
+      <param name="period"> 10 </param>
+      <param name="name">   /cer/laser:o       </param>
+
+      <action phase="startup" level="6" type="attach">
+         <paramlist name="networks">
+            <elem name="cer_laser">  cer_double_laser_device </elem>
+         </paramlist>
+      </action>
+
+      <group name ="ROS">
+         <param name ="useROS"> true </param>
+         <param name ="ROS_nodeName"> /cer-laser </param>
+         <param name ="ROS_topicName"> /laser</param>
+         <param name ="frame_id"> /mobile_base_double_lidar </param>
+      </group>
+
+      <action phase="shutdown" level="5" type="detach" />
+  </device>
+

--- a/CER03/wrappers/rpLidar/laser_front_wrapper.xml
+++ b/CER03/wrappers/rpLidar/laser_front_wrapper.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cerLaserFrontWrapper" type="Rangefinder2DWrapper">
+
+      <param name="period"> 10 </param>
+      <param name="name">   /cer/laser/front:o       </param>
+
+      <action phase="startup" level="5" type="attach">
+         <paramlist name="networks">
+            <elem name="cer_laser">  cer_laser_front_device </elem>
+         </paramlist>
+      </action>
+
+      <group name ="ROS">
+         <param name ="useROS"> true </param>
+         <param name ="ROS_nodeName"> /cer-laserFront </param>
+         <param name ="ROS_topicName"> /laserFront </param>
+         <param name ="frame_id"> /mobile_base_lidar_F </param>
+      </group>
+
+      <action phase="shutdown" level="5" type="detach" />
+  </device>
+

--- a/CER03/wrappers/rpLidar/laser_wrapper.xml
+++ b/CER03/wrappers/rpLidar/laser_wrapper.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cerLaserWrapper" type="Rangefinder2DWrapper">
+
+      <param name="period"> 10 </param>
+      <param name="name">   /cer/laser:o       </param>
+
+      <action phase="startup" level="5" type="attach">
+         <paramlist name="networks">
+            <elem name="cer_laser">  cer_laser_front_device </elem>
+         </paramlist>
+      </action>
+
+      <group name ="ROS">
+         <param name ="useROS"> true </param>
+         <param name ="ROS_nodeName"> /cer-laser </param>
+         <param name ="ROS_topicName"> /laser </param>
+         <param name ="frame_id"> /mobile_base_lidar </param>
+      </group>
+
+      <action phase="shutdown" level="5" type="detach" />
+  </device>
+

--- a/CER03/wrappers/skin/left_hand-skin_wrapper.xml
+++ b/CER03/wrappers/skin/left_hand-skin_wrapper.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<devices robot="CER03" build="1">
+    <device name="left_hand_skin_wrapper" type="skinWrapper">
+        <param name="period">       20                  </param>
+        <param name="total_taxels"> 576                 </param>
+        <param name="device">       skinWrapper         </param>
+        
+        <paramlist name="ports">
+            <elem name="left_hand_skin_index">      0   191     0   191   </elem>
+            <elem name="left_hand_skin_paddle">     192 383     0   191   </elem>
+            <elem name="left_hand_skin_thumb">      384 575     0   191   </elem>
+        </paramlist>
+        
+        <!-- used taxels:
+             left-index-proxy:      24 taxels of port left_hand_skin_index in positions [8*12, (9+1)*12-1]      = [96, 119]
+             left-index-distal:     24 taxels of port left_hand_skin_index in positions [0*12, (1+1)*12-1]      = [0, 23]
+             left-paddle-proxy:     48 taxels of port left_hand_skin_paddle in positions [0*12, (3+1)*12-1]     = [0, 47]
+             left-paddle-distal:    48 taxels of port left_hand_skin_paddle in positions [8*12, (11+1)*12-1]    = [96, 143]
+             left-thumb-proxy:      24 taxels of port left_hand_skin_thumb in positions [8*12, (9+1)*12-1]      = [96, 119]
+             left-thumb-distal:     36 taxels of port left_hand_skin_thumb in positions [0*12, (2+1)*12-1]      = [0, 35]
+          -->
+        
+        <action phase="startup" level="5" type="attach">
+            <paramlist name="networks">
+            <!-- The param value must match the device name in the corresponding emsX file -->
+                <elem name="FirstSetOfSkins"> left_hand_skin </elem>
+            </paramlist>
+        </action>
+
+        <action phase="shutdown" level="5" type="detach" />
+    </device>
+</devices>

--- a/CER03/wrappers/skin/right_hand-skin_wrapper.xml
+++ b/CER03/wrappers/skin/right_hand-skin_wrapper.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<devices robot="CER03" build="1">
+    <device name="right_hand_skin_wrapper" type="skinWrapper">
+        <param name="period">       20                  </param>
+        <param name="total_taxels"> 576                 </param>
+        <param name="device">       skinWrapper         </param>
+        
+        <paramlist name="ports">
+            <elem name="right_hand_skin_index">     0   191     0   191   </elem>
+            <elem name="right_hand_skin_paddle">    192 383     0   191   </elem>
+            <elem name="right_hand_skin_thumb">     384 575     0   191   </elem>
+        </paramlist>
+        
+        <!-- used taxels:
+             right-index-proxy:     24 taxels of port right_hand_skin_index in positions [0*12, (1+1)*12-1]     = [0, 23]
+             right-index-distal:    24 taxels of port right_hand_skin_index in positions [8*12, (9+1)*12-1]     = [96, 119]
+             right-paddle-proxy:    48 taxels of port right_hand_skin_paddle in positions [8*12, (11+1)*12-1]   = [96, 143]
+             right-paddle-distal:   48 taxels of port right_hand_skin_paddle in positions [0*12, (3+1)*12-1]    = [0, 47]
+             right-thumb-proxy:     24 taxels of port right_hand_skin_thumb in positions [0*12, (1+1)*12-1]     = [0, 23]
+             right-thumb-distal:    36 taxels of port right_hand_skin_thumb in positions [8*12, (10+1)*12-1]    = [96, 131]
+          -->        
+        
+        <action phase="startup" level="5" type="attach">
+            <paramlist name="networks">
+            <!-- The param value must match the device name in the corresponding emsX file -->
+                <elem name="FirstSetOfSkins"> right_hand_skin </elem>
+            </paramlist>
+        </action>
+
+        <action phase="shutdown" level="5" type="detach" />
+    </device>
+</devices>

--- a/CER03/yarplaserscannergui.ini
+++ b/CER03/yarplaserscannergui.ini
@@ -1,0 +1,5 @@
+scale            100 
+robot_radius     0.3575 // 715.0 / 2.0 / 1000.0m
+laser_position   0.245  // 245.0 / 1000.0m
+period           50
+sens_port        /cer/laser:o

--- a/CER03/yarpmotorgui.ini
+++ b/CER03/yarpmotorgui.ini
@@ -1,0 +1,4 @@
+name cer
+
+parts (torso torso_tripod mobile_base head left_arm right_arm left_wrist_tripod right_wrist_tripod left_hand right_hand all_joints)
+

--- a/CER03/yarprobotinterface.ini
+++ b/CER03/yarprobotinterface.ini
@@ -1,0 +1,2 @@
+config ./CER.xml
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ set(ROBOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/${ROBOT_NAME}")
 icubcontrib_set_default_prefix()
 
 if(INSTALL_ALL_ROBOTS)
-    # List the subdirectory (http://stackoverflow.com/questions/7787823/cmake-how-to-get-the-name-of-all-subdirectories-of-a-directory)
+    # List the subdirectories (http://stackoverflow.com/questions/7787823/cmake-how-to-get-the-name-of-all-subdirectories-of-a-directory)
     macro(SUBDIRLIST result curdir)
         file(GLOB children RELATIVE ${curdir} ${curdir}/*)
         set(dirlist "")

--- a/all_robots.xml
+++ b/all_robots.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <robot_database  xmlns:xi="http://www.w3.org/2001/XInclude">
+    <xi:include href="./CER01/CER.xml" />
+    <xi:include href="./CER02/CER.xml" />
+    <xi:include href="./CER03/CER.xml" />
 	<xi:include href="./iCubLugano01/icub_all.xml" />
 	<xi:include href="./iCubErzelli01/icub_all.xml" />
 	<xi:include href="./iCubParis01/icub_all.xml" />


### PR DESCRIPTION
This PR moves CER robots from the [`cer`][1] repository into this repository, as we discussed many times in the past. This change will be included in the upcoming Distro 2020.05.

Tested on a Ubuntu Focal system.

cc @Nicogene 

[1]: https://github.com/robotology/cer