### PR TITLE
Update iCubGenova02 torque control gains and right leg calibraiton

### DIFF
--- a/iCubGenova02/calibrators/right_leg-calib.xml
+++ b/iCubGenova02/calibrators/right_leg-calib.xml
@@ -19,7 +19,7 @@
 
 <group name="CALIBRATION">
 <param name="calibrationType">            12          12          12          12          12       12        </param>
-<param name="calibration1">           12927.0        64479       44479.0     45631.0    18847.0    9087.0    </param> 
+<param name="calibration1">           13375.0        64479       44458.0     45631.0    18847.0    9087.0    </param> 
 <param name="calibration2">             0.0          0.0         0.0         0.0         0.0        0.0      </param> 
 <param name="calibration3">             0.0          0.0         0.0         0.0         0.0        0.0      </param> 
 <param name="calibration4">             0.0          0.0         0.0         0.0         0.0        0.0      </param>

--- a/iCubGenova02/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
+++ b/iCubGenova02/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
@@ -67,7 +67,7 @@
         <param name="outputType">           pwm                 </param>
         <param name="fbkControlUnits">      metric_units        </param>
         <param name="outputControlUnits">   dutycycle_percent   </param>
-        <param name="kp">                   0.3         0.3         0.4         0.5     </param>
+        <param name="kp">                   0.6         0.6         0.7         0.9     </param>
         <param name="kd">                   0           0           0           0       </param>
         <param name="ki">                   0           0           0           0       </param>
         <param name="maxOutput">            25          25          25          25      </param>

--- a/iCubGenova02/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
+++ b/iCubGenova02/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
@@ -67,7 +67,7 @@
         <param name="outputType">           pwm                 </param>
         <param name="fbkControlUnits">      metric_units        </param>
         <param name="outputControlUnits">   dutycycle_percent   </param>
-        <param name="kp">            -0.2        0.2       -0.2       -0.2    </param>      
+        <param name="kp">            -0.4        0.45      -0.2       -0.4    </param>      
         <param name="kd">              0          0          0          0     </param>
         <param name="ki">              0          0          0          0     </param>
         <param name="maxOutput">      25         25         25         25     </param>

--- a/iCubGenova02/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
+++ b/iCubGenova02/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
@@ -67,7 +67,7 @@
         <param name="outputType">          pwm                          </param>
         <param name="fbkControlUnits">     metric_units                 </param>
         <param name="outputControlUnits">  dutycycle_percent            </param>
-        <param name="kp">             0         0            </param>
+        <param name="kp">             0.53      0.53           </param>
         <param name="kd">             0         0              </param>
         <param name="ki">             0         0              </param>
         <param name="maxOutput">     25         25             </param>

--- a/iCubGenova02/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
+++ b/iCubGenova02/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
@@ -67,7 +67,7 @@
         <param name="outputType">           pwm                          </param>
         <param name="fbkControlUnits">      metric_units                 </param>
         <param name="outputControlUnits">  dutycycle_percent            </param>
-        <param name="kp">            -0.3       -0.3       -0.4       -0.5     </param>
+        <param name="kp">            -0.6       -0.6       -0.7       -0.9    </param>
         <param name="kd">              0          0          0          0     </param>
         <param name="ki">              0          0          0          0     </param>
         <param name="maxOutput">      25         25         25         25     </param>

--- a/iCubGenova02/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
+++ b/iCubGenova02/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
@@ -67,7 +67,7 @@
         <param name="outputType">          pwm                          </param>
         <param name="fbkControlUnits">     metric_units                 </param>
         <param name="outputControlUnits">  dutycycle_percent            </param>
-        <param name="kp">             0.2       -0.2        0.2        0.2  </param>      
+        <param name="kp">             0.4       -0.45       0.2        0.4    </param>      
         <param name="kd">              0          0          0          0     </param>
         <param name="ki">              0          0          0          0     </param>
         <param name="maxOutput">      25         25         25         25     </param>

--- a/iCubGenova02/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
+++ b/iCubGenova02/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
@@ -67,7 +67,7 @@
         <param name="outputType">          pwm                          </param>
         <param name="fbkControlUnits">     metric_units                 </param>
         <param name="outputControlUnits">  dutycycle_percent            </param>
-        <param name="kp">              0          0             </param>
+        <param name="kp">              0.53       0.53          </param>
         <param name="kd">              0          0             </param>
         <param name="ki">              0          0             </param>
         <param name="maxOutput">      25         25             </param>

--- a/iCubGenova02/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubGenova02/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -67,7 +67,7 @@
         <param name="outputType">          pwm                          </param>
         <param name="fbkControlUnits">     metric_units                 </param>
         <param name="outputControlUnits">  dutycycle_percent            </param>
-        <param name="kp">           -0.3          0       -0.3  </param>
+        <param name="kp">            0.0          0        0.0  </param>
         <param name="kd">              0          0          0  </param>
         <param name="ki">              0          0          0  </param>
         <param name="maxOutput">      25         25         25  </param>

--- a/iCubGenova02/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubGenova02/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -67,7 +67,7 @@
         <param name="outputType">          pwm                          </param>
         <param name="fbkControlUnits">     metric_units                 </param>
         <param name="outputControlUnits">  dutycycle_percent            </param>
-        <param name="kp">              0          0          0  </param>
+        <param name="kp">           -0.3          0       -0.3  </param>
         <param name="kd">              0          0          0  </param>
         <param name="ki">              0          0          0  </param>
         <param name="maxOutput">      25         25         25  </param>


### PR DESCRIPTION
This PR updates:
- gains for the low-level torque control
- fine calibration of the right-leg (after fixing https://github.com/robotology/icub-tech-support/issues/945)