### PR TITLE
Update iCubGenova02 configuration

### DIFF
--- a/iCubGenova02/estimators/wholebodydynamics.xml
+++ b/iCubGenova02/estimators/wholebodydynamics.xml
@@ -11,7 +11,7 @@
         <param name="imuFrameName">imu_frame</param>
         <param name="publishOnROS">true</param>
         <param name="useJointVelocity">true</param>
-        <param name="useJointAcceleration">true</param>
+        <param name="useJointAcceleration">false</param>
         <param name="imuFilterCutoffInHz">3.0</param>
         <param name="forceTorqueFilterCutoffInHz">3.0</param>
         <param name="jointVelFilterCutoffInHz">3.0</param> <!-- used if useJointVelocity is set to true -->

--- a/iCubGenova02/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
+++ b/iCubGenova02/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
@@ -67,7 +67,7 @@
         <param name="outputType">           pwm                 </param>
         <param name="fbkControlUnits">      metric_units        </param>
         <param name="outputControlUnits">   dutycycle_percent   </param>
-        <param name="kp">            -0.4        0.45      -0.2       -0.4    </param>      
+        <param name="kp">            -0.4        0.45       0.0       -0.4    </param>      
         <param name="kd">              0          0          0          0     </param>
         <param name="ki">              0          0          0          0     </param>
         <param name="maxOutput">      25         25         25         25     </param>
@@ -76,7 +76,7 @@
         <param name="stictionUp">      0          0          0          0     </param>
         <param name="stictionDown">    0          0          0          0     </param>
         <param name="kff">             1          1          1          1     </param>
-        <param name="kbemf">        -0.003      0.003        0       -0.003   </param>
+        <param name="kbemf">           0          0          0          0     </param>
         <param name="filterType">      0          0          0          0     </param>
         <param name="ktau">         -0.51       0.56      -0.62      -0.52    </param>
     </group>

--- a/iCubGenova02/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
+++ b/iCubGenova02/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
@@ -67,7 +67,7 @@
         <param name="outputType">          pwm                          </param>
         <param name="fbkControlUnits">     metric_units                 </param>
         <param name="outputControlUnits">  dutycycle_percent            </param>
-        <param name="kp">             0.4       -0.45       0.0        0.4  </param>      
+        <param name="kp">             0.4       -0.45       0.0        0.4    </param>      
         <param name="kd">              0          0          0          0     </param>
         <param name="ki">              0          0          0          0     </param>
         <param name="maxOutput">      25         25         25         25     </param>

--- a/iCubGenova02/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
+++ b/iCubGenova02/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
@@ -67,7 +67,7 @@
         <param name="outputType">          pwm                          </param>
         <param name="fbkControlUnits">     metric_units                 </param>
         <param name="outputControlUnits">  dutycycle_percent            </param>
-        <param name="kp">             0.4       -0.45       0.2        0.4    </param>      
+        <param name="kp">             0.4       -0.45       0.0        0.4  </param>      
         <param name="kd">              0          0          0          0     </param>
         <param name="ki">              0          0          0          0     </param>
         <param name="maxOutput">      25         25         25         25     </param>
@@ -76,7 +76,7 @@
         <param name="stictionUp">      0          0          0          0     </param>
         <param name="stictionDown">    0          0          0          0     </param>
         <param name="kff">             1          1          1          1     </param>
-        <param name="kbemf">         0.003     -0.0025       0        0.0035  </param>
+        <param name="kbemf">           0          0          0          0     </param>
         <param name="filterType">      0          0          0          0     </param>
         <param name="ktau">          0.46      -0.63       0.68       0.52    </param>
     </group>


### PR DESCRIPTION
With this PR I update the `iCubGenova02` configuration files in order to enable it performing balancing on two feet.
In particular the changes are:
- legs friction compensation is set to zero
- set knees Kp to zero
- remove joint acceleration from wholebodydynamics

(it can be observed that the changes reflect what is done on `iCubGenova04`)