### PR TITLE
fix/strain2-v208

### DIFF
--- a/experimentalSetups/singleETHboard/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/experimentalSetups/singleETHboard/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                       </param>    
                         <param name="minor">            0                       </param> 
-                        <param name="build">            7                       </param>
+                        <param name="build">            8                       </param>
                     </group>
                 </group>
                 

--- a/iCubGenova02/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/iCubGenova02/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                       </param>    
                         <param name="minor">            0                       </param> 
-                        <param name="build">            7                       </param>
+                        <param name="build">            8                       </param>
                     </group>
                 </group>
                 

--- a/iCubGenova02/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/iCubGenova02/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                       </param>    
                         <param name="minor">            0                       </param> 
-                        <param name="build">            7                       </param>
+                        <param name="build">            8                       </param>
                     </group>
                 </group>
                 

--- a/iCubGenova02/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/iCubGenova02/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                       </param>    
                         <param name="minor">            0                       </param> 
-                        <param name="build">            7                       </param>
+                        <param name="build">            8                       </param>
                     </group>
                 </group>
                 

--- a/iCubGenova02/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/iCubGenova02/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                       </param>    
                         <param name="minor">            0                       </param> 
-                        <param name="build">            7                       </param>
+                        <param name="build">            8                       </param>
                     </group>
                 </group>
                 

--- a/iCubGenova04/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/iCubGenova04/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                       </param>    
                         <param name="minor">            0                       </param> 
-                        <param name="build">            7                       </param>
+                        <param name="build">            8                       </param>
                     </group>
                 </group>
                 

--- a/iCubGenova04/hardware/FT/left_leg-eb6-j0_3-strain2.xml
+++ b/iCubGenova04/hardware/FT/left_leg-eb6-j0_3-strain2.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                       </param>    
                         <param name="minor">            0                       </param> 
-                        <param name="build">            7                       </param>
+                        <param name="build">            8                       </param>
                     </group>
                 </group>
                 

--- a/iCubGenova04/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/iCubGenova04/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                       </param>    
                         <param name="minor">            0                       </param> 
-                        <param name="build">            7                       </param>
+                        <param name="build">            8                       </param>
                     </group>
                 </group>
                 

--- a/iCubGenova04/hardware/FT/left_leg-eb7-j4_5-strain2.xml
+++ b/iCubGenova04/hardware/FT/left_leg-eb7-j4_5-strain2.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                       </param>    
                         <param name="minor">            0                       </param> 
-                        <param name="build">            7                       </param>
+                        <param name="build">            8                       </param>
                     </group>
                 </group>
                 

--- a/iCubGenova04/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/iCubGenova04/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                       </param>    
                         <param name="minor">            0                       </param> 
-                        <param name="build">            7                       </param>
+                        <param name="build">            8                       </param>
                     </group>
                 </group>
                 

--- a/iCubGenova04/hardware/FT/right_leg-eb8-j0_3-strain2.xml
+++ b/iCubGenova04/hardware/FT/right_leg-eb8-j0_3-strain2.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                       </param>    
                         <param name="minor">            0                       </param> 
-                        <param name="build">            7                       </param>
+                        <param name="build">            8                       </param>
                     </group>
                 </group>
                 

--- a/iCubGenova04/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/iCubGenova04/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                       </param>    
                         <param name="minor">            0                       </param> 
-                        <param name="build">            7                       </param>
+                        <param name="build">            8                       </param>
                     </group>
                 </group>
                 

--- a/iCubGenova04/hardware/FT/right_leg-eb9-j4_5-strain2.xml
+++ b/iCubGenova04/hardware/FT/right_leg-eb9-j4_5-strain2.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                       </param>    
                         <param name="minor">            0                       </param> 
-                        <param name="build">            7                       </param>
+                        <param name="build">            8                       </param>
                     </group>
                 </group>
                 

--- a/iCubGenova04/hardware/inertials/left_leg-eb6-IMU.xml
+++ b/iCubGenova04/hardware/inertials/left_leg-eb6-IMU.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                   </param>
                         <param name="minor">            0                   </param>
-                        <param name="build">            7                   </param>
+                        <param name="build">            8                   </param>
                     </group>
                 </group>
 

--- a/iCubGenova04/hardware/inertials/left_leg-eb7-IMU.xml
+++ b/iCubGenova04/hardware/inertials/left_leg-eb7-IMU.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                   </param>
                         <param name="minor">            0                   </param>
-                        <param name="build">            7                   </param>
+                        <param name="build">            8                   </param>
                     </group>
                 </group>
 

--- a/iCubGenova04/hardware/inertials/left_leg-imu-example.xml
+++ b/iCubGenova04/hardware/inertials/left_leg-imu-example.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                   </param>    
                         <param name="minor">            0                   </param> 
-                        <param name="build">            7                   </param>
+                        <param name="build">            8                   </param>
                     </group>
                 </group>
 

--- a/iCubGenova04/hardware/inertials/right_leg-eb8-IMU.xml
+++ b/iCubGenova04/hardware/inertials/right_leg-eb8-IMU.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                   </param>
                         <param name="minor">            0                   </param>
-                        <param name="build">            7                   </param>
+                        <param name="build">            8                   </param>
                     </group>
                 </group>
 

--- a/iCubGenova04/hardware/inertials/right_leg-eb9-IMU.xml
+++ b/iCubGenova04/hardware/inertials/right_leg-eb9-IMU.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                   </param>
                         <param name="minor">            0                   </param>
-                        <param name="build">            7                   </param>
+                        <param name="build">            8                   </param>
                     </group>
                 </group>
 

--- a/iCubGenova07/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/iCubGenova07/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                       </param>    
                         <param name="minor">            0                       </param> 
-                        <param name="build">            7                       </param>
+                        <param name="build">            8                       </param>
                     </group>
                 </group>
                 

--- a/iCubGenova07/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/iCubGenova07/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                       </param>    
                         <param name="minor">            0                       </param> 
-                        <param name="build">            7                       </param>
+                        <param name="build">            8                       </param>
                     </group>
                 </group>
                 

--- a/iCubGenova07/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/iCubGenova07/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                       </param>    
                         <param name="minor">            0                       </param> 
-                        <param name="build">            7                       </param>
+                        <param name="build">            8                       </param>
                     </group>
                 </group>
                 

--- a/iCubGenova07/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/iCubGenova07/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                       </param>    
                         <param name="minor">            0                       </param> 
-                        <param name="build">            7                       </param>
+                        <param name="build">            8                       </param>
                     </group>
                 </group>
                 

--- a/iCubGenova07/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/iCubGenova07/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                       </param>    
                         <param name="minor">            0                       </param> 
-                        <param name="build">            7                       </param>
+                        <param name="build">            8                       </param>
                     </group>
                 </group>
                 

--- a/iCubGenova07/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/iCubGenova07/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                       </param>    
                         <param name="minor">            0                       </param> 
-                        <param name="build">            7                       </param>
+                        <param name="build">            8                       </param>
                     </group>
                 </group>
                 

--- a/iCubGenova07/hardware/inertials/left_leg-eb6-IMU.xml
+++ b/iCubGenova07/hardware/inertials/left_leg-eb6-IMU.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                   </param>
                         <param name="minor">            0                   </param>
-                        <param name="build">            7                   </param>
+                        <param name="build">            8                   </param>
                     </group>
                 </group>
 

--- a/iCubGenova07/hardware/inertials/left_leg-eb7-IMU.xml
+++ b/iCubGenova07/hardware/inertials/left_leg-eb7-IMU.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                   </param>
                         <param name="minor">            0                   </param>
-                        <param name="build">            7                   </param>
+                        <param name="build">            8                   </param>
                     </group>
                 </group>
 

--- a/iCubGenova07/hardware/inertials/right_leg-eb8-IMU.xml
+++ b/iCubGenova07/hardware/inertials/right_leg-eb8-IMU.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                   </param>
                         <param name="minor">            0                   </param>
-                        <param name="build">            7                   </param>
+                        <param name="build">            8                   </param>
                     </group>
                 </group>
 

--- a/iCubGenova07/hardware/inertials/right_leg-eb9-IMU.xml
+++ b/iCubGenova07/hardware/inertials/right_leg-eb9-IMU.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                   </param>
                         <param name="minor">            0                   </param>
-                        <param name="build">            7                   </param>
+                        <param name="build">            8                   </param>
                     </group>
                 </group>
 

--- a/iCubMoscow01/hardware/inertials/left_leg-eb6-IMU.xml
+++ b/iCubMoscow01/hardware/inertials/left_leg-eb6-IMU.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                   </param>
                         <param name="minor">            0                   </param>
-                        <param name="build">            7                   </param>
+                        <param name="build">            8                   </param>
                     </group>
                 </group>
 

--- a/iCubMoscow01/hardware/inertials/left_leg-eb7-IMU.xml
+++ b/iCubMoscow01/hardware/inertials/left_leg-eb7-IMU.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                   </param>
                         <param name="minor">            0                   </param>
-                        <param name="build">            7                   </param>
+                        <param name="build">            8                   </param>
                     </group>
                 </group>
 

--- a/iCubMoscow01/hardware/inertials/right_leg-eb8-IMU.xml
+++ b/iCubMoscow01/hardware/inertials/right_leg-eb8-IMU.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                   </param>
                         <param name="minor">            0                   </param>
-                        <param name="build">            7                   </param>
+                        <param name="build">            8                   </param>
                     </group>
                 </group>
 

--- a/iCubMoscow01/hardware/inertials/right_leg-eb9-IMU.xml
+++ b/iCubMoscow01/hardware/inertials/right_leg-eb9-IMU.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                   </param>
                         <param name="minor">            0                   </param>
-                        <param name="build">            7                   </param>
+                        <param name="build">            8                   </param>
                     </group>
                 </group>
 

--- a/iCubShenzhen/hardware/inertials/left_leg-eb6-IMU.xml
+++ b/iCubShenzhen/hardware/inertials/left_leg-eb6-IMU.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                   </param>
                         <param name="minor">            0                   </param>
-                        <param name="build">            7                   </param>
+                        <param name="build">            8                   </param>
                     </group>
                 </group>
 

--- a/iCubShenzhen/hardware/inertials/left_leg-eb7-IMU.xml
+++ b/iCubShenzhen/hardware/inertials/left_leg-eb7-IMU.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                   </param>
                         <param name="minor">            0                   </param>
-                        <param name="build">            7                   </param>
+                        <param name="build">            8                   </param>
                     </group>
                 </group>
 

--- a/iCubShenzhen/hardware/inertials/right_leg-eb8-IMU.xml
+++ b/iCubShenzhen/hardware/inertials/right_leg-eb8-IMU.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                   </param>
                         <param name="minor">            0                   </param>
-                        <param name="build">            7                   </param>
+                        <param name="build">            8                   </param>
                     </group>
                 </group>
 

--- a/iCubShenzhen/hardware/inertials/right_leg-eb9-IMU.xml
+++ b/iCubShenzhen/hardware/inertials/right_leg-eb9-IMU.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                   </param>
                         <param name="minor">            0                   </param>
-                        <param name="build">            7                   </param>
+                        <param name="build">            8                   </param>
                     </group>
                 </group>
 

--- a/iCubShenzhen01/hardware/inertials/left_leg-eb6-IMU.xml
+++ b/iCubShenzhen01/hardware/inertials/left_leg-eb6-IMU.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                   </param>
                         <param name="minor">            0                   </param>
-                        <param name="build">            7                   </param>
+                        <param name="build">            8                   </param>
                     </group>
                 </group>
 

--- a/iCubShenzhen01/hardware/inertials/left_leg-eb7-IMU.xml
+++ b/iCubShenzhen01/hardware/inertials/left_leg-eb7-IMU.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                   </param>
                         <param name="minor">            0                   </param>
-                        <param name="build">            7                   </param>
+                        <param name="build">            8                   </param>
                     </group>
                 </group>
 

--- a/iCubShenzhen01/hardware/inertials/right_leg-eb8-IMU.xml
+++ b/iCubShenzhen01/hardware/inertials/right_leg-eb8-IMU.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                   </param>
                         <param name="minor">            0                   </param>
-                        <param name="build">            7                   </param>
+                        <param name="build">            8                   </param>
                     </group>
                 </group>
 

--- a/iCubShenzhen01/hardware/inertials/right_leg-eb9-IMU.xml
+++ b/iCubShenzhen01/hardware/inertials/right_leg-eb9-IMU.xml
@@ -25,7 +25,7 @@
                     <group name="FIRMWARE">
                         <param name="major">            2                   </param>
                         <param name="minor">            0                   </param>
-                        <param name="build">            7                   </param>
+                        <param name="build">            8                   </param>
                     </group>
                 </group>
 


### PR DESCRIPTION
This PR is required to align the xml files to the latest version of the strain2 board which is 2.0.8

The change to 2.0.8 was done only for those xml  files which requested the previous version 2.07, so that the system can be aligned.
Here is the [log change of the new firmware build for strain2](https://github.com/robotology/icub-firmware-build/commit/f11975c9276c855fb5e18ef004c63ae22ecbe5fa)
 