### PR TITLE
[iCubGenova01] updated head calibration zeros

### DIFF
--- a/iCubGenova01/hardware/motorControl/icub_head.xml
+++ b/iCubGenova01/hardware/motorControl/icub_head.xml
@@ -32,7 +32,7 @@
     <param name="AxisName">       "neck_pitch" "neck_roll"    "neck_yaw"    "eyes_tilt"  "eyes_version"  "eyes_vergence" </param>
     <param name="AxisType">       "revolute"  "revolute"    "revolute"    "revolute"   "revolute"     "revolute" </param>
 <param name="Encoder">           11.375     -11.375 11.375  11.375     568.880   284.440      </param>
-<param name="Zeros">             176.50     -182.0 177.00  180.00     -52.80    0.00         </param>
+<param name="Zeros">             176.50     -182.0 177.00  180.00     -50.40    -8.00         </param>
     <param name="fullscalePWM">           1333            1333         1333      1333     1333    1333     </param>
     <param name="ampsToSensor">           1000.0          1000.0       1000.0    1000.0   1000.0  1000.0      </param>
 


### PR DESCRIPTION
The eyes of `iCubGenova01` were not parallel at home position (the right eye was pointing few degrees inward).
I calibrated the eyes following [this procedure](http://wiki.icub.org/wiki/HeadFineCalibration) and now the eyes are fairly parallel.
The PR updates [this file](https://github.com/robotology/robots-configuration/blob/master/iCubGenova01/hardware/motorControl/icub_head.xml) of `iCubGenova01` with the tested values.