### PR TITLE
[iCubGenova09] Tune low level position control

### DIFF
--- a/iCubGenova09/hardware/motorControl/left_arm-eb1-j0_1-mc.xml
+++ b/iCubGenova09/hardware/motorControl/left_arm-eb1-j0_1-mc.xml
@@ -6,12 +6,12 @@
     <xi:include href="../../general.xml"/>
     <xi:include href="../../hardware/electronics/left_arm-eb1-j0_1-eln.xml" />
     <xi:include href="../../hardware/mechanicals/left_arm-eb1-j0_1-mec.xml" />
-    <xi:include href="./left_arm-eb1-j0_1-mc_service.xml" />            
+    <xi:include href="./left_arm-eb1-j0_1-mc_service.xml" />
 
     <!-- joint number                           0                   1                   -->
-    <!-- joint name -->          
+    <!-- joint name                          shoulder_pitch        shoulder_roll        -->
     <group name="LIMITS">
-        <param name="jntPosMax">                13                  160                 </param>  
+        <param name="jntPosMax">                13                  160                 </param>
         <param name="jntPosMin">                -88                 12                  </param>
         <param name="jntVelMax">                120                 120                 </param>
         <param name="motorNominalCurrents">     5000                5000                </param>
@@ -28,10 +28,10 @@
         <param name="stiffness">                0.1                 0.1                 </param>
         <param name="damping">                  0.05                0.05                </param>
     </group>
-    
+
     <group name="CONTROLS">
-        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     </param>                                                                                                        
-        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     </param>                                                                                                        
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
         <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
         <param name="torqueControl">            none                none                </param>
         <param name="currentPid">               2FOC_CUR_CONTROL    2FOC_CUR_CONTROL    </param>
@@ -40,11 +40,11 @@
 
 
     <!-- default position PID: begin -->
-    
+
     <group name="POS_PID_DEFAULT">
 	    <param name="controlLaw">           minjerk             </param>
         <param name="outputType">           pwm                 </param>
-        <param name="fbkControlUnits">      metric_units        </param> 
+        <param name="fbkControlUnits">      metric_units        </param>
         <param name="outputControlUnits">   machine_units       </param>
         <param name="kff">                      0                   0                   </param>
         <param name="kp">                       1500                1000                </param>
@@ -55,12 +55,12 @@
         <param name="stictionUp">               0                   0                   </param>
         <param name="stictionDown">             0                   0                   </param>
     </group>
-    
+
     <!-- default position PID: end -->
 
 
-    <!-- other default PIDs: begin -->  
-    
+    <!-- other default PIDs: begin -->
+
     <group name="2FOC_CUR_CONTROL">
         <param name="controlLaw">           low_lev_current     </param>
         <param name="fbkControlUnits">      machine_units       </param>
@@ -88,15 +88,15 @@
     </group>
 
     <!-- other default PIDs: end -->
-    
-    
-    <!-- custom PIDs: begin -->   
+
+
+    <!-- custom PIDs: begin -->
     <!-- custom PIDs: end -->
-    
+
     <group name="OTHER_CONTROL_PARAMETERS">
         <param name="deadZone">                 0.0049              0.0049              </param>
     </group>
-    
+
 </device>
 
 

--- a/iCubGenova09/hardware/motorControl/left_arm-eb1-j0_1-mc.xml
+++ b/iCubGenova09/hardware/motorControl/left_arm-eb1-j0_1-mc.xml
@@ -46,14 +46,14 @@
         <param name="outputType">           pwm                 </param>
         <param name="fbkControlUnits">      metric_units        </param> 
         <param name="outputControlUnits">   machine_units       </param>
-        <param name="kff">                      0                   0                   </param> 
-        <param name="kp">                       1060                1060                </param>          
-        <param name="kd">                       0                   0                   </param>          
-        <param name="ki">                       980                 980                 </param>              
-        <param name="maxOutput">                8000                8000                </param>                
-        <param name="maxInt">                   2000                2000                </param>                             
-        <param name="stictionUp">               0                   0                   </param>          
-        <param name="stictionDown">             0                   0                   </param>        
+        <param name="kff">                      0                   0                   </param>
+        <param name="kp">                       1500                1000                </param>
+        <param name="kd">                       0                   0                   </param>
+        <param name="ki">                       1000                1000                </param>
+        <param name="maxOutput">                8000                8000                </param>
+        <param name="maxInt">                   2000                2000                </param>
+        <param name="stictionUp">               0                   0                   </param>
+        <param name="stictionDown">             0                   0                   </param>
     </group>
     
     <!-- default position PID: end -->

--- a/iCubGenova09/hardware/motorControl/left_arm-eb2-j2_3-mc.xml
+++ b/iCubGenova09/hardware/motorControl/left_arm-eb2-j2_3-mc.xml
@@ -6,12 +6,12 @@
     <xi:include href="../../general.xml"/>
     <xi:include href="../../hardware/electronics/left_arm-eb2-j2_3-eln.xml" />
     <xi:include href="../../hardware/mechanicals/left_arm-eb2-j2_3-mec.xml" />
-    <xi:include href="./left_arm-eb2-j2_3-mc_service.xml" />            
+    <xi:include href="./left_arm-eb2-j2_3-mc_service.xml" />
 
     <!-- joint number                           0                   1                   -->
-    <!-- joint name -->          
+    <!-- joint name                          shoulder_yaw          elbow                -->
     <group name="LIMITS">
-        <param name="jntPosMax">                80                  75                  </param>  
+        <param name="jntPosMax">                80                  75                  </param>
         <param name="jntPosMin">                -50                 -3                  </param>
         <param name="jntVelMax">                120                 120                 </param>
         <param name="motorNominalCurrents">     5000                5000                </param>
@@ -28,10 +28,10 @@
         <param name="stiffness">                0.1                 0.1                 </param>
         <param name="damping">                  0.05                0.05                </param>
     </group>
-    
+
     <group name="CONTROLS">
-        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     </param>                                                                                                        
-        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     </param>                                                                                                        
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
         <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
         <param name="torqueControl">            none                none                </param>
         <param name="currentPid">               2FOC_CUR_CONTROL    2FOC_CUR_CONTROL    </param>
@@ -40,11 +40,11 @@
 
 
     <!-- default position PID: begin -->
-    
+
     <group name="POS_PID_DEFAULT">
 	    <param name="controlLaw">           minjerk             </param>
         <param name="outputType">           pwm                 </param>
-        <param name="fbkControlUnits">      metric_units        </param> 
+        <param name="fbkControlUnits">      metric_units        </param>
         <param name="outputControlUnits">   machine_units       </param>
         <param name="kff">                      0                   0                   </param>
         <param name="kp">                       1000               -1000                </param>
@@ -55,12 +55,12 @@
         <param name="stictionUp">               0                   0                   </param>
         <param name="stictionDown">             0                   0                   </param>
     </group>
-    
+
     <!-- default position PID: end -->
 
 
-    <!-- other default PIDs: begin -->  
-    
+    <!-- other default PIDs: begin -->
+
     <group name="2FOC_CUR_CONTROL">
         <param name="controlLaw">           low_lev_current     </param>
         <param name="fbkControlUnits">      machine_units       </param>
@@ -88,15 +88,15 @@
     </group>
 
     <!-- other default PIDs: end -->
-    
-    
-    <!-- custom PIDs: begin -->   
+
+
+    <!-- custom PIDs: begin -->
     <!-- custom PIDs: end -->
-    
+
     <group name="OTHER_CONTROL_PARAMETERS">
         <param name="deadZone">                 0.0049              0.0049              </param>
     </group>
-    
+
 </device>
 
 

--- a/iCubGenova09/hardware/motorControl/left_arm-eb2-j2_3-mc.xml
+++ b/iCubGenova09/hardware/motorControl/left_arm-eb2-j2_3-mc.xml
@@ -46,14 +46,14 @@
         <param name="outputType">           pwm                 </param>
         <param name="fbkControlUnits">      metric_units        </param> 
         <param name="outputControlUnits">   machine_units       </param>
-        <param name="kff">                      0                   0                   </param> 
-        <param name="kp">                       1066               -1066               </param>          
-        <param name="kd">                       0                   0                   </param>          
-        <param name="ki">                       1000               -1000               </param>              
-        <param name="maxOutput">                8000                8000                </param>                
-        <param name="maxInt">                   1000                1000                </param>                             
-        <param name="stictionUp">               0                   0                   </param>          
-        <param name="stictionDown">             0                   0                   </param>        
+        <param name="kff">                      0                   0                   </param>
+        <param name="kp">                       1000               -1000                </param>
+        <param name="kd">                       0                   0                   </param>
+        <param name="ki">                       1000               -1000                </param>
+        <param name="maxOutput">                8000                8000                </param>
+        <param name="maxInt">                   1000                1000                </param>
+        <param name="stictionUp">               0                   0                   </param>
+        <param name="stictionDown">             0                   0                   </param>
     </group>
     
     <!-- default position PID: end -->

--- a/iCubGenova09/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
+++ b/iCubGenova09/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
@@ -33,19 +33,19 @@
     <group name="CONTROLS">
        <param name="positionControl">           POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
        <param name="velocityControl">           POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
-       <param name="mixedControl">              POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
+       <param name="mixedControl">              POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
        <param name="torqueControl">             none                none                none                none                </param>
        <param name="currentPid">                none                none                none                none                </param>
-       <param name="speedPid">                  none                none                none                none                </param> 
+       <param name="speedPid">                  none                none                none                none                </param>
     </group>
 
 
     <!-- default position PID: begin -->
-    
+
     <group name="POS_PID_DEFAULT">
         <param name="controlLaw">           minjerk                 </param>
         <param name="outputType">           pwm                     </param>
-        <param name="fbkControlUnits">      metric_units            </param> 
+        <param name="fbkControlUnits">      metric_units            </param>
         <param name="outputControlUnits">   machine_units           </param>
         <param name="kp">                   -500.0      -1000.0     -1000.0     -500.0      </param>
         <param name="kd">                   0           0           0           0           </param>
@@ -58,15 +58,15 @@
     </group>
 
     <!-- default position PID: end -->
-    
 
-    <!-- other default PIDs: begin -->     
+
+    <!-- other default PIDs: begin -->
     <!-- other default PIDs: end -->
-    
-    
-    <!-- custom PIDs: begin -->    
+
+
+    <!-- custom PIDs: begin -->
     <!-- custom PIDs: end -->
-    
+
 </device>
 
 

--- a/iCubGenova09/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
+++ b/iCubGenova09/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
@@ -47,7 +47,7 @@
         <param name="outputType">           pwm                     </param>
         <param name="fbkControlUnits">      metric_units            </param> 
         <param name="outputControlUnits">   machine_units           </param>
-        <param name="kp">                   -200.0      -250.0      -250.0      -500.0      </param>
+        <param name="kp">                   -500.0      -1000.0     -1000.0     -500.0      </param>
         <param name="kd">                   0           0           0           0           </param>
         <param name="ki">                   -200.0      -50.0       -50.0       -50.0       </param>
         <param name="maxOutput">            3360        3360        3360        3360        </param>

--- a/iCubGenova09/hardware/motorControl/left_leg-eb6-j0_1-mc.xml
+++ b/iCubGenova09/hardware/motorControl/left_leg-eb6-j0_1-mc.xml
@@ -5,20 +5,20 @@
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb6-j0_1-mc" type="embObjMotionControl">
     <xi:include href="../../general.xml" />
     <xi:include href="../../hardware/electronics/left_leg-eb6-j0_1-eln.xml" />
-    <xi:include href="../../hardware/mechanicals/left_leg-eb6-j0_1-mec.xml" /> 
+    <xi:include href="../../hardware/mechanicals/left_leg-eb6-j0_1-mec.xml" />
     <xi:include href="./left_leg-eb6-j0_1-mc_service.xml" />
 
     <!-- joint name                           hip_pitch            hip_roll             -->
     <!-- joint number                           0                   1                   -->
-    <!-- joint name -->          
+    <!-- joint name -->
     <group name="LIMITS">
         <param name="jntPosMax">                110                 110                 </param>
         <param name="jntPosMin">                -40                 -8                  </param>
-        <param name="jntVelMax">                240                 240                 </param>   
+        <param name="jntVelMax">                240                 240                 </param>
         <param name="motorNominalCurrents">     5000                5000                </param>
         <param name="motorPeakCurrents">        10000               10000               </param>
         <param name="motorOverloadCurrents">    15000               15000               </param>
-        <param name="motorPwmLimit">            16000               16000               </param>    
+        <param name="motorPwmLimit">            16000               16000               </param>
     </group>
 
     <group name="TIMEOUTS">
@@ -29,10 +29,10 @@
         <param name="stiffness">                0.1                 0.1                 </param>
         <param name="damping">                  0.05                0.05                </param>
     </group>
-    
+
     <group name="CONTROLS">
-        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     </param>                                                                                                        
-        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     </param>                                                                                                        
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
         <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
         <param name="torqueControl">            none                none                </param>
         <param name="currentPid">               2FOC_CUR_CONTROL    2FOC_CUR_CONTROL    </param>
@@ -41,11 +41,11 @@
 
 
     <!-- default position PID: begin -->
-    
+
     <group name="POS_PID_DEFAULT">
 	    <param name="controlLaw">           minjerk             </param>
         <param name="outputType">           pwm                 </param>
-        <param name="fbkControlUnits">      metric_units        </param> 
+        <param name="fbkControlUnits">      metric_units        </param>
         <param name="outputControlUnits">   machine_units       </param>
         <param name="kff">                      0                   0                   </param>
         <param name="kp">                       -3000               7000                </param>
@@ -56,12 +56,12 @@
         <param name="stictionUp">               0                   0                   </param>
         <param name="stictionDown">             0                   0                   </param>
     </group>
-    
+
     <!-- default position PID: end -->
 
 
-    <!-- other default PIDs: begin -->  
-    
+    <!-- other default PIDs: begin -->
+
     <group name="2FOC_CUR_CONTROL">
         <param name="controlLaw">           low_lev_current     </param>
         <param name="fbkControlUnits">      machine_units       </param>
@@ -89,15 +89,15 @@
     </group>
 
     <!-- other default PIDs: end -->
-    
-    
-    <!-- custom PIDs: begin -->   
+
+
+    <!-- custom PIDs: begin -->
     <!-- custom PIDs: end -->
-    
+
     <group name="OTHER_CONTROL_PARAMETERS">
         <param name="deadZone">                 0.0049              0.0049              </param>
     </group>
-    
+
   </device>
 
 

--- a/iCubGenova09/hardware/motorControl/left_leg-eb6-j0_1-mc.xml
+++ b/iCubGenova09/hardware/motorControl/left_leg-eb6-j0_1-mc.xml
@@ -8,6 +8,7 @@
     <xi:include href="../../hardware/mechanicals/left_leg-eb6-j0_1-mec.xml" /> 
     <xi:include href="./left_leg-eb6-j0_1-mc_service.xml" />
 
+    <!-- joint name                           hip_pitch            hip_roll             -->
     <!-- joint number                           0                   1                   -->
     <!-- joint name -->          
     <group name="LIMITS">
@@ -46,14 +47,14 @@
         <param name="outputType">           pwm                 </param>
         <param name="fbkControlUnits">      metric_units        </param> 
         <param name="outputControlUnits">   machine_units       </param>
-        <param name="kff">                      0                   0                   </param> 
-        <param name="kp">                       -1066               2066                </param>          
-        <param name="kd">                       0                   0                   </param>          
-        <param name="ki">                       -10666              14222               </param>              
-        <param name="maxOutput">                8000                8000                </param>                
-        <param name="maxInt">                   1500                1500                </param>                             
-        <param name="stictionUp">               0                   0                   </param>          
-        <param name="stictionDown">             0                   0                   </param>        
+        <param name="kff">                      0                   0                   </param>
+        <param name="kp">                       -3000               7000                </param>
+        <param name="kd">                       0                   0                   </param>
+        <param name="ki">                       -1500               5000                </param>
+        <param name="maxOutput">                8000                8000                </param>
+        <param name="maxInt">                   1500                5000                </param>
+        <param name="stictionUp">               0                   0                   </param>
+        <param name="stictionDown">             0                   0                   </param>
     </group>
     
     <!-- default position PID: end -->

--- a/iCubGenova09/hardware/motorControl/left_leg-eb7-j2_3-mc.xml
+++ b/iCubGenova09/hardware/motorControl/left_leg-eb7-j2_3-mc.xml
@@ -5,7 +5,7 @@
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb7-j2_3-mc" type="embObjMotionControl">
     <xi:include href="../../general.xml" />
     <xi:include href="../../hardware/electronics/left_leg-eb7-j2_3-eln.xml" />
-    <xi:include href="../../hardware/mechanicals/left_leg-eb7-j2_3-mec.xml" />      
+    <xi:include href="../../hardware/mechanicals/left_leg-eb7-j2_3-mec.xml" />
     <xi:include href="./left_leg-eb7-j2_3-mc_service.xml" />
 
     <!-- joint name                           hip_yaw            knee                   -->
@@ -28,10 +28,10 @@
         <param name="stiffness">                0.1                 0.1                 </param>
         <param name="damping">                  0.05                0.05                </param>
     </group>
-    
+
     <group name="CONTROLS">
-        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     </param>                                                                                                        
-        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     </param>                                                                                                        
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
         <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
         <param name="torqueControl">            none                none                </param>
         <param name="currentPid">               2FOC_CUR_CONTROL    2FOC_CUR_CONTROL    </param>
@@ -40,27 +40,27 @@
 
 
     <!-- default position PID: begin -->
-    
+
     <group name="POS_PID_DEFAULT">
 	    <param name="controlLaw">           minjerk             </param>
         <param name="outputType">           pwm                 </param>
-        <param name="fbkControlUnits">      metric_units        </param> 
+        <param name="fbkControlUnits">      metric_units        </param>
         <param name="outputControlUnits">   machine_units       </param>
-        <param name="kff">                      0                   0                   </param> 
-        <param name="kp">                       -711                -1066               </param>          
-        <param name="kd">                       0                   0                   </param>          
-        <param name="ki">                       -7111               -1066               </param>              
-        <param name="maxOutput">                8000                8000                </param>                
-        <param name="maxInt">                   750                 1000                </param>                             
-        <param name="stictionUp">               0                   0                   </param>          
-        <param name="stictionDown">             0                   0                   </param>        
+        <param name="kff">                      0                   0                   </param>
+        <param name="kp">                       -711                -5000               </param>
+        <param name="kd">                       0                   0                   </param>
+        <param name="ki">                       -7111               -1500               </param>
+        <param name="maxOutput">                8000                8000                </param>
+        <param name="maxInt">                   750                 2000                </param>
+        <param name="stictionUp">               0                   0                   </param>
+        <param name="stictionDown">             0                   0                   </param>
     </group>
-    
+
     <!-- default position PID: end -->
 
 
-    <!-- other default PIDs: begin -->  
-    
+    <!-- other default PIDs: begin -->
+
     <group name="2FOC_CUR_CONTROL">
         <param name="controlLaw">           low_lev_current     </param>
         <param name="fbkControlUnits">      machine_units       </param>
@@ -88,15 +88,15 @@
     </group>
 
     <!-- other default PIDs: end -->
-    
-    
-    <!-- custom PIDs: begin -->   
+
+
+    <!-- custom PIDs: begin -->
     <!-- custom PIDs: end -->
-    
+
     <group name="OTHER_CONTROL_PARAMETERS">
         <param name="deadZone">                 0.0049              0.0049              </param>
     </group>
-    
+
 </device>
 
 

--- a/iCubGenova09/hardware/motorControl/left_leg-eb7-j2_3-mc.xml
+++ b/iCubGenova09/hardware/motorControl/left_leg-eb7-j2_3-mc.xml
@@ -8,16 +8,16 @@
     <xi:include href="../../hardware/mechanicals/left_leg-eb7-j2_3-mec.xml" />      
     <xi:include href="./left_leg-eb7-j2_3-mc_service.xml" />
 
+    <!-- joint name                           hip_yaw            knee                   -->
     <!-- joint number                           0                   1                   -->
-    <!-- joint name -->  
     <group name="LIMITS">
         <param name="jntPosMax">                60                  3                   </param>
         <param name="jntPosMin">                -60                 -68                 </param>
-        <param name="jntVelMax">                240                 240                 </param>   
+        <param name="jntVelMax">                240                 240                 </param>
         <param name="motorNominalCurrents">     5000                5000                </param>
         <param name="motorPeakCurrents">        10000               10000               </param>
         <param name="motorOverloadCurrents">    15000               15000               </param>
-        <param name="motorPwmLimit">            16000               16000               </param>    
+        <param name="motorPwmLimit">            16000               16000               </param>
     </group>
 
     <group name="TIMEOUTS">

--- a/iCubGenova09/hardware/motorControl/left_leg-eb8-j4_5-mc.xml
+++ b/iCubGenova09/hardware/motorControl/left_leg-eb8-j4_5-mc.xml
@@ -5,7 +5,7 @@
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb8-j4_5-mc" type="embObjMotionControl">
     <xi:include href="../../general.xml" />
     <xi:include href="../../hardware/electronics/left_leg-eb8-j4_5-eln.xml" />
-    <xi:include href="../../hardware/mechanicals/left_leg-eb8-j4_5-mec.xml" />     
+    <xi:include href="../../hardware/mechanicals/left_leg-eb8-j4_5-mec.xml" />
     <xi:include href="./left_leg-eb8-j4_5-mc_service.xml" />
 
     <!-- joint name                           ankle_pitch            ankle_roll         -->
@@ -28,10 +28,10 @@
         <param name="stiffness">                0.1                 0.1                 </param>
         <param name="damping">                  0.05                0.05                </param>
     </group>
-    
+
     <group name="CONTROLS">
-        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     </param>                                                                                                        
-        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     </param>                                                                                                        
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
         <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
         <param name="torqueControl">            none                none                </param>
         <param name="currentPid">               2FOC_CUR_CONTROL    2FOC_CUR_CONTROL    </param>
@@ -40,11 +40,11 @@
 
 
     <!-- default position PID: begin -->
-    
+
     <group name="POS_PID_DEFAULT">
 	    <param name="controlLaw">           minjerk             </param>
         <param name="outputType">           pwm                 </param>
-        <param name="fbkControlUnits">      metric_units        </param> 
+        <param name="fbkControlUnits">      metric_units        </param>
         <param name="outputControlUnits">   machine_units       </param>
         <param name="kff">                      0                   0                   </param>
         <param name="kp">                       -5000               -3000               </param>
@@ -55,12 +55,12 @@
         <param name="stictionUp">               0                   0                   </param>
         <param name="stictionDown">             0                   0                   </param>
     </group>
-    
+
     <!-- default position PID: end -->
 
 
-    <!-- other default PIDs: begin -->  
-    
+    <!-- other default PIDs: begin -->
+
     <group name="2FOC_CUR_CONTROL">
         <param name="controlLaw">           low_lev_current     </param>
         <param name="fbkControlUnits">      machine_units       </param>
@@ -88,14 +88,14 @@
     </group>
 
     <!-- other default PIDs: end -->
-    
-    
-    <!-- custom PIDs: begin -->   
+
+
+    <!-- custom PIDs: begin -->
     <!-- custom PIDs: end -->
-    
+
     <group name="OTHER_CONTROL_PARAMETERS">
         <param name="deadZone">                 0.0049              0.0049              </param>
     </group>
-    
+
 </device>
 

--- a/iCubGenova09/hardware/motorControl/left_leg-eb8-j4_5-mc.xml
+++ b/iCubGenova09/hardware/motorControl/left_leg-eb8-j4_5-mc.xml
@@ -8,8 +8,8 @@
     <xi:include href="../../hardware/mechanicals/left_leg-eb8-j4_5-mec.xml" />     
     <xi:include href="./left_leg-eb8-j4_5-mc_service.xml" />
 
+    <!-- joint name                           ankle_pitch            ankle_roll         -->
     <!-- joint number                           0                   1                   -->
-    <!-- joint name -->  
     <group name="LIMITS">
         <param name="jntPosMax">                35                  23                  </param>
         <param name="jntPosMin">                -35                 -23                 </param>
@@ -17,7 +17,7 @@
         <param name="motorNominalCurrents">     5000                5000                </param>
         <param name="motorPeakCurrents">        10000               10000               </param>
         <param name="motorOverloadCurrents">    15000               15000               </param>
-        <param name="motorPwmLimit">            16000               16000               </param>    
+        <param name="motorPwmLimit">            16000               16000               </param>
     </group>
 
     <group name="TIMEOUTS">
@@ -46,14 +46,14 @@
         <param name="outputType">           pwm                 </param>
         <param name="fbkControlUnits">      metric_units        </param> 
         <param name="outputControlUnits">   machine_units       </param>
-        <param name="kff">                      0                   0                   </param> 
-        <param name="kp">                       -2105               -2310               </param>          
-        <param name="kd">                       0                   0                   </param>          
-        <param name="ki">                       -0.1               -0.1                 </param>              
-        <param name="maxOutput">                8000                8000                </param>                
-        <param name="maxInt">                   750                 1000                </param>                             
-        <param name="stictionUp">               0                   0                   </param>          
-        <param name="stictionDown">             0                   0                   </param>        
+        <param name="kff">                      0                   0                   </param>
+        <param name="kp">                       -5000               -3000               </param>
+        <param name="kd">                       0                   0                   </param>
+        <param name="ki">                       -1000               -1000                </param>
+        <param name="maxOutput">                8000                8000                </param>
+        <param name="maxInt">                   1000                1000                </param>
+        <param name="stictionUp">               0                   0                   </param>
+        <param name="stictionDown">             0                   0                   </param>
     </group>
     
     <!-- default position PID: end -->

--- a/iCubGenova09/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
+++ b/iCubGenova09/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
@@ -47,7 +47,7 @@
         <param name="outputType">           pwm                     </param>
         <param name="fbkControlUnits">      metric_units            </param> 
         <param name="outputControlUnits">   machine_units           </param>
-        <param name="kp">                   200.0       500.0       500.0       500.0       </param>
+        <param name="kp">                   500.0       1000.0      1000.0      500.0      </param>
         <param name="kd">                   0.0         0.0         0.0         0.0         </param>
         <param name="ki">                   200.0       50.0        50.0        50.0        </param>
         <param name="maxOutput">            3360        3360        3360        3360        </param>

--- a/iCubGenova09/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
+++ b/iCubGenova09/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
@@ -33,10 +33,10 @@
     <group name="CONTROLS">
        <param name="positionControl">           POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
        <param name="velocityControl">           POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
-       <param name="mixedControl">              POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
+       <param name="mixedControl">              POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
        <param name="torqueControl">             none                none                none                none                </param>
        <param name="currentPid">                none                none                none                none                </param>
-       <param name="speedPid">                  none                none                none                none                </param> 
+       <param name="speedPid">                  none                none                none                none                </param>
     </group>
 
 
@@ -45,7 +45,7 @@
     <group name="POS_PID_DEFAULT">
         <param name="controlLaw">           minjerk                 </param>
         <param name="outputType">           pwm                     </param>
-        <param name="fbkControlUnits">      metric_units            </param> 
+        <param name="fbkControlUnits">      metric_units            </param>
         <param name="outputControlUnits">   machine_units           </param>
         <param name="kp">                   500.0       1000.0      1000.0      500.0      </param>
         <param name="kd">                   0.0         0.0         0.0         0.0         </param>
@@ -56,15 +56,15 @@
         <param name="stictionDown">         0           0           0           0           </param>
         <param name="kff">                  0           0           0           0           </param>
     </group>
-    
-    <!-- default position PID: end -->
-    
 
-    <!-- other default PIDs: begin -->  
+    <!-- default position PID: end -->
+
+
+    <!-- other default PIDs: begin -->
     <!-- other default PIDs: end -->
-    
-    
-    <!-- custom PIDs: begin -->    
+
+
+    <!-- custom PIDs: begin -->
     <!-- custom PIDs: end -->
 
 </device>

--- a/iCubGenova09/hardware/motorControl/right_arm-eb3-j0_1-mc.xml
+++ b/iCubGenova09/hardware/motorControl/right_arm-eb3-j0_1-mc.xml
@@ -47,14 +47,14 @@
         <param name="outputType">           pwm                 </param>
         <param name="fbkControlUnits">      metric_units        </param> 
         <param name="outputControlUnits">   machine_units       </param>
-        <param name="kff">                      0                   0                   </param> 
-        <param name="kp">                       -1060               -1000               </param>          
-        <param name="kd">                       0                   0                   </param>          
-        <param name="ki">                       -1000               -1000               </param>              
-        <param name="maxOutput">                8000                8000                </param>                
-        <param name="maxInt">                   2000                2000                </param>                             
-        <param name="stictionUp">               0                   0                   </param>          
-        <param name="stictionDown">             0                   0                   </param>        
+        <param name="kff">                      0                   0                   </param>
+        <param name="kp">                       -1500               -1000               </param>
+        <param name="kd">                       0                   0                   </param>
+        <param name="ki">                       -1000               -1000               </param>
+        <param name="maxOutput">                8000                8000                </param>
+        <param name="maxInt">                   2000                2000                </param>
+        <param name="stictionUp">               0                   0                   </param>
+        <param name="stictionDown">             0                   0                   </param>
     </group>
     
     <!-- default position PID: end -->

--- a/iCubGenova09/hardware/motorControl/right_arm-eb3-j0_1-mc.xml
+++ b/iCubGenova09/hardware/motorControl/right_arm-eb3-j0_1-mc.xml
@@ -7,12 +7,12 @@
     <xi:include href="../../general.xml"/>
     <xi:include href="../../hardware/electronics/right_arm-eb3-j0_1-eln.xml" />
     <xi:include href="../../hardware/mechanicals/right_arm-eb3-j0_1-mec.xml" />
-    <xi:include href="./right_arm-eb3-j0_1-mc_service.xml" />            
+    <xi:include href="./right_arm-eb3-j0_1-mc_service.xml" />
 
     <!-- joint number                           0                   1                   -->
-    <!-- joint name -->          
+    <!-- joint name                          shoulder_pitch            shoulder_roll    -->
     <group name="LIMITS">
-        <param name="jntPosMax">                13                  160                 </param>  
+        <param name="jntPosMax">                13                  160                 </param>
         <param name="jntPosMin">                -88                 12                  </param>
         <param name="jntVelMax">                120                 120                 </param>
         <param name="motorNominalCurrents">     5000                5000                </param>
@@ -29,10 +29,10 @@
         <param name="stiffness">                0.1                 0.1                 </param>
         <param name="damping">                  0.05                0.05                </param>
     </group>
-    
+
     <group name="CONTROLS">
-        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     </param>                                                                                                        
-        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     </param>                                                                                                        
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
         <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
         <param name="torqueControl">            none                none                </param>
         <param name="currentPid">               2FOC_CUR_CONTROL    2FOC_CUR_CONTROL    </param>
@@ -41,11 +41,11 @@
 
 
     <!-- default position PID: begin -->
-    
+
     <group name="POS_PID_DEFAULT">
 	    <param name="controlLaw">           minjerk             </param>
         <param name="outputType">           pwm                 </param>
-        <param name="fbkControlUnits">      metric_units        </param> 
+        <param name="fbkControlUnits">      metric_units        </param>
         <param name="outputControlUnits">   machine_units       </param>
         <param name="kff">                      0                   0                   </param>
         <param name="kp">                       -1500               -1000               </param>
@@ -56,12 +56,12 @@
         <param name="stictionUp">               0                   0                   </param>
         <param name="stictionDown">             0                   0                   </param>
     </group>
-    
+
     <!-- default position PID: end -->
 
 
-    <!-- other default PIDs: begin -->  
-    
+    <!-- other default PIDs: begin -->
+
     <group name="2FOC_CUR_CONTROL">
         <param name="controlLaw">           low_lev_current     </param>
         <param name="fbkControlUnits">      machine_units       </param>
@@ -89,11 +89,11 @@
     </group>
 
     <!-- other default PIDs: end -->
-    
-    
-    <!-- custom PIDs: begin -->   
+
+
+    <!-- custom PIDs: begin -->
     <!-- custom PIDs: end -->
-    
+
     <group name="OTHER_CONTROL_PARAMETERS">
         <param name="deadZone">                 0.0049              0.0049              </param>
     </group>

--- a/iCubGenova09/hardware/motorControl/right_arm-eb4-j2_3-mc.xml
+++ b/iCubGenova09/hardware/motorControl/right_arm-eb4-j2_3-mc.xml
@@ -6,10 +6,12 @@
     <xi:include href="../../general.xml"/>
     <xi:include href="../../hardware/electronics/right_arm-eb4-j2_3-eln.xml" />
     <xi:include href="../../hardware/mechanicals/right_arm-eb4-j2_3-mec.xml" />
-    <xi:include href="./right_arm-eb4-j2_3-mc_service.xml" />            
+    <xi:include href="./right_arm-eb4-j2_3-mc_service.xml" />
 
-    <group name="LIMITS">        
-        <param name="jntPosMax">                80                  75                  </param>  
+    <!-- joint number                           2                   3                   -->
+    <!-- joint name                          shoulder_yaw            elbow              -->
+    <group name="LIMITS">
+        <param name="jntPosMax">                80                  75                  </param>
         <param name="jntPosMin">                -50                 -3                  </param>
         <param name="jntVelMax">                120                 120                 </param>
         <param name="motorNominalCurrents">     5000                5000                </param>
@@ -26,10 +28,10 @@
         <param name="stiffness">                0.1                 0.1                 </param>
         <param name="damping">                  0.05                0.05                </param>
     </group>
-    
+
     <group name="CONTROLS">
-        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     </param>                                                                                                        
-        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     </param>                                                                                                        
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
         <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
         <param name="torqueControl">            none                none                </param>
         <param name="currentPid">               2FOC_CUR_CONTROL    2FOC_CUR_CONTROL    </param>
@@ -38,27 +40,27 @@
 
 
     <!-- default position PID: begin -->
-    
+
     <group name="POS_PID_DEFAULT">
 	    <param name="controlLaw">           minjerk             </param>
         <param name="outputType">           pwm                 </param>
-        <param name="fbkControlUnits">      metric_units        </param> 
+        <param name="fbkControlUnits">      metric_units        </param>
         <param name="outputControlUnits">   machine_units       </param>
-        <param name="kff">                      0                   0                   </param> 
-        <param name="kp">                       -1000               1000                </param>          
-        <param name="kd">                       0                   0                   </param>          
-        <param name="ki">                       -1000               1000                </param>              
-        <param name="maxOutput">                8000                8000                </param>                
-        <param name="maxInt">                   2000                2000                </param>                             
-        <param name="stictionUp">               0                   0                   </param>          
-        <param name="stictionDown">             0                   0                   </param>        
+        <param name="kff">                      0                   0                   </param>
+        <param name="kp">                       -1000               1000                </param>
+        <param name="kd">                       0                   0                   </param>
+        <param name="ki">                       -1000               1000                </param>
+        <param name="maxOutput">                8000                8000                </param>
+        <param name="maxInt">                   2000                2000                </param>
+        <param name="stictionUp">               0                   0                   </param>
+        <param name="stictionDown">             0                   0                   </param>
     </group>
-    
+
     <!-- default position PID: end -->
 
 
-    <!-- other default PIDs: begin -->  
-    
+    <!-- other default PIDs: begin -->
+
     <group name="2FOC_CUR_CONTROL">
         <param name="controlLaw">           low_lev_current     </param>
         <param name="fbkControlUnits">      machine_units       </param>
@@ -86,15 +88,15 @@
     </group>
 
     <!-- other default PIDs: end -->
-    
-    
-    <!-- custom PIDs: begin -->   
+
+
+    <!-- custom PIDs: begin -->
     <!-- custom PIDs: end -->
-    
+
     <group name="OTHER_CONTROL_PARAMETERS">
         <param name="deadZone">                 0.0049              0.0049              </param>
     </group>
-    
+
   </device>
 
 

--- a/iCubGenova09/hardware/motorControl/right_leg-eb10-j0_1-mc.xml
+++ b/iCubGenova09/hardware/motorControl/right_leg-eb10-j0_1-mc.xml
@@ -14,8 +14,8 @@
         <param name="jntPosMax">                110                 110                 </param>
         <param name="jntPosMin">                -40                 -8                  </param>
         <param name="jntVelMax">                240                 240                 </param>
-        <param name="motorNominalCurrents">     5000                5000                </param>
-        <param name="motorPeakCurrents">        10000               10000               </param>
+        <param name="motorNominalCurrents">     5000                6000                </param>
+        <param name="motorPeakCurrents">        10000               11000               </param>
         <param name="motorOverloadCurrents">    15000               15000               </param>
         <param name="motorPwmLimit">            16000               16000               </param>
     </group>
@@ -47,9 +47,9 @@
         <param name="fbkControlUnits">      metric_units        </param>
         <param name="outputControlUnits">   machine_units       </param>
         <param name="kff">                      0                   0                   </param>
-        <param name="kp">                       5000                -7000               </param>
+        <param name="kp">                       5000                -25000               </param>
         <param name="kd">                       0                   0                   </param>
-        <param name="ki">                       1500                -4000               </param>
+        <param name="ki">                       1500                -5000               </param>
         <param name="maxOutput">                8000                8000                </param>
         <param name="maxInt">                   1500                5000                </param>
         <param name="stictionUp">               0                   0                   </param>

--- a/iCubGenova09/hardware/motorControl/right_leg-eb10-j0_1-mc.xml
+++ b/iCubGenova09/hardware/motorControl/right_leg-eb10-j0_1-mc.xml
@@ -9,15 +9,15 @@
     <xi:include href="./right_leg-eb10-j0_1-mc_service.xml" />
 
     <!-- joint number                           0                   1                   -->
-    <!-- joint name -->  
+    <!-- joint name                             hip_pitch         hip_roll              -->
     <group name="LIMITS">
         <param name="jntPosMax">                110                 110                 </param>
         <param name="jntPosMin">                -40                 -8                  </param>
-        <param name="jntVelMax">                240                 240                 </param> 
+        <param name="jntVelMax">                240                 240                 </param>
         <param name="motorNominalCurrents">     5000                5000                </param>
-	    <param name="motorPeakCurrents">        10000               10000               </param>
+        <param name="motorPeakCurrents">        10000               10000               </param>
         <param name="motorOverloadCurrents">    15000               15000               </param>
-        <param name="motorPwmLimit">            16000               16000               </param>    
+        <param name="motorPwmLimit">            16000               16000               </param>
     </group>
 
     <group name="TIMEOUTS">
@@ -28,10 +28,10 @@
         <param name="stiffness">                0.1                 0.1                 </param>
         <param name="damping">                  0.05                0.05                </param>
     </group>
-    
+
     <group name="CONTROLS">
-        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     </param>                                                                                                        
-        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     </param>                                                                                                        
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
         <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
         <param name="torqueControl">            none                none                </param>
         <param name="currentPid">               2FOC_CUR_CONTROL    2FOC_CUR_CONTROL    </param>
@@ -40,11 +40,11 @@
 
 
     <!-- default position PID: begin -->
-    
+
     <group name="POS_PID_DEFAULT">
 	    <param name="controlLaw">           minjerk             </param>
         <param name="outputType">           pwm                 </param>
-        <param name="fbkControlUnits">      metric_units        </param> 
+        <param name="fbkControlUnits">      metric_units        </param>
         <param name="outputControlUnits">   machine_units       </param>
         <param name="kff">                      0                   0                   </param>
         <param name="kp">                       5000                -7000               </param>
@@ -55,12 +55,12 @@
         <param name="stictionUp">               0                   0                   </param>
         <param name="stictionDown">             0                   0                   </param>
     </group>
-    
+
     <!-- default position PID: end -->
 
 
-    <!-- other default PIDs: begin -->  
-    
+    <!-- other default PIDs: begin -->
+
     <group name="2FOC_CUR_CONTROL">
         <param name="controlLaw">           low_lev_current     </param>
         <param name="fbkControlUnits">      machine_units       </param>
@@ -88,15 +88,15 @@
     </group>
 
     <!-- other default PIDs: end -->
-    
-    
-    <!-- custom PIDs: begin -->   
+
+
+    <!-- custom PIDs: begin -->
     <!-- custom PIDs: end -->
-    
+
     <group name="OTHER_CONTROL_PARAMETERS">
         <param name="deadZone">                 0.0049              0.0049              </param>
     </group>
-    
+
 </device>
 
 

--- a/iCubGenova09/hardware/motorControl/right_leg-eb10-j0_1-mc.xml
+++ b/iCubGenova09/hardware/motorControl/right_leg-eb10-j0_1-mc.xml
@@ -46,14 +46,14 @@
         <param name="outputType">           pwm                 </param>
         <param name="fbkControlUnits">      metric_units        </param> 
         <param name="outputControlUnits">   machine_units       </param>
-        <param name="kff">                      0                   0                   </param> 
-        <param name="kp">                       1066                -2066               </param>          
-        <param name="kd">                       0                   0                   </param>          
-        <param name="ki">                       10666               -14222              </param>              
-        <param name="maxOutput">                8000                8000                </param>                
-        <param name="maxInt">                   1500                1500                </param>                             
-        <param name="stictionUp">               0                   0                   </param>          
-        <param name="stictionDown">             0                   0                   </param>        
+        <param name="kff">                      0                   0                   </param>
+        <param name="kp">                       5000                -7000               </param>
+        <param name="kd">                       0                   0                   </param>
+        <param name="ki">                       1500                -4000               </param>
+        <param name="maxOutput">                8000                8000                </param>
+        <param name="maxInt">                   1500                5000                </param>
+        <param name="stictionUp">               0                   0                   </param>
+        <param name="stictionDown">             0                   0                   </param>
     </group>
     
     <!-- default position PID: end -->

--- a/iCubGenova09/hardware/motorControl/right_leg-eb11-j2_3-mc.xml
+++ b/iCubGenova09/hardware/motorControl/right_leg-eb11-j2_3-mc.xml
@@ -46,14 +46,14 @@
         <param name="outputType">           pwm                 </param>
         <param name="fbkControlUnits">      metric_units        </param> 
         <param name="outputControlUnits">   machine_units       </param>
-        <param name="kff">                      0                   0                   </param> 
-        <param name="kp">                       711                 1066                </param>          
-        <param name="kd">                       0                   0                   </param>          
-        <param name="ki">                       7111                1066                </param>              
-        <param name="maxOutput">                8000                8000                </param>                
-        <param name="maxInt">                   750                 1000                </param>                             
-        <param name="stictionUp">               0                   0                   </param>          
-        <param name="stictionDown">             0                   0                   </param>        
+        <param name="kff">                      0                   0                   </param>
+        <param name="kp">                       3000                5000                </param>
+        <param name="kd">                       0                   0                   </param>
+        <param name="ki">                       2000                1500                </param>
+        <param name="maxOutput">                8000                8000                </param>
+        <param name="maxInt">                   2000                2000                </param>
+        <param name="stictionUp">               0                   0                   </param>
+        <param name="stictionDown">             0                   0                   </param>
     </group>
     
     <!-- default position PID: end -->

--- a/iCubGenova09/hardware/motorControl/right_leg-eb11-j2_3-mc.xml
+++ b/iCubGenova09/hardware/motorControl/right_leg-eb11-j2_3-mc.xml
@@ -5,19 +5,19 @@
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb11-j2_3-mc" type="embObjMotionControl">
     <xi:include href="../../general.xml" />
     <xi:include href="../../hardware/electronics/right_leg-eb11-j2_3-eln.xml" />
-    <xi:include href="../../hardware/mechanicals/right_leg-eb11-j2_3-mec.xml" />      
+    <xi:include href="../../hardware/mechanicals/right_leg-eb11-j2_3-mec.xml" />
     <xi:include href="./right_leg-eb11-j2_3-mc_service.xml" />
 
     <!-- joint number                           0                   1                   -->
-    <!-- joint name -->  
+    <!-- joint name                           hip_yaw               knee                -->
     <group name="LIMITS">
         <param name="jntPosMax">                60                  3                   </param>
         <param name="jntPosMin">                -60                 -68                 </param>
-        <param name="jntVelMax">                240                 240                 </param> 
+        <param name="jntVelMax">                240                 240                 </param>
         <param name="motorNominalCurrents">     5000                5000                </param>
-	    <param name="motorPeakCurrents">        10000               10000               </param>
-        <param name="motorOverloadCurrents">    15000               15000               </param>  
-        <param name="motorPwmLimit">            16000               16000               </param>    
+	<param name="motorPeakCurrents">        10000               10000               </param>
+        <param name="motorOverloadCurrents">    15000               15000               </param>
+        <param name="motorPwmLimit">            16000               16000               </param>
     </group>
 
     <group name="TIMEOUTS">
@@ -28,10 +28,10 @@
         <param name="stiffness">                0.1                 0.1                 </param>
         <param name="damping">                  0.05                0.05                </param>
     </group>
-    
+
     <group name="CONTROLS">
-        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     </param>                                                                                                        
-        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     </param>                                                                                                        
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
         <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
         <param name="torqueControl">            none                none                </param>
         <param name="currentPid">               2FOC_CUR_CONTROL    2FOC_CUR_CONTROL    </param>
@@ -40,11 +40,11 @@
 
 
     <!-- default position PID: begin -->
-    
+
     <group name="POS_PID_DEFAULT">
 	    <param name="controlLaw">           minjerk             </param>
         <param name="outputType">           pwm                 </param>
-        <param name="fbkControlUnits">      metric_units        </param> 
+        <param name="fbkControlUnits">      metric_units        </param>
         <param name="outputControlUnits">   machine_units       </param>
         <param name="kff">                      0                   0                   </param>
         <param name="kp">                       3000                5000                </param>
@@ -55,12 +55,12 @@
         <param name="stictionUp">               0                   0                   </param>
         <param name="stictionDown">             0                   0                   </param>
     </group>
-    
+
     <!-- default position PID: end -->
 
 
-    <!-- other default PIDs: begin -->  
-    
+    <!-- other default PIDs: begin -->
+
     <group name="2FOC_CUR_CONTROL">
         <param name="controlLaw">           low_lev_current     </param>
         <param name="fbkControlUnits">      machine_units       </param>
@@ -88,15 +88,15 @@
     </group>
 
     <!-- other default PIDs: end -->
-    
-    
-    <!-- custom PIDs: begin -->   
+
+
+    <!-- custom PIDs: begin -->
     <!-- custom PIDs: end -->
-    
+
     <group name="OTHER_CONTROL_PARAMETERS">
         <param name="deadZone">                 0.0049              0.0049              </param>
     </group>
-    
+
 </device>
 
 

--- a/iCubGenova09/hardware/motorControl/right_leg-eb12-j4_5-mc.xml
+++ b/iCubGenova09/hardware/motorControl/right_leg-eb12-j4_5-mc.xml
@@ -46,14 +46,14 @@
         <param name="outputType">           pwm                 </param>
         <param name="fbkControlUnits">      metric_units        </param> 
         <param name="outputControlUnits">   machine_units       </param>
-        <param name="kff">                      0                   0                   </param> 
-        <param name="kp">                       2105                2310                </param>          
-        <param name="kd">                       0                   0                   </param>          
-        <param name="ki">                       0.1                 0.1                 </param>              
-        <param name="maxOutput">                8000                8000                </param>                
-        <param name="maxInt">                   750                 1000                </param>                             
-        <param name="stictionUp">               0                   0                   </param>          
-        <param name="stictionDown">             0                   0                   </param>        
+        <param name="kff">                      0                   0                   </param>
+        <param name="kp">                       5000                2310                </param>
+        <param name="kd">                       0                   0                   </param>
+        <param name="ki">                       1000                1000                 </param>
+        <param name="maxOutput">                8000                8000                </param>
+        <param name="maxInt">                   1000                1000                </param>
+        <param name="stictionUp">               0                   0                   </param>
+        <param name="stictionDown">             0                   0                   </param>
     </group>
     
     <!-- default position PID: end -->

--- a/iCubGenova09/hardware/motorControl/right_leg-eb12-j4_5-mc.xml
+++ b/iCubGenova09/hardware/motorControl/right_leg-eb12-j4_5-mc.xml
@@ -5,11 +5,11 @@
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb12-j4_5-mc" type="embObjMotionControl">
     <xi:include href="../../general.xml" />
     <xi:include href="../../hardware/electronics/right_leg-eb12-j4_5-eln.xml" />
-    <xi:include href="../../hardware/mechanicals/right_leg-eb12-j4_5-mec.xml" />     
+    <xi:include href="../../hardware/mechanicals/right_leg-eb12-j4_5-mec.xml" />
     <xi:include href="./right_leg-eb12-j4_5-mc_service.xml" />
 
     <!-- joint number                           0                   1                   -->
-    <!-- joint name -->  
+    <!-- joint name                             ankle_pitch         ankle_roll          -->
     <group name="LIMITS">
         <param name="jntPosMax">                35                  23              </param>
         <param name="jntPosMin">                -35                 -23             </param>
@@ -17,9 +17,9 @@
         <param name="motorNominalCurrents">     5000                5000            </param>
         <param name="motorPeakCurrents">        10000               10000           </param>
         <param name="motorOverloadCurrents">    15000               15000           </param>
-        <param name="motorPwmLimit">            16000               16000           </param>    
+        <param name="motorPwmLimit">            16000               16000           </param>
     </group>
-	
+
     <group name="TIMEOUTS">
         <param name="velocity">                 100                 100                 </param>
     </group>
@@ -28,10 +28,10 @@
         <param name="stiffness">                0.1                 0.1                 </param>
         <param name="damping">                  0.05                0.05                </param>
     </group>
-    
+
     <group name="CONTROLS">
-        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     </param>                                                                                                        
-        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     </param>                                                                                                        
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
         <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
         <param name="torqueControl">            none                none                </param>
         <param name="currentPid">               2FOC_CUR_CONTROL    2FOC_CUR_CONTROL    </param>
@@ -40,11 +40,11 @@
 
 
     <!-- default position PID: begin -->
-    
+
     <group name="POS_PID_DEFAULT">
 	    <param name="controlLaw">           minjerk             </param>
         <param name="outputType">           pwm                 </param>
-        <param name="fbkControlUnits">      metric_units        </param> 
+        <param name="fbkControlUnits">      metric_units        </param>
         <param name="outputControlUnits">   machine_units       </param>
         <param name="kff">                      0                   0                   </param>
         <param name="kp">                       5000                2310                </param>
@@ -55,12 +55,12 @@
         <param name="stictionUp">               0                   0                   </param>
         <param name="stictionDown">             0                   0                   </param>
     </group>
-    
+
     <!-- default position PID: end -->
 
 
-    <!-- other default PIDs: begin -->  
-    
+    <!-- other default PIDs: begin -->
+
     <group name="2FOC_CUR_CONTROL">
         <param name="controlLaw">           low_lev_current     </param>
         <param name="fbkControlUnits">      machine_units       </param>
@@ -88,14 +88,14 @@
     </group>
 
     <!-- other default PIDs: end -->
-    
-    
-    <!-- custom PIDs: begin -->   
+
+
+    <!-- custom PIDs: begin -->
     <!-- custom PIDs: end -->
-    
+
     <group name="OTHER_CONTROL_PARAMETERS">
         <param name="deadZone">                 0.0049              0.0049              </param>
     </group>
-    
+
 </device>
 

--- a/iCubGenova09/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubGenova09/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -11,7 +11,7 @@
 
     <!-- joint number                           roll               pitch              yaw               -->
     <!-- joint number                           0                   1                   2               -->
-    <!-- joint name -->          
+    <!-- joint name -->
     <group name="LIMITS">
         <param name="jntPosMax">                23                  45                  43                  </param>
         <param name="jntPosMin">                -23                 -18                 -43                 </param>
@@ -30,7 +30,7 @@
         <param name="stiffness">                0                   0                   0                   </param>
         <param name="damping">                  0                   0                   0                   </param>
     </group>
-    
+
     <group name="CONTROLS">
         <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
         <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
@@ -61,7 +61,7 @@
     <!-- default position PID: end -->
 
 
-    <!-- other default PIDs: begin -->  
+    <!-- other default PIDs: begin -->
 
     <group name="2FOC_CUR_CONTROL">
         <param name="controlLaw">           low_lev_current     </param>
@@ -90,15 +90,15 @@
     </group>
 
     <!-- other default PIDs: end -->
- 
- 
-    <!-- custom PIDs: begin -->    
+
+
+    <!-- custom PIDs: begin -->
     <!-- custom PIDs: end -->
-    
+
     <group name="OTHER_CONTROL_PARAMETERS">
         <param name="deadZone">             0.0049      0.0049      0.0049  </param>
     </group>
-    
+
 </device>
 
 

--- a/iCubGenova09/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubGenova09/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -9,6 +9,7 @@
     <xi:include href="../../hardware/mechanicals/torso-eb5-j0_2-mec.xml" />
     <xi:include href="./torso-eb5-j0_2-mc_service.xml" />
 
+    <!-- joint number                           roll               pitch              yaw               -->
     <!-- joint number                           0                   1                   2               -->
     <!-- joint name -->          
     <group name="LIMITS">
@@ -47,11 +48,11 @@
         <param name="outputType">             pwm                   </param>
         <param name="fbkControlUnits">        metric_units          </param>
         <param name="outputControlUnits">     machine_units         </param>
-        <param name="kp">           1500        1000       -1500        </param>
+        <param name="kp">           7000        4000       -1500        </param>
         <param name="kd">           0           0           0           </param>
-        <param name="ki">           1000        1000       -1000        </param>
+        <param name="ki">           3000        2000       -1000        </param>
         <param name="maxOutput">    8000        8000        8000        </param>
-        <param name="maxInt">       1000        1000        1000        </param>
+        <param name="maxInt">       3000        2000        1000        </param>
         <param name="stictionUp">   0           0           0           </param>
         <param name="stictionDown"> 0           0           0           </param>
         <param name="kff">          0           0           0           </param>

--- a/iCubGenova09/yarprobotinterface.ini
+++ b/iCubGenova09/yarprobotinterface.ini
@@ -1,2 +1,2 @@
-config ./icub_all_no_legs.xml
+config ./icub_all.xml
 


### PR DESCRIPTION
This PR changes the low-level position control gains for iCubGenova09. Furthermore, I also increase the current limits on the `r_hip_roll` to avoid the overcurrent problems.  

@ale-git could you tell me if these new limits seem fine for you

Thank you @isorrentino for the help :smile: 

cc @kouroshD @S-Dafarra @traversaro and @DanielePucci 