### PR TITLE
Fix the velocity feedback of the hand motors and the coupling matrix of the right thumb

### DIFF
--- a/iCubGenova04/hardware/mechanicals/left_arm-eb25-j8_11-mec.xml
+++ b/iCubGenova04/hardware/mechanicals/left_arm-eb25-j8_11-mec.xml
@@ -13,7 +13,7 @@
         <param name="Encoder">                  182.044          182.044            182.044          182.044         </param>    
         <param name="fullscalePWM">            3360            3360             3360            3360            </param>
         <param name="ampsToSensor">            1000.0          1000.0           1000.0          1000.0          </param>
-        <param name="Gearbox_M2J">              256                256                256           256              </param>
+        <param name="Gearbox_M2J">             -256            -256             -256            -256            </param>
         <param name="Gearbox_E2J">   	        1                 1                   1              1               </param>
         <param name="useMotorSpeedFbk">         1                 1                   1              1               </param>
         <param name="MotorType">               "DC"              "DC"                "DC"           "DC"               </param>

--- a/iCubGenova04/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubGenova04/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -13,7 +13,7 @@
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    
         <param name="fullscalePWM">             3360             3360               3360                3360            </param>
         <param name="ampsToSensor">             1000.0           1000.0             1000.0              1000.0          </param>
-        <param name="Gearbox_M2J">              256              256                 256                256             </param>
+        <param name="Gearbox_M2J">              -256             -256               -256                -256            </param>
         <param name="Gearbox_E2J">                1               1                  1                  1             </param>
         <param name="useMotorSpeedFbk">           1               1                  1                  1             </param>
         <param name="MotorType">               "DC"              "DC"                "DC"           "DC"               </param>

--- a/iCubGenova04/hardware/mechanicals/right_arm-eb28-j8_11-mec.xml
+++ b/iCubGenova04/hardware/mechanicals/right_arm-eb28-j8_11-mec.xml
@@ -13,7 +13,7 @@
         <param name="Encoder">                  182.044          182.044            182.044          182.044         </param>    
         <param name="fullscalePWM">             3360             3360               3360            3360             </param>
         <param name="ampsToSensor">             1000.0           1000.0             1000.0          1000.0           </param>
-        <param name="Gearbox_M2J">              256                256                256           256              </param>
+        <param name="Gearbox_M2J">              -256             -256               -256            -256             </param>
         <param name="Gearbox_E2J">   	        1                 1                   1              1               </param>
         <param name="useMotorSpeedFbk">         1                 1                   1              1               </param>
         <param name="MotorType">                "DC"             "DC"                "DC"           "DC"             </param>
@@ -31,14 +31,14 @@
                             
         <param name ="matrixJ2M"> 
             1.000   0.000   0.000   0.000
-           -1.000  +1.000   0.000   0.000
+           +1.000  +1.000   0.000   0.000
             0.000   0.000   1.000   0.000
             0.000   0.000   0.000   1.000   
         </param>
 
          <param name ="matrixM2J"> 
             1.000   0.000   0.000   0.000
-           +1.000  +1.000   0.000   0.000
+           -1.000  +1.000   0.000   0.000
             0.000   0.000   1.000   0.000
             0.000   0.000   0.000   1.000   
         </param>

--- a/iCubGenova04/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubGenova04/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -13,7 +13,7 @@
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   
         <param name="fullscalePWM">             3360              3360                3360             3360              </param>
         <param name="ampsToSensor">             1000.0            1000.0              1000.0           1000.0            </param>
-        <param name="Gearbox_M2J">               256              256                 256                256             </param>
+        <param name="Gearbox_M2J">              -256              -256                -256             -256             </param>
         <param name="Gearbox_E2J">   	           1                1                   1                  1             </param>
         <param name="useMotorSpeedFbk">            1                1                   1                  1             </param>
         <param name="MotorType">                  "DC"             "DC"                "DC"               "DC"           </param>


### PR DESCRIPTION
With this PR, we fix the problem with the right hand and left hand velocity feedbacks. Moreover, the coupling matrix for the right thumb is fixed as well.

Related issue: https://github.com/robotology/icub-tech-support/issues/1019