### PR TITLE
Fix appname for iCubGenovaV3

### DIFF
--- a/experimentalSetups/iCubGenovaV3/CMakeLists.txt
+++ b/experimentalSetups/iCubGenovaV3/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(appname iCubGenova04)
+set(appname iCubGenovaV3)
 
 file(GLOB xml ${CMAKE_CURRENT_SOURCE_DIR}/*.xml)
 file(GLOB ini ${CMAKE_CURRENT_SOURCE_DIR}/*.ini)


### PR DESCRIPTION
With @kourosh we experienced a strange issue while installing the iCubGenova04 files on iCubGenova04, namely it seems that two different directory where both installing to the `iCubGenova04`  directory, and indeed this strange behavior disappear by setting `INSTALL_ALL_ROBOTS` to `OFF`. While debugging this, @S-Dafarra found that the appname of this directory was wrong. In theory this directory is not added even if `INSTALL_ALL_ROBOTS` is `ON` so the problem on the iCubGenova04 still needs to be investigated, but in the meanwhile for cleanup I think it make sense to cleanup the appname used for this directory. 