### PR TITLE
iCubGenova09: Add configuration files for XSens IMU mounted on head

### DIFF
--- a/iCubGenova09/hardware/inertials/head-inertial.xml
+++ b/iCubGenova09/hardware/inertials/head-inertial.xml
@@ -2,9 +2,7 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
 
- <device xmlns:xi="http://www.w3.org/2001/XInclude" name="inertial" type="inertial">
-      <param name="name">  /icub/inertial  </param>
-      <param name="subdevice">  xsensmtx   </param>
-      <param name="serial">  /dev/ttyS0   </param>
+ <device xmlns:xi="http://www.w3.org/2001/XInclude" name="head-inertial" type="xsensmtx">
+      <param name="serial">  /dev/ttyS4   </param>
 </device>
 

--- a/iCubGenova09/icub_all.xml
+++ b/iCubGenova09/icub_all.xml
@@ -69,6 +69,13 @@
     <xi:include href="calibrators/right_leg-calib.xml" />
     <xi:include href="calibrators/torso-calib.xml" />
     
+    <!-- HEAD MTX INERTIAL SENSOR -->
+    <xi:include href="wrappers/inertials/head-imuFilter_wrapper.xml" />
+    <xi:include href="wrappers/inertials/head-imuFilter.xml" />
+    <xi:include href="wrappers/inertials/head-inertials_wrapper.xml" />
+    <xi:include href="wrappers/inertials/head-inertials_wrapper-deprecated.xml" /> 
+    <xi:include href="hardware/inertials/head-inertial.xml" />
+    
     </devices>
 </robot> 
  

--- a/iCubGenova09/icub_all_inertials.xml
+++ b/iCubGenova09/icub_all_inertials.xml
@@ -42,7 +42,11 @@
     <xi:include href="wrappers/motorControl/right_leg-mc_wrapper.xml" />
     
 
-    <!-- INERTIAL SENSOR--> 
+    <!-- HEAD MTX INERTIAL SENSOR -->
+    <xi:include href="wrappers/inertials/head-imuFilter_wrapper.xml" />
+    <xi:include href="wrappers/inertials/head-imuFilter.xml" />
+    <xi:include href="wrappers/inertials/head-inertials_wrapper.xml" />
+    <xi:include href="wrappers/inertials/head-inertials_wrapper-deprecated.xml" /> 
     <xi:include href="hardware/inertials/head-inertial.xml" />
     
     <!-- ANALOG SENSOR MAIS -->

--- a/iCubGenova09/wrappers/inertials/head-imuFilter.xml
+++ b/iCubGenova09/wrappers/inertials/head-imuFilter.xml
@@ -1,0 +1,22 @@
+
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="head-imuFilter" type="imuFilter">
+        <param name="period">       10                  </param>
+        <param name="name">     /imuFilter              </param>
+
+
+        <action phase="startup" level="5" type="attach">
+            <paramlist name="networks">
+                <!-- The name of the element can be any string (we use SetOfIMUs to better express its nature).
+                     Its value must match the device name in the corresponding body_part-jx_y-inertials.xml file
+                     or in body_part-ebX-inertials.xml -->
+                <elem name="SetOfIMUs"> head-inertial</elem>
+            </paramlist>
+        </action>
+
+        <action phase="shutdown" level="5" type="detach" />
+    </device>
+    

--- a/iCubGenova09/wrappers/inertials/head-imuFilter_wrapper.xml
+++ b/iCubGenova09/wrappers/inertials/head-imuFilter_wrapper.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="head-imuFilter_wrapper" type="multipleanalogsensorsserver">
+        <param name="period">       10                  </param>
+        <param name="name">     /imuFilter              </param>
+
+
+        <action phase="startup" level="6" type="attach">
+            <paramlist name="networks">
+                <!-- The name of the element can be any string (we use SetOfIMUs to better express its nature).
+                     Its value must match the device name in the corresponding body_part-jx_y-inertials.xml file
+                     or in body_part-ebX-inertials.xml -->
+                <elem name="SetOfIMUs"> head-imuFilter </elem>
+            </paramlist>
+        </action>
+
+        <action phase="shutdown" level="6" type="detach" />
+    </device>
+    

--- a/iCubGenova09/wrappers/inertials/head-inertials_wrapper-deprecated.xml
+++ b/iCubGenova09/wrappers/inertials/head-inertials_wrapper-deprecated.xml
@@ -1,0 +1,21 @@
+
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="head-inertials_wrapper-deprecated" type="inertial">
+        <param name="name">  /icub/inertial  </param>
+
+
+        <action phase="startup" level="5" type="attach">
+            <paramlist name="networks">
+                <!-- The name of the element can be any string (we use SetOfIMUs to better express its nature).
+                     Its value must match the device name in the corresponding body_part-jx_y-inertials.xml file
+                     or in body_part-ebX-inertials.xml -->
+                <elem name="SetOfIMUs"> head-inertial </elem>
+            </paramlist>
+        </action>
+
+        <action phase="shutdown" level="5" type="detach" />
+    </device> 
+    

--- a/iCubGenova09/wrappers/inertials/head-inertials_wrapper.xml
+++ b/iCubGenova09/wrappers/inertials/head-inertials_wrapper.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="head-inertials_wrapper" type="multipleanalogsensorsserver">
+        <param name="period">       10                  </param>
+        <param name="name">     /icub/head/inertials       </param>
+
+
+        <action phase="startup" level="5" type="attach">
+            <paramlist name="networks">
+                <!-- The name of the element can be any string (we use SetOfIMUs to better express its nature).
+                     Its value must match the device name in the corresponding body_part-jx_y-inertials.xml file
+                     or in body_part-ebX-inertials.xml -->
+                <elem name="SetOfIMUs"> head-inertial </elem>
+            </paramlist>
+        </action>
+
+        <action phase="shutdown" level="5" type="detach" />
+    </device> 
+    


### PR DESCRIPTION
This PR includes modifications to `iCubGenova09` `inertials` configurations to include the XSens IMU mounted on the head temporarily as a replacement for the Bosch IMU in the RFE boards.

- [ ] Running the modified `yarprobotinterface` that includes the head IMU remains to be tested.

cc @pattacini @davidetome @S-Dafarra @GiulioRomualdi @traversaro  @DanielePucci 