### PR TITLE
[iCubGenova01] Calibrate hall sensor encoder of joint l_thumb_oppose

### DIFF
--- a/iCubGenova01/calibrators/left_hand_calib.xml
+++ b/iCubGenova01/calibrators/left_hand_calib.xml
@@ -21,7 +21,7 @@
 <!--USE THIS FOR CAN ROBOT CALIBRATION-->
 <group name="CALIBRATION">
 <param name="calibrationType">                                                                                            3        4        4        4        4        4        4        4        </param>
-<param name="calibration1">                                                                                               1338.9   235.0    15.0     245.0    32.0     245.0    15.0     710.0    </param>
+<param name="calibration1">                                                                                               1204.5   235.0    15.0     245.0    32.0     245.0    15.0     710.0    </param>
 <param name="calibration2">                                                                                               10.0     10.0     30.0     10.0     10.0     10.0     10.0     10.0     </param>
 <param name="calibration3">                                                                                               0.0      6000.0   -6600.0  6000.0   7000.0   6000.0   -7000.0  -14000.0 </param>
 <param name="startupPosition">                                                                                               45.0     0.0      0.0      0.0      0.0      0.0      0.0      0.0      </param>

--- a/iCubGenova01/hardware/motorControl/icub_left_hand.xml
+++ b/iCubGenova01/hardware/motorControl/icub_left_hand.xml
@@ -31,8 +31,8 @@
 <param name="AxisMap">      0             1             2             3             4             5             6             7             </param>       
 <param name="AxisName">     "l_thumb_oppose"     "l_thumb_proximal"     "l_thumb_distal"   "l_index_proximal"    "l_index_distal"    "l_middle_proximal"   "l_middle_distal"    "l_pinky"  </param>
 <param name="AxisType">    "revolute"  "revolute"    "revolute"    "revolute"   "revolute"     "revolute"   "revolute"     "revolute"       </param>
-<param name="Encoder">                                                                                                    8.889    -2.167   -2.765   -2.611   -2.565   -2.722   -2.812   -2.460   </param>
-<param name="Zeros">                                                                                                      140.63   -108.46  -175.43  -93.83   -182.48  -90.00   -175.33  -288.62  </param>
+<param name="Encoder">                                                                                                    9.85    -2.167   -2.765   -2.611   -2.565   -2.722   -2.812   -2.460   </param>
+<param name="Zeros">                                                                                                      112.22   -108.46  -175.43  -93.83   -182.48  -90.00   -175.33  -288.62  </param>
 <param name="fullscalePWM">           1333            1333         1333      1333     1333    1333     1333    1333  </param>
 <param name="ampsToSensor">           1000.0          1000.0       1000.0    1000.0   1000.0  1000.0   1000.0  1000.0   </param>
 


### PR DESCRIPTION
As per the title, this PR changes calibration parameters and conversion parameters for the Hall-effect sensor of the left thumb opposition joint.