### PR TITLE
iCubGenova01: Calibrate encoder of joint l_hand_finger

### DIFF
--- a/iCubGenova01/calibrators/left_arm_calib.xml
+++ b/iCubGenova01/calibrators/left_arm_calib.xml
@@ -12,17 +12,17 @@
  
 <!--USE THIS FOR CAN ROBOT MOTOR CONTROL-->
 <group name="HOME">
-<param name="positionHome">                       -30        30         0          45         0          0          40         15         </param>
+<param name="positionHome">                       -30        30         0          45         0          0          40         30         </param>
 <param name="velocityHome">                       10         10         10         10         30         30         30         100        </param>
 </group>
 
 <!--USE THIS FOR CAN ROBOT CALIBRATION-->
 <group name="CALIBRATION">
 <param name="calibrationType">                    3          3          3          3          0          3          3          3          </param>
-<param name="calibration1">                       2388.8     3241.9     -275.9     1535.6     500.0      2047.5     2047.5     2159.0     </param>
+<param name="calibration1">                       2388.8     3241.9     -275.9     1535.6     500.0      2047.5     2047.5     2412.6     </param>
 <param name="calibration2">                       10.0       10.0       10.0       10.0       20.0       10.0       10.0       100.0      </param>
 <param name="calibration3">                       1337.5     1465.9     3508.4     980.5      0.0        1932.5     3887.5     0.0        </param>
-<param name="startupPosition">                       -30.0      30.0       0.0        45.0       0.0        0.0        0.0        15.0       </param>
+<param name="startupPosition">                       -30.0      30.0       0.0        45.0       0.0        0.0        0.0        30.0       </param>
 <param name="startupVelocity">                       10.0       10.0       10.0       10.0       30.0       30.0       30.0       100.0      </param>
 <param name="startupMaxPwm">                             120        120        120        120        0          0          0          0          </param>
 <param name="startupPosThreshold">                   2          2          2          2          2          2          90         90         </param>

--- a/iCubGenova01/hardware/motorControl/icub_left_arm.xml
+++ b/iCubGenova01/hardware/motorControl/icub_left_arm.xml
@@ -31,8 +31,8 @@
 <param name="AxisMap">      0             1             2             3             4             5             6             7             </param>
 <param name="AxisName">    "l_shoulder_pitch" "l_shoulder_roll" "l_shoulder_yaw" "l_elbow"   "l_wrist_prosup" "l_wrist_pitch" "l_wrist_yaw"  "l_hand_finger" </param>
 <param name="AxisType">    "revolute"  "revolute"    "revolute"    "revolute"   "revolute"     "revolute"     "revolute"     "revolute"    </param>
-<param name="Encoder">      -11.375    -11.375    -11.375    -11.375    706.67     -11.375    11.375     -4.95          </param>
-<param name="Zeros">        -179.00    -327.00    20.26      -187.00    -75.00     -180.00    183.00     -436.16     </param>
+<param name="Encoder">      -11.375    -11.375    -11.375    -11.375    706.67     -11.375    11.375     -6.244          </param>
+<param name="Zeros">        -179.00    -327.00    20.26      -187.00    -75.00     -180.00    183.00     -386.4     </param>
 <param name="fullscalePWM">   800       800           800           800           1333          1333        1333         1333          </param>
 <param name="ampsToSensor">   1000.0    1000.0        1000.0        1000.0        1000.0        1000.0      1000.0       1000.0          </param>   
 
@@ -58,7 +58,7 @@
 </group>
 
 <group name="LIMITS">
-<param name="jntPosMin">          -95.5         0             -30           15            -60           -80           -20           0             </param>       
+<param name="jntPosMin">          -95.5         0             -30           15            -60           -80           -20          15.0             </param>
 <param name="jntPosMax">          10            160.8         75            106            60            25            25          60             </param>
 <param name="motorOverloadCurrents">     7000          7000          7000          7000          1000          800           800           800            </param>
 </group>


### PR DESCRIPTION
As per the title, this PR changes calibration parameters and conversion parameters for the encoder responsible for the the left hand abduction/adduction joints.

After some tests with @julijenv, we realized that, for this hand on this robot, a feasible range of motion is from `60.0` (i.e. closed fingers) to `15.0` (i.e. almost far apart but not completely). Reaching `0.0` is not feasible (mechanically possible but rather difficult in terms of control effort requirements). For this reason the limits were moved from `[0.0, 60.0]` to `[15.0, 60.0]` leading to a overall range of motion of 45 degrees.