### PR TITLE
iCubGenova01: Calibrate hall sensor encoder of joints r_thumb_{oppose, proximal, distal}

### DIFF
--- a/iCubGenova01/calibrators/right_hand_calib.xml
+++ b/iCubGenova01/calibrators/right_hand_calib.xml
@@ -22,7 +22,7 @@
 <!--USE THIS FOR CAN ROBOT CALIBRATION-->
 <group name="CALIBRATION">
 <param name="calibrationType">                                                                                            3        4        4        4        4        4        4        4        </param>
-<param name="calibration1">                                                                                               1352.33  220.0    0.0      238.0    40.0     243.0    15.0     681.0    </param>
+<param name="calibration1">                                                                                               1547.8  251.0    30.0      238.0    40.0     243.0    15.0     681.0    </param>
 <param name="calibration2">                                                                                               10.0     10.0     30.0     10.0     10.0     10.0     10.0     10.0     </param>
 <param name="calibration3">                                                                                               0.0      6000.0   6600.0   6000.0   -7000.0  6000.0   7000.0   14000.0  </param>
 <param name="startupPosition">                                                                                               45.0     0.0      0.0      0.0      0.0      0.0      0.0      0.0      </param>

--- a/iCubGenova01/hardware/motorControl/icub_right_hand.xml
+++ b/iCubGenova01/hardware/motorControl/icub_right_hand.xml
@@ -31,8 +31,8 @@
 <param name="AxisMap">      0             1             2             3             4             5             6             7             </param>       
 <param name="AxisName">    "r_thumb_oppose"     "r_thumb_proximal"     "r_thumb_distal"   "r_index_proximal"    "r_index_distal"    "r_middle_proximal"   "r_middle_distal"    "r_pinky"  </param>
 <param name="AxisType">    "revolute"  "revolute"    "revolute"    "revolute"   "revolute"     "revolute"   "revolute"     "revolute"       </param>
-<param name="Encoder">       7.633    -2.30   -2.753   -2.500   -2.494   -2.70   -2.529   -1.884   </param>
-<param name="Zeros">         167.16   -95.65  -170.00  -95.20   -186.04  -90.0   -175.93  -361.46  </param>
+<param name="Encoder">       10.778    -2.344   -2.771   -2.500   -2.494   -2.70   -2.529   -1.884   </param>
+<param name="Zeros">         133.61   -107.06  -180.83  -95.20   -186.04  -90.0   -175.93  -361.46  </param>
 <param name="fullscalePWM">           1333            1333         1333      1333     1333    1333     1333    1333  </param>
 <param name="ampsToSensor">           1000.0          1000.0       1000.0    1000.0   1000.0  1000.0   1000.0  1000.0   </param>
 


### PR DESCRIPTION
As per the title, this PR changes calibration parameters and conversion parameters for the Hall-effect sensor of the right thumb opposition, proximal and distal joints.