### PR TITLE
iCubGenova01: Calibrate hall effect sensor encoder of left/right hand joints

### DIFF
--- a/iCubGenova01/calibrators/left_hand_calib.xml
+++ b/iCubGenova01/calibrators/left_hand_calib.xml
@@ -21,7 +21,7 @@
 <!--USE THIS FOR CAN ROBOT CALIBRATION-->
 <group name="CALIBRATION">
 <param name="calibrationType">                                                                                            3        4        4        4        4        4        4        4        </param>
-<param name="calibration1">                                                                                               1204.5   235.0    15.0     245.0    32.0     245.0    15.0     710.0    </param>
+<param name="calibration1">                                                                                               1204.5   252.0    16.0     245.0    37.0     254.0    26.0     746.0    </param>
 <param name="calibration2">                                                                                               10.0     10.0     30.0     10.0     10.0     10.0     10.0     10.0     </param>
 <param name="calibration3">                                                                                               0.0      6000.0   -6600.0  6000.0   7000.0   6000.0   -7000.0  -14000.0 </param>
 <param name="startupPosition">                                                                                               45.0     0.0      0.0      0.0      0.0      0.0      0.0      0.0      </param>

--- a/iCubGenova01/calibrators/right_hand_calib.xml
+++ b/iCubGenova01/calibrators/right_hand_calib.xml
@@ -22,7 +22,7 @@
 <!--USE THIS FOR CAN ROBOT CALIBRATION-->
 <group name="CALIBRATION">
 <param name="calibrationType">                                                                                            3        4        4        4        4        4        4        4        </param>
-<param name="calibration1">                                                                                               1547.8  251.0    30.0      238.0    40.0     243.0    15.0     681.0    </param>
+<param name="calibration1">                                                                                               1547.8  255.0    35.0      245.0    29.0     253.0    14.0     716.0    </param>
 <param name="calibration2">                                                                                               10.0     10.0     30.0     10.0     10.0     10.0     10.0     10.0     </param>
 <param name="calibration3">                                                                                               0.0      6000.0   6600.0   6000.0   -7000.0  6000.0   7000.0   14000.0  </param>
 <param name="startupPosition">                                                                                               45.0     0.0      0.0      0.0      0.0      0.0      0.0      0.0      </param>

--- a/iCubGenova01/hardware/motorControl/icub_left_hand.xml
+++ b/iCubGenova01/hardware/motorControl/icub_left_hand.xml
@@ -31,8 +31,8 @@
 <param name="AxisMap">      0             1             2             3             4             5             6             7             </param>       
 <param name="AxisName">     "l_thumb_oppose"     "l_thumb_proximal"     "l_thumb_distal"   "l_index_proximal"    "l_index_distal"    "l_middle_proximal"   "l_middle_distal"    "l_pinky"  </param>
 <param name="AxisType">    "revolute"  "revolute"    "revolute"    "revolute"   "revolute"     "revolute"   "revolute"     "revolute"       </param>
-<param name="Encoder">                                                                                                    9.85    -2.167   -2.765   -2.611   -2.565   -2.722   -2.812   -2.460   </param>
-<param name="Zeros">                                                                                                      112.22   -108.46  -175.43  -93.83   -182.48  -90.00   -175.33  -288.62  </param>
+<param name="Encoder">                                                                                                    9.85    -2.433   -2.712   -2.544   -2.494   -2.822   -2.694   -2.096   </param>
+<param name="Zeros">                                                                                                      112.22   -103.56  -175.90  -96.29   -184.83  -90.00   -179.65  -355.92  </param>
 <param name="fullscalePWM">           1333            1333         1333      1333     1333    1333     1333    1333  </param>
 <param name="ampsToSensor">           1000.0          1000.0       1000.0    1000.0   1000.0  1000.0   1000.0  1000.0   </param>
 

--- a/iCubGenova01/hardware/motorControl/icub_right_hand.xml
+++ b/iCubGenova01/hardware/motorControl/icub_right_hand.xml
@@ -31,8 +31,8 @@
 <param name="AxisMap">      0             1             2             3             4             5             6             7             </param>       
 <param name="AxisName">    "r_thumb_oppose"     "r_thumb_proximal"     "r_thumb_distal"   "r_index_proximal"    "r_index_distal"    "r_middle_proximal"   "r_middle_distal"    "r_pinky"  </param>
 <param name="AxisType">    "revolute"  "revolute"    "revolute"    "revolute"   "revolute"     "revolute"   "revolute"     "revolute"       </param>
-<param name="Encoder">       10.778    -2.344   -2.771   -2.500   -2.494   -2.70   -2.529   -1.884   </param>
-<param name="Zeros">         133.61   -107.06  -180.83  -95.20   -186.04  -90.0   -175.93  -361.46  </param>
+<param name="Encoder">       10.778    -2.344   -2.771   -2.500   -2.753   -2.733   -2.794   -1.972   </param>
+<param name="Zeros">         133.61   -107.06  -180.83  -98.00   -180.53  -92.56   -175.01  -363.08  </param>
 <param name="fullscalePWM">           1333            1333         1333      1333     1333    1333     1333    1333  </param>
 <param name="ampsToSensor">           1000.0          1000.0       1000.0    1000.0   1000.0  1000.0   1000.0  1000.0   </param>
 


### PR DESCRIPTION
As per the title, this PR changes calibration parameters and conversion parameters for the Hall-effect sensor of:

- right hand
  - all joints of index, middle, ring and little
- left hand
  - all joints of index, middle, ring and little
  - all joints of thumb excluding opposition