### PR TITLE
iCubGenova09 corrected parameters in skin configuration files

### DIFF
--- a/iCubGenova09/hardware/skin/left_upperarm-eb2-skin.xml
+++ b/iCubGenova09/hardware/skin/left_upperarm-eb2-skin.xml
@@ -7,7 +7,7 @@
  
         <xi:include href="../../hardware/electronics/left_arm-eb2-j2_3-eln.xml" />
         <group name="patches">
-            <param name="skinCanAddrsPatch1"> 5 </param> 
+            <param name="skinCanAddrsPatch2"> 13 </param> 
         </group>
         <xi:include href="./left_upperarm-eb2-skinSpec.xml" /> 
     </device>  

--- a/iCubGenova09/hardware/skin/left_upperarm-eb2-skinSpec.xml
+++ b/iCubGenova09/hardware/skin/left_upperarm-eb2-skinSpec.xml
@@ -14,15 +14,14 @@
             <param name="diagnostic">    false  </param>     <!-- used to config high level -->
         </group>
         
-		<!-- to enable the full upperarm uncommment this  >
+		<!-- to enable the full upperarm uncommment this  -->
        <group name="defaultCfgTriangle">
             <param name="enabled">         true  </param> 
             <param name="shift">           2  </param>
             <param name="cdcOffset">       0x2200  </param>
         </group>
- -->
-		<!-- this is the configuration to enable only the front part -->
-		<!-- check the correct CAN ID and insure it is coherent with the upstream file -->
+<!--  -->
+		<!-- this is the configuration to enable only the front part >
 		<group name="defaultCfgTriangle">
             <param name="enabled">         false  </param> 
             <param name="shift">           2  </param>
@@ -31,8 +30,8 @@
  
         < group name="specialCfgTriangles">
             <param name="numOfSets">         1  </param>
-            <param name="triangleSetCfg1">     1            13        3             10             2              1            0x2200      </param>
+            <param name="triangleSetCfg1">     2            13        3             10             2              1            0x2200      </param>
         </group>
-
+-->
         
 </params>

--- a/iCubGenova09/hardware/skin/right_upperarm-eb4-skin.xml
+++ b/iCubGenova09/hardware/skin/right_upperarm-eb4-skin.xml
@@ -7,7 +7,7 @@
  
         <xi:include href="../../hardware/electronics/right_arm-eb4-j2_3-eln.xml" />
         <group name="patches">
-            <param name="skinCanAddrsPatch1"> 5  </param> 
+            <param name="skinCanAddrsPatch2"> 13  </param> 
         </group>
         <xi:include href="./right_upperarm-eb4-skinSpec.xml" /> 
     </device>  

--- a/iCubGenova09/hardware/skin/right_upperarm-eb4-skinSpec.xml
+++ b/iCubGenova09/hardware/skin/right_upperarm-eb4-skinSpec.xml
@@ -14,15 +14,15 @@
             <param name="diagnostic">    false  </param>     <!-- used to config high level -->
         </group>     
         
-		<!-- to enable the full upperarm uncommment this  >
+		<!-- to enable the full upperarm uncommment this  -->
        <group name="defaultCfgTriangle">
             <param name="enabled">         true  </param> 
             <param name="shift">           2  </param>
             <param name="cdcOffset">       0x2200  </param>
         </group>
- -->
+ <!-- -->
 		<!-- this is the configuration to enable only the front part -->
-		<!-- check the correct CAN ID and insure it is coherent with the upstream file -->
+<!--
 		<group name="defaultCfgTriangle">
             <param name="enabled">         false  </param> 
             <param name="shift">           2  </param>
@@ -31,9 +31,9 @@
  
         < group name="specialCfgTriangles">
             <param name="numOfSets">         1  </param>
-            <param name="triangleSetCfg1">     1            13        3             10             2              1            0x2200      </param>
+            <param name="triangleSetCfg1">     2            13        3             10             2              1            0x2200      </param>
         </group>
-
+-->
         
         
 </params>

--- a/iCubGenova09/network.iTeenGenova01.xml
+++ b/iCubGenova09/network.iTeenGenova01.xml
@@ -147,7 +147,7 @@
 
     <part name="right_arm">
 
-        <board type='ems4' name="right_arm-eb4-j0_1">
+        <board type='ems4' name="right_arm-eb3-j0_1">
             <ondevice>ETH</ondevice>
             <ataddress ip="10.0.1.3" />
 			<connected bus="ETH" prev="10.0.1.26" next="10.0.1.4" />


### PR DESCRIPTION
After testing on the real robot I updated a few worng parameters escaped in the original work, namely:
1. the CAN bus is consistently set to `2 ` on all files
2. the CAN ID is fixed in every file
3. I put as default the configuration with all triangles activated even though only the ones for the front patch are currently present (there is no concern about bus throughput since there is only a couple of patches)