### PR TITLE
Laser frame_id fix

### DIFF
--- a/CER01/wrappers/rpLidar/laser_wrapper.xml
+++ b/CER01/wrappers/rpLidar/laser_wrapper.xml
@@ -15,7 +15,7 @@
          <param name ="useROS"> true </param>
          <param name ="ROS_nodeName"> /cer-laser </param>
          <param name ="ROS_topicName"> /laser </param>
-         <param name ="frame_id"> /mobile_base_lidar </param>
+         <param name ="frame_id"> mobile_base_lidar </param>
       </group>
 
       <action phase="shutdown" level="5" type="detach" />

--- a/CER02/wrappers/rpLidar/laser_back_wrapper.xml
+++ b/CER02/wrappers/rpLidar/laser_back_wrapper.xml
@@ -15,7 +15,7 @@
          <param name ="useROS"> true </param>
          <param name ="ROS_nodeName"> /cer-laserBack </param>
          <param name ="ROS_topicName"> /laserBack </param>
-         <param name ="frame_id"> /mobile_base_lidar_B </param>>
+         <param name ="frame_id"> mobile_base_lidar_B </param>>
 
       </group>
 

--- a/CER02/wrappers/rpLidar/laser_double_wrapper.xml
+++ b/CER02/wrappers/rpLidar/laser_double_wrapper.xml
@@ -15,7 +15,7 @@
          <param name ="useROS"> true </param>
          <param name ="ROS_nodeName"> /cer-laser </param>
          <param name ="ROS_topicName"> /laser</param>
-         <param name ="frame_id"> /mobile_base_double_lidar </param>
+         <param name ="frame_id"> mobile_base_double_lidar </param>
       </group>
 
       <action phase="shutdown" level="5" type="detach" />

--- a/CER02/wrappers/rpLidar/laser_front_wrapper.xml
+++ b/CER02/wrappers/rpLidar/laser_front_wrapper.xml
@@ -15,7 +15,7 @@
          <param name ="useROS"> true </param>
          <param name ="ROS_nodeName"> /cer-laserFront </param>
          <param name ="ROS_topicName"> /laserFront </param>
-         <param name ="frame_id"> /mobile_base_lidar_F </param>
+         <param name ="frame_id"> mobile_base_lidar_F </param>
       </group>
 
       <action phase="shutdown" level="5" type="detach" />

--- a/CER02/wrappers/rpLidar/laser_wrapper.xml
+++ b/CER02/wrappers/rpLidar/laser_wrapper.xml
@@ -15,7 +15,7 @@
          <param name ="useROS"> true </param>
          <param name ="ROS_nodeName"> /cer-laser </param>
          <param name ="ROS_topicName"> /laser </param>
-         <param name ="frame_id"> /mobile_base_lidar </param>
+         <param name ="frame_id"> mobile_base_lidar </param>
       </group>
 
       <action phase="shutdown" level="5" type="detach" />

--- a/CER03/wrappers/rpLidar/laser_back_wrapper.xml
+++ b/CER03/wrappers/rpLidar/laser_back_wrapper.xml
@@ -15,7 +15,7 @@
          <param name ="useROS"> true </param>
          <param name ="ROS_nodeName"> /cer-laserBack </param>
          <param name ="ROS_topicName"> /laserBack </param>
-         <param name ="frame_id"> /mobile_base_lidar_B </param>>
+         <param name ="frame_id"> mobile_base_lidar_B </param>>
 
       </group>
 

--- a/CER03/wrappers/rpLidar/laser_double_wrapper.xml
+++ b/CER03/wrappers/rpLidar/laser_double_wrapper.xml
@@ -15,7 +15,7 @@
          <param name ="useROS"> true </param>
          <param name ="ROS_nodeName"> /cer-laser </param>
          <param name ="ROS_topicName"> /laser</param>
-         <param name ="frame_id"> /mobile_base_double_lidar </param>
+         <param name ="frame_id"> mobile_base_double_lidar </param>
       </group>
 
       <action phase="shutdown" level="5" type="detach" />

--- a/CER03/wrappers/rpLidar/laser_front_wrapper.xml
+++ b/CER03/wrappers/rpLidar/laser_front_wrapper.xml
@@ -15,7 +15,7 @@
          <param name ="useROS"> true </param>
          <param name ="ROS_nodeName"> /cer-laserFront </param>
          <param name ="ROS_topicName"> /laserFront </param>
-         <param name ="frame_id"> /mobile_base_lidar_F </param>
+         <param name ="frame_id"> mobile_base_lidar_F </param>
       </group>
 
       <action phase="shutdown" level="5" type="detach" />

--- a/CER03/wrappers/rpLidar/laser_wrapper.xml
+++ b/CER03/wrappers/rpLidar/laser_wrapper.xml
@@ -15,7 +15,7 @@
          <param name ="useROS"> true </param>
          <param name ="ROS_nodeName"> /cer-laser </param>
          <param name ="ROS_topicName"> /laser </param>
-         <param name ="frame_id"> /mobile_base_lidar </param>
+         <param name ="frame_id"> mobile_base_lidar </param>
       </group>
 
       <action phase="shutdown" level="5" type="detach" />


### PR DESCRIPTION
Fix for all CER robots: lidar `frame_id` was not correct.
Removed / from all `frame_id` parameters