### PR TITLE
Fix/camera config erzelli02

### DIFF
--- a/iCubErzelli02/camera/dragonfly2_config_left.ini
+++ b/iCubErzelli02/camera/dragonfly2_config_left.ini
@@ -1,4 +1,4 @@
-device grabber
+device grabberDual
 subdevice dragonfly2
 width 320
 height 240

--- a/iCubErzelli02/camera/dragonfly2_config_left_bayer_320_240.ini
+++ b/iCubErzelli02/camera/dragonfly2_config_left_bayer_320_240.ini
@@ -1,4 +1,4 @@
-device grabber
+device grabberDual
 subdevice dragonfly2raw
 width 320
 height 240

--- a/iCubErzelli02/camera/dragonfly2_config_left_bayer_640_480.ini
+++ b/iCubErzelli02/camera/dragonfly2_config_left_bayer_640_480.ini
@@ -1,4 +1,4 @@
-device grabber
+device grabberDual
 subdevice dragonfly2
 width 640
 height 480

--- a/iCubErzelli02/camera/dragonfly2_config_right.ini
+++ b/iCubErzelli02/camera/dragonfly2_config_right.ini
@@ -1,4 +1,4 @@
-device grabber
+device grabberDual
 subdevice dragonfly2
 width 320
 height 240

--- a/iCubErzelli02/camera/dragonfly2_config_right_bayer_320_240.ini
+++ b/iCubErzelli02/camera/dragonfly2_config_right_bayer_320_240.ini
@@ -1,4 +1,4 @@
-device grabber
+device grabberDual
 subdevice dragonfly2raw
 width 320
 height 240

--- a/iCubErzelli02/camera/dragonfly2_config_right_bayer_640_480.ini
+++ b/iCubErzelli02/camera/dragonfly2_config_right_bayer_640_480.ini
@@ -1,4 +1,4 @@
-device grabber
+device grabberDual
 subdevice dragonfly2raw
 width 640
 height 480


### PR DESCRIPTION
The `grabber` wrapper has been deprecated in yarp 3.3 (see https://github.com/robotology/yarp/commit/1ad59e91f88b642f617f143b0493531cac8d9b7d)

Sorry for the multiple commits, they can be squashed in one.
