### PR TITLE
Fix iCub 3 head kinematics

### DIFF
--- a/iCubGenova09/iKinGazeCtrl.ini
+++ b/iCubGenova09/iKinGazeCtrl.ini
@@ -1,5 +1,5 @@
 robot icub
-head_version 2.7
+head_version 3.0
 saccades off
 
 [cameras]


### PR DESCRIPTION
This PR reverts the change introduced by #226 on the iCub 3 head.

The kinematics of the iCub 3 torso is peculiar and the head needs to account for that.
Therefore, the version of the head kinematics shall stick to `3.0`.

Don't worry, the 3.0 kinematics of the head has only the torso different. To this end, just compare the following lines:
- https://github.com/robotology/icub-main/blob/master/src/libraries/iKin/src/iKinFwd.cpp#L2463-L2467
- https://github.com/robotology/icub-main/blob/master/src/libraries/iKin/src/iKinFwd.cpp#L2481-L2485

They actually match each other.

cc @vvasco @S-Dafarra 