### PR TITLE
Add extra scripts for iCubGenova02

### DIFF
--- a/iCubGenova02/extra/scripts/README.md
+++ b/iCubGenova02/extra/scripts/README.md
@@ -1,0 +1,14 @@
+# Additional Commands
+
+This folder contains a set of script and aliases that ease the use of the robot. 
+In order to use them, we assume that ``robots-configuration`` has been installed using the [``robotology-superbuild``](https://github.com/robotology/robotology-superbuild), and that the ``ROBOTOLOGY_SUPERBUILD_SOURCE_DIR`` and ``YARP_ROBOT_NAME`` environmental variables have been set.
+Then, in the ``.bashrc_iCub`` file, append the following lines
+```sh
+additionalCommandsFile=${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}/src/robots-configuration/${YARP_ROBOT_NAME}/extra/scripts/additionalCommands.sh
+
+if [ -f "$additionalCommandsFile" ]; then
+    source $additionalCommandsFile
+fi
+```
+
+After opening a new terminal, you can type ``helpRobot`` to get a list of useful commands.

--- a/iCubGenova02/extra/scripts/additionalCommands.sh
+++ b/iCubGenova02/extra/scripts/additionalCommands.sh
@@ -1,0 +1,39 @@
+## Additional aliases and commands to use the robot
+
+getParentDir () {
+    SOURCE="${1}"
+    while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+      DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+      SOURCE="$(readlink "$SOURCE")"
+      [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+    done
+    DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+}
+
+getParentDir "${BASH_SOURCE[0]}"
+
+# The directory where this script is
+export ADDITIONAL_COMMANDS_DIR="$DIR"
+
+
+#Robots Configuration settings
+alias robotsConfigurationInstaller='bash ${ADDITIONAL_COMMANDS_DIR}/installRobotsConfiguration.sh'
+export ROBOTS_CONFIGURATION_DIR=${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}/src/robots-configuration/${YARP_ROBOT_NAME}
+alias gotoRobotsConfigurationFolder='cd $ROBOTS_CONFIGURATION_DIR'
+
+##
+alias goToBuildSuperbuild='cd ../../build/src/${PWD##*/}'
+
+## Alias for running a diff between the source and the install of the configuration files
+alias configurationSourceInstallDiff='bash ${ADDITIONAL_COMMANDS_DIR}/checkConfigurationFiles.sh'
+
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+## Alias for displaying info messages about the other aliases
+alias helpRobot='echo -e "Here some useful commands:
+${GREEN}robotsConfigurationInstaller${NC} Takes care of installing the robot configuration files from any folder.
+${GREEN}gotoRobotsConfigurationFolder${NC} Go to the source folder of the robot configuration files.
+${GREEN}configurationSourceInstallDiff${NC} Performs a diff between the source and install configuration files. If there is no difference, it prints nothing.
+${GREEN}goToBuildSuperbuild${NC} Go to the corresponding build folder of the robotology superbuild."'
+echo -e "Type ${GREEN}helpRobot${NC} for a list of useful commands."
+

--- a/iCubGenova02/extra/scripts/checkConfigurationFiles.sh
+++ b/iCubGenova02/extra/scripts/checkConfigurationFiles.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+diff -r --exclude="CMakeLists.txt" $ROBOTOLOGY_SUPERBUILD_SOURCE_DIR/src/robots-configuration/$YARP_ROBOT_NAME $ROBOTOLOGY_SUPERBUILD_SOURCE_DIR/build/install/share/ICUBcontrib/robots/$YARP_ROBOT_NAME | grep -ve dcm_walking -ve extra > /tmp/diff_out 2>&1
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+if [[ -s /tmp/diff_out ]]; then
+    echo -e "${RED}There are differences.${NC}"
+    cat /tmp/diff_out
+else
+    echo -e "${GREEN}The configuration files in the source and in the install folder coincide.${NC}"
+fi

--- a/iCubGenova02/extra/scripts/installRobotsConfiguration.sh
+++ b/iCubGenova02/extra/scripts/installRobotsConfiguration.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if [[ -v "${ICUB_BUILD_PATHNAME}" ]]; then
+    BUILD_DIR=${ICUB_BUILD_PATHNAME}
+else
+    BUILD_DIR='build';
+fi
+
+echo "Running make install in ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}/${BUILD_DIR}/src/robots-configuration"
+
+cd ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}/${BUILD_DIR}/src/robots-configuration
+cmake . && make install


### PR DESCRIPTION
Following what was done for `iCubGenova04` (https://github.com/robotology/robots-configuration/pull/251), this PR adds some useful scripts in the `iCubGenova02`.

In particular, the following alias can be used:
- `robotsConfigurationInstaller` Takes care of installing the robot configuration files from any folder.
- `gotoRobotsConfigurationFolder` Go to the source folder of the robot configuration files.
- `configurationSourceInstallDiff` Performs a diff between the source and install configuration files. If there is no difference, it prints nothing.
- `goToBuildSuperbuild` Go to the corresponding build folder of the robotology superbuild.

A Readme (`iCubGenova02/extra/scripts/README.md`) is added, and explains how to use the additional commands.
