### PR TITLE
Erzelli02: fix cameras ini

### DIFF
--- a/iCubErzelli02/camera/dragonfly2_config_left.ini
+++ b/iCubErzelli02/camera/dragonfly2_config_left.ini
@@ -1,9 +1,8 @@
-device grabberDual
-subdevice dragonfly2
+device dragonfly2
 width 320
 height 240
 video_type 1
-white_balance 0.506 0.494 
+white_balance 0.506 0.494
 gain 0.312
 shutter 0.913
 name /icub/cam/left
@@ -16,5 +15,5 @@ gamma 0.4
 saturation 0.271
 framerate 30
 #d 0
-guid 00b09d0100b96860 
+guid 00b09d0100b96860
 #<64bit global identifier, without the leading 0x> then remove the d option

--- a/iCubErzelli02/camera/dragonfly2_config_left_bayer_320_240.ini
+++ b/iCubErzelli02/camera/dragonfly2_config_left_bayer_320_240.ini
@@ -1,5 +1,4 @@
-device grabberDual
-subdevice dragonfly2raw
+device dragonfly2raw
 width 320
 height 240
 video_type 3
@@ -9,7 +8,7 @@ shutter 0.666
 name /icub/cam/left
 brightness 0
 DR2
-stamp 
+stamp
 sharpness 1.0
 hue 0.48
 gamma 0.4

--- a/iCubErzelli02/camera/dragonfly2_config_left_bayer_640_480.ini
+++ b/iCubErzelli02/camera/dragonfly2_config_left_bayer_640_480.ini
@@ -1,12 +1,11 @@
-device grabberDual
-subdevice dragonfly2
+device dragonfly2
 width 640
 height 480
 video_type 3
-white_balance 0.477 0.514 
-gain 0.0 
+white_balance 0.477 0.514
+gain 0.0
 shutter 0.666
-name /icub/cam/left  
+name /icub/cam/left
 brightness 0
 DR2
 stamp

--- a/iCubErzelli02/camera/dragonfly2_config_right.ini
+++ b/iCubErzelli02/camera/dragonfly2_config_right.ini
@@ -1,15 +1,14 @@
-device grabberDual
-subdevice dragonfly2
+device dragonfly2
 width 320
 height 240
 video_type 1
-white_balance 0.506 0.494 
+white_balance 0.506 0.494
 gain 0.312
 shutter 0.913
 name /icub/cam/right
 brightness 0
 DR2
-stamp 
+stamp
 sharpness 0.5
 hue 0.48
 gamma 0.4

--- a/iCubErzelli02/camera/dragonfly2_config_right_bayer_320_240.ini
+++ b/iCubErzelli02/camera/dragonfly2_config_right_bayer_320_240.ini
@@ -1,5 +1,4 @@
-device grabberDual
-subdevice dragonfly2raw
+device dragonfly2raw
 width 320
 height 240
 video_type 3
@@ -9,7 +8,7 @@ shutter 0.666
 name /icub/cam/right
 brightness 0
 DR2
-stamp 
+stamp
 sharpness 1.0
 hue 0.48
 gamma 0.4
@@ -17,5 +16,5 @@ saturation 0.271
 framerate 30
 use_network_time 1
 #d 1
-guid 00b09d0100b96862 
+guid 00b09d0100b96862
 #<64bit global identifier, without the leading 0x> then remove the d option

--- a/iCubErzelli02/camera/dragonfly2_config_right_bayer_640_480.ini
+++ b/iCubErzelli02/camera/dragonfly2_config_right_bayer_640_480.ini
@@ -1,5 +1,4 @@
-device grabberDual
-subdevice dragonfly2raw
+device dragonfly2raw
 width 640
 height 480
 video_type 3
@@ -9,7 +8,7 @@ shutter 0.666
 name /icub/cam/right
 brightness 0
 DR2
-stamp 
+stamp
 sharpness 1.0
 hue 0.48
 gamma 0.4
@@ -17,5 +16,5 @@ saturation 0.271
 framerate 30
 use_network_time 1
 #d 1
-guid 00b09d0100b96862 
+guid 00b09d0100b96862
 #<64bit global identifier, without the leading 0x> then remove the d option


### PR DESCRIPTION
When running the device with the `ServerGrabberDual*.ini` was spawning 2 wrappers