### PR TITLE
Sign change for torso pitch joint on all R1 robots

### DIFF
--- a/R1SN001/hardware/motorControl/cer_torso_equivalent-mc.xml
+++ b/R1SN001/hardware/motorControl/cer_torso_equivalent-mc.xml
@@ -11,7 +11,7 @@
       <param name="Joints">    3       </param>
       <!-- <param name="AxisMap">   0 1 2   </param> -->
       <!-- <param name="Verbose">   true    </param> -->
-      <param name="Encoder">   1 1 1   </param>
+      <param name="Encoder">   1 -1 1   </param>
     </group>
 
     <group name="TRIPOD">

--- a/R1SN002/hardware/motorControl/cer_torso_equivalent-mc.xml
+++ b/R1SN002/hardware/motorControl/cer_torso_equivalent-mc.xml
@@ -11,7 +11,7 @@
       <param name="Joints">    3       </param>
       <!-- <param name="AxisMap">   0 1 2   </param> -->
       <!-- <param name="Verbose">   true    </param> -->
-      <param name="Encoder">   1 1 1   </param>
+      <param name="Encoder">   1 -1 1   </param>
     </group>
 
     <group name="TRIPOD">

--- a/R1SN003/hardware/motorControl/cer_torso_equivalent-mc.xml
+++ b/R1SN003/hardware/motorControl/cer_torso_equivalent-mc.xml
@@ -11,7 +11,7 @@
       <param name="Joints">    3       </param>
       <!-- <param name="AxisMap">   0 1 2   </param> -->
       <!-- <param name="Verbose">   true    </param> -->
-      <param name="Encoder">   1 1 1   </param>
+      <param name="Encoder">   1 -1 1   </param>
     </group>
 
     <group name="TRIPOD">

--- a/R1SN003/hardware/rpLidar/laserA2_hw_back.xml
+++ b/R1SN003/hardware/rpLidar/laserA2_hw_back.xml
@@ -5,7 +5,7 @@
        <group name="GENERAL">
             <param name="name">            cer_laserBack </param>
             <param name="serial_baudrate"> 115200        </param>
-            <param name="serial_port">     /dev/ttyUSB0  </param>
+            <param name="serial_port">     /dev/ttyUSB1  </param>
             <param name="sample_buffer_life">  1         </param>
        </group>
        <group name="SENSOR">                      

--- a/R1SN003/hardware/rpLidar/laserA2_hw_front.xml
+++ b/R1SN003/hardware/rpLidar/laserA2_hw_front.xml
@@ -5,7 +5,7 @@
        <group name="GENERAL">
             <param name="name">            cer_laserFront     </param>
             <param name="serial_baudrate"> 115200       </param>
-            <param name="serial_port">     /dev/ttyUSB1 </param>
+            <param name="serial_port">     /dev/ttyUSB0 </param>
             <param name="sample_buffer_life">  1        </param>
        </group>
        <group name="SENSOR">    


### PR DESCRIPTION
This PR has two main purposes:

1) swap the front and back lidars on R1 SN003 (they were not properly connected)

2) fix a **MAJOR** issue on the sign of the torso pitch joint (affecting all R1 robots) which was not correct according to the kinematic definition of the robot. Please refer to https://github.com/robotology/cer/issues/121 for further details. 
Please note that this change may affect the behavior of **user modules** that control the R1 pitch torso joint!