### PR TITLE
[Experimental setup wristmk2_handmk3] fixed the name of the joints in the hand mk3

### DIFF
--- a/experimentalSetups/wristmk2_handmk3/hardware/mechanicals/hv3_left_hand-mcp9-mec.xml
+++ b/experimentalSetups/wristmk2_handmk3/hardware/mechanicals/hv3_left_hand-mcp9-mec.xml
@@ -6,18 +6,18 @@
         <param name="MotioncontrolVersion"> 6 </param>
         <param name="Joints"> 4 </param> 
         
-        <!-- joint number in sub-part       0             1               2               3             -->
-        <!-- joint name                                                                                 -->         
-        <param name="AxisMap">              0               1               2               3           </param>
-        <param name="AxisName">             "l_thumb"       "l_index"       "l_medium"      "l_pinky"   </param>
-        <param name="AxisType">             "revolute"      "revolute"      "revolute"      "revolute"  </param>
-        <param name="Encoder">              182.044         182.044         182.044         182.044     </param>
-        <param name="fullscalePWM">         3360            3360            3360            3360        </param>
-        <param name="ampsToSensor">         1000.0          1000.0          1000.0          1000.0      </param>
-        <param name="Gearbox_M2J">          159             159             159             159        </param>
-        <param name="Gearbox_E2J">          1               1               1               1           </param>
-        <param name="useMotorSpeedFbk">     0               0               0               0           </param>
-        <param name="MotorType">            "DC"            "DC"            "DC"            "DC"        </param>
+        <!-- joint number in sub-part       0                       1                       2                           3                       -->
+        <!-- joint name                                                                                                                         -->         
+        <param name="AxisMap">              0                       1                       2                           3                       </param>
+        <param name="AxisName">             "l_hand_thumb_proximal" "l_hand_index_proximal" "l_hand_medium_proximal"    "l_hand_pinky_proximal" </param>
+        <param name="AxisType">             "revolute"              "revolute"              "revolute"                  "revolute"              </param>
+        <param name="Encoder">              182.044                 182.044                 182.044                     182.044                 </param>
+        <param name="fullscalePWM">         3360                    3360                    3360                        3360                    </param>
+        <param name="ampsToSensor">         1000.0                  1000.0                  1000.0                      1000.0                  </param>
+        <param name="Gearbox_M2J">          159                     159                     159                         159                     </param>
+        <param name="Gearbox_E2J">          1                       1                       1                           1                       </param>
+        <param name="useMotorSpeedFbk">     0                       0                       0                           0                       </param>
+        <param name="MotorType">            "DC"                    "DC"                    "DC"                        "DC"                    </param>
                 
         <param name="Verbose"> 0 </param>
     </group>

--- a/experimentalSetups/wristmk2_handmk3/hardware/mechanicals/hv3_left_hand7-mcp9-mec.xml
+++ b/experimentalSetups/wristmk2_handmk3/hardware/mechanicals/hv3_left_hand7-mcp9-mec.xml
@@ -6,18 +6,18 @@
         <param name="MotioncontrolVersion"> 6 </param>
         <param name="Joints"> 7 </param> 
         
-        <!-- joint number in sub-part       0               1               2               3               4               5               6               -->
-        <!-- joint name                                                                                                                                     -->         
-        <param name="AxisMap">              0               1               2               3               4               5               6               </param>
-        <param name="AxisName">             "l_thumb_open"  "l_index_open"  "l_medium_open" "l_pinky_open"  "l_thumb_metac" "l_thumb_rot"   "l_index_adduc" </param>
-        <param name="AxisType">             "revolute"      "revolute"      "revolute"      "revolute"      "revolute"      "revolute"      "revolute"      </param>
-        <param name="Encoder">              182.044         182.044         182.044         182.044         182.044         182.044         182.044         </param>
-        <param name="fullscalePWM">         3360            3360            3360            3360            3360            3360            3360            </param>
-        <param name="ampsToSensor">         1000.0          1000.0          1000.0          1000.0          1000.0          1000.0          1000.0          </param>
-        <param name="Gearbox_M2J">          159             159             159             159             159             159             159             </param>
-        <param name="Gearbox_E2J">          1               1               1               1               1               1               1               </param>
-        <param name="useMotorSpeedFbk">     0               0               0               0               0               0               0               </param>
-        <param name="MotorType">            "DC"            "DC"            "DC"            "DC"            "DC"            "DC"            "DC"            </param>
+        <!-- joint number in sub-part       0                       1                       2                           3                       4                   5                       6                           -->
+        <!-- joint name                                                                                                                                                                                                 -->             
+        <param name="AxisMap">              0                       1                       2                           3                       4                   5                       6                           </param>
+        <param name="AxisName">             "l_hand_thumb_proximal" "l_hand_index_proximal" "l_hand_medium_proximal"    "l_hand_pinky_proximal" "l_hand_metacarpus" "l_hand_thumb_rotation" "l_hand_index_adduction"    </param>
+        <param name="AxisType">             "revolute"              "revolute"              "revolute"                  "revolute"              "revolute"          "revolute"              "revolute"                  </param>
+        <param name="Encoder">              182.044                 182.044                 182.044                     182.044                 182.044             182.044                 182.044                     </param>
+        <param name="fullscalePWM">         3360                    3360                    3360                        3360                    3360                3360                    3360                        </param>
+        <param name="ampsToSensor">         1000.0                  1000.0                  1000.0                      1000.0                  1000.0              1000.0                  1000.0                      </param>
+        <param name="Gearbox_M2J">          159                     159                     159                         159                     159                 159                     159                         </param>
+        <param name="Gearbox_E2J">          1                       1                       1                           1                       1                   1                       1                           </param>
+        <param name="useMotorSpeedFbk">     0                       0                       0                           0                       0                   0                       0                           </param>
+        <param name="MotorType">            "DC"                    "DC"                    "DC"                        "DC"                    "DC"                "DC"                    "DC"                        </param>
                 
         <param name="Verbose"> 0 </param>
     </group>


### PR DESCRIPTION
Aligned the names of the joints of the hand mk3 to the chosen convention.
In particular we control the movement of the following joints:

![image](https://user-images.githubusercontent.com/7148284/121875353-a238dc80-cd08-11eb-92d7-0795ad797a0b.png)

| Ref. | Joint name                   |
| ---- | ---------------------------- |
|      |                              |
|      |                              |
| P1   | l_hand_pinky_proximal_joint  |
| M1   | l_hand_medium_proximal_joint |
| i1   | l_hand_index_proximal_joint  |
| i3   | l_hand_index_adduction_joint |
| T1   | l_hand_thumb_proximal_joint  |
| T3   | l_hand_thumb_rotation_joint  |
| X1   | l_hand_metacarpus_joint      |