### PR TITLE
Fix camera wrappers for R1SN003

### DIFF
--- a/R1SN003/wrappers/camera/pointcloudsensor_ros.xml
+++ b/R1SN003/wrappers/camera/pointcloudsensor_ros.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
-<device xmlns:xi="http://www.w3.org/2001/XInclude" name="pointCloudWrapR" type="RGBDToPointCloudSensor_nws_ros">
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="pointCloudWrapR" type="rgbdToPointCloudSensor_nws_ros">
     <param name="period"> 0.033 </param>
-    <param name="nodeName">    /camera/rgbdPointCloud_nws_ros </param>
-    <param name="pointCloudTopicName">  /camera/depth/color/points  </param>
-    <param name="frame_Id">    depth_center</param>
+    <param name="node_name">    /camera/rgbdPointCloud_nws_ros </param>
+    <param name="topic_name">  /camera/depth/color/points  </param>
+    <param name="frame_id">    depth_center</param>
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">
             <elem name="subdevicergbd"> realsense2dev </elem>

--- a/R1SN003/wrappers/camera/rgbdsensor_ros.xml
+++ b/R1SN003/wrappers/camera/rgbdsensor_ros.xml
@@ -2,13 +2,12 @@
 <!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="RGBDWrapperros" type="rgbdSensor_nws_ros">
-    <param name="period"> 33</param>
-    <param name="colorTopicName">    /camera/rgbdSensor_nws_ros/color/image_raw    </param>
-    <param name="depthTopicName">    /camera/rgbdSensor_nws_ros/depth/image_rect_raw    </param>
-    <param name="colorInfoTopicName">    /camera/rgbdSensor_nws_ros/color/camera_info     </param>
-    <param name="depthInfoTopicName">    /camera/rgbdSensor_nws_ros/depth/camera_info   </param>
-    <param name="frame_Id">    depth_center    </param>
-    <param name="nodeName">    /camera/rgbdSensor_nws_ros/rgbdwrapperros    </param>
+    <param name="period"> 0.033 </param>
+    <param name="color_topic_name">    /camera_rgbd/color/image_rect_color    </param>
+    <param name="depth_topic_name">    /camera_rgbd/depth/image_rect    </param>
+    <param name="color_frame_id">    depth_center    </param>
+    <param name="depth_frame_id">    depth_center    </param>
+    <param name="node_name">    /rgbdsensor_ros_node    </param>
 
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">

--- a/R1SN003/wrappers/camera/rgbdsensor_yarp.xml
+++ b/R1SN003/wrappers/camera/rgbdsensor_yarp.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="RGBDWrapperyarp" type="rgbdSensor_nws_yarp">
-    <param name="period"> 33 </param>
+    <param name="period"> 0.033 </param>
     <param name="name">    /cer/realsense </param>
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">

--- a/R1SN003nws/wrappers/camera/rgbdsensor_ros.xml
+++ b/R1SN003nws/wrappers/camera/rgbdsensor_ros.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="RGBDWrapperros" type="rgbdSensor_nws_ros">
-    <param name="period"> 33</param>
+    <param name="period"> 0.033 </param>
     <param name="color_topic_name">    /camera_rgbd/color/image_rect_color    </param>
     <param name="depth_topic_name">    /camera_rgbd/depth/image_rect    </param>
     <param name="color_frame_id">    depth_center    </param>

--- a/R1SN003nws/wrappers/camera/rgbdsensor_yarp.xml
+++ b/R1SN003nws/wrappers/camera/rgbdsensor_yarp.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="RGBDWrapperyarp" type="rgbdSensor_nws_yarp">
-    <param name="period"> 33 </param>
+    <param name="period"> 0.033 </param>
     <param name="name">    /cer/realsense </param>
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">


### PR DESCRIPTION
Removed errors from camera related nws files in the `R1SN003` and `R1SN003nws` folders:
* `R1SN003/wrappers/camera/pointcloudsensor_ros.xml`
  * Parameters names changed in order to match the ones required by the device
  * Device name changed from `RGBDToPointCloudSensor_nws_ros` to `rgbdToPointCloudSensor_nws_ros`
* `R1SN003/wrappers/camera/rgbdsensor_ros.xml`
  * Parameters names changed in order to match the one required by the device
  * Period value changed from milliseconds to seconds
* `R1SN003/wrappers/camera/rgbdsensor_yarp.xml`
  * Period value changed from milliseconds to seconds
* `R1SN003nws/wrappers/camera/rgbdsensor_ros.xml`
  * Period value changed from milliseconds to seconds
* `R1SN003nws/wrappers/camera/rgbdsensor_yarp.xml`
  * Period value changed from milliseconds to seconds
