### PR TITLE
fixed missing param for embObjFTsensor

### DIFF
--- a/iCubNancy01/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/iCubNancy01/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -39,12 +39,14 @@
 
             <group name="SETTINGS">        
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_leg_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_leg_strain   </param>   
+                <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->             
             </group>
             
             <group name="STRAIN_SETTINGS">        
                 <param name="useCalibration">           true                    </param>          
-            </group>            
+            </group>   
+           
             
         </group>
     

--- a/iCubNancy01/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/iCubNancy01/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -39,12 +39,15 @@
 
             <group name="SETTINGS">        
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_l_lower_leg_strain   </param>    
+                <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->                         
             </group>
             
             <group name="STRAIN_SETTINGS">        
                 <param name="useCalibration">           true                    </param>          
-            </group>            
+            </group>   
+            
+           
             
         </group>
     

--- a/iCubNancy01/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/iCubNancy01/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -39,13 +39,14 @@
 
             <group name="SETTINGS">        
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_leg_strain   </param>  
+                <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->                           
             </group>
             
             <group name="STRAIN_SETTINGS">        
                 <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+            </group>  
+       
         </group>
     
   </device>

--- a/iCubNancy01/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/iCubNancy01/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -39,12 +39,15 @@
 
             <group name="SETTINGS">        
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_lower_leg_strain   </param>  
+                <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->                                           
             </group>
             
             <group name="STRAIN_SETTINGS">        
                 <param name="useCalibration">           true                    </param>          
-            </group>            
+            </group>     
+            
+         
             
         </group>
     


### PR DESCRIPTION
added missing `temperature-acquisitionRate` param fo `embObjFTsensor` device

cc @Uboldi80 