### PR TITLE
ROS robot_state_publisher deprecation fix

### DIFF
--- a/R1SN000/robotStatePublisher.launch
+++ b/R1SN000/robotStatePublisher.launch
@@ -4,6 +4,6 @@
 
   <param name="robot_description" command="$(find xacro)/xacro --inorder $(arg model)" />
 
-  <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
 
 </launch>

--- a/R1SN001/robotStatePublisher.launch
+++ b/R1SN001/robotStatePublisher.launch
@@ -4,6 +4,6 @@
 
   <param name="robot_description" command="$(find xacro)/xacro --inorder $(arg model)" />
 
-  <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
 
 </launch>

--- a/R1SN002/robotStatePublisher.launch
+++ b/R1SN002/robotStatePublisher.launch
@@ -4,6 +4,6 @@
 
   <param name="robot_description" command="$(find xacro)/xacro --inorder $(arg model)" />
 
-  <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
 
 </launch>

--- a/R1SN003/robotStatePublisher.launch
+++ b/R1SN003/robotStatePublisher.launch
@@ -4,6 +4,6 @@
 
   <param name="robot_description" command="$(find xacro)/xacro --inorder $(arg model)" />
 
-  <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
 
 </launch>

--- a/R1SN003nws/robotStatePublisher.launch
+++ b/R1SN003nws/robotStatePublisher.launch
@@ -4,6 +4,6 @@
 
   <param name="robot_description" command="$(find xacro)/xacro --inorder $(arg model)" />
 
-  <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
 
 </launch>


### PR DESCRIPTION
Fixes error on any ROS above Melodic that doesn't recognize the robot state publisher type: state_publisher.

This was apparently an alias that has been deprecated for years and was removed with ROS Noetic. The robots still use Melodic so this was not a problem yet. It should not be a problem though. Tested in simulation.

https://github.com/ros/robot_state_publisher/pull/87  --> Look at number 5.