### PR TITLE
Fix joint names of iCub hands and eyes

### DIFF
--- a/experimentalSetups/arm-v3/hardware/mechanicals/left_arm-j12_15-mec.xml
+++ b/experimentalSetups/arm-v3/hardware/mechanicals/left_arm-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index_distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index_distal" "l_middle_proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   <!-- joint as effectively mapped onto the hw of the board -->
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    <!-- m.a.: encoderconversionfactor -->

--- a/experimentalSetups/arm-v3/hardware/mechanicals/left_arm-j12_15-mec.xml
+++ b/experimentalSetups/arm-v3/hardware/mechanicals/left_arm-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_little-fingers"  </param> 
+        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   <!-- joint as effectively mapped onto the hw of the board -->
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    <!-- m.a.: encoderconversionfactor -->

--- a/experimentalSetups/arm-v3/hardware/mechanicals/left_arm-j12_15-mec.xml
+++ b/experimentalSetups/arm-v3/hardware/mechanicals/left_arm-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   <!-- joint as effectively mapped onto the hw of the board -->
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    <!-- m.a.: encoderconversionfactor -->

--- a/experimentalSetups/arm-v3/hardware/mechanicals/left_arm-j12_15-mec.xml
+++ b/experimentalSetups/arm-v3/hardware/mechanicals/left_arm-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index_distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   <!-- joint as effectively mapped onto the hw of the board -->
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    <!-- m.a.: encoderconversionfactor -->

--- a/experimentalSetups/arm-v3/hardware/mechanicals/left_lower_arm-j12_15-mec.xml
+++ b/experimentalSetups/arm-v3/hardware/mechanicals/left_lower_arm-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   <!-- joint as effectively mapped onto the hw of the board -->
         <param name="HasHallSensor">            0                0                   0                  0               </param>

--- a/experimentalSetups/arm-v3/hardware/mechanicals/left_lower_arm-j12_15-mec.xml
+++ b/experimentalSetups/arm-v3/hardware/mechanicals/left_lower_arm-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index_distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   <!-- joint as effectively mapped onto the hw of the board -->
         <param name="HasHallSensor">            0                0                   0                  0               </param>

--- a/experimentalSetups/arm-v3/hardware/mechanicals/left_lower_arm-j12_15-mec.xml
+++ b/experimentalSetups/arm-v3/hardware/mechanicals/left_lower_arm-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_little-fingers"  </param> 
+        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   <!-- joint as effectively mapped onto the hw of the board -->
         <param name="HasHallSensor">            0                0                   0                  0               </param>

--- a/experimentalSetups/arm-v3/hardware/mechanicals/left_lower_arm-j12_15-mec.xml
+++ b/experimentalSetups/arm-v3/hardware/mechanicals/left_lower_arm-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index_distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index_distal" "l_middle_proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   <!-- joint as effectively mapped onto the hw of the board -->
         <param name="HasHallSensor">            0                0                   0                  0               </param>

--- a/experimentalSetups/arm-v3/hardware/motorControl/left_arm-j12_15-mc.xml
+++ b/experimentalSetups/arm-v3/hardware/motorControl/left_arm-j12_15-mc.xml
@@ -12,7 +12,7 @@
         <xi:include href="hardware/motorControl/left_arm-j12_15-mc-service.xml" />
 
         <!-- joint number in sub-part           0               1               2               3          -->
-        <!-- joint name                    index-distal   middle-proximal   middle-distal   little-fingers -->     
+        <!-- joint name                    index_distal   middle-proximal   middle-distal   little-fingers -->     
         <group name="LIMITS">
             <param name="jntPosMax">              180          90              180             270          </param>
             <param name="jntPosMin">                0           0                0               0           </param> 

--- a/experimentalSetups/arm-v3/hardware/motorControl/left_lower_arm-j12_15-mc.xml
+++ b/experimentalSetups/arm-v3/hardware/motorControl/left_lower_arm-j12_15-mc.xml
@@ -11,7 +11,7 @@
         <xi:include href="hardware/motorControl/left_arm-j12_15-mc-service.xml"/>
 
         <!-- joint number in sub-part           0               1               2               3          -->
-        <!-- joint name                    index-distal   middle-proximal   middle-distal   little-fingers -->     
+        <!-- joint name                    index_distal   middle-proximal   middle-distal   little-fingers -->     
         <group name="LIMITS">
             <param name="jntPosMax">              180          90              180             270          </param>
             <param name="jntPosMin">                0           0                0               0           </param> 

--- a/experimentalSetups/head_face-v3/hardware/mechanicals/head-j2_5-mec.xml
+++ b/experimentalSetups/head_face-v3/hardware/mechanicals/head-j2_5-mec.xml
@@ -14,7 +14,7 @@
         <!-- joint number in sub-part           0             1               2               3           -->
         <!-- joint name                         neck_yaw       eyes_tilt       eyes_version       eyes_vergence   -->     <!-- j2 is right-eye, j3 is left-eye -->
         <param name="AxisMap">                  0              1               2               3                   </param>   <!-- joint as effectively mapped onto the hw of the board -->
-        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_verg"           </param>
+        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_vergence"           </param>
         <param name="AxisType">                "revolute"    "revolute"         "revolute"    "revolute"           </param>
         <param name="HasHallSensor">            0              0               0               0                   </param>
         <param name="HasTempSensor">            0              0               0               0                   </param>

--- a/experimentalSetups/iCubGenova02-VelCtrl/hardware/mechanicals/head-eb21-j2_5-mec.xml
+++ b/experimentalSetups/iCubGenova02-VelCtrl/hardware/mechanicals/head-eb21-j2_5-mec.xml
@@ -9,7 +9,7 @@
 
 
         <param name="AxisMap">                  0              1               2               3                   </param> 
-        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_verg"           </param>
+        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_vergence"           </param>
         <param name="AxisType">                "revolute"    "revolute"         "revolute"    "revolute"           </param>
         <param name="Encoder">                  182.044        182.044         182.044         182.044             </param>   
         <param name="fullscalePWM">           3360            3360           3360            3360                  </param>

--- a/experimentalSetups/iCubGenova02-VelCtrl/hardware/mechanicals/head-eb21-j2_5-mec.xml
+++ b/experimentalSetups/iCubGenova02-VelCtrl/hardware/mechanicals/head-eb21-j2_5-mec.xml
@@ -9,7 +9,7 @@
 
 
         <param name="AxisMap">                  0              1               2               3                   </param> 
-        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_vers"   "eyes_verg"           </param>
+        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_verg"           </param>
         <param name="AxisType">                "revolute"    "revolute"         "revolute"    "revolute"           </param>
         <param name="Encoder">                  182.044        182.044         182.044         182.044             </param>   
         <param name="fullscalePWM">           3360            3360           3360            3360                  </param>

--- a/experimentalSetups/iCubGenovaV3-VelCtrl/hardware/mechanicals/head-eb21-j2_5-mec.xml
+++ b/experimentalSetups/iCubGenovaV3-VelCtrl/hardware/mechanicals/head-eb21-j2_5-mec.xml
@@ -9,7 +9,7 @@
         <!-- joint number in sub-part           0             1               2               3           -->
         <!-- joint name                         neck-yaw       eyes-tilt       eyes-vers       eyes-verg   -->     <!-- j2 is right-eye, j3 is left-eye -->
         <param name="AxisMap">                  0              1               2               3                   </param> 
-        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_verg"           </param>
+        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_vergence"           </param>
         <param name="AxisType">                "revolute"    "revolute"         "revolute"    "revolute"           </param>
         <param name="Encoder">                  182.044        182.044         182.044         182.044             </param>   
         <param name="fullscalePWM">           3360            3360           3360            3360                </param>

--- a/experimentalSetups/iCubGenovaV3-VelCtrl/hardware/mechanicals/head-eb21-j2_5-mec.xml
+++ b/experimentalSetups/iCubGenovaV3-VelCtrl/hardware/mechanicals/head-eb21-j2_5-mec.xml
@@ -9,7 +9,7 @@
         <!-- joint number in sub-part           0             1               2               3           -->
         <!-- joint name                         neck-yaw       eyes-tilt       eyes-vers       eyes-verg   -->     <!-- j2 is right-eye, j3 is left-eye -->
         <param name="AxisMap">                  0              1               2               3                   </param> 
-        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_vers"   "eyes_verg"           </param>
+        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_verg"           </param>
         <param name="AxisType">                "revolute"    "revolute"         "revolute"    "revolute"           </param>
         <param name="Encoder">                  182.044        182.044         182.044         182.044             </param>   
         <param name="fullscalePWM">           3360            3360           3360            3360                </param>

--- a/experimentalSetups/iCubGenovaV3-VelCtrl/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/experimentalSetups/iCubGenovaV3-VelCtrl/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index_distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index_distal" "l_middle_proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/experimentalSetups/iCubGenovaV3-VelCtrl/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/experimentalSetups/iCubGenovaV3-VelCtrl/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index_distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/experimentalSetups/iCubGenovaV3-VelCtrl/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/experimentalSetups/iCubGenovaV3-VelCtrl/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/experimentalSetups/iCubGenovaV3-VelCtrl/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/experimentalSetups/iCubGenovaV3-VelCtrl/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_little-fingers"  </param> 
+        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/experimentalSetups/iCubGenovaV3-VelCtrl/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/experimentalSetups/iCubGenovaV3-VelCtrl/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle-distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_little-fingers"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/experimentalSetups/iCubGenovaV3-VelCtrl/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/experimentalSetups/iCubGenovaV3-VelCtrl/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
+        <param name="AxisName">                 "r_index_distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/experimentalSetups/iCubGenovaV3-VelCtrl/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/experimentalSetups/iCubGenovaV3-VelCtrl/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/experimentalSetups/iCubGenovaV3-VelCtrl/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/experimentalSetups/iCubGenovaV3-VelCtrl/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle-proximal" "r_middle-distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle-distal" "r_little-fingers"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/experimentalSetups/iCubGenovaV3-VelCtrl/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
+++ b/experimentalSetups/iCubGenovaV3-VelCtrl/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
@@ -12,7 +12,7 @@
         <xi:include href="./left_arm-eb26-j12_15-mc_service.xml" />
 
         <!-- joint number in sub-part           0               1               2               3          -->
-        <!-- joint name                    index-distal   middle-proximal   middle-distal   little-fingers -->     
+        <!-- joint name                    index_distal   middle-proximal   middle-distal   little-fingers -->     
         <group name="LIMITS">
             <param name="jntPosMax">              180          90              180             270        </param>
             <param name="jntPosMin">                0           0                0               0        </param> 

--- a/experimentalSetups/iCubGenovaV3-VelCtrl/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
+++ b/experimentalSetups/iCubGenovaV3-VelCtrl/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
@@ -12,7 +12,7 @@
         <xi:include href="./right_arm-eb29-j12_15-mc_service.xml" />
 
         <!-- joint number in sub-part           0               1               2               3          -->
-        <!-- joint name                    index-distal   middle-proximal   middle-distal   little-fingers -->     
+        <!-- joint name                    index_distal   middle-proximal   middle-distal   little-fingers -->     
         <group name="LIMITS">
             <param name="jntPosMax">              180          90              180             270          </param>
             <param name="jntPosMin">                0           0                0               0           </param> 

--- a/experimentalSetups/iCubGenovaV3/hardware/mechanicals/head-eb21-j2_5-mec.xml
+++ b/experimentalSetups/iCubGenovaV3/hardware/mechanicals/head-eb21-j2_5-mec.xml
@@ -9,7 +9,7 @@
         <!-- joint number in sub-part           0             1               2               3           -->
         <!-- joint name                         neck-yaw       eyes-tilt       eyes-vers       eyes-verg   -->     <!-- j2 is right-eye, j3 is left-eye -->
         <param name="AxisMap">                  0              1               2               3                   </param> 
-        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_verg"           </param>
+        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_vergence"           </param>
         <param name="AxisType">                "revolute"    "revolute"         "revolute"    "revolute"           </param>
         <param name="Encoder">                  182.044        182.044         182.044         182.044             </param>   
         <param name="fullscalePWM">           3360            3360           3360            3360                </param>

--- a/experimentalSetups/iCubGenovaV3/hardware/mechanicals/head-eb21-j2_5-mec.xml
+++ b/experimentalSetups/iCubGenovaV3/hardware/mechanicals/head-eb21-j2_5-mec.xml
@@ -9,7 +9,7 @@
         <!-- joint number in sub-part           0             1               2               3           -->
         <!-- joint name                         neck-yaw       eyes-tilt       eyes-vers       eyes-verg   -->     <!-- j2 is right-eye, j3 is left-eye -->
         <param name="AxisMap">                  0              1               2               3                   </param> 
-        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_vers"   "eyes_verg"           </param>
+        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_verg"           </param>
         <param name="AxisType">                "revolute"    "revolute"         "revolute"    "revolute"           </param>
         <param name="Encoder">                  182.044        182.044         182.044         182.044             </param>   
         <param name="fullscalePWM">           3360            3360           3360            3360                </param>

--- a/experimentalSetups/iCubGenovaV3/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/experimentalSetups/iCubGenovaV3/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index_distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index_distal" "l_middle_proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/experimentalSetups/iCubGenovaV3/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/experimentalSetups/iCubGenovaV3/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index_distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/experimentalSetups/iCubGenovaV3/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/experimentalSetups/iCubGenovaV3/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/experimentalSetups/iCubGenovaV3/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/experimentalSetups/iCubGenovaV3/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_little-fingers"  </param> 
+        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/experimentalSetups/iCubGenovaV3/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/experimentalSetups/iCubGenovaV3/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle-distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_little-fingers"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/experimentalSetups/iCubGenovaV3/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/experimentalSetups/iCubGenovaV3/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
+        <param name="AxisName">                 "r_index_distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/experimentalSetups/iCubGenovaV3/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/experimentalSetups/iCubGenovaV3/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/experimentalSetups/iCubGenovaV3/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/experimentalSetups/iCubGenovaV3/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle-proximal" "r_middle-distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle-distal" "r_little-fingers"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/experimentalSetups/iCubGenovaV3/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
+++ b/experimentalSetups/iCubGenovaV3/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
@@ -12,7 +12,7 @@
         <xi:include href="./left_arm-eb26-j12_15-mc_service.xml" />
 
         <!-- joint number in sub-part           0               1               2               3          -->
-        <!-- joint name                    index-distal   middle-proximal   middle-distal   little-fingers -->     
+        <!-- joint name                    index_distal   middle-proximal   middle-distal   little-fingers -->     
         <group name="LIMITS">
             <param name="jntPosMax">              180          90              180             270        </param>
             <param name="jntPosMin">                0           0                0               0        </param> 

--- a/experimentalSetups/iCubGenovaV3/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
+++ b/experimentalSetups/iCubGenovaV3/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
@@ -12,7 +12,7 @@
         <xi:include href="./right_arm-eb29-j12_15-mc_service.xml" />
 
         <!-- joint number in sub-part           0               1               2               3          -->
-        <!-- joint name                    index-distal   middle-proximal   middle-distal   little-fingers -->     
+        <!-- joint name                    index_distal   middle-proximal   middle-distal   little-fingers -->     
         <group name="LIMITS">
             <param name="jntPosMax">              180          90              180             270          </param>
             <param name="jntPosMin">                0           0                0               0           </param> 

--- a/iCubChemnitz01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubChemnitz01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle-distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_little-fingers"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubChemnitz01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubChemnitz01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
+        <param name="AxisName">                 "r_index_distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubChemnitz01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubChemnitz01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubChemnitz01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubChemnitz01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle-proximal" "r_middle-distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle-distal" "r_little-fingers"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubChemnitz01/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
+++ b/iCubChemnitz01/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
@@ -10,7 +10,7 @@
     <xi:include href="./right_arm-eb29-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3               -->
-    <!-- joint name                             index-distal        middle-proximal     middle-distal       little-fingers  -->     
+    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers  -->     
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270             </param>
         <param name="jntPosMin">                0                   0                   0                   0               </param> 

--- a/iCubEdinburgh01/hardware/mechanicals/head-eb21-j2_5-mec.xml
+++ b/iCubEdinburgh01/hardware/mechanicals/head-eb21-j2_5-mec.xml
@@ -9,7 +9,7 @@
         <!-- joint number in sub-part           0             1               2               3           -->
         <!-- joint name                         neck-yaw       eyes-tilt       eyes-vers       eyes-verg   -->     <!-- j2 is right-eye, j3 is left-eye -->
         <param name="AxisMap">                  0              1               2               3                   </param> 
-        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_vers"   "eyes_verg"           </param>
+        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_verg"           </param>
         <param name="AxisType">                "revolute"    "revolute"         "revolute"    "revolute"           </param>
         <param name="Encoder">                  182.044        182.044         182.044         182.044             </param>   
         <param name="fullscalePWM">             3360            3360           3360            3360                </param>

--- a/iCubEdinburgh01/hardware/mechanicals/head-eb21-j2_5-mec.xml
+++ b/iCubEdinburgh01/hardware/mechanicals/head-eb21-j2_5-mec.xml
@@ -9,7 +9,7 @@
         <!-- joint number in sub-part           0             1               2               3           -->
         <!-- joint name                         neck-yaw       eyes-tilt       eyes-vers       eyes-verg   -->     <!-- j2 is right-eye, j3 is left-eye -->
         <param name="AxisMap">                  0              1               2               3                   </param> 
-        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_verg"           </param>
+        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_vergence"           </param>
         <param name="AxisType">                "revolute"    "revolute"         "revolute"    "revolute"           </param>
         <param name="Encoder">                  182.044        182.044         182.044         182.044             </param>   
         <param name="fullscalePWM">             3360            3360           3360            3360                </param>

--- a/iCubEdinburgh01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubEdinburgh01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index_distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index_distal" "l_middle_proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubEdinburgh01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubEdinburgh01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index_distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubEdinburgh01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubEdinburgh01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubEdinburgh01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubEdinburgh01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_little-fingers"  </param> 
+        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubEdinburgh01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubEdinburgh01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle-distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_little-fingers"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubEdinburgh01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubEdinburgh01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
+        <param name="AxisName">                 "r_index_distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubEdinburgh01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubEdinburgh01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubEdinburgh01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubEdinburgh01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle-proximal" "r_middle-distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle-distal" "r_little-fingers"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubEdinburgh01/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
+++ b/iCubEdinburgh01/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
@@ -12,7 +12,7 @@
         <xi:include href="./left_arm-eb26-j12_15-mc_service.xml" />
 
         <!-- joint number in sub-part           0               1               2               3          -->
-        <!-- joint name                    index-distal   middle-proximal   middle-distal   little-fingers -->     
+        <!-- joint name                    index_distal   middle-proximal   middle-distal   little-fingers -->     
         <group name="LIMITS">
             <param name="jntPosMax">              180          90              180             270        </param>
             <param name="jntPosMin">                0           0                0               0        </param> 

--- a/iCubEdinburgh01/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
+++ b/iCubEdinburgh01/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
@@ -12,7 +12,7 @@
         <xi:include href="./right_arm-eb29-j12_15-mc_service.xml" />
 
         <!-- joint number in sub-part           0               1               2               3          -->
-        <!-- joint name                    index-distal   middle-proximal   middle-distal   little-fingers -->     
+        <!-- joint name                    index_distal   middle-proximal   middle-distal   little-fingers -->     
         <group name="LIMITS">
             <param name="jntPosMax">              180          90              180             270          </param>
             <param name="jntPosMin">                0           0                0               0           </param> 

--- a/iCubErzelli01/hardware/mechanicals/head-eb21-j2_5-mec.xml
+++ b/iCubErzelli01/hardware/mechanicals/head-eb21-j2_5-mec.xml
@@ -9,7 +9,7 @@
         <!-- joint number in sub-part           0             1               2               3           -->
         <!-- joint name                         neck-yaw       eyes-tilt       eyes-vers       eyes-verg   -->     <!-- j2 is right-eye, j3 is left-eye -->
         <param name="AxisMap">                  0              1               2               3                   </param> 
-        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_verg"           </param>
+        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_vergence"           </param>
         <param name="AxisType">                "revolute"    "revolute"         "revolute"    "revolute"           </param>
         <param name="Encoder">                  182.044        182.044         182.044         182.044             </param>   
         <param name="fullscalePWM">           3360            3360           3360            3360                </param>

--- a/iCubErzelli01/hardware/mechanicals/head-eb21-j2_5-mec.xml
+++ b/iCubErzelli01/hardware/mechanicals/head-eb21-j2_5-mec.xml
@@ -9,7 +9,7 @@
         <!-- joint number in sub-part           0             1               2               3           -->
         <!-- joint name                         neck-yaw       eyes-tilt       eyes-vers       eyes-verg   -->     <!-- j2 is right-eye, j3 is left-eye -->
         <param name="AxisMap">                  0              1               2               3                   </param> 
-        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_vers"   "eyes_verg"           </param>
+        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_verg"           </param>
         <param name="AxisType">                "revolute"    "revolute"         "revolute"    "revolute"           </param>
         <param name="Encoder">                  182.044        182.044         182.044         182.044             </param>   
         <param name="fullscalePWM">           3360            3360           3360            3360                </param>

--- a/iCubErzelli01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubErzelli01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index_distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index_distal" "l_middle_proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubErzelli01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubErzelli01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index_distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubErzelli01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubErzelli01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubErzelli01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubErzelli01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_little-fingers"  </param> 
+        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubErzelli01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubErzelli01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle-distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_little-fingers"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubErzelli01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubErzelli01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
+        <param name="AxisName">                 "r_index_distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubErzelli01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubErzelli01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubErzelli01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubErzelli01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle-proximal" "r_middle-distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle-distal" "r_little-fingers"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubErzelli01/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
+++ b/iCubErzelli01/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
@@ -10,7 +10,7 @@
     <xi:include href="./left_arm-eb26-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3                   -->
-    <!-- joint name                             index-distal        middle-proximal     middle-distal       little-fingers      -->     
+    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers      -->     
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270                 </param>
         <param name="jntPosMin">                0                   0                   0                   0                   </param> 

--- a/iCubErzelli01/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
+++ b/iCubErzelli01/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
@@ -10,7 +10,7 @@
     <xi:include href="./right_arm-eb29-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3               -->
-    <!-- joint name                             index-distal        middle-proximal     middle-distal       little-fingers  -->     
+    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers  -->     
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270             </param>
         <param name="jntPosMin">                0                   0                   0                   0               </param> 

--- a/iCubErzelli02/hardware/mechanicals/head-eb21-j2_5-mec.xml
+++ b/iCubErzelli02/hardware/mechanicals/head-eb21-j2_5-mec.xml
@@ -9,7 +9,7 @@
         <!-- joint number in sub-part           0             1               2               3           -->
         <!-- joint name                         neck-yaw       eyes-tilt       eyes-vers       eyes-verg   -->     <!-- j2 is right-eye, j3 is left-eye -->
         <param name="AxisMap">                  0              1               2               3                   </param> 
-        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_verg"           </param>
+        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_vergence"           </param>
         <param name="AxisType">                "revolute"    "revolute"         "revolute"    "revolute"           </param>
         <param name="Encoder">                  182.044        182.044         182.044         182.044             </param>   
         <param name="fullscalePWM">           3360            3360           3360            3360                </param>

--- a/iCubErzelli02/hardware/mechanicals/head-eb21-j2_5-mec.xml
+++ b/iCubErzelli02/hardware/mechanicals/head-eb21-j2_5-mec.xml
@@ -9,7 +9,7 @@
         <!-- joint number in sub-part           0             1               2               3           -->
         <!-- joint name                         neck-yaw       eyes-tilt       eyes-vers       eyes-verg   -->     <!-- j2 is right-eye, j3 is left-eye -->
         <param name="AxisMap">                  0              1               2               3                   </param> 
-        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_vers"   "eyes_verg"           </param>
+        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_verg"           </param>
         <param name="AxisType">                "revolute"    "revolute"         "revolute"    "revolute"           </param>
         <param name="Encoder">                  182.044        182.044         182.044         182.044             </param>   
         <param name="fullscalePWM">           3360            3360           3360            3360                </param>

--- a/iCubErzelli02/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubErzelli02/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index_distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index_distal" "l_middle_proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubErzelli02/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubErzelli02/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index_distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubErzelli02/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubErzelli02/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubErzelli02/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubErzelli02/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_little-fingers"  </param> 
+        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubErzelli02/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubErzelli02/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle-distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_little-fingers"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubErzelli02/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubErzelli02/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
+        <param name="AxisName">                 "r_index_distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubErzelli02/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubErzelli02/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubErzelli02/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubErzelli02/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle-proximal" "r_middle-distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle-distal" "r_little-fingers"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubErzelli02/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
@@ -10,7 +10,7 @@
     <xi:include href="./left_arm-eb26-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3                   -->
-    <!-- joint name                             index-distal        middle-proximal     middle-distal       little-fingers      -->     
+    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers      -->     
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270                 </param>
         <param name="jntPosMin">                0                   0                   0                   0                   </param> 

--- a/iCubErzelli02/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
@@ -10,7 +10,7 @@
     <xi:include href="./right_arm-eb29-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3               -->
-    <!-- joint name                             index-distal        middle-proximal     middle-distal       little-fingers  -->     
+    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers  -->     
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270             </param>
         <param name="jntPosMin">                0                   0                   0                   0               </param> 

--- a/iCubErzelli03/hardware/mechanicals/head-eb21-j2_5-mec.xml
+++ b/iCubErzelli03/hardware/mechanicals/head-eb21-j2_5-mec.xml
@@ -9,7 +9,7 @@
         <!-- joint number in sub-part           0             1               2               3           -->
         <!-- joint name                         neck-yaw       eyes-tilt       eyes-vers       eyes-verg   -->     <!-- j2 is right-eye, j3 is left-eye -->
         <param name="AxisMap">                  0              1               2               3                   </param> 
-        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_verg"           </param>
+        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_vergence"           </param>
         <param name="AxisType">                "revolute"    "revolute"         "revolute"    "revolute"           </param>
         <param name="Encoder">                  182.044        182.044         182.044         182.044             </param>   
         <param name="fullscalePWM">           3360            3360           3360            3360                </param>

--- a/iCubErzelli03/hardware/mechanicals/head-eb21-j2_5-mec.xml
+++ b/iCubErzelli03/hardware/mechanicals/head-eb21-j2_5-mec.xml
@@ -9,7 +9,7 @@
         <!-- joint number in sub-part           0             1               2               3           -->
         <!-- joint name                         neck-yaw       eyes-tilt       eyes-vers       eyes-verg   -->     <!-- j2 is right-eye, j3 is left-eye -->
         <param name="AxisMap">                  0              1               2               3                   </param> 
-        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_vers"   "eyes_verg"           </param>
+        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_verg"           </param>
         <param name="AxisType">                "revolute"    "revolute"         "revolute"    "revolute"           </param>
         <param name="Encoder">                  182.044        182.044         182.044         182.044             </param>   
         <param name="fullscalePWM">           3360            3360           3360            3360                </param>

--- a/iCubGenova02/hardware/mechanicals/head-eb21-j2_5-mec.xml
+++ b/iCubGenova02/hardware/mechanicals/head-eb21-j2_5-mec.xml
@@ -9,7 +9,7 @@
 
 
         <param name="AxisMap">                  0              1               2               3                   </param> 
-        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_verg"           </param>
+        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_vergence"           </param>
         <param name="AxisType">                "revolute"    "revolute"         "revolute"    "revolute"           </param>
         <param name="Encoder">                  182.044        182.044         182.044         182.044             </param>   
         <param name="fullscalePWM">           3360            3360           3360            3360                  </param>

--- a/iCubGenova02/hardware/mechanicals/head-eb21-j2_5-mec.xml
+++ b/iCubGenova02/hardware/mechanicals/head-eb21-j2_5-mec.xml
@@ -9,7 +9,7 @@
 
 
         <param name="AxisMap">                  0              1               2               3                   </param> 
-        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_vers"   "eyes_verg"           </param>
+        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_verg"           </param>
         <param name="AxisType">                "revolute"    "revolute"         "revolute"    "revolute"           </param>
         <param name="Encoder">                  182.044        182.044         182.044         182.044             </param>   
         <param name="fullscalePWM">           3360            3360           3360            3360                  </param>

--- a/iCubGenova04/hardware/mechanicals/head-eb21-j2_5-mec.xml
+++ b/iCubGenova04/hardware/mechanicals/head-eb21-j2_5-mec.xml
@@ -9,7 +9,7 @@
         <!-- joint number in sub-part           0             1               2               3           -->
         <!-- joint name                         neck-yaw       eyes-tilt       eyes-vers       eyes-verg   -->     <!-- j2 is right-eye, j3 is left-eye -->
         <param name="AxisMap">                  0              1               2               3                   </param> 
-        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_verg"           </param>
+        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_vergence"           </param>
         <param name="AxisType">                "revolute"    "revolute"         "revolute"    "revolute"           </param>
         <param name="Encoder">                  182.044        182.044         182.044         182.044             </param>   
         <param name="fullscalePWM">           3360            3360           3360            3360                </param>

--- a/iCubGenova04/hardware/mechanicals/head-eb21-j2_5-mec.xml
+++ b/iCubGenova04/hardware/mechanicals/head-eb21-j2_5-mec.xml
@@ -9,7 +9,7 @@
         <!-- joint number in sub-part           0             1               2               3           -->
         <!-- joint name                         neck-yaw       eyes-tilt       eyes-vers       eyes-verg   -->     <!-- j2 is right-eye, j3 is left-eye -->
         <param name="AxisMap">                  0              1               2               3                   </param> 
-        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_vers"   "eyes_verg"           </param>
+        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_verg"           </param>
         <param name="AxisType">                "revolute"    "revolute"         "revolute"    "revolute"           </param>
         <param name="Encoder">                  182.044        182.044         182.044         182.044             </param>   
         <param name="fullscalePWM">           3360            3360           3360            3360                </param>

--- a/iCubGenova04/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubGenova04/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index_distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index_distal" "l_middle_proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubGenova04/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubGenova04/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index_distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubGenova04/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubGenova04/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubGenova04/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubGenova04/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_little-fingers"  </param> 
+        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubGenova04/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubGenova04/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle-distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_little-fingers"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubGenova04/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubGenova04/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
+        <param name="AxisName">                 "r_index_distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubGenova04/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubGenova04/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubGenova04/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubGenova04/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle-proximal" "r_middle-distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle-distal" "r_little-fingers"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubGenova04/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
+++ b/iCubGenova04/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
@@ -10,7 +10,7 @@
     <xi:include href="./left_arm-eb26-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3                   -->
-    <!-- joint name                             index-distal        middle-proximal     middle-distal       little-fingers      -->     
+    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers      -->     
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270                 </param>
         <param name="jntPosMin">                0                   0                   0                   0                   </param> 

--- a/iCubGenova04/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
+++ b/iCubGenova04/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
@@ -10,7 +10,7 @@
     <xi:include href="./right_arm-eb29-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3               -->
-    <!-- joint name                             index-distal        middle-proximal     middle-distal       little-fingers  -->     
+    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers  -->     
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270             </param>
         <param name="jntPosMin">                0                   0                   0                   0               </param> 

--- a/iCubGenova07/hardware/mechanicals/head-eb21-j2_5-mec.xml
+++ b/iCubGenova07/hardware/mechanicals/head-eb21-j2_5-mec.xml
@@ -9,7 +9,7 @@
         <!-- joint number in sub-part           0             1               2               3           -->
         <!-- joint name                         neck-yaw       eyes-tilt       eyes-vers       eyes-verg   -->     <!-- j2 is right-eye, j3 is left-eye -->
         <param name="AxisMap">                  0              1               2               3                   </param> 
-        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_verg"           </param>
+        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_vergence"           </param>
         <param name="AxisType">                "revolute"    "revolute"         "revolute"    "revolute"           </param>
         <param name="Encoder">                  182.044        182.044         182.044         182.044             </param>   
         <param name="fullscalePWM">           3360            3360           3360            3360                </param>

--- a/iCubGenova07/hardware/mechanicals/head-eb21-j2_5-mec.xml
+++ b/iCubGenova07/hardware/mechanicals/head-eb21-j2_5-mec.xml
@@ -9,7 +9,7 @@
         <!-- joint number in sub-part           0             1               2               3           -->
         <!-- joint name                         neck-yaw       eyes-tilt       eyes-vers       eyes-verg   -->     <!-- j2 is right-eye, j3 is left-eye -->
         <param name="AxisMap">                  0              1               2               3                   </param> 
-        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_vers"   "eyes_verg"           </param>
+        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_verg"           </param>
         <param name="AxisType">                "revolute"    "revolute"         "revolute"    "revolute"           </param>
         <param name="Encoder">                  182.044        182.044         182.044         182.044             </param>   
         <param name="fullscalePWM">           3360            3360           3360            3360                </param>

--- a/iCubGenova07/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubGenova07/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index_distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index_distal" "l_middle_proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubGenova07/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubGenova07/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index_distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubGenova07/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubGenova07/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubGenova07/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubGenova07/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_little-fingers"  </param> 
+        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubGenova07/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubGenova07/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle-distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_little-fingers"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubGenova07/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubGenova07/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
+        <param name="AxisName">                 "r_index_distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubGenova07/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubGenova07/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubGenova07/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubGenova07/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle-proximal" "r_middle-distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle-distal" "r_little-fingers"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubGenova07/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
+++ b/iCubGenova07/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
@@ -10,7 +10,7 @@
     <xi:include href="./left_arm-eb26-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3                   -->
-    <!-- joint name                             index-distal        middle-proximal     middle-distal       little-fingers      -->     
+    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers      -->     
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270                 </param>
         <param name="jntPosMin">                0                   0                   0                   0                   </param> 

--- a/iCubGenova07/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
+++ b/iCubGenova07/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
@@ -10,7 +10,7 @@
     <xi:include href="./right_arm-eb29-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3               -->
-    <!-- joint name                             index-distal        middle-proximal     middle-distal       little-fingers  -->     
+    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers  -->     
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270             </param>
         <param name="jntPosMin">                0                   0                   0                   0               </param> 

--- a/iCubGenova08/hardware/mechanicals/head-eb21-j2_5-mec.xml
+++ b/iCubGenova08/hardware/mechanicals/head-eb21-j2_5-mec.xml
@@ -9,7 +9,7 @@
         <!-- joint number in sub-part           0             1               2               3           -->
         <!-- joint name                         neck-yaw       eyes-tilt       eyes-vers       eyes-verg   -->     <!-- j2 is right-eye, j3 is left-eye -->
         <param name="AxisMap">                  0              1               2               3                   </param> 
-        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_verg"           </param>
+        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_vergence"           </param>
         <param name="AxisType">                "revolute"    "revolute"         "revolute"    "revolute"           </param>
         <param name="Encoder">                  182.044        182.044         182.044         182.044             </param>   
         <param name="fullscalePWM">           3360            3360           3360            3360                </param>

--- a/iCubGenova08/hardware/mechanicals/head-eb21-j2_5-mec.xml
+++ b/iCubGenova08/hardware/mechanicals/head-eb21-j2_5-mec.xml
@@ -9,7 +9,7 @@
         <!-- joint number in sub-part           0             1               2               3           -->
         <!-- joint name                         neck-yaw       eyes-tilt       eyes-vers       eyes-verg   -->     <!-- j2 is right-eye, j3 is left-eye -->
         <param name="AxisMap">                  0              1               2               3                   </param> 
-        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_vers"   "eyes_verg"           </param>
+        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_verg"           </param>
         <param name="AxisType">                "revolute"    "revolute"         "revolute"    "revolute"           </param>
         <param name="Encoder">                  182.044        182.044         182.044         182.044             </param>   
         <param name="fullscalePWM">           3360            3360           3360            3360                </param>

--- a/iCubGenova08/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubGenova08/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index_distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index_distal" "l_middle_proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubGenova08/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubGenova08/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index_distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubGenova08/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubGenova08/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubGenova08/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubGenova08/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_little-fingers"  </param> 
+        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubGenova08/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubGenova08/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle-distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_little-fingers"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubGenova08/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubGenova08/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
+        <param name="AxisName">                 "r_index_distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubGenova08/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubGenova08/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubGenova08/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubGenova08/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle-proximal" "r_middle-distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle-distal" "r_little-fingers"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubGenova08/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
+++ b/iCubGenova08/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
@@ -10,7 +10,7 @@
     <xi:include href="./left_arm-eb26-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3                   -->
-    <!-- joint name                             index-distal        middle-proximal     middle-distal       little-fingers      -->     
+    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers      -->     
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270                 </param>
         <param name="jntPosMin">                0                   0                   0                   0                   </param> 

--- a/iCubGenova08/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
+++ b/iCubGenova08/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
@@ -10,7 +10,7 @@
     <xi:include href="./right_arm-eb29-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3               -->
-    <!-- joint name                             index-distal        middle-proximal     middle-distal       little-fingers  -->     
+    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers  -->     
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270             </param>
         <param name="jntPosMin">                0                   0                   0                   0               </param> 

--- a/iCubGenova09/hardware/mechanicals/head-eb21-j2_5-mec.xml
+++ b/iCubGenova09/hardware/mechanicals/head-eb21-j2_5-mec.xml
@@ -9,7 +9,7 @@
         <!-- joint number in sub-part           0             1               2               3           -->
         <!-- joint name                         neck-yaw       eyes-tilt       eyes-vers       eyes-verg   -->     <!-- j2 is right-eye, j3 is left-eye -->
         <param name="AxisMap">                  0              1               2               3                   </param> 
-        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_verg"           </param>
+        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_vergence"           </param>
         <param name="AxisType">                "revolute"    "revolute"         "revolute"    "revolute"           </param>
         <param name="Encoder">                  182.044        182.044         182.044         182.044             </param>   
         <param name="fullscalePWM">           3360            3360           3360            3360                </param>

--- a/iCubGenova09/hardware/mechanicals/head-eb21-j2_5-mec.xml
+++ b/iCubGenova09/hardware/mechanicals/head-eb21-j2_5-mec.xml
@@ -9,7 +9,7 @@
         <!-- joint number in sub-part           0             1               2               3           -->
         <!-- joint name                         neck-yaw       eyes-tilt       eyes-vers       eyes-verg   -->     <!-- j2 is right-eye, j3 is left-eye -->
         <param name="AxisMap">                  0              1               2               3                   </param> 
-        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_vers"   "eyes_verg"           </param>
+        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_verg"           </param>
         <param name="AxisType">                "revolute"    "revolute"         "revolute"    "revolute"           </param>
         <param name="Encoder">                  182.044        182.044         182.044         182.044             </param>   
         <param name="fullscalePWM">           3360            3360           3360            3360                </param>

--- a/iCubGenova09/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubGenova09/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index_distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index_distal" "l_middle_proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubGenova09/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubGenova09/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index_distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubGenova09/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubGenova09/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubGenova09/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubGenova09/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_little-fingers"  </param> 
+        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubGenova09/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubGenova09/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle-distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_little-fingers"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubGenova09/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubGenova09/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
+        <param name="AxisName">                 "r_index_distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubGenova09/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubGenova09/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubGenova09/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubGenova09/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle-proximal" "r_middle-distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle-distal" "r_little-fingers"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubGenova09/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
+++ b/iCubGenova09/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
@@ -10,7 +10,7 @@
     <xi:include href="./left_arm-eb26-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3                   -->
-    <!-- joint name                             index-distal        middle-proximal     middle-distal       little-fingers      -->     
+    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers      -->     
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270                 </param>
         <param name="jntPosMin">                0                   0                   0                   0                   </param> 

--- a/iCubGenova09/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
+++ b/iCubGenova09/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
@@ -10,7 +10,7 @@
     <xi:include href="./right_arm-eb29-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3               -->
-    <!-- joint name                             index-distal        middle-proximal     middle-distal       little-fingers  -->     
+    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers  -->     
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270             </param>
         <param name="jntPosMin">                0                   0                   0                   0               </param> 

--- a/iCubGenova10/hardware/mechanicals/head-eb21-j2_5-mec.xml
+++ b/iCubGenova10/hardware/mechanicals/head-eb21-j2_5-mec.xml
@@ -9,7 +9,7 @@
         <!-- joint number in sub-part           0             1               2               3           -->
         <!-- joint name                         neck-yaw       eyes-tilt       eyes-vers       eyes-verg   -->     <!-- j2 is right-eye, j3 is left-eye -->
         <param name="AxisMap">                  0              1               2               3                   </param> 
-        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_verg"           </param>
+        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_vergence"           </param>
         <param name="AxisType">                "revolute"    "revolute"         "revolute"    "revolute"           </param>
         <param name="Encoder">                  182.044        182.044         182.044         182.044             </param>   
         <param name="fullscalePWM">           3360            3360           3360            3360                </param>

--- a/iCubGenova10/hardware/mechanicals/head-eb21-j2_5-mec.xml
+++ b/iCubGenova10/hardware/mechanicals/head-eb21-j2_5-mec.xml
@@ -9,7 +9,7 @@
         <!-- joint number in sub-part           0             1               2               3           -->
         <!-- joint name                         neck-yaw       eyes-tilt       eyes-vers       eyes-verg   -->     <!-- j2 is right-eye, j3 is left-eye -->
         <param name="AxisMap">                  0              1               2               3                   </param> 
-        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_vers"   "eyes_verg"           </param>
+        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_verg"           </param>
         <param name="AxisType">                "revolute"    "revolute"         "revolute"    "revolute"           </param>
         <param name="Encoder">                  182.044        182.044         182.044         182.044             </param>   
         <param name="fullscalePWM">           3360            3360           3360            3360                </param>

--- a/iCubGenova10/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubGenova10/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index_distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index_distal" "l_middle_proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubGenova10/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubGenova10/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index_distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubGenova10/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubGenova10/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubGenova10/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubGenova10/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_little-fingers"  </param> 
+        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubGenova10/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubGenova10/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle-distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_little-fingers"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubGenova10/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubGenova10/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
+        <param name="AxisName">                 "r_index_distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubGenova10/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubGenova10/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubGenova10/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubGenova10/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle-proximal" "r_middle-distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle-distal" "r_little-fingers"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubGenova10/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
+++ b/iCubGenova10/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
@@ -10,7 +10,7 @@
     <xi:include href="./left_arm-eb26-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3                   -->
-    <!-- joint name                             index-distal        middle-proximal     middle-distal       little-fingers      -->     
+    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers      -->     
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270                 </param>
         <param name="jntPosMin">                0                   0                   0                   0                   </param> 

--- a/iCubGenova10/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
+++ b/iCubGenova10/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
@@ -10,7 +10,7 @@
     <xi:include href="./right_arm-eb29-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3               -->
-    <!-- joint name                             index-distal        middle-proximal     middle-distal       little-fingers  -->     
+    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers  -->     
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270             </param>
         <param name="jntPosMin">                0                   0                   0                   0               </param> 

--- a/iCubHamburg01/hardware/mechanicals/head-eb21-j2_5-mec.xml
+++ b/iCubHamburg01/hardware/mechanicals/head-eb21-j2_5-mec.xml
@@ -9,7 +9,7 @@
         <!-- joint number in sub-part           0             1               2               3           -->
         <!-- joint name                         neck-yaw       eyes-tilt       eyes-vers       eyes-verg   -->     <!-- j2 is right-eye, j3 is left-eye -->
         <param name="AxisMap">                  0              1               2               3                   </param> 
-        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_verg"           </param>
+        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_vergence"           </param>
         <param name="AxisType">                "revolute"    "revolute"         "revolute"    "revolute"           </param>
         <param name="Encoder">                  182.044        182.044         182.044         182.044             </param>   
         <param name="fullscalePWM">           3360            3360           3360            3360                </param>

--- a/iCubHamburg01/hardware/mechanicals/head-eb21-j2_5-mec.xml
+++ b/iCubHamburg01/hardware/mechanicals/head-eb21-j2_5-mec.xml
@@ -9,7 +9,7 @@
         <!-- joint number in sub-part           0             1               2               3           -->
         <!-- joint name                         neck-yaw       eyes-tilt       eyes-vers       eyes-verg   -->     <!-- j2 is right-eye, j3 is left-eye -->
         <param name="AxisMap">                  0              1               2               3                   </param> 
-        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_vers"   "eyes_verg"           </param>
+        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_verg"           </param>
         <param name="AxisType">                "revolute"    "revolute"         "revolute"    "revolute"           </param>
         <param name="Encoder">                  182.044        182.044         182.044         182.044             </param>   
         <param name="fullscalePWM">           3360            3360           3360            3360                </param>

--- a/iCubHongKong01/hardware/mechanicals/head-eb21-j2_5-mec.xml
+++ b/iCubHongKong01/hardware/mechanicals/head-eb21-j2_5-mec.xml
@@ -9,7 +9,7 @@
         <!-- joint number in sub-part           0             1               2               3           -->
         <!-- joint name                         neck-yaw       eyes-tilt       eyes-vers       eyes-verg   -->     <!-- j2 is right-eye, j3 is left-eye -->
         <param name="AxisMap">                  0              1               2               3                   </param> 
-        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_verg"           </param>
+        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_vergence"           </param>
         <param name="AxisType">                "revolute"    "revolute"         "revolute"    "revolute"           </param>
         <param name="Encoder">                  182.044        182.044         182.044         182.044             </param>   
         <param name="fullscalePWM">           3360            3360           3360            3360                </param>

--- a/iCubHongKong01/hardware/mechanicals/head-eb21-j2_5-mec.xml
+++ b/iCubHongKong01/hardware/mechanicals/head-eb21-j2_5-mec.xml
@@ -9,7 +9,7 @@
         <!-- joint number in sub-part           0             1               2               3           -->
         <!-- joint name                         neck-yaw       eyes-tilt       eyes-vers       eyes-verg   -->     <!-- j2 is right-eye, j3 is left-eye -->
         <param name="AxisMap">                  0              1               2               3                   </param> 
-        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_vers"   "eyes_verg"           </param>
+        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_verg"           </param>
         <param name="AxisType">                "revolute"    "revolute"         "revolute"    "revolute"           </param>
         <param name="Encoder">                  182.044        182.044         182.044         182.044             </param>   
         <param name="fullscalePWM">           3360            3360           3360            3360                </param>

--- a/iCubHongKong01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubHongKong01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index_distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index_distal" "l_middle_proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubHongKong01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubHongKong01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index_distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubHongKong01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubHongKong01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubHongKong01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubHongKong01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_little-fingers"  </param> 
+        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubHongKong01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubHongKong01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle-distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_little-fingers"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubHongKong01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubHongKong01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
+        <param name="AxisName">                 "r_index_distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubHongKong01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubHongKong01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubHongKong01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubHongKong01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle-proximal" "r_middle-distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle-distal" "r_little-fingers"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubHongKong01/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
+++ b/iCubHongKong01/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
@@ -10,7 +10,7 @@
     <xi:include href="./left_arm-eb26-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3                   -->
-    <!-- joint name                             index-distal        middle-proximal     middle-distal       little-fingers      -->     
+    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers      -->     
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270                 </param>
         <param name="jntPosMin">                0                   0                   0                   0                   </param> 

--- a/iCubHongKong01/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
+++ b/iCubHongKong01/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
@@ -10,7 +10,7 @@
     <xi:include href="./right_arm-eb29-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3               -->
-    <!-- joint name                             index-distal        middle-proximal     middle-distal       little-fingers  -->     
+    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers  -->     
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270             </param>
         <param name="jntPosMin">                0                   0                   0                   0               </param> 

--- a/iCubLausanne02/hardware/mechanicals/head-eb21-j2_5-mec.xml
+++ b/iCubLausanne02/hardware/mechanicals/head-eb21-j2_5-mec.xml
@@ -14,7 +14,7 @@
         <!-- joint number in sub-part           0             1               2               3           -->
         <!-- joint name                         neck-yaw       eyes-tilt       eyes-vers       eyes-verg   -->     <!-- j2 is right-eye, j3 is left-eye -->
         <param name="AxisMap">                  0              1               2               3                   </param> 
-        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_vers"   "eyes_verg"           </param>
+        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_verg"           </param>
         <param name="AxisType">                "revolute"    "revolute"         "revolute"    "revolute"           </param>
         <param name="Encoder">                  182.044        182.044         182.044         182.044             </param>   
         <param name="fullscalePWM">           3360            3360           3360            3360                </param>

--- a/iCubLausanne02/hardware/mechanicals/head-eb21-j2_5-mec.xml
+++ b/iCubLausanne02/hardware/mechanicals/head-eb21-j2_5-mec.xml
@@ -14,7 +14,7 @@
         <!-- joint number in sub-part           0             1               2               3           -->
         <!-- joint name                         neck-yaw       eyes-tilt       eyes-vers       eyes-verg   -->     <!-- j2 is right-eye, j3 is left-eye -->
         <param name="AxisMap">                  0              1               2               3                   </param> 
-        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_verg"           </param>
+        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_vergence"           </param>
         <param name="AxisType">                "revolute"    "revolute"         "revolute"    "revolute"           </param>
         <param name="Encoder">                  182.044        182.044         182.044         182.044             </param>   
         <param name="fullscalePWM">           3360            3360           3360            3360                </param>

--- a/iCubLausanne02/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubLausanne02/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index_distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index_distal" "l_middle_proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubLausanne02/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubLausanne02/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index_distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubLausanne02/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubLausanne02/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubLausanne02/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubLausanne02/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_little-fingers"  </param> 
+        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubLausanne02/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubLausanne02/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle-distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_little-fingers"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubLausanne02/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubLausanne02/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
+        <param name="AxisName">                 "r_index_distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubLausanne02/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubLausanne02/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubLausanne02/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubLausanne02/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle-proximal" "r_middle-distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle-distal" "r_little-fingers"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubLausanne02/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
+++ b/iCubLausanne02/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
@@ -12,7 +12,7 @@
         <xi:include href="./left_arm-eb26-j12_15-mc_service.xml" />
 
         <!-- joint number in sub-part           0               1               2               3          -->
-        <!-- joint name                    index-distal   middle-proximal   middle-distal   little-fingers -->     
+        <!-- joint name                    index_distal   middle-proximal   middle-distal   little-fingers -->     
         <group name="LIMITS">
             <param name="jntPosMax">              180          90              180             270        </param>
             <param name="jntPosMin">                0           0                0               0        </param> 

--- a/iCubLausanne02/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
+++ b/iCubLausanne02/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
@@ -12,7 +12,7 @@
         <xi:include href="./right_arm-eb29-j12_15-mc_service.xml" />
 
         <!-- joint number in sub-part           0               1               2               3          -->
-        <!-- joint name                    index-distal   middle-proximal   middle-distal   little-fingers -->     
+        <!-- joint name                    index_distal   middle-proximal   middle-distal   little-fingers -->     
         <group name="LIMITS">
             <param name="jntPosMax">              180          90              180             270          </param>
             <param name="jntPosMin">                0           0                0               0           </param> 

--- a/iCubMoscow01/hardware/mechanicals/head-eb21-j2_5-mec.xml
+++ b/iCubMoscow01/hardware/mechanicals/head-eb21-j2_5-mec.xml
@@ -9,7 +9,7 @@
         <!-- joint number in sub-part           0             1               2               3           -->
         <!-- joint name                         neck-yaw       eyes-tilt       eyes-vers       eyes-verg   -->     <!-- j2 is right-eye, j3 is left-eye -->
         <param name="AxisMap">                  0              1               2               3                   </param> 
-        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_verg"           </param>
+        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_vergence"           </param>
         <param name="AxisType">                "revolute"    "revolute"         "revolute"    "revolute"           </param>
         <param name="Encoder">                  182.044        182.044         182.044         182.044             </param>   
         <param name="fullscalePWM">           3360            3360           3360            3360                </param>

--- a/iCubMoscow01/hardware/mechanicals/head-eb21-j2_5-mec.xml
+++ b/iCubMoscow01/hardware/mechanicals/head-eb21-j2_5-mec.xml
@@ -9,7 +9,7 @@
         <!-- joint number in sub-part           0             1               2               3           -->
         <!-- joint name                         neck-yaw       eyes-tilt       eyes-vers       eyes-verg   -->     <!-- j2 is right-eye, j3 is left-eye -->
         <param name="AxisMap">                  0              1               2               3                   </param> 
-        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_vers"   "eyes_verg"           </param>
+        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_verg"           </param>
         <param name="AxisType">                "revolute"    "revolute"         "revolute"    "revolute"           </param>
         <param name="Encoder">                  182.044        182.044         182.044         182.044             </param>   
         <param name="fullscalePWM">           3360            3360           3360            3360                </param>

--- a/iCubMoscow01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubMoscow01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index_distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index_distal" "l_middle_proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubMoscow01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubMoscow01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index_distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubMoscow01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubMoscow01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubMoscow01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubMoscow01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_little-fingers"  </param> 
+        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubMoscow01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubMoscow01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle-distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_little-fingers"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubMoscow01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubMoscow01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
+        <param name="AxisName">                 "r_index_distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubMoscow01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubMoscow01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubMoscow01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubMoscow01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle-proximal" "r_middle-distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle-distal" "r_little-fingers"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubMoscow01/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
+++ b/iCubMoscow01/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
@@ -10,7 +10,7 @@
     <xi:include href="./left_arm-eb26-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3                   -->
-    <!-- joint name                             index-distal        middle-proximal     middle-distal       little-fingers      -->     
+    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers      -->     
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270                 </param>
         <param name="jntPosMin">                0                   0                   0                   0                   </param> 

--- a/iCubMoscow01/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
+++ b/iCubMoscow01/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
@@ -10,7 +10,7 @@
     <xi:include href="./right_arm-eb29-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3               -->
-    <!-- joint name                             index-distal        middle-proximal     middle-distal       little-fingers  -->     
+    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers  -->     
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270             </param>
         <param name="jntPosMin">                0                   0                   0                   0               </param> 

--- a/iCubPrague01/hardware/mechanicals/head-eb21-j2_5-mec.xml
+++ b/iCubPrague01/hardware/mechanicals/head-eb21-j2_5-mec.xml
@@ -9,7 +9,7 @@
         <!-- joint number in sub-part           0             1               2               3           -->
         <!-- joint name                         neck-yaw       eyes-tilt       eyes-vers       eyes-verg   -->     <!-- j2 is right-eye, j3 is left-eye -->
         <param name="AxisMap">                  0              1               2               3                   </param> 
-        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_verg"           </param>
+        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_vergence"           </param>
         <param name="AxisType">                "revolute"    "revolute"         "revolute"    "revolute"           </param>
         <param name="Encoder">                  182.044        182.044         182.044         182.044             </param>   
         <param name="fullscalePWM">           3360            3360           3360            3360                </param>

--- a/iCubPrague01/hardware/mechanicals/head-eb21-j2_5-mec.xml
+++ b/iCubPrague01/hardware/mechanicals/head-eb21-j2_5-mec.xml
@@ -9,7 +9,7 @@
         <!-- joint number in sub-part           0             1               2               3           -->
         <!-- joint name                         neck-yaw       eyes-tilt       eyes-vers       eyes-verg   -->     <!-- j2 is right-eye, j3 is left-eye -->
         <param name="AxisMap">                  0              1               2               3                   </param> 
-        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_vers"   "eyes_verg"           </param>
+        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_verg"           </param>
         <param name="AxisType">                "revolute"    "revolute"         "revolute"    "revolute"           </param>
         <param name="Encoder">                  182.044        182.044         182.044         182.044             </param>   
         <param name="fullscalePWM">           3360            3360           3360            3360                </param>

--- a/iCubPrague01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubPrague01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index_distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index_distal" "l_middle_proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubPrague01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubPrague01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index_distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubPrague01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubPrague01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubPrague01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubPrague01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_little-fingers"  </param> 
+        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubPrague01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubPrague01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle-distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_little-fingers"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubPrague01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubPrague01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
+        <param name="AxisName">                 "r_index_distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubPrague01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubPrague01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubPrague01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubPrague01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle-proximal" "r_middle-distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle-distal" "r_little-fingers"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubPrague01/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
+++ b/iCubPrague01/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
@@ -10,7 +10,7 @@
     <xi:include href="./left_arm-eb26-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3                   -->
-    <!-- joint name                             index-distal        middle-proximal     middle-distal       little-fingers      -->     
+    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers      -->     
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270                 </param>
         <param name="jntPosMin">                0                   0                   0                   0                   </param> 

--- a/iCubPrague01/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
+++ b/iCubPrague01/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
@@ -10,7 +10,7 @@
     <xi:include href="./right_arm-eb29-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3               -->
-    <!-- joint name                             index-distal        middle-proximal     middle-distal       little-fingers  -->     
+    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers  -->     
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270             </param>
         <param name="jntPosMin">                0                   0                   0                   0               </param> 

--- a/iCubShenzhen/hardware/mechanicals/head-eb21-j2_5-mec.xml
+++ b/iCubShenzhen/hardware/mechanicals/head-eb21-j2_5-mec.xml
@@ -9,7 +9,7 @@
         <!-- joint number in sub-part           0             1               2               3           -->
         <!-- joint name                         neck-yaw       eyes-tilt       eyes-vers       eyes-verg   -->     <!-- j2 is right-eye, j3 is left-eye -->
         <param name="AxisMap">                  0              1               2               3                   </param> 
-        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_verg"           </param>
+        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_vergence"           </param>
         <param name="AxisType">                "revolute"    "revolute"         "revolute"    "revolute"           </param>
         <param name="Encoder">                  182.044        182.044         182.044         182.044             </param>   
         <param name="fullscalePWM">           3360            3360           3360            3360                </param>

--- a/iCubShenzhen/hardware/mechanicals/head-eb21-j2_5-mec.xml
+++ b/iCubShenzhen/hardware/mechanicals/head-eb21-j2_5-mec.xml
@@ -9,7 +9,7 @@
         <!-- joint number in sub-part           0             1               2               3           -->
         <!-- joint name                         neck-yaw       eyes-tilt       eyes-vers       eyes-verg   -->     <!-- j2 is right-eye, j3 is left-eye -->
         <param name="AxisMap">                  0              1               2               3                   </param> 
-        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_vers"   "eyes_verg"           </param>
+        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_verg"           </param>
         <param name="AxisType">                "revolute"    "revolute"         "revolute"    "revolute"           </param>
         <param name="Encoder">                  182.044        182.044         182.044         182.044             </param>   
         <param name="fullscalePWM">           3360            3360           3360            3360                </param>

--- a/iCubShenzhen/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubShenzhen/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index_distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index_distal" "l_middle_proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubShenzhen/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubShenzhen/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index_distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubShenzhen/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubShenzhen/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubShenzhen/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubShenzhen/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_little-fingers"  </param> 
+        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubShenzhen/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubShenzhen/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle-distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_little-fingers"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubShenzhen/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubShenzhen/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
+        <param name="AxisName">                 "r_index_distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubShenzhen/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubShenzhen/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubShenzhen/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubShenzhen/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle-proximal" "r_middle-distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle-distal" "r_little-fingers"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubShenzhen/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
+++ b/iCubShenzhen/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
@@ -12,7 +12,7 @@
         <xi:include href="./left_arm-eb26-j12_15-mc_service.xml" />
 
         <!-- joint number in sub-part           0               1               2               3          -->
-        <!-- joint name                    index-distal   middle-proximal   middle-distal   little-fingers -->     
+        <!-- joint name                    index_distal   middle-proximal   middle-distal   little-fingers -->     
         <group name="LIMITS">
             <param name="jntPosMax">              180          90              180             270        </param>
             <param name="jntPosMin">                0           0                0               0        </param> 

--- a/iCubShenzhen/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
+++ b/iCubShenzhen/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
@@ -12,7 +12,7 @@
         <xi:include href="./right_arm-eb29-j12_15-mc_service.xml" />
 
         <!-- joint number in sub-part           0               1               2               3          -->
-        <!-- joint name                    index-distal   middle-proximal   middle-distal   little-fingers -->     
+        <!-- joint name                    index_distal   middle-proximal   middle-distal   little-fingers -->     
         <group name="LIMITS">
             <param name="jntPosMax">              180          90              180             270          </param>
             <param name="jntPosMin">                0           0                0               0           </param> 

--- a/iCubShenzhen01/hardware/mechanicals/head-eb21-j2_5-mec.xml
+++ b/iCubShenzhen01/hardware/mechanicals/head-eb21-j2_5-mec.xml
@@ -9,7 +9,7 @@
         <!-- joint number in sub-part           0             1               2               3           -->
         <!-- joint name                         neck-yaw       eyes-tilt       eyes-vers       eyes-verg   -->     <!-- j2 is right-eye, j3 is left-eye -->
         <param name="AxisMap">                  0              1               2               3                   </param> 
-        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_verg"           </param>
+        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_vergence"           </param>
         <param name="AxisType">                "revolute"    "revolute"         "revolute"    "revolute"           </param>
         <param name="Encoder">                  182.044        182.044         182.044         182.044             </param>   
         <param name="fullscalePWM">           3360            3360           3360            3360                </param>

--- a/iCubShenzhen01/hardware/mechanicals/head-eb21-j2_5-mec.xml
+++ b/iCubShenzhen01/hardware/mechanicals/head-eb21-j2_5-mec.xml
@@ -9,7 +9,7 @@
         <!-- joint number in sub-part           0             1               2               3           -->
         <!-- joint name                         neck-yaw       eyes-tilt       eyes-vers       eyes-verg   -->     <!-- j2 is right-eye, j3 is left-eye -->
         <param name="AxisMap">                  0              1               2               3                   </param> 
-        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_vers"   "eyes_verg"           </param>
+        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_verg"           </param>
         <param name="AxisType">                "revolute"    "revolute"         "revolute"    "revolute"           </param>
         <param name="Encoder">                  182.044        182.044         182.044         182.044             </param>   
         <param name="fullscalePWM">           3360            3360           3360            3360                </param>

--- a/iCubShenzhen01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubShenzhen01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index_distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index_distal" "l_middle_proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubShenzhen01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubShenzhen01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index_distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubShenzhen01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubShenzhen01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubShenzhen01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubShenzhen01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_little-fingers"  </param> 
+        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubShenzhen01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubShenzhen01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle-distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_little-fingers"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubShenzhen01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubShenzhen01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
+        <param name="AxisName">                 "r_index_distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubShenzhen01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubShenzhen01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubShenzhen01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubShenzhen01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle-proximal" "r_middle-distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle-distal" "r_little-fingers"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubShenzhen01/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
+++ b/iCubShenzhen01/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
@@ -10,7 +10,7 @@
     <xi:include href="./left_arm-eb26-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3                   -->
-    <!-- joint name                             index-distal        middle-proximal     middle-distal       little-fingers      -->     
+    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers      -->     
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270                 </param>
         <param name="jntPosMin">                0                   0                   0                   0                   </param> 

--- a/iCubShenzhen01/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
+++ b/iCubShenzhen01/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
@@ -10,7 +10,7 @@
     <xi:include href="./right_arm-eb29-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3               -->
-    <!-- joint name                             index-distal        middle-proximal     middle-distal       little-fingers  -->     
+    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers  -->     
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270             </param>
         <param name="jntPosMin">                0                   0                   0                   0               </param> 

--- a/iCubSingapore01/hardware/mechanicals/head-eb21-j2_5-mec.xml
+++ b/iCubSingapore01/hardware/mechanicals/head-eb21-j2_5-mec.xml
@@ -9,7 +9,7 @@
         <!-- joint number in sub-part           0             1               2               3           -->
         <!-- joint name                         neck-yaw       eyes-tilt       eyes-vers       eyes-verg   -->     <!-- j2 is right-eye, j3 is left-eye -->
         <param name="AxisMap">                  0              1               2               3                   </param> 
-        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_verg"           </param>
+        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_vergence"           </param>
         <param name="AxisType">                "revolute"    "revolute"         "revolute"    "revolute"           </param>
         <param name="Encoder">                  182.044        182.044         182.044         182.044             </param>   
         <param name="fullscalePWM">           3360            3360           3360            3360                </param>

--- a/iCubSingapore01/hardware/mechanicals/head-eb21-j2_5-mec.xml
+++ b/iCubSingapore01/hardware/mechanicals/head-eb21-j2_5-mec.xml
@@ -9,7 +9,7 @@
         <!-- joint number in sub-part           0             1               2               3           -->
         <!-- joint name                         neck-yaw       eyes-tilt       eyes-vers       eyes-verg   -->     <!-- j2 is right-eye, j3 is left-eye -->
         <param name="AxisMap">                  0              1               2               3                   </param> 
-        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_vers"   "eyes_verg"           </param>
+        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_verg"           </param>
         <param name="AxisType">                "revolute"    "revolute"         "revolute"    "revolute"           </param>
         <param name="Encoder">                  182.044        182.044         182.044         182.044             </param>   
         <param name="fullscalePWM">           3360            3360           3360            3360                </param>

--- a/iCubSingapore01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubSingapore01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index_distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index_distal" "l_middle_proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubSingapore01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubSingapore01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index_distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubSingapore01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubSingapore01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubSingapore01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubSingapore01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_little-fingers"  </param> 
+        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubSingapore01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubSingapore01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle-distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_little-fingers"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubSingapore01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubSingapore01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
+        <param name="AxisName">                 "r_index_distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubSingapore01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubSingapore01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubSingapore01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubSingapore01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle-proximal" "r_middle-distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle-distal" "r_little-fingers"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubSingapore01/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
+++ b/iCubSingapore01/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
@@ -10,7 +10,7 @@
     <xi:include href="./left_arm-eb26-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3                   -->
-    <!-- joint name                             index-distal        middle-proximal     middle-distal       little-fingers      -->     
+    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers      -->     
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270                 </param>
         <param name="jntPosMin">                0                   0                   0                   0                   </param> 

--- a/iCubSingapore01/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
+++ b/iCubSingapore01/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
@@ -10,7 +10,7 @@
     <xi:include href="./right_arm-eb29-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3               -->
-    <!-- joint name                             index-distal        middle-proximal     middle-distal       little-fingers  -->     
+    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers  -->     
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270             </param>
         <param name="jntPosMin">                0                   0                   0                   0               </param> 

--- a/iCubWaterloo01/hardware/mechanicals/head-eb21-j2_5-mec.xml
+++ b/iCubWaterloo01/hardware/mechanicals/head-eb21-j2_5-mec.xml
@@ -9,7 +9,7 @@
         <!-- joint number in sub-part           0             1               2               3           -->
         <!-- joint name                         neck-yaw       eyes-tilt       eyes-vers       eyes-verg   -->     <!-- j2 is right-eye, j3 is left-eye -->
         <param name="AxisMap">                  0              1               2               3                   </param> 
-        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_verg"           </param>
+        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_vergence"           </param>
         <param name="AxisType">                "revolute"    "revolute"         "revolute"    "revolute"           </param>
         <param name="Encoder">                  182.044        182.044         182.044         182.044             </param>   
         <param name="fullscalePWM">           3360            3360           3360            3360                </param>

--- a/iCubWaterloo01/hardware/mechanicals/head-eb21-j2_5-mec.xml
+++ b/iCubWaterloo01/hardware/mechanicals/head-eb21-j2_5-mec.xml
@@ -9,7 +9,7 @@
         <!-- joint number in sub-part           0             1               2               3           -->
         <!-- joint name                         neck-yaw       eyes-tilt       eyes-vers       eyes-verg   -->     <!-- j2 is right-eye, j3 is left-eye -->
         <param name="AxisMap">                  0              1               2               3                   </param> 
-        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_vers"   "eyes_verg"           </param>
+        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_verg"           </param>
         <param name="AxisType">                "revolute"    "revolute"         "revolute"    "revolute"           </param>
         <param name="Encoder">                  182.044        182.044         182.044         182.044             </param>   
         <param name="fullscalePWM">           3360            3360           3360            3360                </param>

--- a/iCubWaterloo01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubWaterloo01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index_distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index_distal" "l_middle_proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubWaterloo01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubWaterloo01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index_distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubWaterloo01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubWaterloo01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubWaterloo01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubWaterloo01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_little-fingers"  </param> 
+        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubWaterloo01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubWaterloo01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle-distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_little-fingers"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubWaterloo01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubWaterloo01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
+        <param name="AxisName">                 "r_index_distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubWaterloo01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubWaterloo01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubWaterloo01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubWaterloo01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle-proximal" "r_middle-distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle-distal" "r_little-fingers"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubWaterloo01/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
+++ b/iCubWaterloo01/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
@@ -10,7 +10,7 @@
     <xi:include href="./left_arm-eb26-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3                   -->
-    <!-- joint name                             index-distal        middle-proximal     middle-distal       little-fingers      -->     
+    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers      -->     
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270                 </param>
         <param name="jntPosMin">                0                   0                   0                   0                   </param> 

--- a/iCubWaterloo01/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
+++ b/iCubWaterloo01/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
@@ -10,7 +10,7 @@
     <xi:include href="./right_arm-eb29-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3               -->
-    <!-- joint name                             index-distal        middle-proximal     middle-distal       little-fingers  -->     
+    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers  -->     
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270             </param>
         <param name="jntPosMin">                0                   0                   0                   0               </param> 

--- a/iCubZagreb01/hardware/mechanicals/head-eb21-j2_5-mec.xml
+++ b/iCubZagreb01/hardware/mechanicals/head-eb21-j2_5-mec.xml
@@ -9,7 +9,7 @@
         <!-- joint number in sub-part           0             1               2               3           -->
         <!-- joint name                         neck-yaw       eyes-tilt       eyes-vers       eyes-verg   -->     <!-- j2 is right-eye, j3 is left-eye -->
         <param name="AxisMap">                  0              1               2               3                   </param> 
-        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_verg"           </param>
+        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_vergence"           </param>
         <param name="AxisType">                "revolute"    "revolute"         "revolute"    "revolute"           </param>
         <param name="Encoder">                  182.044        182.044         182.044         182.044             </param>   
         <param name="fullscalePWM">           3360            3360           3360            3360                </param>

--- a/iCubZagreb01/hardware/mechanicals/head-eb21-j2_5-mec.xml
+++ b/iCubZagreb01/hardware/mechanicals/head-eb21-j2_5-mec.xml
@@ -9,7 +9,7 @@
         <!-- joint number in sub-part           0             1               2               3           -->
         <!-- joint name                         neck-yaw       eyes-tilt       eyes-vers       eyes-verg   -->     <!-- j2 is right-eye, j3 is left-eye -->
         <param name="AxisMap">                  0              1               2               3                   </param> 
-        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_vers"   "eyes_verg"           </param>
+        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_verg"           </param>
         <param name="AxisType">                "revolute"    "revolute"         "revolute"    "revolute"           </param>
         <param name="Encoder">                  182.044        182.044         182.044         182.044             </param>   
         <param name="fullscalePWM">           3360            3360           3360            3360                </param>

--- a/iCubZagreb01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubZagreb01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index_distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index_distal" "l_middle_proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubZagreb01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubZagreb01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index_distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubZagreb01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubZagreb01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubZagreb01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubZagreb01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_little-fingers"  </param> 
+        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iCubZagreb01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubZagreb01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle-distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_little-fingers"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubZagreb01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubZagreb01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
+        <param name="AxisName">                 "r_index_distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubZagreb01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubZagreb01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubZagreb01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubZagreb01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle-proximal" "r_middle-distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle-distal" "r_little-fingers"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iCubZagreb01/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
+++ b/iCubZagreb01/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
@@ -10,7 +10,7 @@
     <xi:include href="./left_arm-eb26-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3                   -->
-    <!-- joint name                             index-distal        middle-proximal     middle-distal       little-fingers      -->     
+    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers      -->     
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270                 </param>
         <param name="jntPosMin">                0                   0                   0                   0                   </param> 

--- a/iCubZagreb01/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
+++ b/iCubZagreb01/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
@@ -10,7 +10,7 @@
     <xi:include href="./right_arm-eb29-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3               -->
-    <!-- joint name                             index-distal        middle-proximal     middle-distal       little-fingers  -->     
+    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers  -->     
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270             </param>
         <param name="jntPosMin">                0                   0                   0                   0               </param> 

--- a/iRonCub-Mk1/hardware/mechanicals/head-eb21-j2_5-mec.xml
+++ b/iRonCub-Mk1/hardware/mechanicals/head-eb21-j2_5-mec.xml
@@ -9,7 +9,7 @@
         <!-- joint number in sub-part           0             1               2               3           -->
         <!-- joint name                         neck-yaw       eyes-tilt       eyes-vers       eyes-verg   -->     <!-- j2 is right-eye, j3 is left-eye -->
         <param name="AxisMap">                  0              1               2               3                   </param> 
-        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_verg"           </param>
+        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_vergence"           </param>
         <param name="AxisType">                "revolute"    "revolute"         "revolute"    "revolute"           </param>
         <param name="Encoder">                  182.044        182.044         182.044         182.044             </param>   
         <param name="fullscalePWM">           3360            3360           3360            3360                </param>

--- a/iRonCub-Mk1/hardware/mechanicals/head-eb21-j2_5-mec.xml
+++ b/iRonCub-Mk1/hardware/mechanicals/head-eb21-j2_5-mec.xml
@@ -9,7 +9,7 @@
         <!-- joint number in sub-part           0             1               2               3           -->
         <!-- joint name                         neck-yaw       eyes-tilt       eyes-vers       eyes-verg   -->     <!-- j2 is right-eye, j3 is left-eye -->
         <param name="AxisMap">                  0              1               2               3                   </param> 
-        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_vers"   "eyes_verg"           </param>
+        <param name="AxisName">                "neck_yaw"      "eyes_tilt"     "eyes_version"   "eyes_verg"           </param>
         <param name="AxisType">                "revolute"    "revolute"         "revolute"    "revolute"           </param>
         <param name="Encoder">                  182.044        182.044         182.044         182.044             </param>   
         <param name="fullscalePWM">           3360            3360           3360            3360                </param>

--- a/iRonCub-Mk1/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iRonCub-Mk1/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index_distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index_distal" "l_middle_proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iRonCub-Mk1/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iRonCub-Mk1/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index_distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iRonCub-Mk1/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iRonCub-Mk1/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_pinky"  </param> 
+        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle_distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iRonCub-Mk1/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iRonCub-Mk1/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_little-fingers"  </param> 
+        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
         <param name="AxisMap">                  0                1                   2                  3               </param>   
         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    

--- a/iRonCub-Mk1/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iRonCub-Mk1/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle-distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_little-fingers"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iRonCub-Mk1/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iRonCub-Mk1/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
+        <param name="AxisName">                 "r_index_distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iRonCub-Mk1/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iRonCub-Mk1/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   

--- a/iRonCub-Mk1/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iRonCub-Mk1/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -7,7 +7,7 @@
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle-proximal" "r_middle-distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index-distal" "r_middle_proximal" "r_middle-distal" "r_little-fingers"  </param> 
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
         <param name="AxisMap">                  0                1                   2                  3                </param>   
          <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   


### PR DESCRIPTION
Some joint names of the hands and of the eyes have been changed in order to be compliant to the names described in the [documentation](https://icub-tech-iit.github.io/documentation/icub_kinematics/icub-joints/icub-joints/)

It fixes #295 