### PR TITLE
Fixes for nws odometry and cer joints

### DIFF
--- a/R1SN003nws/hardware/odometry/odometry.xml
+++ b/R1SN003nws/hardware/odometry/odometry.xml
@@ -2,8 +2,8 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_odometry" type="cerOdometry">
-    <param name="geom_r">   10 </param>
-    <param name="geom_l">   10 </param>
+    <param name="geom_r">   0.16416 </param> <!--//m wheels radius          ((320.0 / 2 / 1000.0)*1.026) -->
+    <param name="geom_l">   0.338   </param> <!--//m wheels distance                                     -->
     
     <action phase="startup" level="20" type="attach">
             <param name="device">  cer_mobile_base_mc_remapper </param>

--- a/R1SN003nws/wrappers/motorControl/cer_alljoints_remapper.xml
+++ b/R1SN003nws/wrappers/motorControl/cer_alljoints_remapper.xml
@@ -4,7 +4,8 @@
     <param name="joints"> 28 </param>
     <paramlist name="networks">
         <elem name="head">(            0  1   0  1 )</elem>
-        <elem name="torso">(           2  5   0  3 )</elem>
+        <elem name="torso">(           2  4   0  2 )</elem>
+        <elem name="torso_yaw">(       5  5   3  3 )</elem>
         <elem name="right_arm">(       6  13  0  7 )</elem>
         <elem name="left_arm">(        14 21  0  7 )</elem>
         <elem name="right_hand">(      22 23  0  1 )</elem>
@@ -14,7 +15,8 @@
     <action phase="startup" level="6" type="attach">
         <paramlist name="networks">
             <elem name="head">            cer_head_mc               </elem>
-            <elem name="torso">           cer_torso_mc              </elem>
+            <elem name="torso">           cer_torso_equivalent_mc   </elem>
+            <elem name="torso_yaw">       cer_torso_mc              </elem>
             <elem name="base">            cer_mobile_base_mc        </elem>
             <elem name="right_arm">       cer_right_arm_no_hand_mc_remapper  </elem>
             <elem name="right_hand">      cer_right_hand_mc         </elem>

--- a/R1SN003nws/wrappers/odometry/odometry_nws_ros.xml
+++ b/R1SN003nws/wrappers/odometry/odometry_nws_ros.xml
@@ -4,8 +4,8 @@
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_odometry_nws_ros" type="odometry2D_nws_ros">
     <param name="topic_name">   /odometry </param>
     <param name="node_name">    /cer_odometry_nws_ros </param>
-    <param name="base_frame">   mobile_base_link </param>
-    <param name="odom_frame">   odometry </param>
+    <param name="base_frame">   mobile_base_body_link </param>
+    <param name="odom_frame">   odom </param>
     
     <action phase="startup" level="10" type="attach">
             <param name="device">  cer_odometry </param>


### PR DESCRIPTION
Fixes to cer torso joints remapper in the config files by @randaz81 .

Fixes odometry tf and topic.

The changes in the wheels radius are the latest values that have been used in the R1SN003 before summer and where tested in GAM in Torino too. They simply where never committed.