### PR TITLE
Hard stop calibration configuration for iCubGenova09 legs.

### DIFF
--- a/iCubGenova09/calibrators/left_leg-calib.xml
+++ b/iCubGenova09/calibrators/left_leg-calib.xml
@@ -15,27 +15,23 @@
 
 
 
-  <group name="CALIBRATION">
-    <param name="calibrationType">                    12              12          12          12           12         12           </param> <!--
-    <param name="calibration1">                       24444         29251        18367       -46782     -13812      -47721     </param> -->
-    <param name="calibration1">                       40461         29421        50502       -13781     15352      -34276     </param> 
-
-    <param name="calibration2">                       0.0            0.0        0.0           0.0         0.0       0.0     </param> 
-    <param name="calibration3">                        0.0            0.0        0.0          0.0         0.0       0.0    </param> 
-
-    <param name="calibration4">                       0.0            0.0        0.0          0.0         0.0       0.0      </param>
-    <param name="calibration5">                       0.0            0.0        0.0          0.0         0.0       0.0      </param>
-    <param name="calibrationZero">                    0.0            0.0        0.0          0.0         0.0       0.0      </param>
-
-    <param name="calibrationDelta">     -2.53     -4.738      1.254     0.0     0.0     -2.813</param>
-
-    <param name="startupPosition">                    5              15          0           -20           0         0           </param>
-    <param name="startupVelocity">                    10.0           10.0       10.0         10.0        10.0      10.0        </param>
-    <param name="startupMaxPwm">                      3000           3000       3000         3000        3000      3000        </param>
-    <param name="startupPosThreshold">                2              2          2            2           2         2           </param>
+   <group name="CALIBRATION">
+    <param name="calibrationType">                    10             10           10            10         10      10       </param>
+    <param name="calibration1">                      -4000           4500        -2500         -2000       2500   -2000     </param>
+    <param name="calibration2">                       0.0            0.0          0             0          0       0        </param> 
+    <param name="calibration3">                       0.0            0.0          0             0          0       0        </param> 
+    <param name="calibration4">                       0.0            0.0          0             0          0       0        </param>
+    <param name="calibration5">                       0.0            0.0          0             0          0       0        </param>
+    <param name="calibrationZero">                    93.5           119          80.761        5.273     -46.150  24.456   </param>
+    <param name="calibrationDelta">                   0              0            0             0          0       0        </param>
+    
+    <param name="startupPosition">                    90              20          0            -70         0       0        </param>
+    <param name="startupVelocity">                    10.0            10.0        10.0          10         10      10       </param>
+    <param name="startupMaxPwm">                      12000           8000        3000          8000       4000    3000     </param>
+    <param name="startupPosThreshold">                2               2           2             2          2       2        </param>
   </group>
 
-  <param name="CALIB_ORDER"> (0) (1) (2) (3) (4) (5)  </param>
+  <param name="CALIB_ORDER"> (2) (4) (5) (3) (0) (1) </param>
 
   <action phase="startup" level="10" type="calibrate">
     <param name="target">left_leg-mc_wrapper</param>

--- a/iCubGenova09/calibrators/right_leg-calib.xml
+++ b/iCubGenova09/calibrators/right_leg-calib.xml
@@ -9,32 +9,29 @@
   </group>
 
   <group name="HOME">
-    <param name="positionHome">                       0.00             5.00        0.00     -5.00           0.00          0.00          </param>
-    <param name="velocityHome">                       10.00           10.00       10.00     10.00          10.00         10.00         </param>
+    <param name="positionHome">                       0.00             5.00        0.00     -5.00           0.00          0.00        </param>
+    <param name="velocityHome">                       10.00           10.00       10.00     10.00          10.00         10.00        </param>
   </group>
 
 
 
   <group name="CALIBRATION">
-    <param name="calibrationType">                    12              12          12            12         12      12      </param> <!--
-    <param name="calibration1">                      -46315         -27486       -21455      29918       27285     7866    </param> -->
-    <param name="calibration1">                      -46203         -26675       -54991      28574      -21495     9657    </param>
-    <param name="calibration2">                       0.0            0.0        0.0          0.0         0.0       0.0     </param> 
-    <param name="calibration3">                       0.0            0.0        0.0          0.0         0.0       0.0     </param> 
+    <param name="calibrationType">                    10             10           10            10         10      10       </param>
+    <param name="calibration1">                       4000          -4500         2500          2000      -2500    2000     </param>
+    <param name="calibration2">                       0.0            0.0          0             0          0       0        </param> 
+    <param name="calibration3">                       0.0            0.0          0             0          0       0        </param> 
+    <param name="calibration4">                       0.0            0.0          0             0          0       0        </param>
+    <param name="calibration5">                       0.0            0.0          0             0          0       0        </param>
+    <param name="calibrationZero">                    93.5           119          80.761        5.273     -46.150  24.456   </param>
+    <param name="calibrationDelta">                   0              0            0             0          0       0        </param>
     
-    <param name="calibration4">                       0.0            0.0        0.0          0.0         0.0       0.0      </param>
-    <param name="calibration5">                       0.0            0.0        0.0          0.0         0.0       0.0      </param>
-    <param name="calibrationZero">                    0.0            0.0        0.0          0.0         0.0       0.0      </param>
-
-    <param name="calibrationDelta">    10.890     -4.182      3.323     -5.416      0.0     -6.539</param>
-
-    <param name="startupPosition">                    5               15           0        -20.0           0             0             </param>
-    <param name="startupVelocity">                    10.0            10.0        10.0      10.0           10.0          10.0          </param>
-    <param name="startupMaxPwm">                      3000            3000        3000      3000           3000          3000          </param>
-    <param name="startupPosThreshold">                2               2           2         2              2             2             </param>
+    <param name="startupPosition">                    90              20          0            -70         0       0        </param>
+    <param name="startupVelocity">                    10.0            10.0        10.0          10         10      10       </param>
+    <param name="startupMaxPwm">                      12000           8000        3000          8000       4000    3000     </param>
+    <param name="startupPosThreshold">                2               2           2             2          2       2        </param>
   </group>
 
-  <param name="CALIB_ORDER">(0) (1) (2) (3) (4) (5)</param>
+  <param name="CALIB_ORDER"> (4) (5) (2) (3) (0) (1)  </param>
   <!-- (1) (2) (3) (4) (5) -->
 
   <action phase="startup" level="10" type="calibrate">

--- a/iCubGenova09/hardware/mechanicals/left_leg-eb7-j0_2-mec.xml
+++ b/iCubGenova09/hardware/mechanicals/left_leg-eb7-j0_2-mec.xml
@@ -12,14 +12,14 @@
         <param name="fullscalePWM">       32000           32000             32000   </param>
         <param name="ampsToSensor">       1000.0          1000.0            1000.0   </param>
         <param name="Gearbox_M2J">        -100.0           100.0            -100.0   </param>
-        <param name="Gearbox_E2J">   	     1               1                 1 </param>
+        <param name="Gearbox_E2J">   	       64             64                 64 </param>
         <param name="useMotorSpeedFbk">      1               1               1   </param>
         <param name="MotorType">       "MOOG_C2900580"    "MOOG_C2900576" "MOOG_C2900576"   </param>
         <param name="Verbose">0</param>
     </group>
     
     <group name="LIMITS">
-        <param name="hardwareJntPosMax">   114           118      80.5  </param>
+        <param name="hardwareJntPosMax">    94           120      80.5  </param>
         <param name="hardwareJntPosMin">   -47           -20     -80.5  </param>
         <param name="rotorPosMin">           0             0       0  </param> 
         <param name="rotorPosMax">           0             0       0  </param>

--- a/iCubGenova09/hardware/mechanicals/left_leg-eb8-j3_5-mec.xml
+++ b/iCubGenova09/hardware/mechanicals/left_leg-eb8-j3_5-mec.xml
@@ -12,7 +12,7 @@
         <param name="fullscalePWM">        32000     32000            32000         </param>
         <param name="ampsToSensor">        1000.0   1000.0          1000.0         </param>
         <param name="Gearbox_M2J">         -100.0   -100.00           -100.00        </param>
-        <param name="Gearbox_E2J">         1     1                1           </param>
+        <param name="Gearbox_E2J">         64       64               32           </param>
          <param name="useMotorSpeedFbk">   1        1                1           </param>
         <param name="MotorType">           "MOOG_C2900580"     "MOOG_C2900580"   "MOOG_C2900575" </param>
        

--- a/iCubGenova09/hardware/mechanicals/right_leg-eb11-j0_2-mec.xml
+++ b/iCubGenova09/hardware/mechanicals/right_leg-eb11-j0_2-mec.xml
@@ -13,7 +13,7 @@
         <param name="fullscalePWM">     32000              32000           32000  </param>
         <param name="ampsToSensor">     1000.0             1000.0           1000.0  </param>
         <param name="Gearbox_M2J">      100.00             -100.00          100.0  </param>
-        <param name="Gearbox_E2J">   	1                  1                  1</param>
+        <param name="Gearbox_E2J">   	  64                 64               64 </param>
         <param name="useMotorSpeedFbk"> 1                  1                1  </param>
         <param name="MotorType">       "MOOG_C2900580"     "MOOG_C2900576" "MOOG_C2900576"  </param>
 
@@ -22,10 +22,10 @@
     
     <group name="LIMITS">
         <!--                                 0        1             	2            -->
-        <param name="hardwareJntPosMax">       114            118   80.5      </param>
-        <param name="hardwareJntPosMin">       -47            -20  -80.5      </param>
-        <param name="rotorPosMin">            0              0      0   </param> 
-        <param name="rotorPosMax">            0              0      0   </param>
+        <param name="hardwareJntPosMax">     94       120   80.5      </param>
+        <param name="hardwareJntPosMin">    -47       -20  -80.5      </param>
+        <param name="rotorPosMin">            0         0      0      </param> 
+        <param name="rotorPosMax">            0         0      0      </param>
     </group>
 
     <group name="2FOC">

--- a/iCubGenova09/hardware/mechanicals/right_leg-eb12-j3_5-mec.xml
+++ b/iCubGenova09/hardware/mechanicals/right_leg-eb12-j3_5-mec.xml
@@ -12,7 +12,7 @@
         <param name="fullscalePWM">           32000     32000               32000           </param>
         <param name="ampsToSensor">           1000.0      1000.0              1000.0         </param>
         <param name="Gearbox_M2J">             100.0    100.0               100.0         </param>
-        <param name="Gearbox_E2J">               1    1.0                1.0          </param>
+        <param name="Gearbox_E2J">               64        64                 32         </param>
         <param name="useMotorSpeedFbk">          1         1                  1            </param>
         <param name="MotorType">           "MOOG_C2900580"  "MOOG_C2900580"      "MOOG_C2900575"  </param>
         <param name="Verbose">   0   </param>

--- a/iCubGenova09/hardware/motorControl/left_leg-eb7-j0_2-mc.xml
+++ b/iCubGenova09/hardware/motorControl/left_leg-eb7-j0_2-mc.xml
@@ -12,7 +12,7 @@
     <!-- joint number                           0                   1           0          -->
     <!-- joint name -->
     <group name="LIMITS">
-        <param name="jntPosMax">                110                 100       70        </param>
+        <param name="jntPosMax">                 90                 100       70        </param>
         <param name="jntPosMin">                -40                 -5        -70       </param>
         <param name="jntVelMax">                240                 240       240       </param>
         <param name="motorNominalCurrents">     15000               15000     5000      </param>

--- a/iCubGenova09/hardware/motorControl/left_leg-eb7-j0_2-mc_service.xml
+++ b/iCubGenova09/hardware/motorControl/left_leg-eb7-j0_2-mc_service.xml
@@ -39,7 +39,7 @@
                     <param name="type">             amo                 amo         amo        </param>  
                     <param name="port">             CONN:P6             CONN:P7     CONN:P8    </param>
                     <param name="position">         atjoint             atjoint     atjoint    </param>
-                    <param name="resolution">       1048576             1048576     1048576    </param> 
+                    <param name="resolution">       16384               16384       16384    </param> 
                     <param name="tolerance">        0.703               0.703       0.703      </param>  
                 </group>        
                 

--- a/iCubGenova09/hardware/motorControl/left_leg-eb8-j3_5-mc_service.xml
+++ b/iCubGenova09/hardware/motorControl/left_leg-eb8-j3_5-mc_service.xml
@@ -38,7 +38,7 @@
                     <param name="type">          amo         amo                amo                 </param>  
                     <param name="port">          CONN:P7     CONN:P6            CONN:P8             </param>
                     <param name="position">      atjoint     atjoint            atjoint             </param> 
-                    <param name="resolution">   -1048576     1048576           -1048576             </param>
+                    <param name="resolution">   -16384       16384              -16384             </param>
                     <param name="tolerance">     0.703       0.703               0.703               </param>  
                 </group>        
                 

--- a/iCubGenova09/hardware/motorControl/right_leg-eb11-j0_2-mc.xml
+++ b/iCubGenova09/hardware/motorControl/right_leg-eb11-j0_2-mc.xml
@@ -12,7 +12,7 @@
     <!-- joint number                           0                   1           0          -->
     <!-- joint name -->
     <group name="LIMITS">
-        <param name="jntPosMax">                110                 100       70        </param>
+        <param name="jntPosMax">                 90                 100       70        </param>
         <param name="jntPosMin">                -40                 -5        -70       </param>
         <param name="jntVelMax">                240                 240       240       </param>
         <param name="motorNominalCurrents">     15000               15000     5000      </param>

--- a/iCubGenova09/hardware/motorControl/right_leg-eb11-j0_2-mc_service.xml
+++ b/iCubGenova09/hardware/motorControl/right_leg-eb11-j0_2-mc_service.xml
@@ -39,7 +39,7 @@
                     <param name="type">             amo                 amo         amo        </param>  
                     <param name="port">             CONN:P6             CONN:P7     CONN:P8    </param>
                     <param name="position">         atjoint             atjoint     atjoint    </param>
-                    <param name="resolution">       -1048576           -1048576    -1048576    </param> 
+                    <param name="resolution">      -16384              -16384      -16384      </param>      
                     <param name="tolerance">        0.703               0.703       0.703      </param>  
                 </group>        
                 

--- a/iCubGenova09/hardware/motorControl/right_leg-eb12-j3_5-mc_service.xml
+++ b/iCubGenova09/hardware/motorControl/right_leg-eb12-j3_5-mc_service.xml
@@ -38,8 +38,8 @@
                     <param name="type">          amo         amo                amo                 </param>  
                     <param name="port">          CONN:P7     CONN:P6            CONN:P8             </param>
                     <param name="position">      atjoint     atjoint            atjoint             </param> 
-                    <param name="resolution">   1048576     -1048576           1048576             </param>
-                    <param name="tolerance">     0.703       0.703               0.703               </param>  
+                    <param name="resolution">    16384      -16384              16384               </param>
+                    <param name="tolerance">     0.703       0.703              0.703               </param>  
                 </group>        
                 
                 <group name="ENCODER2">


### PR DESCRIPTION
The iCubGenova09 legs are now calibrated with type 10 (hard stop) as in R1 pronosupination.