### PR TITLE
iCubGenova01 - Update right thumb configuration

### DIFF
--- a/iCubGenova01/calibrators/right_hand_calib.xml
+++ b/iCubGenova01/calibrators/right_hand_calib.xml
@@ -22,7 +22,7 @@
 <!--USE THIS FOR CAN ROBOT CALIBRATION-->
 <group name="CALIBRATION">
 <param name="calibrationType">                                                                                            3        4        4        4        4        4        4        4        </param>
-<param name="calibration1">                                                                                               1742.4  255.0    5.0      196.0    13.0     207.0    22.0     627.0    </param>
+<param name="calibration1">                                                                                               1742.4  180.0    5.0      196.0    13.0     207.0    22.0     627.0    </param>
 <param name="calibration2">                                                                                               10.0     10.0     30.0     10.0     10.0     10.0     10.0     10.0     </param>
 <param name="calibration3">                                                                                               0.0      6000.0   6600.0   6000.0   -7000.0  6000.0   7000.0   14000.0  </param>
 <param name="startupPosition">                                                                                               45.0     0.0      0.0      0.0      0.0      0.0      0.0      0.0      </param>

--- a/iCubGenova01/hardware/motorControl/icub_right_hand.xml
+++ b/iCubGenova01/hardware/motorControl/icub_right_hand.xml
@@ -34,7 +34,7 @@
 <param name="Encoder">       6.844    -1.8   -2.441   -2.078   -2.365   -2.300   -2.359   -1.716   </param>
 <param name="Zeros">         244.58   -100.0  -172.05  -94.33   -175.50  -90.00   -179.33  -365.38  </param>
 <param name="fullscalePWM">           1333            1333         1333      1333     1333    1333     1333    1333  </param>
-<param name="ampsToSensor">           1000.0          1000.0       1000.0    1000.0   1000.0  1000.0   1000.0  1000.0   </param>
+<param name="ampsToSensor">           600.0          600.0       1000.0    1000.0   1000.0  1000.0   1000.0  1000.0   </param>
 
 <param name="TorqueId">     0             0             0             0             0             0             0             0             </param>       
 <param name="TorqueChan">   0             0             0             0             0             0             0             0             </param>       
@@ -60,8 +60,8 @@
 </group>       
  
 <group name="POS_PIDS">      
-<param name="kp">           -8000         -8000         8000          -8000         -8000         -8000         8000          -120          </param>       
-<param name="kd">           -32000        -32000        32000         -32000        -32000        -32000        32000         -1250         </param>       
+<param name="kp">           -6000         -6000         8000          -8000         -8000         -8000         8000          -120          </param>
+<param name="kd">           -26000        -26000        32000         -32000        -32000        -32000        32000         -1250         </param>
 <param name="ki">           -5            -5            5             -5            -5            -5            5             0             </param>       
 <param name="maxOutput">       1333          1333          1333          1333          1333          1333          1333          1333          </param>       
 <param name="maxInt">       1333          1333          1333          1333          1333          1333          1333          1333          </param>       

--- a/iCubGenova01/hardware/motorControl/icub_right_hand.xml
+++ b/iCubGenova01/hardware/motorControl/icub_right_hand.xml
@@ -31,8 +31,8 @@
 <param name="AxisMap">      0             1             2             3             4             5             6             7             </param>       
 <param name="AxisName">    "r_thumb_oppose"     "r_thumb_proximal"     "r_thumb_distal"   "r_index_proximal"    "r_index_distal"    "r_middle_proximal"   "r_middle_distal"    "r_pinky"  </param>
 <param name="AxisType">    "revolute"  "revolute"    "revolute"    "revolute"   "revolute"     "revolute"   "revolute"     "revolute"       </param>
-<param name="Encoder">       6.844    -2.567   -2.453   -2.078   -2.365   -2.300   -2.359   -1.716   </param>
-<param name="Zeros">         244.58   -99.35  -172.04  -94.33   -175.50  -90.00   -179.33  -365.38  </param>
+<param name="Encoder">       6.844    -1.8   -2.441   -2.078   -2.365   -2.300   -2.359   -1.716   </param>
+<param name="Zeros">         244.58   -100.0  -172.05  -94.33   -175.50  -90.00   -179.33  -365.38  </param>
 <param name="fullscalePWM">           1333            1333         1333      1333     1333    1333     1333    1333  </param>
 <param name="ampsToSensor">           1000.0          1000.0       1000.0    1000.0   1000.0  1000.0   1000.0  1000.0   </param>
 


### PR DESCRIPTION
After fixing https://github.com/robotology/icub-tech-support/issues/1236,

this PR update the Calibration for the right thumb proximal and distal.

It also updates the PID gains and the `ampsToSensor` parameter fof the right thumb opposition and proximal.