### PR TITLE
Restored missing "ground_link" to cer.urdf files

### DIFF
--- a/R1SN000/cer.urdf
+++ b/R1SN000/cer.urdf
@@ -29,6 +29,13 @@
     <child link="base_link"/>
     <dynamics damping="0.1"/>
   </joint>
+  <link name="ground_link"/>
+  <joint name="ground_link_fixed_joint" type="fixed">
+    <origin xyz="0 0 -0.2" rpy="0 0 0"/>
+    <parent link="base_link"/>
+    <child link="ground_link"/>
+    <dynamics damping="0.1"/>
+  </joint>
   <link name="mobile_base_lidar"/>
   <joint name="mobile_base_lidar_fixed_joint" type="fixed">
     <origin xyz="0.07 0 0.031" rpy="0 0 0"/>

--- a/R1SN002/cer.urdf
+++ b/R1SN002/cer.urdf
@@ -29,6 +29,13 @@
     <child link="base_link"/>
     <dynamics damping="0.1"/>
   </joint>
+  <link name="ground_link"/>
+  <joint name="ground_link_fixed_joint" type="fixed">
+    <origin xyz="0 0 -0.2" rpy="0 0 0"/>
+    <parent link="base_link"/>
+    <child link="ground_link"/>
+    <dynamics damping="0.1"/>
+  </joint>
   <link name="mobile_base_lidar_F"/>
   <joint name="mobile_base_lidar_F_fixed_joint" type="fixed">
     <origin xyz="0.07 0 0.031" rpy="0 0 0"/>

--- a/R1SN003/cer.urdf
+++ b/R1SN003/cer.urdf
@@ -29,6 +29,13 @@
     <child link="base_link"/>
     <dynamics damping="0.1"/>
   </joint>
+  <link name="ground_link"/>
+  <joint name="ground_link_fixed_joint" type="fixed">
+    <origin xyz="0 0 -0.2" rpy="0 0 0"/>
+    <parent link="base_link"/>
+    <child link="ground_link"/>
+    <dynamics damping="0.1"/>
+  </joint>
   <link name="mobile_base_lidar_F"/>
   <joint name="mobile_base_lidar_F_fixed_joint" type="fixed">
     <origin xyz="0.07 0 0.031" rpy="0 0 0"/>

--- a/R1SN003nws/cer.urdf
+++ b/R1SN003nws/cer.urdf
@@ -29,6 +29,13 @@
     <child link="base_link"/>
     <dynamics damping="0.1"/>
   </joint>
+  <link name="ground_link"/>
+  <joint name="ground_link_fixed_joint" type="fixed">
+    <origin xyz="0 0 -0.2" rpy="0 0 0"/>
+    <parent link="base_link"/>
+    <child link="ground_link"/>
+    <dynamics damping="0.1"/>
+  </joint>
   <link name="mobile_base_lidar_F"/>
   <joint name="mobile_base_lidar_F_fixed_joint" type="fixed">
     <origin xyz="0.07 0 0.031" rpy="0 0 0"/>


### PR DESCRIPTION
I just restored a previously present link that has been removed from almost all the R1 `.urdf` files. 