### PR TITLE
iCubGenova01 - Calibrate left thumb oppose and distal joints

### DIFF
--- a/iCubGenova01/calibrators/left_hand_calib.xml
+++ b/iCubGenova01/calibrators/left_hand_calib.xml
@@ -21,7 +21,7 @@
 <!--USE THIS FOR CAN ROBOT CALIBRATION-->
 <group name="CALIBRATION">
 <param name="calibrationType">                                                                                            3        4        4        4        4        4        4        4        </param>
-<param name="calibration1">                                                                                               1314.1   255.0    5.0     247.0    38.0     255.0    0.0     650.0    </param>
+<param name="calibration1">                                                                                               1960.4   255.0    5.0     247.0    38.0     255.0    0.0     650.0    </param>
 <param name="calibration2">                                                                                               10.0     10.0     30.0     10.0     10.0     10.0     10.0     10.0     </param>
 <param name="calibration3">                                                                                               0.0      6000.0   -6600.0  6000.0   7000.0   6000.0   -7000.0  -14000.0 </param>
 <param name="startupPosition">                                                                                               45.0     0.0      0.0      0.0      0.0      0.0      0.0      0.0      </param>

--- a/iCubGenova01/hardware/motorControl/icub_left_hand.xml
+++ b/iCubGenova01/hardware/motorControl/icub_left_hand.xml
@@ -31,8 +31,8 @@
 <param name="AxisMap">      0             1             2             3             4             5             6             7             </param>
 <param name="AxisName">     "l_thumb_oppose"     "l_thumb_proximal"     "l_thumb_distal"   "l_index_proximal"    "l_index_distal"    "l_middle_proximal"   "l_middle_distal"    "l_pinky"  </param>
 <param name="AxisType">    "revolute"  "revolute"    "revolute"    "revolute"   "revolute"     "revolute"   "revolute"     "revolute"       </param>
-<param name="Encoder">                                                                                                    7.611    -2.478   -2.765   -2.744   -2.406   -2.833   -2.576   -2.040   </param>
-<param name="Zeros">                                                                                                      162.66   -102.91  -171.81  -90.00   -185.79  -90.00   -170.00  -318.63  </param>
+<param name="Encoder">                                                                                                    3.744    -2.478   -2.947   -2.744   -2.406   -2.833   -2.576   -2.040   </param>
+<param name="Zeros">                                                                                                      513.56   -102.91  -171.36  -90.00   -185.79  -90.00   -170.00  -318.63  </param>
 <param name="fullscalePWM">           1333            1333         1333      1333     1333    1333     1333    1333  </param>
 <param name="ampsToSensor">           1000.0          1000.0       1000.0    1000.0   1000.0  1000.0   1000.0  1000.0   </param>
 


### PR DESCRIPTION
This PR modifies calibration and motor control values of the left thumb opposition and distal joints to take into account https://github.com/robotology/icub-tech-support/issues/1284