### PR TITLE
AMC_BLDC: Update LIMITS for rotor position

### DIFF
--- a/experimentalSetups/wristmk2_handmk3_ems_amcbldc/hardware/mechanicals/wrist-eb2-j0_2-mec.xml
+++ b/experimentalSetups/wristmk2_handmk3_ems_amcbldc/hardware/mechanicals/wrist-eb2-j0_2-mec.xml
@@ -21,8 +21,8 @@
     <group name="LIMITS">
         <param name="hardwareJntPosMax">     52          </param>
         <param name="hardwareJntPosMin">    -62          </param>
-        <param name="rotorPosMin">           -20           </param>
-        <param name="rotorPosMax">           20           </param>
+        <param name="rotorPosMin">           0           </param>
+        <param name="rotorPosMax">           0           </param>
     </group>
 
     <group name="2FOC">

--- a/experimentalSetups/wristmk2_handmk3_ems_amcbldc/hardware/motorControl/wrist-eb2-j0_2-mc.xml
+++ b/experimentalSetups/wristmk2_handmk3_ems_amcbldc/hardware/motorControl/wrist-eb2-j0_2-mc.xml
@@ -66,10 +66,10 @@
         <param name="controlLaw">           low_lev_current     </param>
         <param name="fbkControlUnits">      machine_units       </param>
         <param name="outputControlUnits">   machine_units       </param>
-        <param name="kp">                   8       </param>
+        <param name="kp">                   2.0       </param>
         <param name="kd">                   0       </param>
-        <param name="ki">                   2       </param>
-        <param name="shift">                10      </param>
+        <param name="ki">                   500.0       </param>
+        <param name="shift">                0      </param>
         <param name="maxOutput">            32000   </param>
         <param name="maxInt">               32000   </param>
         <param name="kff">                   0      </param>


### PR DESCRIPTION
**What's changed in this PR:**

- `experimentalSetups\wristmk2_handmk3_ems_amcbldc\hardware\mechanicals\wrist-eb2-j0_2-mec.xml` updated to allow the motor to rotate in both direction in AMC_BLDC wrist-setup.