### PR TITLE
Add extra folder to iCubErzelli02

### DIFF
--- a/iCubErzelli02/extra/applications/FaceExpressionsRetargeting.xml
+++ b/iCubErzelli02/extra/applications/FaceExpressionsRetargeting.xml
@@ -1,0 +1,39 @@
+<!-- Copyright (C) 2021 Fondazione Istituto Italiano di Tecnologia (IIT) -->
+<!-- All Rights Reserved. -->
+
+<application>
+
+  <name>FaceExpressionsRetargeting</name>
+  <description>Application to run Psychophysiological related modules for retargeting.</description>
+  <version>1.0</version>
+  <authors>
+    <author email="stefano.dafarra@iit.it">Stefano Dafarra</author>
+  </authors>
+
+   <!-- Modules -->
+   <module>
+     <name>SRanipalModule</name>
+     <parameters>--forceEyeCalibration true --noGaze false --useRawEyelids --gazeVelocityGain 2.0 --gazeDeadzone 0.02 --rawEyelidsCloseValue 30 --rawEyelidsOpenValue 50</parameters>
+     <node>icub-virtualizer</node>
+   </module>
+
+  <!-- Connections -->
+  <connection>
+    <from>/SRanipalModule/emotions:o</from>
+    <to>/icub/face/emotions/in</to>
+    <protocol>fast_tcp</protocol>
+  </connection>
+  
+  <connection>
+    <from>/SRanipalModule/face/raw:o</from>
+    <to>/icub/face/raw/in</to>
+    <protocol>fast_tcp</protocol>
+  </connection>
+  
+  <connection>
+    <from>/SRanipalModule/VR/rpc:o</from>
+    <to>/joypadDevice/Oculus/rpc</to>
+    <protocol>fast_tcp</protocol>
+  </connection>
+
+</application>

--- a/iCubErzelli02/extra/applications/faceExpressions.xml
+++ b/iCubErzelli02/extra/applications/faceExpressions.xml
@@ -1,0 +1,21 @@
+<application>
+<name>Face Expressions</name>
+<module>
+      <name>yarpdev</name>
+      <parameters>--name /icub/face/raw --device serial --subdevice serialport --context faceExpressions --from serialport.ini</parameters>
+	  <node>icub-head</node>
+	<tag>face_device</tag>
+   </module>
+   <module>
+      <name>emotionInterface</name>
+      <parameters>--name /icub/face/emotions --context faceExpressions --from emotions.ini</parameters>
+      <node>icub-head</node>
+	<tag>emotions_interface</tag>
+   </module>
+<connection>
+  <from>/icub/face/emotions/out</from>
+  <to>/icub/face/raw/in</to>
+  <protocol>tcp</protocol>
+</connection> 
+</application>
+  

--- a/iCubErzelli02/extra/contexts/yarpmanager/cluster-config.xml
+++ b/iCubErzelli02/extra/contexts/yarpmanager/cluster-config.xml
@@ -1,0 +1,12 @@
+<cluster name="icub02" user="icub">
+
+<!-- specify type="yarpserver" or type="yarpserver3" to use the old or new nameserver default behavior is to use yarpserver3 -->
+<nameserver namespace="/icub02" node="iiticublap112" type="yarpserver"> </nameserver>
+
+<!-- specify nodes, if you want to enable display on desktop please specify which desktop to use
+this is usually the value of the DISPLAY variable when logged on -->
+<node address="10.0.0.2">icub-head</node>
+<node display=":0" address="10.0.0.130">iiticublap112</node>
+
+</cluster>
+

--- a/iCubErzelli02/extra/scripts/README.md
+++ b/iCubErzelli02/extra/scripts/README.md
@@ -1,0 +1,14 @@
+# Additional Commands
+
+This folder contains a set of script and aliases that ease the use of the robot. 
+In order to use them, we assume that ``robots-configuration`` has been installed using the [``robotology-superbuild``](https://github.com/robotology/robotology-superbuild), and that the ``ROBOTOLOGY_SUPERBUILD_SOURCE_DIR`` and ``YARP_ROBOT_NAME`` environmental variables have been set.
+Then, in the ``.bashrc_iCub`` file, append the following lines
+```sh
+additionalCommandsFile=${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}/src/robots-configuration/${YARP_ROBOT_NAME}/extra/scripts/additionalCommands.sh
+
+if [ -f "$additionalCommandsFile" ]; then
+    source $additionalCommandsFile
+fi
+```
+
+After opening a new terminal, you can type ``helpRobot`` to get a list of useful commands.

--- a/iCubErzelli02/extra/scripts/additionalCommands.sh
+++ b/iCubErzelli02/extra/scripts/additionalCommands.sh
@@ -1,0 +1,59 @@
+## Additional aliases and commands to use the robot
+
+getParentDir () {
+    SOURCE="${1}"
+    while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+      DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+      SOURCE="$(readlink "$SOURCE")"
+      [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+    done
+    DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+}
+
+getParentDir "${BASH_SOURCE[0]}"
+
+# The directory where this script is
+export ADDITIONAL_COMMANDS_DIR="$DIR"
+
+
+#Robots Configuration settings
+alias robotsConfigurationInstaller='bash ${ADDITIONAL_COMMANDS_DIR}/installRobotsConfiguration.sh'
+export ROBOTS_CONFIGURATION_DIR=${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}/src/robots-configuration/${YARP_ROBOT_NAME}
+alias gotoRobotsConfigurationFolder='cd $ROBOTS_CONFIGURATION_DIR'
+
+#Automatic Joypad configuration
+alias connectToJoypad='sudo expect ${ADDITIONAL_COMMANDS_DIR}/bluetoothConnect.sh 28:9A:4B:08:E1:1B'
+
+# Go to DCM folder
+alias dcmFolder='cd ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}/src/walking-controllers/src/WalkingModule/app/robots/${YARP_ROBOT_NAME}'
+
+# Go to the corresponding build folder in the superbuild
+alias goToBuildSuperbuild='cd ../../build/src/${PWD##*/}'
+
+## Alias for running a diff between the source and the install of the configuration files
+alias configurationSourceInstallDiff='bash ${ADDITIONAL_COMMANDS_DIR}/checkConfigurationFiles.sh'
+
+alias test-speaker='speaker-test -t wav -c 1'
+
+# Test if the microphone is working
+test-microphone() {
+    arecord -vvv -f dat /dev/null
+}
+
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+## Alias for displaying info messages about the other aliases
+alias helpRobot='echo -e "Here some useful commands:
+${GREEN}robotsConfigurationInstaller${NC} Takes care of installing the robot configuration files from any folder.
+${GREEN}gotoRobotsConfigurationFolder${NC} Go to the source folder of the robot configuration files.
+${GREEN}configurationSourceInstallDiff${NC} Performs a diff between the source and install configuration files. If there is no difference, it prints nothing.
+${GREEN}connectToJoypad${NC} To reconnect the bluetooth connection of the robot joypad.
+${GREEN}test-speaker${NC} Test if the speaker is working.
+${GREEN}test-microphone${NC} Test if the micorphone is working.
+${GREEN}dcmFolder${NC} Go to the robot walking configuration files.
+${GREEN}goToBuildSuperbuild${NC} Go to the corresponding build folder of the robotology superbuild."'
+
+if [ "$PS1" ]; then
+  echo -e "Type ${GREEN}helpRobot${NC} for a list of useful commands."
+fi
+

--- a/iCubErzelli02/extra/scripts/bluetoothConnect.sh
+++ b/iCubErzelli02/extra/scripts/bluetoothConnect.sh
@@ -1,0 +1,61 @@
+
+#!/usr/bin/expect -f
+
+set address [lindex $argv 0]
+
+spawn sudo bluetoothctl
+
+# Set timeout to 30 sec (-1 for infinity)
+set timeout 30
+
+# Remove the device if it was already connected
+send "remove $address\r"
+expect {
+    -re "Device $address not available" {send_user \
+        "\n--------------\nDevice was not paired before. Continuing.\n\n--------------\n"}
+    -re "Device has been removed"
+    }
+
+# Scan for the device
+send "scan on\r"
+expect {
+    timeout {send_user "\n!!!!!!!\nDevice does not seem to be available.\n\n!!!!!!!!\n" ; \
+        send "quit\r" ; expect eof ; exit 1}
+    -re "$address"
+    }
+send_user "\n--------------\n$address found!\n\n--------------\n"
+send "scan off\r"
+
+# Trust the device (useful since we are not setting any PIN)
+send "trust $address\r"
+expect {
+    timeout {send_user "\n!!!!!!!\nUnable to trust the device.\n\n!!!!!!!!\n" ; \
+        send "quit\r" ; expect eof ; exit 1}
+    -re "trust succeeded"
+    }
+send_user "\n--------------\nTrust succeded!\n\n--------------\n"
+
+#Pair the device
+send "pair $address\r"
+expect {
+    timeout {send_user "\n!!!!!!!\nUnable to pair the device.\n\n!!!!!!!!\n" ; \
+    send "quit\r" ; expect eof ; exit 1}
+    -re "Pairing successful"
+    }
+send_user "\n--------------\nPairing succeded!\n\n--------------\n"
+
+#Connect the device
+send "connect $address\r"
+expect {
+        timeout {send_user "\n!!!!!!!\nUnable to connect to the device.\n\n!!!!!!!!\n" ; \
+        send "quit\r" ; expect eof ; exit 1}
+        -re "Connection successful"
+    }
+send_user "\n--------------\nConnection succeded! The Joystick is ready to be used!!\n\n--------------\n"
+
+#Exit
+send "quit\r"
+expect eof
+exit 0
+
+#iCubGenova04 joypad address: 28:9A:4B:0A:5F:6D

--- a/iCubErzelli02/extra/scripts/checkConfigurationFiles.sh
+++ b/iCubErzelli02/extra/scripts/checkConfigurationFiles.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+diff -r --exclude="CMakeLists.txt" $ROBOTOLOGY_SUPERBUILD_SOURCE_DIR/src/robots-configuration/$YARP_ROBOT_NAME $ROBOTOLOGY_SUPERBUILD_SOURCE_DIR/build/install/share/ICUBcontrib/robots/$YARP_ROBOT_NAME | grep -ve dcm_walking -ve extra > /tmp/diff_out 2>&1
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+if [[ -s /tmp/diff_out ]]; then
+    echo -e "${RED}There are differences.${NC}"
+    cat /tmp/diff_out
+else
+    echo -e "${GREEN}The configuration files in the source and in the install folder coincide.${NC}"
+fi

--- a/iCubErzelli02/extra/scripts/installRobotsConfiguration.sh
+++ b/iCubErzelli02/extra/scripts/installRobotsConfiguration.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if [[ -v "${ICUB_BUILD_PATHNAME}" ]]; then
+    BUILD_DIR=${ICUB_BUILD_PATHNAME}
+else
+    BUILD_DIR='build';
+fi
+
+echo "Running make install in ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}/${BUILD_DIR}/src/robots-configuration"
+
+cd ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}/${BUILD_DIR}/src/robots-configuration
+cmake . && make install


### PR DESCRIPTION
cc @vtikha @RiccardoGrieco

This PR only adds the ``extra`` folder to iCubErzelli02 with some files that were useful when running the teleoperation remotely. These modifications have no effect until they are sourced in the ``.bashrc_iCub``.