### PR TITLE
Update configurations files for wristmk2_handmk3_ems_amc_bldc

### DIFF
--- a/experimentalSetups/wristmk2_handmk3_ems_amcbldc/hardware/motorControl/wrist-eb2-j0_2-mc.xml
+++ b/experimentalSetups/wristmk2_handmk3_ems_amcbldc/hardware/motorControl/wrist-eb2-j0_2-mc.xml
@@ -16,8 +16,8 @@
         <param name="jntPosMin">               -60              </param>
         <param name="jntVelMax">                90              </param>
         <param name="motorNominalCurrents">     1000            </param>
-        <param name="motorPeakCurrents">        1500            </param>
-        <param name="motorOverloadCurrents">    1000            </param>
+        <param name="motorPeakCurrents">        400             </param>
+        <param name="motorOverloadCurrents">    2000            </param>
         <param name="motorPwmLimit">            16000           </param>
     </group>
 

--- a/experimentalSetups/wristmk2_handmk3_ems_amcbldc/hardware/motorControl/wrist-eb2-j0_2-mc.xml
+++ b/experimentalSetups/wristmk2_handmk3_ems_amcbldc/hardware/motorControl/wrist-eb2-j0_2-mc.xml
@@ -16,7 +16,7 @@
         <param name="jntPosMin">               -60              </param>
         <param name="jntVelMax">                90              </param>
         <param name="motorNominalCurrents">     1000            </param>
-        <param name="motorPeakCurrents">        400             </param>
+        <param name="motorPeakCurrents">        1000            </param>
         <param name="motorOverloadCurrents">    2000            </param>
         <param name="motorPwmLimit">            16000           </param>
     </group>


### PR DESCRIPTION
This PR contains an update to the `current limits` used during the FOC motor control.

- Overcurrent and the Peakcurrent have been set to 2000 mA and 400 mA respectively.
