### PR TITLE
AMC_BLDC: Update configuration files to work with the whole wrist

### DIFF
--- a/experimentalSetups/wristmk2_handmk3_ems_amcbldc/calibrators/wrist-calib.xml
+++ b/experimentalSetups/wristmk2_handmk3_ems_amcbldc/calibrators/wrist-calib.xml
@@ -6,34 +6,34 @@
     <xi:include href="../general.xml" />
 
     <group name="GENERAL">
-        <param name="joints"> 1 </param> <!-- the number of joints of the robot part -->
+        <param name="joints"> 3 </param> <!-- the number of joints of the robot part -->
         <param name="deviceName"> Wrist_Calibrator </param>
     </group>
 
     <group name="HOME">
-        <param name="positionHome">                     0       </param>
-        <param name="velocityHome">                     10      </param>
+        <param name="positionHome">                     0       0       0       </param>
+        <param name="velocityHome">                     10      10      10      </param>
     </group>
 
     <group name="CALIBRATION">
-        <param name="calibrationType">                  12      </param>
+        <param name="calibrationType">                  12      12      12      </param>
 
 
-        <param name="calibration1">                     3823   </param>
-        <param name="calibration2">                     0       </param>
-        <param name="calibration3">                     0       </param>
-        <param name="calibration4">                     0       </param>
-        <param name="calibration5">                     0       </param>
-        <param name="calibrationZero">                  0       </param>
-        <param name="calibrationDelta">                 0       </param>
+        <param name="calibration1">                     6172    18789   11688   </param>
+        <param name="calibration2">                     0       0       0       </param>
+        <param name="calibration3">                     0       0       0       </param>
+        <param name="calibration4">                     0       0       0       </param>
+        <param name="calibration5">                     0       0       0       </param>
+        <param name="calibrationZero">                  0       0       0       </param>
+        <param name="calibrationDelta">                 0       0       0       </param>
 
-        <param name="startupPosition">                  0.0     </param>
-        <param name="startupVelocity">                  30.0    </param>
-        <param name="startupMaxPwm">                    16000    </param>
-        <param name="startupPosThreshold">              2       </param>
+        <param name="startupPosition">                  0.0     0.0     0.0     </param>
+        <param name="startupVelocity">                  30.0    30.0    30.0    </param>
+        <param name="startupMaxPwm">                    16000   16000   16000   </param>
+        <param name="startupPosThreshold">              2       2       2       </param>
     </group>
 
-    <param name="CALIB_ORDER"> (0) </param>
+    <param name="CALIB_ORDER"> (0 1 2) </param>
 
     <action phase="startup" level="10" type="calibrate">
         <param name="target">wrist-mc_wrapper</param>

--- a/experimentalSetups/wristmk2_handmk3_ems_amcbldc/hardware/mechanicals/wrist-eb2-j0_2-mec.xml
+++ b/experimentalSetups/wristmk2_handmk3_ems_amcbldc/hardware/mechanicals/wrist-eb2-j0_2-mec.xml
@@ -4,35 +4,35 @@
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="new_forearm" build="1">
     <group name="GENERAL">
         <param name="MotioncontrolVersion"> 6 </param>
-        <param name="Joints"> 1 </param>
-        <param name="AxisMap">               0           </param>
-        <param name="AxisName">         "wrist_pitch"    </param>
-        <param name="AxisType">         "revolute"       </param>
-        <param name="Encoder">          182.044          </param>
-        <param name="fullscalePWM">     32000            </param>
-        <param name="ampsToSensor">     1000.0           </param>
-        <param name="Gearbox_M2J">     -384.44           </param>
-        <param name="Gearbox_E2J">      1.778            </param>
-        <param name="useMotorSpeedFbk"> 0                </param>
-        <param name="MotorType">        "BLL_MOOG"       </param>
+        <param name="Joints"> 3 </param>
+        <param name="AxisMap">               0             1             2           </param>
+        <param name="AxisName">         "wrist_yaw"   "wrist_pitch" "wrist_roll"     </param>
+        <param name="AxisType">         "revolute"    "revolute"    "revolute"       </param>
+        <param name="Encoder">          182.044       182.044       182.044          </param>
+        <param name="fullscalePWM">     32000         32000         32000            </param>
+        <param name="ampsToSensor">     1000.0        1000.0        1000.0           </param>
+        <param name="Gearbox_M2J">     -384.44       -384.44       -384.44           </param>
+        <param name="Gearbox_E2J">      1.778         1.778         1.778            </param>
+        <param name="useMotorSpeedFbk"> 0             0             0                </param>
+        <param name="MotorType">        "BLL_MOOG"    "BLL_MOOG"    "BLL_MOOG"       </param>
         <param name="Verbose">      0   </param>
     </group>
 
     <group name="LIMITS">
-        <param name="hardwareJntPosMax">     52          </param>
-        <param name="hardwareJntPosMin">    -62          </param>
-        <param name="rotorPosMin">           0           </param>
-        <param name="rotorPosMax">           0           </param>
+        <param name="hardwareJntPosMax">     92            52            32          </param>
+        <param name="hardwareJntPosMin">    -92           -62           -32          </param>
+        <param name="rotorPosMin">           0             0             0           </param>
+        <param name="rotorPosMax">           0             0             0           </param>
     </group>
 
     <group name="2FOC">
-        <param name="HasHallSensor">         1           </param>
-        <param name="HasTempSensor">         0           </param>
-        <param name="HasRotorEncoder">       0           </param>
-        <param name="HasRotorEncoderIndex">  0           </param>
-        <param name="HasSpeedEncoder">       0           </param>
-        <param name="RotorIndexOffset">      0           </param>
-        <param name="MotorPoles">            14          </param>
+        <param name="HasHallSensor">         1             1             1           </param>
+        <param name="HasTempSensor">         0             0             0           </param>
+        <param name="HasRotorEncoder">       0             0             0           </param>
+        <param name="HasRotorEncoderIndex">  0             0             0           </param>
+        <param name="HasSpeedEncoder">       0             0             0           </param>
+        <param name="RotorIndexOffset">      0             0             0           </param>
+        <param name="MotorPoles">            14            14            14          </param>
    </group>
 
     <group name="COUPLINGS">
@@ -63,10 +63,10 @@
     <group name="JOINTSET_CFG">
         <param name= "numberofsets"> 1 </param>
         <group name="JOINTSET_0">
-            <param name="listofjoints">  0         </param>
-            <param name="constraint">    none      </param>
-            <param name="param1">        0         </param>
-            <param name="param2">        0         </param>
+            <param name="listofjoints">  0 1 2         </param>
+            <param name="constraint">    none          </param>
+            <param name="param1">        0             </param>
+            <param name="param2">        0             </param>
         </group>
     </group>
 

--- a/experimentalSetups/wristmk2_handmk3_ems_amcbldc/hardware/motorControl/wrist-eb2-j0_2-mc.xml
+++ b/experimentalSetups/wristmk2_handmk3_ems_amcbldc/hardware/motorControl/wrist-eb2-j0_2-mc.xml
@@ -9,34 +9,34 @@
     <xi:include href="../../hardware/mechanicals/wrist-eb2-j0_2-mec.xml" />
     <xi:include href="./wrist-eb2-j0_2-mc_service.xml" />
 
-    <!-- joint number                           1               -->
+    <!-- joint number                           0                   1                   2               -->
     <!-- joint name -->
     <group name="LIMITS">
-        <param name="jntPosMax">                50              </param>
-        <param name="jntPosMin">               -60              </param>
-        <param name="jntVelMax">                90              </param>
-        <param name="motorNominalCurrents">     1000            </param>
-        <param name="motorPeakCurrents">        1000            </param>
-        <param name="motorOverloadCurrents">    2000            </param>
-        <param name="motorPwmLimit">            16000           </param>
+        <param name="jntPosMax">                90                  50                  30                  </param>
+        <param name="jntPosMin">               -90                 -60                 -30                  </param>
+        <param name="jntVelMax">                90                  90                  90                  </param>
+        <param name="motorNominalCurrents">     1000                1000                1000                </param>
+        <param name="motorPeakCurrents">        1500                1500                1500                </param>
+        <param name="motorOverloadCurrents">    2000                2000                2000                </param>
+        <param name="motorPwmLimit">            16000               16000               16000               </param>
     </group>
 
     <group name="TIMEOUTS">
-        <param name="velocity">                 100             </param>
+        <param name="velocity">                 100                 100                 100                 </param>
     </group>
 
     <group name="IMPEDANCE">
-        <param name="stiffness">                0               </param>
-        <param name="damping">                  0               </param>
+        <param name="stiffness">                0                   0                   0                   </param>
+        <param name="damping">                  0                   0                   0                   </param>
     </group>
 
     <group name="CONTROLS">
-        <param name="positionControl">          POS_PID_DEFAULT    </param>
-        <param name="velocityControl">          POS_PID_DEFAULT    </param>
-        <param name="mixedControl">             POS_PID_DEFAULT    </param>
-        <param name="torqueControl">            none               </param>
-        <param name="currentPid">               2FOC_CUR_CONTROL   </param>
-        <param name="speedPid">                 2FOC_VEL_CONTROL   </param>
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="torqueControl">            none                none                none                </param>
+        <param name="currentPid">               2FOC_CUR_CONTROL    2FOC_CUR_CONTROL    2FOC_CUR_CONTROL    </param>
+        <param name="speedPid">                 2FOC_VEL_CONTROL    2FOC_VEL_CONTROL    2FOC_VEL_CONTROL    </param>
     </group>
 
 
@@ -47,14 +47,14 @@
         <param name="outputType">             current               </param>
         <param name="fbkControlUnits">        metric_units          </param>
         <param name="outputControlUnits">     machine_units         </param>
-        <param name="kp">          -30    </param>
-        <param name="kd">           -10.0    </param>
-        <param name="ki">          -100    </param>
-        <param name="maxOutput">    500   </param>
-        <param name="maxInt">       200    </param>
-        <param name="stictionUp">   0       </param>
-        <param name="stictionDown"> 0       </param>
-        <param name="kff">          0       </param>
+        <param name="kp">          -30         -30         -30      </param>
+        <param name="kd">          -10         -10         -10      </param>
+        <param name="ki">          -100        -100        -100     </param>
+        <param name="maxOutput">    500         500         500     </param>
+        <param name="maxInt">       200         200         200     </param>
+        <param name="stictionUp">   0           0           0       </param>
+        <param name="stictionDown"> 0           0           0       </param>
+        <param name="kff">          0           0           0       </param>
     </group>
 
     <!-- default position PID: end -->
@@ -66,26 +66,26 @@
         <param name="controlLaw">           low_lev_current     </param>
         <param name="fbkControlUnits">      machine_units       </param>
         <param name="outputControlUnits">   machine_units       </param>
-        <param name="kp">                   2.0       </param>
-        <param name="kd">                   0       </param>
-        <param name="ki">                   500.0       </param>
-        <param name="shift">                0      </param>
-        <param name="maxOutput">            32000   </param>
-        <param name="maxInt">               32000   </param>
-        <param name="kff">                   0      </param>
+        <param name="kp">                   2           2           2       </param>
+        <param name="kd">                   0           0           0       </param>
+        <param name="ki">                   500         500         500     </param>
+        <param name="shift">                0           0           0       </param>
+        <param name="maxOutput">            32000       32000       32000   </param>
+        <param name="maxInt">               32000       32000       32000   </param>
+        <param name="kff">                  0            0          0       </param>
     </group>
 
     <group name="2FOC_VEL_CONTROL">
         <param name="controlLaw">           low_lev_speed       </param>
         <param name="fbkControlUnits">      machine_units       </param>
         <param name="outputControlUnits">   machine_units       </param>
-        <param name="kff">                  0       </param>
-        <param name="kp">                   12      </param>
-        <param name="kd">                   0       </param>
-        <param name="ki">                   16      </param>
-        <param name="shift">                10      </param>
-        <param name="maxOutput">            32000   </param>
-        <param name="maxInt">               32000   </param>
+        <param name="kff">                  0           0           0       </param>
+        <param name="kp">                   12          12          12      </param>
+        <param name="kd">                   0           0           0       </param>
+        <param name="ki">                   16          16          16      </param>
+        <param name="shift">                10          10          10      </param>
+        <param name="maxOutput">            32000       32000       32000   </param>
+        <param name="maxInt">               32000       32000       32000   </param>
     </group>
 
     <!-- other default PIDs: end -->

--- a/experimentalSetups/wristmk2_handmk3_ems_amcbldc/hardware/motorControl/wrist-eb2-j0_2-mc_service.xml
+++ b/experimentalSetups/wristmk2_handmk3_ems_amcbldc/hardware/motorControl/wrist-eb2-j0_2-mc_service.xml
@@ -29,24 +29,24 @@
             <group name="JOINTMAPPING">
 
                 <group name="ACTUATOR">
-                    <param name="type">             foc         </param>
-                    <param name="port">             CAN1:1:0      </param>
+                    <param name="type">             eomc_act_foc        foc                 foc         </param>
+                    <param name="port">             CAN1:1:0            CAN1:2:0            CAN1:3:0    </param>
                 </group>
 
                 <group name="ENCODER1">
-                    <param name="type">             aea         </param>
-                    <param name="port">             CONN:P7     </param>
-                    <param name="position">         atjoint     </param>
-                    <param name="resolution">       4096        </param>
-                    <param name="tolerance">        0.4         </param>
+                    <param name="type">             eomc_enc_aea        aea                 aea         </param>
+                    <param name="port">             CONN:P6             CONN:P7             CONN:P8     </param>
+                    <param name="position">         eomc_pos_atjoint    atjoint             atjoint     </param>
+                    <param name="resolution">       4096                4096                4096        </param>
+                    <param name="tolerance">        0.4                 0.4                 0.4         </param>
                 </group>
 
                 <group name="ENCODER2">
-                    <param name="type">             none        </param>
-                    <param name="port">             CONN:none   </param>
-                    <param name="position">         none        </param>
-                    <param name="resolution">       0           </param>
-                    <param name="tolerance">        0           </param>
+                    <param name="type">             none                none                none        </param>
+                    <param name="port">             CONN:none           CONN:none           CONN:none   </param>
+                    <param name="position">         none                none                none        </param>
+                    <param name="resolution">       0                   0                   0           </param>
+                    <param name="tolerance">        0                   0                   0           </param>
                 </group>
 
             </group>

--- a/experimentalSetups/wristmk2_handmk3_ems_amcbldc/wrappers/motorControl/wrist-mc_wrapper.xml
+++ b/experimentalSetups/wristmk2_handmk3_ems_amcbldc/wrappers/motorControl/wrist-mc_wrapper.xml
@@ -5,13 +5,13 @@
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="wrist-mc_wrapper" type="controlboardwrapper2">
         <paramlist name="networks">
             <!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
-            <elem name="FirstSetOfJoints">  0  0  0  0 </elem>
+            <elem name="FirstSetOfJoints">  0  2  0  2 </elem>
         </paramlist>
        
         <param name="period"> 10            </param>
         <param name="name">   /nfa/wrist_mc </param>
         <param name="ports">  wrist_mc      </param>
-        <param name="joints"> 1             </param>
+        <param name="joints"> 3             </param>
        
        
         <action phase="startup" level="5" type="attach">


### PR DESCRIPTION
What's new:
- The XML files within the `experimentalSetups/wristmk2_handmk3_ems_amcbldc/` folder have been updated in order to work with the whole wrist of the `wrist-setup`.

**Note:**
- Before this PR we were able to move only 1 joint over 3 of the `wrist-setup`