### PR TITLE
[iCubGenova03] - Left wrist calibration

### DIFF
--- a/iCubGenova03/calibrators/left_arm_calib.xml
+++ b/iCubGenova03/calibrators/left_arm_calib.xml
@@ -22,7 +22,7 @@
 <param name="calibrationType">                    3          3          3          3          0          3          3          3          </param>
 <param name="calibration1">                       2388.8     3241.9     -275.9     1535.6     500.0      2047.5     2047.5     2074.0     </param>
 <param name="calibration2">                       10.0       10.0       10.0       10.0       20.0       10.0       10.0       100.0      </param>
-<param name="calibration3">                       2734.5     762.9      1522.6     1352.5     0.0        3434.5     1659.5     0.0        </param>
+<param name="calibration3">                       2734.5     762.9      1522.6     1352.5     0.0        3532.5     1662.5     0.0        </param>
 <param name="startupPosition">                       -30.0      30.0       0.0        45.0       0.0        0.0        0.0        15.0       </param>
 <param name="startupVelocity">                       10.0       10.0       10.0       10.0       30.0       30.0       30.0       100.0      </param>
 <param name="startupMaxPwm">                             120        120        120        120        0          0          0          0          </param>


### PR DESCRIPTION
As shown in https://github.com/robotology/icub-tech-support/issues/1364, we had to calibrate the left wrist after a maintenance session. We tested the configuration with the researchers and now the robot calibrates well without hand shaking.