### PR TITLE
ecub joint setup configuration: removing encoder limits

### DIFF
--- a/experimentalSetups/5-setup/hardware/mechanicals/5-setup-mec.xml
+++ b/experimentalSetups/5-setup/hardware/mechanicals/5-setup-mec.xml
@@ -19,8 +19,8 @@
     </group>                                                 
                                                              
     <group name="LIMITS">                                    
-        <param name="hardwareJntPosMax">    1800                 </param>
-        <param name="hardwareJntPosMin">   -1800                 </param>
+        <param name="hardwareJntPosMax">    0                 </param>
+        <param name="hardwareJntPosMin">    0                 </param>
         <param name="rotorPosMin">          0                     </param> 
         <param name="rotorPosMax">          0                     </param>
     </group>                                                 

--- a/experimentalSetups/5-setup/hardware/motorControl/5-setup-mc.xml
+++ b/experimentalSetups/5-setup/hardware/motorControl/5-setup-mc.xml
@@ -12,9 +12,9 @@
     <!-- joint number                           0                ->
     <!-- joint name -->
     <group name="LIMITS">
-        <param name="jntPosMax">                1800               </param>
-        <param name="jntPosMin">               -1800               </param>
-        <param name="jntVelMax">                720                 </param>
+        <param name="jntPosMax">                0               </param>
+        <param name="jntPosMin">                0               </param>
+        <param name="jntVelMax">                7200                 </param>
         <param name="motorNominalCurrents">     1000                </param>
         <param name="motorPeakCurrents">        2000                </param>
         <param name="motorOverloadCurrents">    15000               </param>


### PR DESCRIPTION
I am interested to doing velocity control on the setup. Thus I removed the hardware and software limits on the encoder position and also increased the maximum  joint velocity limit. 

cc @ale-git 