### PR TITLE
Update wristmk2_handmk_3_ems_amcbldc configuration files 

### DIFF
--- a/experimentalSetups/wristmk2_handmk3_ems_amcbldc/calibrators/wrist-calib.xml
+++ b/experimentalSetups/wristmk2_handmk3_ems_amcbldc/calibrators/wrist-calib.xml
@@ -35,14 +35,13 @@
     <param name="CALIB_ORDER"> (0 1 2) </param>
 
     <action phase="startup" level="10" type="calibrate">
-        <param name="target">wrist-mc_wrapper</param>
+        <param name="target">wrist-mc_remapper</param>
     </action>
 
     <action phase="interrupt1" level="1" type="park">
-        <param name="target">wrist-mc_wrapper</param>
+        <param name="target">wrist-mc_remapper</param>
     </action>
 
     <action phase="interrupt3" level="1" type="abort" />
 
 </device>
-

--- a/experimentalSetups/wristmk2_handmk3_ems_amcbldc/new_forearm-no_hand.xml
+++ b/experimentalSetups/wristmk2_handmk3_ems_amcbldc/new_forearm-no_hand.xml
@@ -11,6 +11,7 @@
             <!-- WRIST MC -->
             <xi:include href="hardware/motorControl/wrist-eb2-j0_2-mc.xml" />
             <xi:include href="wrappers/motorControl/wrist-mc_wrapper.xml" />  
+            <xi:include href="wrappers/motorControl/wrist-mc_remapper.xml" />  
     
             <!--  CALIBRATORS -->  
             <xi:include href="calibrators/wrist-calib.xml" />

--- a/experimentalSetups/wristmk2_handmk3_ems_amcbldc/wrappers/motorControl/wrist-mc_wrapper.xml
+++ b/experimentalSetups/wristmk2_handmk3_ems_amcbldc/wrappers/motorControl/wrist-mc_wrapper.xml
@@ -2,27 +2,10 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
 
-    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="wrist-mc_wrapper" type="controlboardwrapper2">
-        <paramlist name="networks">
-            <!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
-            <elem name="FirstSetOfJoints">  0  2  0  2 </elem>
-        </paramlist>
-       
-        <param name="period"> 10            </param>
-        <param name="name">   /nfa/wrist_mc </param>
-        <param name="ports">  wrist_mc      </param>
-        <param name="joints"> 3             </param>
-       
-       
-        <action phase="startup" level="5" type="attach">
-            <paramlist name="networks">
-                <!-- The param value must match the device name in the corresponding body_part-ebX-jA_B-mc.xml file -->
-                <elem name="FirstSetOfJoints">  wrist-eb2-j0_2-mc </elem>
-                <elem name="Calibrator">        wrist-calibrator  </elem>
-            </paramlist>
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="wrist-mc_wrapper" type="controlBoard_nws_yarp">
+        <param name="name"> /nfa/wrist_mc </param>
+        <action phase="startup" level="10" type="attach">
+            <param name="device"> wrist-mc_remapper </param>
         </action>
-       
-        <action phase="shutdown" level="5" type="detach" />
-   
+        <action phase="shutdown" level="15" type="detach" />
     </device>
-


### PR DESCRIPTION
This PR updated the files in `experimentalSetups/wristmk2_handmk_3_ems_amcbldc` to stop using the deprecated `controlboardwrapper` in favor of the nws/nwc wrapper-remapper setup in the rest of the configuration files.

This way the wrist setup can be used with the latest version of yarprobotinterface.