### PR TITLE
Add `wrist-mc_remapper` file

### DIFF
--- a/experimentalSetups/wristmk2_handmk3_ems_amcbldc/wrappers/motorControl/wrist-mc_remapper.xml
+++ b/experimentalSetups/wristmk2_handmk3_ems_amcbldc/wrappers/motorControl/wrist-mc_remapper.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="wrist-mc_remapper" type="controlboardremapper">
+    <paramlist name="networks">
+        <elem name="FirstSetOfJoints">  0  2  0  2 </elem>
+    </paramlist>
+    <param name="joints"> 3 </param>
+    <action phase="startup" level="5" type="attach">
+        <paramlist name="networks">
+            <elem name="FirstSetOfJoints">  wrist-eb2-j0_2-mc    </elem>
+        </paramlist>
+    </action>
+    <action phase="shutdown" level="20" type="detach" />
+</device>


### PR DESCRIPTION
This PR fixes an error in #368 where in the configuration files of wristmk2_handmk3, the wrist remapper file was not added to the commit.