### PR TITLE
wristmk2_handmk3: fixed configuration files with correct parameters

### DIFF
--- a/experimentalSetups/wristmk2_handmk3_ems_amcbldc/hardware/mechanicals/wrist-eb2-j0_2-mec.xml
+++ b/experimentalSetups/wristmk2_handmk3_ems_amcbldc/hardware/mechanicals/wrist-eb2-j0_2-mec.xml
@@ -28,8 +28,8 @@
     <group name="2FOC">
         <param name="HasHallSensor">         1             1             1           </param>
         <param name="HasTempSensor">         0             0             0           </param>
-        <param name="HasRotorEncoder">       0             0             0           </param>
-        <param name="HasRotorEncoderIndex">  0             0             0           </param>
+        <param name="HasRotorEncoder">       1             1             1           </param>
+        <param name="HasRotorEncoderIndex">  1             1             1           </param>
         <param name="HasSpeedEncoder">       0             0             0           </param>
         <param name="RotorIndexOffset">      0             0             0           </param>
         <param name="MotorPoles">            14            14            14          </param>

--- a/experimentalSetups/wristmk2_handmk3_ems_amcbldc/hardware/motorControl/wrist-eb2-j0_2-mc_service.xml
+++ b/experimentalSetups/wristmk2_handmk3_ems_amcbldc/hardware/motorControl/wrist-eb2-j0_2-mc_service.xml
@@ -42,12 +42,12 @@
                 </group>
 
                 <group name="ENCODER2">
-                    <param name="type">             none                none                none        </param>
-                    <param name="port">             CONN:none           CONN:none           CONN:none   </param>
-                    <param name="position">         none                none                none        </param>
-                    <param name="resolution">       0                   0                   0           </param>
-                    <param name="tolerance">        0                   0                   0           </param>
-                </group>
+                    <param name="type">             roie                roie                roie          </param>
+                    <param name="port">             CAN1:1:0            CAN1:2:0            CAN1:3:0      </param>
+                    <param name="position">         atmotor             atmotor             atmotor       </param>
+                    <param name="resolution">       16000               16000               16000         </param>
+                    <param name="tolerance">         0                   0                   0             </param>  
+                </group> 
 
             </group>
 
@@ -56,4 +56,3 @@
     </group>
 
 </params>
-


### PR DESCRIPTION
This PR fixes an error in some of the values inside the configuration files of `wristmk2_handmk3_ems_amcbldc`. 

With the previous values the wrist setup was unable to move. This went unnoticed since the wrist boards were previously unable to process the configuration messages. 

Now that the boards are able to process these messages, we updated the configuration values of the wrist so it can move as usual. 