### PR TITLE
Add `lego-setup-amc-amcbldc` folder under experimentalSetups

### DIFF
--- a/experimentalSetups/lego_setup_amc_amcbldc/calibrators/wrist-calib.xml
+++ b/experimentalSetups/lego_setup_amc_amcbldc/calibrators/wrist-calib.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="wrist-calibrator" type="parametricCalibratorEth">
+
+    <xi:include href="../general.xml" />
+
+    <group name="GENERAL">
+        <param name="joints"> 1 </param> <!-- the number of joints of the robot part -->
+        <param name="deviceName"> Wrist_Calibrator </param>
+    </group>
+
+    <group name="HOME">
+        <param name="positionHome">                     0       </param>
+        <param name="velocityHome">                     10      </param>
+    </group>
+
+    <group name="CALIBRATION">
+        <param name="calibrationType">                  12      </param>
+
+        <param name="calibration1">                     6865    </param>
+        <param name="calibration2">                     0       </param>
+        <param name="calibration3">                     0       </param>
+        <param name="calibration4">                     0       </param>
+        <param name="calibration5">                     0       </param>
+        <param name="calibrationZero">                  0       </param>
+        <param name="calibrationDelta">                 0       </param>
+
+        <param name="startupPosition">                  0.0     </param>
+        <param name="startupVelocity">                  30.0    </param>
+        <param name="startupMaxPwm">                    16000   </param>
+        <param name="startupPosThreshold">              2       </param>
+    </group>
+
+    <param name="CALIB_ORDER"> (0) </param>
+
+    <action phase="startup" level="10" type="calibrate">
+        <param name="target">wrist-mc_remapper</param>
+    </action>
+
+    <action phase="interrupt1" level="1" type="park">
+        <param name="target">wrist-mc_remapper</param>
+    </action>
+
+    <action phase="interrupt3" level="1" type="abort" />
+
+</device>

--- a/experimentalSetups/lego_setup_amc_amcbldc/firmwareupdater.ini
+++ b/experimentalSetups/lego_setup_amc_amcbldc/firmwareupdater.ini
@@ -1,0 +1,2 @@
+[DRIVERS]
+ETH "eth"

--- a/experimentalSetups/lego_setup_amc_amcbldc/general.xml
+++ b/experimentalSetups/lego_setup_amc_amcbldc/general.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="wristmk2" build="1">
+  
+  <group name="GENERAL">
+      <param name="skipCalibration">    false  </param>
+      <param name="useRawEncoderData">  false  </param>
+      <param name="useLimitedPWM">      false  </param>
+      <param name="verbose">            false  </param>
+  </group>
+</params>

--- a/experimentalSetups/lego_setup_amc_amcbldc/hardware/electronics/pc104.xml
+++ b/experimentalSetups/lego_setup_amc_amcbldc/hardware/electronics/pc104.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="new_forearm" build="1">
+
+    <group name="PC104">
+        <param name="PC104IpAddress">           10.0.1.104      </param>
+        <param name="PC104IpPort">              12345           </param>
+        <param name="PC104TXrate">              1               </param> 
+        <param name="PC104RXrate">              5               </param>
+    </group>
+
+</params>
+

--- a/experimentalSetups/lego_setup_amc_amcbldc/hardware/electronics/wrist-eb2-j0_2-eln.xml
+++ b/experimentalSetups/lego_setup_amc_amcbldc/hardware/electronics/wrist-eb2-j0_2-eln.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="new_forearm" build="1">
+
+    <xi:include href="./pc104.xml" />
+
+    <group name="ETH_BOARD">
+
+        <group name="ETH_BOARD_PROPERTIES">
+            <param name="IpAddress">                10.0.1.1                </param>
+            <param name="IpPort">                   12345                   </param>
+            <param name="Type">                     amc                    </param>
+            <param name="maxSizeRXpacket">          768                     </param>
+            <param name="maxSizeROP">               384                     </param>
+        </group>
+
+        <group name="ETH_BOARD_SETTINGS">
+            <param name="Name">                     "wrist-eb2-j0_2"        </param>
+            <group name="RUNNINGMODE">
+                <param name="period">                   1000                </param>
+                <param name="maxTimeOfRXactivity">      400                 </param>
+                <param name="maxTimeOfDOactivity">      300                 </param>
+                <param name="maxTimeOfTXactivity">      300                 </param>
+                <param name="TXrateOfRegularROPs">      5                   </param>
+            </group>
+        </group>
+
+        <group name="ETH_BOARD_ACTIONS">
+            <group name="MONITOR_ITS_PRESENCE">
+                <param name="enabled">                  true                </param>
+                <param name="timeout">                  0.020               </param>
+                <param name="periodOfMissingReport">    60.0                </param>
+            </group>
+        </group>
+
+    </group>
+
+</params>
+

--- a/experimentalSetups/lego_setup_amc_amcbldc/hardware/mechanicals/wrist-eb2-j0_2-mec.xml
+++ b/experimentalSetups/lego_setup_amc_amcbldc/hardware/mechanicals/wrist-eb2-j0_2-mec.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="new_forearm" build="1">
+    <group name="GENERAL">
+        <param name="MotioncontrolVersion"> 6 </param>
+        <param name="Joints"> 1 </param>
+        <param name="AxisMap">               0          </param>
+        <param name="AxisName">         "wrist_yaw"     </param>
+        <param name="AxisType">         "revolute"      </param>
+        <param name="Encoder">          182.044         </param>
+        <param name="fullscalePWM">     32000           </param>
+        <param name="ampsToSensor">     1000.0          </param>
+        <param name="Gearbox_M2J">     -384.44          </param>
+        <param name="Gearbox_E2J">      1.778           </param>
+        <param name="useMotorSpeedFbk"> 0               </param>
+        <param name="MotorType">        "BLL_MOOG"      </param>
+        <param name="Verbose">          0   </param>
+    </group>
+
+    <group name="LIMITS">
+        <param name="hardwareJntPosMax">     180           </param>
+        <param name="hardwareJntPosMin">     -180           </param>
+        <param name="rotorPosMin">           0            </param>
+        <param name="rotorPosMax">           0            </param>
+    </group>
+
+    <group name="2FOC">
+        <param name="HasHallSensor">         1            </param>
+        <param name="HasTempSensor">         0            </param>
+        <param name="HasRotorEncoder">       1            </param>
+        <param name="HasRotorEncoderIndex">  1            </param>
+        <param name="HasSpeedEncoder">       0            </param>
+        <param name="RotorIndexOffset">      0            </param>
+        <param name="MotorPoles">            8           </param>
+   </group>
+
+    <group name="COUPLINGS">
+
+        <param name ="matrixJ2M">
+            1.0 0.0 0.0 0.0
+            0.0 1.0 0.0 0.0
+            0.0 0.0 1.0 0.0
+            0.0 0.0 0.0 1.0
+        </param>
+
+        <param name ="matrixM2J">
+            1.0 0.0 0.0 0.0
+            0.0 1.0 0.0 0.0
+            0.0 0.0 1.0 0.0
+            0.0 0.0 0.0 1.0
+        </param>
+
+        <param name ="matrixE2J">
+            1.00    0.00    0.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00    0.00    0.00
+            0.00    0.00    1.00    0.00    0.00    0.00
+            0.00    0.00    0.00    1.00    0.00    0.00
+        </param>
+
+    </group>
+
+    <group name="JOINTSET_CFG">
+        <param name= "numberofsets"> 1 </param>
+        <group name="JOINTSET_0">
+            <param name="listofjoints">  0         </param>
+            <param name="constraint">    none      </param>
+            <param name="param1">        0         </param>
+            <param name="param2">        0         </param>
+        </group>
+    </group>
+
+</params>

--- a/experimentalSetups/lego_setup_amc_amcbldc/hardware/motorControl/wrist-eb2-j0_2-mc.xml
+++ b/experimentalSetups/lego_setup_amc_amcbldc/hardware/motorControl/wrist-eb2-j0_2-mc.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="wrist-eb2-j0_2-mc" type="embObjMotionControl">
+
+    <xi:include href="../../general.xml" />
+    <xi:include href="../../hardware/electronics/wrist-eb2-j0_2-eln.xml" />
+    <xi:include href="../../hardware/mechanicals/wrist-eb2-j0_2-mec.xml" />
+    <xi:include href="./wrist-eb2-j0_2-mc_service.xml" />
+
+    <!-- joint number                           0                   -->
+    <!-- joint name -->
+    <group name="LIMITS">
+        <param name="jntPosMax">                180                 </param>
+        <param name="jntPosMin">                -180                 </param>
+        <param name="jntVelMax">                90                 </param>
+        <param name="motorNominalCurrents">     1000               </param>
+        <param name="motorPeakCurrents">        1500               </param>
+        <param name="motorOverloadCurrents">    2000               </param>
+        <param name="motorPwmLimit">            16000              </param>
+    </group>
+
+    <group name="TIMEOUTS">
+        <param name="velocity">                 100                </param>
+    </group>
+
+    <group name="IMPEDANCE">
+        <param name="stiffness">                0                  </param>
+        <param name="damping">                  0                  </param>
+    </group>
+
+    <group name="CONTROLS">
+        <param name="positionControl">          POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     </param>
+        <param name="mixedControl">             POS_PID_DEFAULT     </param>
+        <param name="torqueControl">            none                </param>
+        <param name="currentPid">               2FOC_CUR_CONTROL    </param>
+        <param name="speedPid">                 2FOC_VEL_CONTROL    </param>
+    </group>
+
+
+    <!-- default position PID: begin -->
+
+    <group name="POS_PID_DEFAULT">
+        <param name="controlLaw">             minjerk               </param>
+        <param name="outputType">             current               </param>
+        <param name="fbkControlUnits">        metric_units          </param>
+        <param name="outputControlUnits">     machine_units         </param>
+        <param name="kp">                    -30                    </param>
+        <param name="kd">                    -10                    </param>
+        <param name="ki">                    -100                   </param>
+        <param name="maxOutput">              500                   </param>
+        <param name="maxInt">                 200                   </param>
+        <param name="stictionUp">             0                     </param>
+        <param name="stictionDown">           0                     </param>
+        <param name="kff">                    0                     </param>
+    </group>
+
+    <!-- default position PID: end -->
+
+
+    <!-- other default PIDs: begin -->
+
+    <group name="2FOC_CUR_CONTROL">
+        <param name="controlLaw">           low_lev_current     </param>
+        <param name="fbkControlUnits">      machine_units       </param>
+        <param name="outputControlUnits">   machine_units       </param>
+        <param name="kp">                   2                   </param>
+        <param name="kd">                   0                   </param>
+        <param name="ki">                   500                 </param>
+        <param name="shift">                0                   </param>
+        <param name="maxOutput">            32000               </param>
+        <param name="maxInt">               32000               </param>
+        <param name="kff">                  0                   </param>
+    </group>
+
+    <group name="2FOC_VEL_CONTROL">
+        <param name="controlLaw">           low_lev_speed       </param>
+        <param name="fbkControlUnits">      machine_units       </param>
+        <param name="outputControlUnits">   machine_units       </param>
+        <param name="kff">                  0                   </param>
+        <param name="kp">                   12                  </param>
+        <param name="kd">                   0                   </param>
+        <param name="ki">                   16                  </param>
+        <param name="shift">                10                  </param>
+        <param name="maxOutput">            32000               </param>
+        <param name="maxInt">               32000               </param>
+    </group>
+
+    <!-- other default PIDs: end -->
+
+
+    <!-- custom PIDs: begin -->
+
+    <!-- custom PIDs: end -->
+
+</device>
+
+

--- a/experimentalSetups/lego_setup_amc_amcbldc/hardware/motorControl/wrist-eb2-j0_2-mc_service.xml
+++ b/experimentalSetups/lego_setup_amc_amcbldc/hardware/motorControl/wrist-eb2-j0_2-mc_service.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="new_forearm" build="1">
+
+    <group name="SERVICE">
+
+        <param name="type"> eomn_serv_MC_foc </param>
+
+        <group name="PROPERTIES">
+
+            <group name="ETHBOARD">
+                <param name="type">                 ems4        </param>
+            </group>
+
+            <group name="CANBOARDS">
+                <param name="type">                 foc         </param>
+                <group name="PROTOCOL">
+                    <param name="major">            0           </param>
+                    <param name="minor">            0           </param>
+                </group>
+                <group name="FIRMWARE">
+                    <param name="major">            0           </param>
+                    <param name="minor">            0           </param>
+                    <param name="build">            0           </param>
+                </group>
+            </group>
+
+            <group name="JOINTMAPPING">
+
+                <group name="ACTUATOR">
+                    <param name="type">             eomc_act_foc      </param>
+                    <param name="port">             CAN1:1:0          </param>
+                </group>
+
+                <group name="ENCODER1">
+                    <param name="type">             eomc_enc_aea      </param>
+                    <param name="port">             CONN:P6           </param>
+                    <param name="position">         eomc_pos_atjoint  </param>
+                    <param name="resolution">       4096              </param>
+                    <param name="tolerance">        0.4               </param>
+                </group>
+
+                <group name="ENCODER2">
+                    <param name="type">             roie              </param>
+                    <param name="port">             CAN1:1:0          </param>
+                    <param name="position">         atmotor           </param>
+                    <param name="resolution">       16000             </param>
+                    <param name="tolerance">         0                </param>
+                </group>
+
+            </group>
+
+        </group>
+
+    </group>
+
+</params>

--- a/experimentalSetups/lego_setup_amc_amcbldc/new_forearm-no_hand.xml
+++ b/experimentalSetups/lego_setup_amc_amcbldc/new_forearm-no_hand.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+    <robot name="new_forearm" build="1" portprefix="nfa" xmlns:xi="http://www.w3.org/2001/XInclude">
+        <params>
+            <xi:include href="hardware/electronics/pc104.xml" />
+        </params>
+
+        <devices>
+    
+            <!-- WRIST MC -->
+            <xi:include href="hardware/motorControl/wrist-eb2-j0_2-mc.xml" />
+            <xi:include href="wrappers/motorControl/wrist-mc_wrapper.xml" />  
+            <xi:include href="wrappers/motorControl/wrist-mc_remapper.xml" />  
+    
+            <!--  CALIBRATORS -->  
+            <xi:include href="calibrators/wrist-calib.xml" />
+        
+    </devices>
+</robot>

--- a/experimentalSetups/lego_setup_amc_amcbldc/sequence-close-open.posleft_hand_mc
+++ b/experimentalSetups/lego_setup_amc_amcbldc/sequence-close-open.posleft_hand_mc
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Sequence_posleft_hand_mc TotPositions="5" ReferencePart="left_hand_mc">
+    <Position Index="0" Timing="1.00">
+        <JointPositions Count="4">
+            <PosValue>10.00</PosValue>
+            <PosValue>10.00</PosValue>
+            <PosValue>10.00</PosValue>
+            <PosValue>10.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="4">
+            <SpeedValue>40.00</SpeedValue>
+            <SpeedValue>40.00</SpeedValue>
+            <SpeedValue>40.00</SpeedValue>
+            <SpeedValue>40.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="1" Timing="1.00">
+        <JointPositions Count="4">
+            <PosValue>70.00</PosValue>
+            <PosValue>10.00</PosValue>
+            <PosValue>10.00</PosValue>
+            <PosValue>10.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="4">
+            <SpeedValue>40.00</SpeedValue>
+            <SpeedValue>40.00</SpeedValue>
+            <SpeedValue>40.00</SpeedValue>
+            <SpeedValue>40.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="2" Timing="1.00">
+        <JointPositions Count="4">
+            <PosValue>70.00</PosValue>
+            <PosValue>70.00</PosValue>
+            <PosValue>10.00</PosValue>
+            <PosValue>10.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="4">
+            <SpeedValue>40.00</SpeedValue>
+            <SpeedValue>40.00</SpeedValue>
+            <SpeedValue>40.00</SpeedValue>
+            <SpeedValue>40.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="3" Timing="1.00">
+        <JointPositions Count="4">
+            <PosValue>70.00</PosValue>
+            <PosValue>70.00</PosValue>
+            <PosValue>70.00</PosValue>
+            <PosValue>10.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="4">
+            <SpeedValue>40.00</SpeedValue>
+            <SpeedValue>40.00</SpeedValue>
+            <SpeedValue>40.00</SpeedValue>
+            <SpeedValue>40.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="4" Timing="1.00">
+        <JointPositions Count="4">
+            <PosValue>70.00</PosValue>
+            <PosValue>70.00</PosValue>
+            <PosValue>70.00</PosValue>
+            <PosValue>70.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="4">
+            <SpeedValue>40.00</SpeedValue>
+            <SpeedValue>40.00</SpeedValue>
+            <SpeedValue>40.00</SpeedValue>
+            <SpeedValue>40.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+</Sequence_posleft_hand_mc>

--- a/experimentalSetups/lego_setup_amc_amcbldc/wrappers/motorControl/wrist-mc_remapper.xml
+++ b/experimentalSetups/lego_setup_amc_amcbldc/wrappers/motorControl/wrist-mc_remapper.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="wrist-mc_remapper" type="controlboardremapper">
+    <paramlist name="networks">
+        <elem name="FirstSetOfJoints">  0  0  0  0 </elem>
+    </paramlist>
+    <param name="joints"> 1 </param>
+    <action phase="startup" level="5" type="attach">
+        <paramlist name="networks">
+            <elem name="FirstSetOfJoints">  wrist-eb2-j0_2-mc    </elem>
+        </paramlist>
+    </action>
+    <action phase="shutdown" level="20" type="detach" />
+</device>

--- a/experimentalSetups/lego_setup_amc_amcbldc/wrappers/motorControl/wrist-mc_wrapper.xml
+++ b/experimentalSetups/lego_setup_amc_amcbldc/wrappers/motorControl/wrist-mc_wrapper.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="wrist-mc_wrapper" type="controlBoard_nws_yarp">
+        <param name="name"> /nfa/wrist_mc </param>
+        <action phase="startup" level="10" type="attach">
+            <param name="device"> wrist-mc_remapper </param>
+        </action>
+        <action phase="shutdown" level="15" type="detach" />
+    </device>

--- a/experimentalSetups/lego_setup_amc_amcbldc/yarpmotorgui.ini
+++ b/experimentalSetups/lego_setup_amc_amcbldc/yarpmotorgui.ini
@@ -1,0 +1,4 @@
+robot nfa
+
+parts (wrist_mc)
+

--- a/experimentalSetups/lego_setup_amc_amcbldc/yarprobotinterface.ini
+++ b/experimentalSetups/lego_setup_amc_amcbldc/yarprobotinterface.ini
@@ -1,0 +1,2 @@
+config ./new_forearm-no_hand.xml
+


### PR DESCRIPTION
What's new:
- Add `lego-setup-amc-amcbldc` folder under experimentalSetups. The XML file allow to configure a single joint setup composed of AMC + AMC_BLDC + AEA2 + BLDC MOTOR. 


**Note:**
- Probably there are some parameters to tune for the BLDC currently mounted on the `Lego-setup`