### PR TITLE
Update `lego-setup` config files for both `emc-amc_bldc` and `amc-amcbldc`

### DIFF
--- a/experimentalSetups/lego_setup_amc_amcbldc/hardware/mechanicals/wrist-eb2-j0_2-mec.xml
+++ b/experimentalSetups/lego_setup_amc_amcbldc/hardware/mechanicals/wrist-eb2-j0_2-mec.xml
@@ -32,7 +32,7 @@
         <param name="HasRotorEncoderIndex">  1            </param>
         <param name="HasSpeedEncoder">       0            </param>
         <param name="RotorIndexOffset">      0            </param>
-        <param name="MotorPoles">            8           </param>
+        <param name="MotorPoles">            14           </param>
    </group>
 
     <group name="COUPLINGS">

--- a/experimentalSetups/lego_setup_ems_amcbldc/hardware/mechanicals/wrist-eb2-j0_2-mec.xml
+++ b/experimentalSetups/lego_setup_ems_amcbldc/hardware/mechanicals/wrist-eb2-j0_2-mec.xml
@@ -32,7 +32,7 @@
         <param name="HasRotorEncoderIndex">  1            </param>
         <param name="HasSpeedEncoder">       0            </param>
         <param name="RotorIndexOffset">      0            </param>
-        <param name="MotorPoles">            8           </param>
+        <param name="MotorPoles">            14           </param>
    </group>
 
     <group name="COUPLINGS">


### PR DESCRIPTION
This PR is a quick update to the motor poles parameter in the configuration files used to work with the `lego-setup` and the new `Faulhaber` motor.