### PR TITLE
Updated the `wristmk2_handmk3_amc_amcbldc` with the correct values of motor configuration

### DIFF
--- a/experimentalSetups/wristmk2_handmk3_amc_amcbldc/hardware/mechanicals/wrist-eb2-j0_2-mec.xml
+++ b/experimentalSetups/wristmk2_handmk3_amc_amcbldc/hardware/mechanicals/wrist-eb2-j0_2-mec.xml
@@ -28,8 +28,8 @@
     <group name="2FOC">
         <param name="HasHallSensor">         1             1             1           </param>
         <param name="HasTempSensor">         0             0             0           </param>
-        <param name="HasRotorEncoder">       1             1             1           </param>
-        <param name="HasRotorEncoderIndex">  1             1             1           </param>
+        <param name="HasRotorEncoder">       0             0             0           </param>
+        <param name="HasRotorEncoderIndex">  0             0             0           </param>
         <param name="HasSpeedEncoder">       0             0             0           </param>
         <param name="RotorIndexOffset">      0             0             0           </param>
         <param name="MotorPoles">            14            14            14          </param>

--- a/experimentalSetups/wristmk2_handmk3_amc_amcbldc/hardware/motorControl/wrist-eb2-j0_2-mc_service.xml
+++ b/experimentalSetups/wristmk2_handmk3_amc_amcbldc/hardware/motorControl/wrist-eb2-j0_2-mc_service.xml
@@ -42,11 +42,11 @@
                 </group>
 
                 <group name="ENCODER2">
-                    <param name="type">             roie                roie                roie          </param>
-                    <param name="port">             CAN1:1:0            CAN1:2:0            CAN1:3:0      </param>
-                    <param name="position">         atmotor             atmotor             atmotor       </param>
-                    <param name="resolution">       16000               16000               16000         </param>
-                    <param name="tolerance">         0                   0                   0             </param>  
+                    <param name="type">             none                none                none       </param>
+                    <param name="port">             CAN1:1:0            CAN1:2:0            CAN1:3:0   </param>
+                    <param name="position">         atmotor             atmotor             atmotor    </param>
+                    <param name="resolution">        0                   0                   0         </param>
+                    <param name="tolerance">         0                   0                   0         </param>  
                 </group> 
 
             </group>


### PR DESCRIPTION
Alongside @ale-git, we updated  the `wristmk2_handmk3_amc_amcbldc` with the correct values of motor configuration.

It has been used with [this fw](https://github.com/robotology/icub-firmware/pull/300).

This change lets to configure the motor in `amcbldc `board at run time.
 