### PR TITLE
AMC – Update config files for both `lego-setup` and `wrist-setup`

### DIFF
--- a/experimentalSetups/lego_setup_amc_amcbldc/hardware/motorControl/wrist-eb2-j0_2-mc_service.xml
+++ b/experimentalSetups/lego_setup_amc_amcbldc/hardware/motorControl/wrist-eb2-j0_2-mc_service.xml
@@ -35,7 +35,7 @@
 
                 <group name="ENCODER1">
                     <param name="type">             eomc_enc_aea      </param>
-                    <param name="port">             CONN:P1           </param>
+                    <param name="port">             CONN:J5_X1         </param>
                     <param name="position">         eomc_pos_atjoint  </param>
                     <param name="resolution">       4096              </param>
                     <param name="tolerance">        0.4               </param>

--- a/experimentalSetups/wristmk2_handmk3_amc_amcbldc/hardware/motorControl/wrist-eb2-j0_2-mc_service.xml
+++ b/experimentalSetups/wristmk2_handmk3_amc_amcbldc/hardware/motorControl/wrist-eb2-j0_2-mc_service.xml
@@ -35,7 +35,7 @@
 
                 <group name="ENCODER1">
                     <param name="type">             eomc_enc_aea        aea                 aea         </param>
-                    <param name="port">             CONN:P1             CONN:P2             CONN:P3     </param>
+                    <param name="port">             CONN:J5_X1          CONN:J5_X2          CONN:J5_X3     </param>
                     <param name="position">         eomc_pos_atjoint    atjoint             atjoint     </param>
                     <param name="resolution">       4096                4096                4096        </param>
                     <param name="tolerance">        0.4                 0.4                 0.4         </param>


### PR DESCRIPTION
What's new:

- replaced connectors name from `PY` to `J5_XY` where `Y` is one in `{1,2,3}`


**Notes:**
- This change reflects the changes done in https://github.com/robotology/icub-firmware-shared/pull/68

