### PR TITLE
Adding `5-setup-mrie` config files

### DIFF
--- a/experimentalSetups/5-setup-mrie/5-setup.xml
+++ b/experimentalSetups/5-setup-mrie/5-setup.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<robot name="5-setup" build="1" portprefix="icub" xmlns:xi="http://www.w3.org/2001/XInclude">
+
+  <devices>
+    <params>
+    <xi:include href="hardware/electronics/pc104.xml" />
+    </params>
+
+    <!-- motor controllers wrappers -->
+    <xi:include href="wrappers/motorControl/5-setup-mc_wrapper.xml" />
+    <xi:include href="wrappers/motorControl/5-setup-mc_remapper.xml" />
+
+    <!-- TORSO -->
+    <xi:include href="hardware/motorControl/5-setup-mc.xml" />
+
+    <!--  CALIBRATORS -->
+    <xi:include href="calibrators/5-setup-calib.xml" />
+
+  </devices>
+</robot>

--- a/experimentalSetups/5-setup-mrie/CMakeLists.txt
+++ b/experimentalSetups/5-setup-mrie/CMakeLists.txt
@@ -1,0 +1,11 @@
+set(appname 5-setup-mrie)
+
+file(GLOB xml ${CMAKE_CURRENT_SOURCE_DIR}/*.xml)
+file(GLOB ini ${CMAKE_CURRENT_SOURCE_DIR}/*.ini)
+
+yarp_install(FILES ${xml} DESTINATION ${ICUBCONTRIB_ROBOTS_INSTALL_DIR}/${appname})
+yarp_install(FILES ${ini} DESTINATION ${ICUBCONTRIB_ROBOTS_INSTALL_DIR}/${appname})
+yarp_install(DIRECTORY calibrators DESTINATION ${ICUBCONTRIB_ROBOTS_INSTALL_DIR}/${appname})
+yarp_install(DIRECTORY wrappers DESTINATION ${ICUBCONTRIB_ROBOTS_INSTALL_DIR}/${appname})
+yarp_install(DIRECTORY hardware DESTINATION ${ICUBCONTRIB_ROBOTS_INSTALL_DIR}/${appname})
+

--- a/experimentalSetups/5-setup-mrie/calibrators/5-setup-calib.xml
+++ b/experimentalSetups/5-setup-mrie/calibrators/5-setup-calib.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="5-setup-calibrator" type="parametricCalibratorEth">
+                <xi:include href="../general.xml" />
+                
+		<group name="GENERAL">
+		    <param name="joints"> 1 </param> <!-- the number of joints of the robot part -->
+		    <param name="deviceName"> 5-Setup_Calibrator </param>
+		</group>
+
+<group name="HOME">
+<param name="positionHome">                         0                        </param>
+<param name="velocityHome">                         10                       </param>
+</group>                                                              
+                                                                      
+                                                                      
+                                                                      
+<group name="CALIBRATION">                                            
+<!--                                                roll                          -->
+<param name="calibrationType">                      12                       </param>
+                                                                                      <!--
+<param name="calibration1">	                        58233                    </param> --> 
+<param name="calibration1">	                        0                        </param>
+<param name="calibration2">                         0                        </param> 
+<param name="calibration3">                         0                        </param> 
+                                                                      
+                                                                      
+<param name="calibration4">                         0                        </param>
+<param name="calibration5">                         0                        </param>
+<param name="calibrationZero">                      0                        </param>
+<param name="calibrationDelta">                     0                        </param>
+                                                                      
+<param name="startupPosition">                      0                        </param>
+<param name="startupVelocity">                      10                       </param>
+<param name="startupMaxPwm">                        5500                     </param>
+<param name="startupPosThreshold">                  2                        </param>
+</group>
+
+ <!-- check old calibrator for the correct sequence, then ask to Randazz -->
+		<param name="CALIB_ORDER"> (0)  </param>
+
+		<action phase="startup" level="10" type="calibrate">
+		    <param name="target">5-setup-mc_remapper</param>
+		</action>
+
+		<action phase="interrupt1" level="1" type="park">
+		    <param name="target">5-setup-mc_remapper</param>
+		</action>
+
+		<action phase="interrupt3" level="1" type="abort" />
+
+	</device>
+

--- a/experimentalSetups/5-setup-mrie/firmwareupdater.ini
+++ b/experimentalSetups/5-setup-mrie/firmwareupdater.ini
@@ -1,0 +1,2 @@
+[DRIVERS]
+ETH "eth"

--- a/experimentalSetups/5-setup-mrie/general.xml
+++ b/experimentalSetups/5-setup-mrie/general.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="iCubGenova09" build="1">
+  
+  <group name="GENERAL">
+      <param name="skipCalibration">    false  </param>
+      <param name="useRawEncoderData">  false  </param>
+      <param name="useLimitedPWM">      false  </param>
+      <param name="verbose">            false  </param>
+  </group>
+</params>

--- a/experimentalSetups/5-setup-mrie/hardware/electronics/5-setup-eln.xml
+++ b/experimentalSetups/5-setup-mrie/hardware/electronics/5-setup-eln.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="5-setup" build="1">
+
+    <xi:include href="./pc104.xml" />
+    
+    <group name="ETH_BOARD">
+   
+        <group name="ETH_BOARD_PROPERTIES">
+            <param name="IpAddress">                10.0.1.1                </param>
+            <param name="IpPort">                   12345                   </param>
+            <param name="Type">                     ems4                    </param>
+            <param name="maxSizeRXpacket">          768                     </param>
+            <param name="maxSizeROP">               384                     </param>
+        </group>
+
+        <group name="ETH_BOARD_SETTINGS">
+            <param name="Name">                     "5-setup"        </param> 
+            <group name="RUNNINGMODE">
+                <param name="period">                   1000                </param>
+                <param name="maxTimeOfRXactivity">      400                 </param>
+                <param name="maxTimeOfDOactivity">      300                 </param>   
+                <param name="maxTimeOfTXactivity">      300                 </param>                
+                <param name="TXrateOfRegularROPs">      5                   </param> 
+            </group>              
+        </group>                 
+        
+        <group name="ETH_BOARD_ACTIONS">
+            <group name="MONITOR_ITS_PRESENCE">
+                <param name="enabled">                  true                </param> 
+                <param name="timeout">                  0.020               </param> 
+                <param name="periodOfMissingReport">    60.0                </param> 
+            </group>
+        </group>
+
+    </group>  
+
+</params>
+

--- a/experimentalSetups/5-setup-mrie/hardware/electronics/pc104.xml
+++ b/experimentalSetups/5-setup-mrie/hardware/electronics/pc104.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="iCubGenova09" build="1">
+
+    <group name="PC104">
+        <param name="PC104IpAddress">           10.0.1.104      </param>
+        <param name="PC104IpPort">              12345           </param>
+        <param name="PC104TXrate">              1               </param> 
+        <param name="PC104RXrate">              5               </param>
+    </group>
+
+</params>
+

--- a/experimentalSetups/5-setup-mrie/hardware/mechanicals/5-setup-mec.xml
+++ b/experimentalSetups/5-setup-mrie/hardware/mechanicals/5-setup-mec.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="5-setup" build="1">
+    <group name="GENERAL">
+        <param name="MotioncontrolVersion"> 6 </param>
+        <param name="Joints"> 1 </param> 
+        <param name="AxisMap">              0                     </param>   
+        <param name="AxisName">             "setup"          </param>
+        <param name="AxisType">             "revolute"            </param>
+        <param name="Encoder">              182.044               </param>
+        <param name="fullscalePWM">         32000                 </param>
+        <param name="ampsToSensor">         1000.0                </param>
+        <param name="Gearbox_M2J">          1                     </param>
+        <param name="Gearbox_E2J">          1                     </param>
+        <param name="useMotorSpeedFbk">     1                     </param> 
+        <param name="MotorType">            "MOOG_C2900576"       </param>
+        <param name="Verbose"> 0 </param>                    
+    </group>                                                 
+                                                             
+    <group name="LIMITS">                                    
+        <param name="hardwareJntPosMax">    0                 </param>
+        <param name="hardwareJntPosMin">    0                 </param>
+        <param name="rotorPosMin">          0                     </param> 
+        <param name="rotorPosMax">          0                     </param>
+    </group>                                                 
+                                                             
+    <group name="2FOC">                                      
+		<param name="Verbose">              0                    </param>
+        <param name="AutoCalibration">      0                    </param>
+        <param name="HasHallSensor">        0                    </param>
+        <param name="HasTempSensor">        0                    </param>
+        <param name="HasRotorEncoder">      1                    </param>
+        <param name="HasRotorEncoderIndex"> 1                    </param>
+        <param name="HasSpeedEncoder">      0                    </param>
+        <param name="RotorIndexOffset">     12                    </param>
+        <param name="MotorPoles">           20                   </param>
+   </group>
+
+    <group name="COUPLINGS"> 
+        <param name ="matrixJ2M"> 
+            1.000    0.000    0.000    0.000
+            0.000    1.000    0.000    0.000
+            0.000    0.000    1.000    0.000
+            0.000    0.000    0.000    1.000   
+        </param>
+
+        <param name ="matrixM2J"> 
+            1.000    0.000    0.000    0.000
+            0.000    1.000    0.000    0.000
+            0.000    0.000    1.000    0.000
+            0.000    0.000    0.000    1.000   
+        </param>
+       
+        <param name ="matrixE2J">  
+            1.00    0.00    0.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00    0.00    0.00
+            0.00    0.00    1.00    0.00    0.00    0.00
+            0.00    0.00    0.00    1.00    0.00    0.00   
+        </param>
+    </group>                
+    
+    <group name="JOINTSET_CFG"> 
+        <param name= "numberofsets"> 1 </param>
+        <group name="JOINTSET_0">
+            <param name="listofjoints">  0             </param>
+            <param name="constraint">    none          </param>
+            <param name="param1">        0             </param>
+            <param name="param2">        0             </param>
+        </group> 
+    </group>                     
+ 
+</params>

--- a/experimentalSetups/5-setup-mrie/hardware/motorControl/5-setup-mc.xml
+++ b/experimentalSetups/5-setup-mrie/hardware/motorControl/5-setup-mc.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="5-setup-mc" type="embObjMotionControl">
+
+    <xi:include href="../../general.xml" />
+    <xi:include href="../../hardware/electronics/5-setup-eln.xml" />
+    <xi:include href="../../hardware/mechanicals/5-setup-mec.xml" />
+    <xi:include href="./5-setup-mc_service.xml" />
+
+    <!-- joint number                           0                -->
+    <!-- joint name -->
+    <group name="LIMITS">
+        <param name="jntPosMax">                0               </param>
+        <param name="jntPosMin">                0               </param>
+        <param name="jntVelMax">                18000                 </param>
+        <param name="motorNominalCurrents">     3500                </param>
+        <param name="motorPeakCurrents">        5100                </param>
+        <param name="motorOverloadCurrents">    15000               </param>
+        <param name="motorPwmLimit">            12000               </param>
+    </group>
+
+    <group name="TIMEOUTS">
+        <param name="velocity">                 100                 </param>
+    </group>
+
+    <group name="IMPEDANCE">
+        <param name="stiffness">                0                   </param>
+        <param name="damping">                  0                   </param>
+    </group>
+
+    <group name="CONTROLS">
+        <param name="positionControl">          POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     </param>
+        <param name="mixedControl">             POS_PID_DEFAULT     </param>
+        <param name="torqueControl">            TRQ_PID_DEFAULT     </param>
+        <param name="currentPid">               2FOC_CUR_CONTROL    </param>
+        <param name="speedPid">                 2FOC_VEL_CONTROL    </param>
+    </group>
+
+
+    <!-- default position PID: begin -->
+
+    <group name="POS_PID_DEFAULT">
+        <param name="controlLaw">             minjerk               </param>
+        <param name="outputType">             pwm                   </param>
+        <param name="fbkControlUnits">        metric_units          </param>
+        <param name="outputControlUnits">     machine_units         </param>
+        <param name="kp">           300              </param>
+        <param name="kd">           0                </param>
+        <param name="ki">           60              </param>
+        <param name="maxOutput">    12000           </param>
+        <param name="maxInt">       3000           </param>
+        <param name="stictionUp">   0              </param>
+        <param name="stictionDown"> 0              </param>
+        <param name="kff">          0              </param>
+    </group>
+
+    <!-- default position PID: end -->
+
+
+    <!-- default torque PID: begin -->
+    <group name="TRQ_PID_DEFAULT">
+        <param name="controlLaw">          torque                       </param>
+        <param name="outputType">          pwm                          </param>
+        <param name="fbkControlUnits">     metric_units                 </param>
+        <param name="outputControlUnits">  dutycycle_percent            </param>
+        <param name="kp">              0    </param>
+        <param name="kd">              0    </param>
+        <param name="ki">              0    </param>
+        <param name="maxOutput">      25    </param>
+        <param name="maxInt">       1.56    </param>
+        <param name="ko">              0    </param>
+        <param name="stictionUp">      0    </param>
+        <param name="stictionDown">    0    </param>
+        <param name="kff">             1    </param>
+        <param name="kbemf">       0.0016   </param>
+        <param name="filterType">      0    </param>
+        <param name="ktau">         0.63    </param>
+    </group>
+    <!-- default torque PID: end -->
+
+
+    <!-- other default PIDs: begin -->
+
+    <group name="2FOC_CUR_CONTROL">
+        <param name="controlLaw">           low_lev_current     </param>
+        <param name="fbkControlUnits">      machine_units       </param>
+        <param name="outputControlUnits">   machine_units       </param>
+        <param name="kp">                   8          </param>
+        <param name="kd">                   0          </param>
+        <param name="ki">                   2          </param>
+        <param name="shift">                10         </param>
+        <param name="maxOutput">            32000      </param>
+        <param name="maxInt">               32000      </param>
+        <param name="kff">                  0          </param>
+    </group>
+
+    <group name="2FOC_VEL_CONTROL">
+        <param name="controlLaw">           low_lev_speed       </param>
+        <param name="fbkControlUnits">      machine_units       </param>
+        <param name="outputControlUnits">   machine_units       </param>
+        <param name="kff">                  0         </param>
+        <param name="kp">                   12        </param>
+        <param name="kd">                   0         </param>
+        <param name="ki">                   16        </param>
+        <param name="shift">                10        </param>
+        <param name="maxOutput">            32000     </param>
+        <param name="maxInt">               32000     </param>
+    </group>
+
+    <!-- other default PIDs: end -->
+
+
+    <!-- custom PIDs: begin -->
+    <!-- custom PIDs: end -->
+
+    <group name="OTHER_CONTROL_PARAMETERS">
+        <param name="deadZone">             0.0049    </param>
+    </group>
+
+</device>
+
+

--- a/experimentalSetups/5-setup-mrie/hardware/motorControl/5-setup-mc_service.xml
+++ b/experimentalSetups/5-setup-mrie/hardware/motorControl/5-setup-mc_service.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="5-setup" build="1">
+
+    <group name="SERVICE">
+        
+        <param name="type"> eomn_serv_MC_foc </param> 
+    
+        <group name="PROPERTIES">
+        
+            <group name="ETHBOARD">
+                <param name="type">                 ems4        </param> 
+            </group>          
+
+            <group name="CANBOARDS"> 
+                <param name="type">                 foc         </param> 
+                <group name="PROTOCOL">
+                    <param name="major">            1           </param>    
+                    <param name="minor">            6           </param>     
+                </group>                    
+                <group name="FIRMWARE">
+                    <param name="major">            3           </param>    
+                    <param name="minor">            3           </param> 
+                    <param name="build">            3           </param>
+                </group>
+            </group>
+            
+            
+
+            <group name="JOINTMAPPING">
+
+                <group name="ACTUATOR">
+                    <!--                            setup                     -->
+                    <param name="type">             eomc_act_foc        </param>
+                    <param name="port">             CAN1:1:0            </param>
+                </group>                                           
+                                                                   
+                <group name="ENCODER1">                            
+                    <param name="type">             none                </param>  
+                    <param name="port">             CONN:none           </param>
+                    <param name="position">         none                </param>
+                    <param name="resolution">       0                   </param> 
+                    <param name="tolerance">        0                   </param>  
+                </group>                                           
+                                                                   
+                <group name="ENCODER2">                            
+                    <param name="type">             roie                </param>
+                    <param name="port">             CAN1:1:0            </param>
+                    <param name="position">         atmotor             </param>
+                    <param name="resolution">       20800               </param>
+                    <param name="tolerance">        3.6                 </param>  
+                </group> 
+ 
+            </group>    
+            
+           
+            
+        </group>
+           
+    </group>
+    
+  
+</params>
+

--- a/experimentalSetups/5-setup-mrie/network.5-setup.xml
+++ b/experimentalSetups/5-setup-mrie/network.5-setup.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0"?>
+
+<!--    description 
+
+        this file contains the boards mounted on the robot grouped by body parts.
+
+        there is only one group called host which contains name and as many rows as the supported
+        devices. each one is tagged <hasdevice> and contains a type (ETH or CFW) and an address 
+        (in ip format or just a number for the case of CFW).
+        
+        then there are many groups called part. each one may contain many groups called boards: 
+        one per physical board on the robot on that part.
+        
+        every <board> has two compulsory properties: type, name. it may also have an 
+        every <board> has two compulsory properties: type, name. it may also have an 
+        additional property: required. so far the only value of required is "version".
+        each <board> contains three compulsory fields: ondevice, ataddress, connected. 
+        and it may have an additional field: version (if there is the required="version" property).
+        here is description of each of the previous:
+        -   type: must have a valid board name in short format: ems4, mc4plus, foc, strain, 
+            strain2, mtb, mtb4, mais, mc4, etc.
+        -   name: can be any string.
+        -   required: if present can be only ="version". it tells that that board MUST match
+            a given version of firmware. it is used to identify amongst the many versions of mc4 
+            boards.
+        -   ondevice: tells on which device the board is located. it can be ETH (for ETH robots)
+            or CFW for first generation CAN robots. 
+        -   ataddress: contains the network address under device. if device is ETH there is
+            ip="10.0.1.x" and if the board is a CAN board there is also canbus="c" canadr="a".
+            if the device is CFW, then there is only canbus="c" canadr="a".
+        -   connected: contains the connection information. if bus ETH there are: prev and next
+            which are the previous and the next ip addresses (they both must be present). the last
+            board must have next="none". if bus is CAN there are no extra fields.
+        -   version: contains the required version. typically only major and minor values are specified.
+         
+        the aim of this files is to be parsed by the python program robotFWmanager.py
+  -->
+
+<robotnetwork>
+
+    <host name="icub-head" >
+        <hasdevice type= "ETH" address="10.0.1.104" />
+    </host>
+
+    <part name="5-setup">
+        <board type='ems4' name="5-setup">
+            <ondevice>ETH</ondevice>
+            <ataddress ip="10.0.1.5" />
+			<connected bus="ETH" prev="10.0.1.104" next="none" />
+        </board>
+
+        <board type='foc' name="foc.5.1">
+            <ondevice>ETH</ondevice>
+            <ataddress ip="10.0.1.5" canbus="1" canadr="1"  />
+            <connected bus="CAN" />
+        </board>
+    </part>
+
+    <part name="custom">
+ 
+    </part>
+
+
+    <part name="test">
+
+    </part>
+
+
+</robotnetwork>
+

--- a/experimentalSetups/5-setup-mrie/wrappers/motorControl/5-setup-mc_remapper.xml
+++ b/experimentalSetups/5-setup-mrie/wrappers/motorControl/5-setup-mc_remapper.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="5-setup-mc_remapper" type="controlboardremapper">
+    <paramlist name="networks">
+        <elem name="5-setup_joints">(  0 0 0 0 )</elem>
+    </paramlist>
+    <param name="joints"> 1			</param>
+    <action phase="startup" level="5" type="attach">
+        <paramlist name="networks">
+            <elem name="5-setup_joints">  5-setup-mc </elem>
+        </paramlist>
+    </action>
+    <action phase="shutdown" level="20" type="detach" />
+</device>

--- a/experimentalSetups/5-setup-mrie/wrappers/motorControl/5-setup-mc_wrapper.xml
+++ b/experimentalSetups/5-setup-mrie/wrappers/motorControl/5-setup-mc_wrapper.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+    
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="5-setup-mc_nws_yarp" type="controlBoard_nws_yarp">
+    <param name="name"> /icub/5-setup </param>
+    <action phase="startup" level="10" type="attach">
+        <param name="device"> 5-setup-mc_remapper </param>
+    </action>
+    <action phase="shutdown" level="15" type="detach" />
+</device>

--- a/experimentalSetups/5-setup-mrie/yarpmotorgui.ini
+++ b/experimentalSetups/5-setup-mrie/yarpmotorgui.ini
@@ -1,0 +1,7 @@
+//name of the robot          
+robot icub      
+//parts to be opened by the GUI            
+parts (5-setup)               
+ 
+ //DO NOT REMOVE THIS LINE    
+ 

--- a/experimentalSetups/5-setup-mrie/yarprobotinterface.ini
+++ b/experimentalSetups/5-setup-mrie/yarprobotinterface.ini
@@ -1,0 +1,2 @@
+config ./5-setup.xml
+


### PR DESCRIPTION
This PR adds a subfolder named `5-setup-mrie` which contains configuration files similar to the `5-setup` but changing some parameters to be used with the motor group of eCub medium joint with new optical disk and MRIE board (different from the one to be used with brake which has the dev kit).

cc @ale-git @valegagge  