### PR TITLE
Wrist mk2: Update position PID values 

### DIFF
--- a/experimentalSetups/wristmk2_handmk3_amc_amcbldc/hardware/motorControl/wrist-eb2-j0_2-mc.xml
+++ b/experimentalSetups/wristmk2_handmk3_amc_amcbldc/hardware/motorControl/wrist-eb2-j0_2-mc.xml
@@ -47,9 +47,9 @@
         <param name="outputType">             current               </param>
         <param name="fbkControlUnits">        metric_units          </param>
         <param name="outputControlUnits">     machine_units         </param>
-        <param name="kp">          -30         -30         -30      </param>
-        <param name="kd">          -10         -10         -10      </param>
-        <param name="ki">          -100        -100        -100     </param>
+        <param name="kp">          -67         -67         -67      </param>
+        <param name="kd">          -11         -11         -11      </param>
+        <param name="ki">          -294        -294        -294     </param>
         <param name="maxOutput">    500         500         500     </param>
         <param name="maxInt">       200         200         200     </param>
         <param name="stictionUp">   0           0           0       </param>


### PR DESCRIPTION
This PR updates the values of the position PID of the wrist mk2 for all three joints. The values were found by automatically tuning the controllers on an identified linear model.

The improvements are significant:

## Test on the wrist

![wristtraj](https://user-images.githubusercontent.com/38140169/191067748-6572d43d-b833-49d9-9efd-0d42d4f49423.png)

![wristerr](https://user-images.githubusercontent.com/38140169/191067767-bed7cc01-d629-4465-a509-df757d4ce2cb.png)

![wristeul](https://user-images.githubusercontent.com/38140169/191067782-a802ec59-aa49-4405-8a75-a4ce7c7a8452.png)

## Metrics
I moved only the roll DoF, so ideally I would like the others to be zero.
To compare the results, I can compute the MSE with respect to a zero reference of the yaw and pitch DoFs:

| UoM: (deg^2) |Before| After|
| --- | --- | --- |
| **Yaw** |0.234| 0.0432|
| **Pitch** |0.126| 0.0502|