### PR TITLE
AMC – Update config files for `wrist-setup`

### DIFF
--- a/experimentalSetups/wristmk2_handmk3_amc_amcbldc/hardware/mechanicals/wrist-eb2-j0_2-mec.xml
+++ b/experimentalSetups/wristmk2_handmk3_amc_amcbldc/hardware/mechanicals/wrist-eb2-j0_2-mec.xml
@@ -14,7 +14,7 @@
         <param name="Gearbox_M2J">     -384.44       -384.44       -384.44           </param>
         <param name="Gearbox_E2J">      1.778         1.778         1.778            </param>
         <param name="useMotorSpeedFbk"> 0             0             0                </param>
-        <param name="MotorType">        "BLL_MOOG"    "BLL_MOOG"    "BLL_MOOG"       </param>
+        <param name="MotorType">        "FAULHABER"    "FAULHABER"    "FAULHABER"       </param>
         <param name="Verbose">      0   </param>
     </group>
 


### PR DESCRIPTION
What's new:

- Replace the name `BLL_MOOG` with `FAULHABER` in param `MotorType` of group `GENERAL`

**Note:**
- Tested on `wrist-setup`