### PR TITLE
iCubGenova09: remove the grabberDual ini files

### DIFF
--- a/iCubGenova09/camera/ServerGrabberDualPylon.ini
+++ b/iCubGenova09/camera/ServerGrabberDualPylon.ini
@@ -1,8 +1,0 @@
-device grabberDual
-capabilities COLOR
-name /icub/cam
-split true
-twoCameras true
-left_config  camera/pylonCamera_config_left.ini
-right_config camera/pylonCamera_config_right.ini
-

--- a/iCubGenova09/camera/ServerGrabberDualPylonFHD.ini
+++ b/iCubGenova09/camera/ServerGrabberDualPylonFHD.ini
@@ -1,8 +1,0 @@
-device grabberDual
-capabilities COLOR
-name /icub/cam
-split true
-twoCameras true
-left_config  camera/pylonCamera_config_left_fhd.ini
-right_config camera/pylonCamera_config_right_fhd.ini
-

--- a/iCubGenova09/camera/ServerGrabberDualPylonHD.ini
+++ b/iCubGenova09/camera/ServerGrabberDualPylonHD.ini
@@ -1,8 +1,0 @@
-device grabberDual
-capabilities COLOR
-name /icub/cam
-split true
-twoCameras true
-left_config  camera/pylonCamera_config_left_hd.ini
-right_config camera/pylonCamera_config_right_hd.ini
-


### PR DESCRIPTION
Since `grabberDual` gave us performance problems with the new cameras, and it is deprecated, I would remove the ini files.

cc @S-Dafarra @GiulioRomualdi 