### PR TITLE
Update config files for `lego-setup` + `wrist-setup` for both `EMS` and `AMC` 

### DIFF
--- a/experimentalSetups/lego_setup_amc_amcbldc/hardware/mechanicals/wrist-eb2-j0_2-mec.xml
+++ b/experimentalSetups/lego_setup_amc_amcbldc/hardware/mechanicals/wrist-eb2-j0_2-mec.xml
@@ -25,7 +25,7 @@
         <param name="rotorPosMax">           0            </param>
     </group>
 
-    <group name="2FOC">
+    <group name="AMCBLDC">
         <param name="HasHallSensor">         1            </param>
         <param name="HasTempSensor">         0            </param>
         <param name="HasRotorEncoder">       0            </param>

--- a/experimentalSetups/lego_setup_amc_amcbldc/hardware/motorControl/wrist-eb2-j0_2-mc_service.xml
+++ b/experimentalSetups/lego_setup_amc_amcbldc/hardware/motorControl/wrist-eb2-j0_2-mc_service.xml
@@ -16,13 +16,13 @@
             <group name="CANBOARDS">
                 <param name="type">                 amcbldc     </param>
                 <group name="PROTOCOL">
-                    <param name="major">            0           </param>
+                    <param name="major">            2           </param>
                     <param name="minor">            0           </param>
                 </group>
                 <group name="FIRMWARE">
-                    <param name="major">            0           </param>
+                    <param name="major">            1           </param>
                     <param name="minor">            0           </param>
-                    <param name="build">            0           </param>
+                    <param name="build">            7           </param>
                 </group>
             </group>
 

--- a/experimentalSetups/lego_setup_amc_amcbldc/new_forearm-no_hand.xml
+++ b/experimentalSetups/lego_setup_amc_amcbldc/new_forearm-no_hand.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
-    <robot name="new_forearm" build="1" portprefix="nfa" xmlns:xi="http://www.w3.org/2001/XInclude">
+    <robot name="new_forearm" build="1" portprefix="/nfa" xmlns:xi="http://www.w3.org/2001/XInclude">
         <params>
             <xi:include href="hardware/electronics/pc104.xml" />
         </params>

--- a/experimentalSetups/lego_setup_ems_amcbldc/hardware/mechanicals/wrist-eb2-j0_2-mec.xml
+++ b/experimentalSetups/lego_setup_ems_amcbldc/hardware/mechanicals/wrist-eb2-j0_2-mec.xml
@@ -25,7 +25,7 @@
         <param name="rotorPosMax">           0            </param>
     </group>
 
-    <group name="2FOC">
+    <group name="AMCBLDC">
         <param name="HasHallSensor">         1            </param>
         <param name="HasTempSensor">         0            </param>
         <param name="HasRotorEncoder">       1            </param>

--- a/experimentalSetups/lego_setup_ems_amcbldc/hardware/motorControl/wrist-eb2-j0_2-mc_service.xml
+++ b/experimentalSetups/lego_setup_ems_amcbldc/hardware/motorControl/wrist-eb2-j0_2-mc_service.xml
@@ -14,15 +14,15 @@
             </group>
 
             <group name="CANBOARDS">
-                <param name="type">                 foc         </param>
+                <param name="type">                 amcbldc     </param>
                 <group name="PROTOCOL">
-                    <param name="major">            0           </param>
+                    <param name="major">            2           </param>
                     <param name="minor">            0           </param>
                 </group>
                 <group name="FIRMWARE">
-                    <param name="major">            0           </param>
+                    <param name="major">            1           </param>
                     <param name="minor">            0           </param>
-                    <param name="build">            0           </param>
+                    <param name="build">            7           </param>
                 </group>
             </group>
 

--- a/experimentalSetups/lego_setup_ems_amcbldc/new_forearm-no_hand.xml
+++ b/experimentalSetups/lego_setup_ems_amcbldc/new_forearm-no_hand.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
-    <robot name="new_forearm" build="1" portprefix="nfa" xmlns:xi="http://www.w3.org/2001/XInclude">
+    <robot name="new_forearm" build="1" portprefix="/nfa" xmlns:xi="http://www.w3.org/2001/XInclude">
         <params>
             <xi:include href="hardware/electronics/pc104.xml" />
         </params>

--- a/experimentalSetups/wristmk2_handmk3_amc_amcbldc/hardware/mechanicals/wrist-eb2-j0_2-mec.xml
+++ b/experimentalSetups/wristmk2_handmk3_amc_amcbldc/hardware/mechanicals/wrist-eb2-j0_2-mec.xml
@@ -25,7 +25,7 @@
         <param name="rotorPosMax">           0             0             0           </param>
     </group>
 
-    <group name="2FOC">
+    <group name="AMCBLDC">
         <param name="HasHallSensor">         1             1             1           </param>
         <param name="HasTempSensor">         0             0             0           </param>
         <param name="HasRotorEncoder">       0             0             0           </param>

--- a/experimentalSetups/wristmk2_handmk3_amc_amcbldc/hardware/motorControl/wrist-eb2-j0_2-mc_service.xml
+++ b/experimentalSetups/wristmk2_handmk3_amc_amcbldc/hardware/motorControl/wrist-eb2-j0_2-mc_service.xml
@@ -16,13 +16,13 @@
             <group name="CANBOARDS">
                 <param name="type">                 amcbldc     </param>
                 <group name="PROTOCOL">
-                    <param name="major">            0           </param>
+                    <param name="major">            2           </param>
                     <param name="minor">            0           </param>
                 </group>
                 <group name="FIRMWARE">
-                    <param name="major">            0           </param>
+                    <param name="major">            1           </param>
                     <param name="minor">            0           </param>
-                    <param name="build">            0           </param>
+                    <param name="build">            7           </param>
                 </group>
             </group>
 

--- a/experimentalSetups/wristmk2_handmk3_amc_amcbldc/new_forearm-no_hand.xml
+++ b/experimentalSetups/wristmk2_handmk3_amc_amcbldc/new_forearm-no_hand.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
-    <robot name="new_forearm" build="1" portprefix="nfa" xmlns:xi="http://www.w3.org/2001/XInclude">
+    <robot name="new_forearm" build="1" portprefix="/nfa" xmlns:xi="http://www.w3.org/2001/XInclude">
         <params>
             <xi:include href="hardware/electronics/pc104.xml" />
         </params>

--- a/experimentalSetups/wristmk2_handmk3_ems_amcbldc/hardware/mechanicals/wrist-eb2-j0_2-mec.xml
+++ b/experimentalSetups/wristmk2_handmk3_ems_amcbldc/hardware/mechanicals/wrist-eb2-j0_2-mec.xml
@@ -14,7 +14,7 @@
         <param name="Gearbox_M2J">     -384.44       -384.44       -384.44           </param>
         <param name="Gearbox_E2J">      1.778         1.778         1.778            </param>
         <param name="useMotorSpeedFbk"> 0             0             0                </param>
-        <param name="MotorType">        "BLL_MOOG"    "BLL_MOOG"    "BLL_MOOG"       </param>
+        <param name="MotorType">        "FAULHABER"   "FAULHABER"   "FAULHABER"      </param>
         <param name="Verbose">      0   </param>
     </group>
 
@@ -28,8 +28,8 @@
     <group name="2FOC">
         <param name="HasHallSensor">         1             1             1           </param>
         <param name="HasTempSensor">         0             0             0           </param>
-        <param name="HasRotorEncoder">       1             1             1           </param>
-        <param name="HasRotorEncoderIndex">  1             1             1           </param>
+        <param name="HasRotorEncoder">       0             0             0           </param>
+        <param name="HasRotorEncoderIndex">  0             0             0           </param>
         <param name="HasSpeedEncoder">       0             0             0           </param>
         <param name="RotorIndexOffset">      0             0             0           </param>
         <param name="MotorPoles">            14            14            14          </param>

--- a/experimentalSetups/wristmk2_handmk3_ems_amcbldc/hardware/mechanicals/wrist-eb2-j0_2-mec.xml
+++ b/experimentalSetups/wristmk2_handmk3_ems_amcbldc/hardware/mechanicals/wrist-eb2-j0_2-mec.xml
@@ -25,7 +25,7 @@
         <param name="rotorPosMax">           0             0             0           </param>
     </group>
 
-    <group name="2FOC">
+    <group name="AMCBLDC">
         <param name="HasHallSensor">         1             1             1           </param>
         <param name="HasTempSensor">         0             0             0           </param>
         <param name="HasRotorEncoder">       0             0             0           </param>

--- a/experimentalSetups/wristmk2_handmk3_ems_amcbldc/hardware/motorControl/wrist-eb2-j0_2-mc.xml
+++ b/experimentalSetups/wristmk2_handmk3_ems_amcbldc/hardware/motorControl/wrist-eb2-j0_2-mc.xml
@@ -47,9 +47,9 @@
         <param name="outputType">             current               </param>
         <param name="fbkControlUnits">        metric_units          </param>
         <param name="outputControlUnits">     machine_units         </param>
-        <param name="kp">          -30         -30         -30      </param>
-        <param name="kd">          -10         -10         -10      </param>
-        <param name="ki">          -100        -100        -100     </param>
+        <param name="kp">          -67         -67         -67      </param>
+        <param name="kd">          -11         -11         -11      </param>
+        <param name="ki">          -294        -294        -294     </param>
         <param name="maxOutput">    500         500         500     </param>
         <param name="maxInt">       200         200         200     </param>
         <param name="stictionUp">   0           0           0       </param>

--- a/experimentalSetups/wristmk2_handmk3_ems_amcbldc/hardware/motorControl/wrist-eb2-j0_2-mc_service.xml
+++ b/experimentalSetups/wristmk2_handmk3_ems_amcbldc/hardware/motorControl/wrist-eb2-j0_2-mc_service.xml
@@ -42,11 +42,11 @@
                 </group>
 
                 <group name="ENCODER2">
-                    <param name="type">             roie                roie                roie          </param>
+                    <param name="type">             none                none                none          </param>
                     <param name="port">             CAN1:1:0            CAN1:2:0            CAN1:3:0      </param>
                     <param name="position">         atmotor             atmotor             atmotor       </param>
-                    <param name="resolution">       16000               16000               16000         </param>
-                    <param name="tolerance">         0                   0                   0             </param>  
+                    <param name="resolution">        0                   0                   0            </param>
+                    <param name="tolerance">         0                   0                   0            </param>
                 </group> 
 
             </group>

--- a/experimentalSetups/wristmk2_handmk3_ems_amcbldc/hardware/motorControl/wrist-eb2-j0_2-mc_service.xml
+++ b/experimentalSetups/wristmk2_handmk3_ems_amcbldc/hardware/motorControl/wrist-eb2-j0_2-mc_service.xml
@@ -14,15 +14,15 @@
             </group>
 
             <group name="CANBOARDS">
-                <param name="type">                 foc         </param>
+                <param name="type">                 amcbldc         </param>
                 <group name="PROTOCOL">
-                    <param name="major">            0           </param>
+                    <param name="major">            2           </param>
                     <param name="minor">            0           </param>
                 </group>
                 <group name="FIRMWARE">
-                    <param name="major">            0           </param>
+                    <param name="major">            1           </param>
                     <param name="minor">            0           </param>
-                    <param name="build">            0           </param>
+                    <param name="build">            7           </param>
                 </group>
             </group>
 

--- a/experimentalSetups/wristmk2_handmk3_ems_amcbldc/new_forearm-no_hand.xml
+++ b/experimentalSetups/wristmk2_handmk3_ems_amcbldc/new_forearm-no_hand.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
-    <robot name="new_forearm" build="1" portprefix="nfa" xmlns:xi="http://www.w3.org/2001/XInclude">
+    <robot name="new_forearm" build="1" portprefix="/nfa" xmlns:xi="http://www.w3.org/2001/XInclude">
         <params>
             <xi:include href="hardware/electronics/pc104.xml" />
         </params>


### PR DESCRIPTION
What's new:
- the config files for `wrist-setup` now contain the complete information for the `amcbldc` board instead of `2foc`. In detail, it is now possible to specify the version of protocol and FW for the `amcbldc` board with the right values instead of using `0.0` and `0.0.0` as a workaround.
- the `wrist-setup-ems-amcbldc` config files have been updated according to the changes done after the HAL configurability. 

**Notes:**
- the versions fields for protocol and FW have to be managed as the same fields increase in `icub-firmware` for `amcbldc`.

cc @pattacini 