### PR TITLE
ergocub: remove sign in calibration 12 and update pitch roll neck gains

### DIFF
--- a/ergoCubSN000/calibrators/head-calib.xml
+++ b/ergoCubSN000/calibrators/head-calib.xml
@@ -20,8 +20,8 @@
         <!-- joint name                         neck-pitch  neck-roll   neck-yaw    eyes-tilt -->
         <group name="CALIBRATION">
             <param name="calibrationType">      12          12         12           12         </param>
-            <param name="calibration1">   	39103	    -18095      61615	    52575      </param>
-            <param name="calibration2">         0           0           0	    0         </param>
+            <param name="calibration1">   	39103	    18095      61615	    52575      </param>
+            <param name="calibration2">         0           0           0	    0          </param>
             <param name="calibration3">         0           0           0           0          </param>
 
             <param name="calibration4">         0           0           0           0    </param>

--- a/ergoCubSN000/hardware/motorControl/head-eb20-j0_1-mc.xml
+++ b/ergoCubSN000/hardware/motorControl/head-eb20-j0_1-mc.xml
@@ -47,9 +47,9 @@
         <param name="outputType">               pwm             </param>
         <param name="fbkControlUnits">          metric_units    </param>
         <param name="outputControlUnits">       machine_units   </param>
-        <param name="kp">                       -645        +547        </param>
-        <param name="kd">                       -18         +15         </param>
-        <param name="ki">                       -2983       +2879       </param>
+        <param name="kp">                       -537        +571        </param>
+        <param name="kd">                       -17         +14         </param>
+        <param name="ki">                       -2822       +2923       </param>
         <param name="maxOutput">                3360        3360        </param>
         <param name="maxInt">                   3360        3360        </param>
         <param name="stictionUp">               0           0           </param>


### PR DESCRIPTION
This PR fixes an important aspect in the calibration of the head joints of ergoCub, by removing the minus sign. This is because calibration type 12 needs the absolute value of the encoder.

Additionally, the PID values of the neck pitch and roll are updated to the latest autotuning results.