### PR TITLE
ergoCubSN000: fix calibration files after optical disc substitution

### DIFF
--- a/ergoCubSN000/calibrators/left_leg-calib.xml
+++ b/ergoCubSN000/calibrators/left_leg-calib.xml
@@ -17,7 +17,7 @@
 
    <group name="CALIBRATION">
     <param name="calibrationType">                    12             12           12            12         12      12       </param>
-    <param name="calibration1">                       792            308          220          -367        873    -4100     </param>
+    <param name="calibration1">                       714            501          999          -679        606    -427     </param>
     <param name="calibration2">                       0.0            0.0          0             0          0       0        </param> 
     <param name="calibration3">                       0.0            0.0          0             0          0       0        </param> 
     <param name="calibration4">                       0.0            0.0          0             0          0       0        </param>

--- a/ergoCubSN000/calibrators/right_leg-calib.xml
+++ b/ergoCubSN000/calibrators/right_leg-calib.xml
@@ -17,7 +17,7 @@
 
   <group name="CALIBRATION">
     <param name="calibrationType">                    12             12           12            12         12      12       </param>
-    <param name="calibration1">                       -963          -247         -615          925      -617    367     </param>
+    <param name="calibration1">                       -2439          -855         -350          4569      -602    2501     </param>
     <param name="calibration2">                       0.0            0.0          0             0           0       0        </param> 
     <param name="calibration3">                       0.0            0.0          0             0          0       0        </param> 
     <param name="calibration4">                       0.0            0.0          0             0          0       0        </param>
@@ -27,7 +27,7 @@
     
     <param name="startupPosition">                    0               5           0            -5          0       0        </param>
     <param name="startupVelocity">                    10.0            10.0        10.0          10         10      10       </param>
-    <param name="startupMaxPwm">                      12000           12000       4000          8000       4000    3000     </param>
+    <param name="startupMaxPwm">                      12000           8000       4000          8000       4000    3000     </param>
     <param name="startupPosThreshold">                2               2           2             2          2       2        </param>
   </group>
 

--- a/ergoCubSN000/hardware/mechanicals/right_leg-eb6-j0_3-mec.xml
+++ b/ergoCubSN000/hardware/mechanicals/right_leg-eb6-j0_3-mec.xml
@@ -36,9 +36,9 @@
         <param name="HasRotorEncoder">       1             1        1   1  </param>
         <param name="HasRotorEncoderIndex">  1             1        1   1  </param>
         <param name="HasSpeedEncoder">       0             0        0   0  </param>
-        <param name="RotorIndexOffset">      203           286      48  184   </param>
+        <param name="RotorIndexOffset">      203           295      49   184   </param>
         <param name="MotorPoles">            12            8        8   12  </param>
-   </group>
+ </group>
 
     <group name="COUPLINGS"> 
                                 
@@ -92,4 +92,4 @@
             <param name="param2">         0             </param>
         </group> 
     </group>                          
-</params>
+    </params>


### PR DESCRIPTION
The disc of the `r_hip_roll` was substituted because damaged, 