### PR TITLE
ergoCub: Update configuration files

### DIFF
--- a/ergoCubSN000/hardware/motorControl/head-eb20-j0_1-mc.xml
+++ b/ergoCubSN000/hardware/motorControl/head-eb20-j0_1-mc.xml
@@ -16,7 +16,7 @@
         <param name="jntPosMax">                +22                 +20                 </param>
         <param name="jntVelMax">                1000                1000                </param>
         <param name="motorOverloadCurrents">    5000                5000                </param>
-        <param name="motorNominalCurrents">     1500                1500                </param>
+        <param name="motorNominalCurrents">     2000                2000                </param>
         <param name="motorPeakCurrents">        3000                3000                </param>
         <param name="motorPwmLimit">            3360                3360                </param>
     </group>

--- a/ergoCubSN000/hardware/motorControl/left_arm-eb2-j0_1-mc.xml
+++ b/ergoCubSN000/hardware/motorControl/left_arm-eb2-j0_1-mc.xml
@@ -12,7 +12,7 @@
     <!-- joint name                          shoulder_pitch        shoulder_roll        -->
     <group name="LIMITS">
         <param name="jntPosMax">                14                  130                 </param>
-        <param name="jntPosMin">                -88                 17                  </param>
+        <param name="jntPosMin">                -88                 0                  </param>
         <param name="jntVelMax">                120                 120                 </param>
         <param name="motorNominalCurrents">     5000                5000                </param>
         <param name="motorPeakCurrents">        12000               12000               </param>

--- a/ergoCubSN000/hardware/motorControl/right_arm-eb1-j0_1-mc.xml
+++ b/ergoCubSN000/hardware/motorControl/right_arm-eb1-j0_1-mc.xml
@@ -13,7 +13,7 @@
     <!-- joint name                          shoulder_pitch            shoulder_roll    -->
     <group name="LIMITS">
         <param name="jntPosMax">                14                  130                </param>
-        <param name="jntPosMin">                -88                 17                  </param>
+        <param name="jntPosMin">                -88                 0                  </param>
         <param name="jntVelMax">                120                 120                 </param>
         <param name="motorNominalCurrents">     5000                5000                </param>
         <param name="motorPeakCurrents">        12000               12000               </param>


### PR DESCRIPTION
What's new:
- head: decrease `motorNominalCurrents` (pith, roll) limits
- left_arm: decrease `jntPosMin` (shoulder_roll) limits
- right_arm: decrease `jntPosMin` (shoulder_roll) limits


**Notes:**
These parameters have been tuned during the Rome event 2022.