### PR TITLE
[iCubGenova11] Do not start legs by default

### DIFF
--- a/iCubGenova11/yarprobotinterface.ini
+++ b/iCubGenova11/yarprobotinterface.ini
@@ -1,3 +1,3 @@
-config ./icub_all.xml
+config ./icub_all_no_legs.xml
 
 


### PR DESCRIPTION
As per the title.

Given that we are using a new stand for the robot with variable height and that not all the legs configurations are now collision free, given the geometry of the stand, we would like to disable the legs by default.