### PR TITLE
iCubGenova11: add mc and ft ros2 nws

### DIFF
--- a/iCubGenova11/icub_all_ros2.xml
+++ b/iCubGenova11/icub_all_ros2.xml
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<robot name="iCubGenova11" portprefix="icub" build="1">
+    <params>
+    <xi:include href="hardware/electronics/pc104.xml" />
+    </params>
+
+    <devices>
+
+    <!-- motor controllers wrappers -->
+    <xi:include href="wrappers/motorControl/left_arm-mc_wrapper.xml" />
+    <xi:include href="wrappers/motorControl/right_arm-mc_wrapper.xml" />
+    <xi:include href="wrappers/motorControl/left_leg-mc_wrapper.xml" />
+    <xi:include href="wrappers/motorControl/right_leg-mc_wrapper.xml" />
+    <xi:include href="wrappers/motorControl/head-mc_wrapper.xml" />
+    <xi:include href="wrappers/motorControl/face-mc_wrapper.xml" />
+    <xi:include href="wrappers/motorControl/torso-mc_wrapper.xml" />
+
+    <xi:include href="wrappers/motorControl/left_arm-mc_remapper.xml" />
+    <xi:include href="wrappers/motorControl/right_arm-mc_remapper.xml" />
+    <xi:include href="wrappers/motorControl/left_leg-mc_remapper.xml" />
+    <xi:include href="wrappers/motorControl/right_leg-mc_remapper.xml" />
+    <xi:include href="wrappers/motorControl/head-mc_remapper.xml" />
+    <xi:include href="wrappers/motorControl/face-mc_remapper.xml" />
+    <xi:include href="wrappers/motorControl/torso-mc_remapper.xml" />
+    <xi:include href="wrappers/motorControl/alljoints-mc_remapper.xml" />
+
+    <!-- Cameras -->
+    <xi:include href="camera/dragonfly2_config_left.xml" />
+    <xi:include href="camera/dragonfly2_config_right.xml" />
+    <xi:include href="wrappers/camera/left_cam-nws_yarp.xml" />
+    <xi:include href="wrappers/camera/right_cam-nws_yarp.xml" />
+
+    <!-- CARTESIANS -->
+    <xi:include href="cartesian/left_arm-cartesian.xml" />
+    <xi:include href="cartesian/right_arm-cartesian.xml" />
+
+    <!-- HEAD -->
+    <xi:include href="./hardware/motorControl/head-eb20-j0_1-mc.xml" />
+    <xi:include href="./hardware/motorControl/head-eb21-j2_5-mc.xml" />
+
+    <!-- FACE -->
+    <xi:include href="./hardware/motorControl/face-eb22-j0-mc.xml" />
+
+    <!-- TORSO -->
+    <xi:include href="hardware/motorControl/torso-eb5-j0_2-mc.xml" />
+
+    <!-- LEFT ARM -->
+    <xi:include href="hardware/motorControl/left_arm-eb1-j0_3-mc.xml" />
+    <xi:include href="hardware/motorControl/left_arm-eb24-j4_7-mc.xml" />
+    <xi:include href="hardware/motorControl/left_arm-eb25-j8_11-mc.xml" />
+    <xi:include href="hardware/motorControl/left_arm-eb26-j12_15-mc.xml" />
+
+    <!-- RIGHT ARM -->
+    <xi:include href="hardware/motorControl/right_arm-eb3-j0_3-mc.xml" />
+    <xi:include href="hardware/motorControl/right_arm-eb27-j4_7-mc.xml" />
+    <xi:include href="hardware/motorControl/right_arm-eb28-j8_11-mc.xml" />
+    <xi:include href="hardware/motorControl/right_arm-eb29-j12_15-mc.xml" />
+
+
+    <!-- LEFT LEG -->
+    <xi:include href="hardware/motorControl/left_leg-eb6-j0_3-mc.xml" />
+    <xi:include href="hardware/motorControl/left_leg-eb7-j4_5-mc.xml" />
+
+    <!-- RIGHT LEG -->
+    <xi:include href="hardware/motorControl/right_leg-eb8-j0_3-mc.xml" />
+    <xi:include href="hardware/motorControl/right_leg-eb9-j4_5-mc.xml" />
+
+
+    <!-- INERTIAL SENSOR -->
+    <xi:include href="wrappers/inertials/head-imuFilter_wrapper.xml" />
+    <xi:include href="wrappers/inertials/head-imuFilter.xml" />
+    <xi:include href="wrappers/inertials/head-inertials_wrapper.xml" />
+    <xi:include href="hardware/inertials/head-inertial.xml" />
+
+    <xi:include href="wrappers/inertials/waist-inertials_remapper.xml" />
+    <xi:include href="wrappers/inertials/waist-inertials_wrapper.xml" />
+    <xi:include href="wrappers/inertials/waist-inertials_wrapper-deprecated.xml" />
+    <xi:include href="hardware/inertials/waist-inertial.xml" />
+    <xi:include href="hardware/inertials/waist-eb5-inertials.xml" />
+
+
+    <!-- ANALOG SENSOR MAIS -->
+    <xi:include href="wrappers/MAIS/left_arm-mais_wrapper.xml" />
+    <xi:include href="wrappers/MAIS/right_arm-mais_wrapper.xml" />
+    <xi:include href="hardware/MAIS/left_arm-eb26-j12_15-mais.xml" />
+    <xi:include href="hardware/MAIS/right_arm-eb29-j12_15-mais.xml" />
+
+    <!--  SKINS  -->
+    <xi:include href="wrappers/skin/left_arm-skin_wrapper.xml" />
+    <xi:include href="hardware/skin/left_arm-eb24-j4_7-skin.xml" />
+    <xi:include href="wrappers/skin/right_arm-skin_wrapper.xml" />
+    <xi:include href="hardware/skin/right_arm-eb27-j4_7-skin.xml" />
+    <xi:include href="wrappers/skin/left_leg-skin_wrapper.xml" />
+    <xi:include href="wrappers/skin/right_leg-skin_wrapper.xml" />
+    <xi:include href="hardware/skin/left_leg-eb10-skin.xml" />
+    <xi:include href="hardware/skin/right_leg-eb11-skin.xml" />
+    <xi:include href="wrappers/skin/torso-skin_wrapper.xml" />
+    <xi:include href="hardware/skin/torso-eb22-skin.xml" />
+
+    <!-- ANALOG SENSOR FT -->
+
+    <xi:include href="wrappers/FT/left_arm-FT_wrapper.xml" />
+    <xi:include href="wrappers/FT/right_arm-FT_wrapper.xml" />
+    <xi:include href="wrappers/FT/right_leg-FT_wrapper.xml" />
+    <xi:include href="wrappers/FT/left_leg-FT_wrapper.xml" />
+    <xi:include href="wrappers/FT/right_foot-FT_wrapper.xml" />
+    <xi:include href="wrappers/FT/left_foot-FT_wrapper.xml" />
+    <xi:include href="hardware/FT/left_arm-eb1-j0_3-strain.xml" />
+    <xi:include href="hardware/FT/right_arm-eb3-j0_3-strain.xml" />
+    <xi:include href="hardware/FT/left_leg-eb6-j0_3-strain.xml" />
+    <xi:include href="hardware/FT/left_leg-eb7-j4_5-strain.xml" />
+    <xi:include href="hardware/FT/right_leg-eb8-j0_3-strain.xml" />
+    <xi:include href="hardware/FT/right_leg-eb9-j4_5-strain.xml" />
+
+    <!-- VIRTUAL ANALOG SENSORS (WRAPPER ONLY)-->
+    <xi:include href="wrappers/VFT/left_arm-VFT_wrapper.xml" />
+    <xi:include href="wrappers/VFT/right_leg-VFT_wrapper.xml" />
+    <xi:include href="wrappers/VFT/left_leg-VFT_wrapper.xml" />
+    <xi:include href="wrappers/VFT/right_arm-VFT_wrapper.xml" />
+    <xi:include href="wrappers/VFT/torso-VFT_wrapper.xml" />
+
+    <!--  CALIBRATORS -->
+    <xi:include href="calibrators/left_arm-calib.xml" />
+    <xi:include href="calibrators/right_arm-calib.xml" />
+    <xi:include href="calibrators/left_leg-calib.xml" />
+    <xi:include href="calibrators/right_leg-calib.xml" />
+    <xi:include href="calibrators/torso-calib.xml" />
+    <xi:include href="calibrators/head-calib.xml" />
+    <xi:include href="calibrators/face-calib.xml" />
+
+    <!-- ROS2 -->
+    <xi:include href="wrappers/motorControl/alljoints-mc_nws_ros2.xml" />
+    <xi:include href="wrappers/camera/left_cam-nws_ros2.xml" />
+    <xi:include href="wrappers/camera/right_cam-nws_ros2.xml" />
+    <xi:include href="wrappers/FT/left_arm-FT_nws_ros2.xml" />
+    <xi:include href="wrappers/FT/right_arm-FT_nws_ros2.xml" />
+    <xi:include href="wrappers/FT/left_leg-FT_nws_ros2.xml" />
+    <xi:include href="wrappers/FT/right_leg-FT_nws_ros2.xml" />
+    <xi:include href="wrappers/FT/left_foot-FT_nws_ros2.xml" />
+    <xi:include href="wrappers/FT/right_foot-FT_nws_ros2.xml" />
+
+    </devices>
+</robot>
+

--- a/iCubGenova11/wrappers/FT/left_arm-FT_nws_ros2.xml
+++ b/iCubGenova11/wrappers/FT/left_arm-FT_nws_ros2.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-FT_wrapper_ros2" type="wrenchStamped_nws_ros2">
+        <param name="topic_name">      /left_arm_ft                      </param>
+        <param name="node_name">      icub_left_arm_ft          </param>
+        <param name="period">      0.1                          </param>
+
+        <action phase="startup" level="10" type="attach">
+            <paramlist name="networks">
+        <!-- The param value must match the device name in the corresponding body_part-ebX-jA_B-strain.xml file -->
+                <elem name="FirstStrain">  left_arm-eb1-j0_3-strain </elem>
+            </paramlist>
+        </action>
+
+        <action phase="shutdown" level="15" type="detach" />
+    </device>
+

--- a/iCubGenova11/wrappers/FT/left_foot-FT_nws_ros2.xml
+++ b/iCubGenova11/wrappers/FT/left_foot-FT_nws_ros2.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_foot-FT_wrapper_ros2" type="wrenchStamped_nws_ros2">
+        <param name="topic_name">      /left_foot_ft                      </param>
+        <param name="node_name">      icub_left_foot_ft          </param>
+        <param name="period">      0.1                          </param>
+
+        <action phase="startup" level="10" type="attach">
+            <paramlist name="networks">
+        <!-- The param value must match the device name in the corresponding body_part-ebX-jA_B-strain.xml file -->
+                <elem name="FirstStrain">  left_leg-eb7-j4_5-strain  </elem>
+            </paramlist>
+        </action>
+
+        <action phase="shutdown" level="15" type="detach" />
+    </device>
+

--- a/iCubGenova11/wrappers/FT/left_leg-FT_nws_ros2.xml
+++ b/iCubGenova11/wrappers/FT/left_leg-FT_nws_ros2.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-FT_wrapper_ros2" type="wrenchStamped_nws_ros2">
+        <param name="topic_name">      /left_leg_ft                      </param>
+        <param name="node_name">      icub_left_leg_ft          </param>
+        <param name="period">      0.1                          </param>
+
+        <action phase="startup" level="10" type="attach">
+            <paramlist name="networks">
+        <!-- The param value must match the device name in the corresponding body_part-ebX-jA_B-strain.xml file -->
+                <elem name="FirstStrain">  left_leg-eb6-j0_3-strain  </elem>
+            </paramlist>
+        </action>
+
+        <action phase="shutdown" level="15" type="detach" />
+    </device>
+

--- a/iCubGenova11/wrappers/FT/right_arm-FT_nws_ros2.xml
+++ b/iCubGenova11/wrappers/FT/right_arm-FT_nws_ros2.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-FT_wrapper_ros2" type="wrenchStamped_nws_ros2">
+        <param name="topic_name">      /right_arm_ft                      </param>
+        <param name="node_name">      icub_right_arm_ft          </param>
+        <param name="period">      0.1                          </param>
+
+        <action phase="startup" level="10" type="attach">
+            <paramlist name="networks">
+        <!-- The param value must match the device name in the corresponding body_part-ebX-jA_B-strain.xml file -->
+                <elem name="FirstStrain">  right_arm-eb3-j0_3-strain  </elem>
+            </paramlist>
+        </action>
+
+        <action phase="shutdown" level="15" type="detach" />
+    </device>
+

--- a/iCubGenova11/wrappers/FT/right_foot-FT_nws_ros2.xml
+++ b/iCubGenova11/wrappers/FT/right_foot-FT_nws_ros2.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_foot-FT_wrapper_ros2" type="wrenchStamped_nws_ros2">
+        <param name="topic_name">      /right_foot_ft                      </param>
+        <param name="node_name">      icub_right_foot_ft          </param>
+        <param name="period">      0.1                          </param>
+
+        <action phase="startup" level="10" type="attach">
+            <paramlist name="networks">
+        <!-- The param value must match the device name in the corresponding body_part-ebX-jA_B-strain.xml file -->
+                <elem name="FirstStrain">  right_leg-eb9-j4_5-strain  </elem>
+            </paramlist>
+        </action>
+
+        <action phase="shutdown" level="15" type="detach" />
+    </device>
+

--- a/iCubGenova11/wrappers/FT/right_leg-FT_nws_ros2.xml
+++ b/iCubGenova11/wrappers/FT/right_leg-FT_nws_ros2.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-FT_wrapper_ros2" type="wrenchStamped_nws_ros2">
+        <param name="topic_name">      /right_leg_ft                      </param>
+        <param name="node_name">      icub_right_leg_ft          </param>
+        <param name="period">      0.1                          </param>
+
+        <action phase="startup" level="10" type="attach">
+            <paramlist name="networks">
+        <!-- The param value must match the device name in the corresponding body_part-ebX-jA_B-strain.xml file -->
+                <elem name="FirstStrain">  right_leg-eb8-j0_3-strain  </elem>
+            </paramlist>
+        </action>
+
+        <action phase="shutdown" level="15" type="detach" />
+    </device>
+

--- a/iCubGenova11/wrappers/motorControl/alljoints-mc_nws_ros2.xml
+++ b/iCubGenova11/wrappers/motorControl/alljoints-mc_nws_ros2.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-mc_nws_ros2" type="controlBoard_nws_ros2">
+    <param name="node_name"> icub_cb_node </param>
+    <param name="topic_name"> /joint_states </param>
+    <action phase="startup" level="15" type="attach">
+        <param name="device"> alljoints-mc_remapper </param>
+    </action>
+    <action phase="shutdown" level="20" type="detach" />
+</device>

--- a/iCubGenova11/wrappers/motorControl/alljoints-mc_remapper.xml
+++ b/iCubGenova11/wrappers/motorControl/alljoints-mc_remapper.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-mc_remapper" type="controlboardremapper">
+    <paramlist name="networks">
+        <elem name="head_joints">       (  0   5   0  5 )</elem>
+        <elem name="face_joints">       (  6   6   0  0 )</elem>
+        <elem name="left_arm_joints">   (  7  22   0  15 )</elem>
+        <elem name="right_arm_joints">  ( 23  38   0  15 )</elem>
+        <elem name="torso_joints">      ( 39  41   0  2 )</elem>
+        <elem name="left_leg_joints">   ( 42  47   0  5 )</elem>
+        <elem name="right_leg_joints">  ( 48  53   0  5 )</elem>
+    </paramlist>
+    <param name="joints"> 54 </param>
+    <action phase="startup" level="6" type="attach">
+        <paramlist name="networks">
+            <elem name="head_joints">       head-mc_remapper </elem>
+            <elem name="face_joints">       face-mc_remapper </elem>
+            <elem name="left_arm_joints">   left_arm-mc_remapper</elem>
+            <elem name="right_arm_joints">  right_arm-mc_remapper </elem>
+            <elem name="torso_joints">      torso-mc_remapper </elem>
+            <elem name="left_leg_joints">   left_leg-mc_remapper </elem>
+            <elem name="right_leg_joints">  right_leg-mc_remapper </elem>
+        </paramlist>
+    </action>
+    <action phase="shutdown" level="19" type="detach" />
+</device>


### PR DESCRIPTION
This PR adds the xml files for running the ft and mc ros2 nws.

It has been tested on the robot.

![immagine](https://user-images.githubusercontent.com/19152494/213159853-0dfa006a-e3b0-429c-83d9-96e0be5ab6ab.png)


Probably more check/fixes are needed on the urdf in order to visualize the data correctly on `rviz`, meanwhile here is an example of visualization of data on `rqt`:

![immagine](https://user-images.githubusercontent.com/19152494/213159924-d96ee930-7dde-4277-bcfd-fdffc6b089fd.png)



cc @maggia80 @pattacini @randaz81 @elandini84 @xEnVrE 