### PR TITLE
Fix joint names for the hands

### DIFF
--- a/R1SN002/wrappers/skin/left_hand-skin_wrapper.xml
+++ b/R1SN002/wrappers/skin/left_hand-skin_wrapper.xml
@@ -6,22 +6,22 @@
         <param name="period">       20                  </param>
         <param name="total_taxels"> 576                 </param>
         <param name="device">       skinWrapper         </param>
-        
+
         <paramlist name="ports">
             <elem name="left_hand_skin_index">      0   191     0   191   </elem>
             <elem name="left_hand_skin_paddle">     192 383     0   191   </elem>
             <elem name="left_hand_skin_thumb">      384 575     0   191   </elem>
         </paramlist>
-        
+
         <!-- used taxels:
              left-index-proxy:      24 taxels of port left_hand_skin_index in positions [8*12, (9+1)*12-1]      = [96, 119]
-             left-index-distal:     24 taxels of port left_hand_skin_index in positions [0*12, (1+1)*12-1]      = [0, 23]
+             left-index_distal:     24 taxels of port left_hand_skin_index in positions [0*12, (1+1)*12-1]      = [0, 23]
              left-paddle-proxy:     48 taxels of port left_hand_skin_paddle in positions [0*12, (3+1)*12-1]     = [0, 47]
              left-paddle-distal:    48 taxels of port left_hand_skin_paddle in positions [8*12, (11+1)*12-1]    = [96, 143]
              left-thumb-proxy:      24 taxels of port left_hand_skin_thumb in positions [8*12, (9+1)*12-1]      = [96, 119]
              left-thumb-distal:     36 taxels of port left_hand_skin_thumb in positions [0*12, (2+1)*12-1]      = [0, 35]
           -->
-        
+
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
             <!-- The param value must match the device name in the corresponding emsX file -->

--- a/R1SN002/wrappers/skin/right_hand-skin_wrapper.xml
+++ b/R1SN002/wrappers/skin/right_hand-skin_wrapper.xml
@@ -6,22 +6,22 @@
         <param name="period">       20                  </param>
         <param name="total_taxels"> 576                 </param>
         <param name="device">       skinWrapper         </param>
-        
+
         <paramlist name="ports">
             <elem name="right_hand_skin_index">     0   191     0   191   </elem>
             <elem name="right_hand_skin_paddle">    192 383     0   191   </elem>
             <elem name="right_hand_skin_thumb">     384 575     0   191   </elem>
         </paramlist>
-        
+
         <!-- used taxels:
              right-index-proxy:     24 taxels of port right_hand_skin_index in positions [0*12, (1+1)*12-1]     = [0, 23]
-             right-index-distal:    24 taxels of port right_hand_skin_index in positions [8*12, (9+1)*12-1]     = [96, 119]
+             right-index_distal:    24 taxels of port right_hand_skin_index in positions [8*12, (9+1)*12-1]     = [96, 119]
              right-paddle-proxy:    48 taxels of port right_hand_skin_paddle in positions [8*12, (11+1)*12-1]   = [96, 143]
              right-paddle-distal:   48 taxels of port right_hand_skin_paddle in positions [0*12, (3+1)*12-1]    = [0, 47]
              right-thumb-proxy:     24 taxels of port right_hand_skin_thumb in positions [0*12, (1+1)*12-1]     = [0, 23]
              right-thumb-distal:    36 taxels of port right_hand_skin_thumb in positions [8*12, (10+1)*12-1]    = [96, 131]
-          -->        
-        
+          -->
+
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
             <!-- The param value must match the device name in the corresponding emsX file -->

--- a/R1SN003/wrappers/skin/left_hand-skin_wrapper.xml
+++ b/R1SN003/wrappers/skin/left_hand-skin_wrapper.xml
@@ -6,22 +6,22 @@
         <param name="period">       20                  </param>
         <param name="total_taxels"> 576                 </param>
         <param name="device">       skinWrapper         </param>
-        
+
         <paramlist name="ports">
             <elem name="left_hand_skin_index">      0   191     0   191   </elem>
             <elem name="left_hand_skin_paddle">     192 383     0   191   </elem>
             <elem name="left_hand_skin_thumb">      384 575     0   191   </elem>
         </paramlist>
-        
+
         <!-- used taxels:
              left-index-proxy:      24 taxels of port left_hand_skin_index in positions [8*12, (9+1)*12-1]      = [96, 119]
-             left-index-distal:     24 taxels of port left_hand_skin_index in positions [0*12, (1+1)*12-1]      = [0, 23]
+             left-index_distal:     24 taxels of port left_hand_skin_index in positions [0*12, (1+1)*12-1]      = [0, 23]
              left-paddle-proxy:     48 taxels of port left_hand_skin_paddle in positions [0*12, (3+1)*12-1]     = [0, 47]
              left-paddle-distal:    48 taxels of port left_hand_skin_paddle in positions [8*12, (11+1)*12-1]    = [96, 143]
              left-thumb-proxy:      24 taxels of port left_hand_skin_thumb in positions [8*12, (9+1)*12-1]      = [96, 119]
              left-thumb-distal:     36 taxels of port left_hand_skin_thumb in positions [0*12, (2+1)*12-1]      = [0, 35]
           -->
-        
+
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
             <!-- The param value must match the device name in the corresponding emsX file -->

--- a/R1SN003/wrappers/skin/right_hand-skin_wrapper.xml
+++ b/R1SN003/wrappers/skin/right_hand-skin_wrapper.xml
@@ -6,22 +6,22 @@
         <param name="period">       20                  </param>
         <param name="total_taxels"> 576                 </param>
         <param name="device">       skinWrapper         </param>
-        
+
         <paramlist name="ports">
             <elem name="right_hand_skin_index">     0   191     0   191   </elem>
             <elem name="right_hand_skin_paddle">    192 383     0   191   </elem>
             <elem name="right_hand_skin_thumb">     384 575     0   191   </elem>
         </paramlist>
-        
+
         <!-- used taxels:
              right-index-proxy:     24 taxels of port right_hand_skin_index in positions [0*12, (1+1)*12-1]     = [0, 23]
-             right-index-distal:    24 taxels of port right_hand_skin_index in positions [8*12, (9+1)*12-1]     = [96, 119]
+             right-index_distal:    24 taxels of port right_hand_skin_index in positions [8*12, (9+1)*12-1]     = [96, 119]
              right-paddle-proxy:    48 taxels of port right_hand_skin_paddle in positions [8*12, (11+1)*12-1]   = [96, 143]
              right-paddle-distal:   48 taxels of port right_hand_skin_paddle in positions [0*12, (3+1)*12-1]    = [0, 47]
              right-thumb-proxy:     24 taxels of port right_hand_skin_thumb in positions [0*12, (1+1)*12-1]     = [0, 23]
              right-thumb-distal:    36 taxels of port right_hand_skin_thumb in positions [8*12, (10+1)*12-1]    = [96, 131]
-          -->        
-        
+          -->
+
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
             <!-- The param value must match the device name in the corresponding emsX file -->

--- a/experimentalSetups/arm-v3/hardware/motorControl/left_arm-j12_15-mc.xml
+++ b/experimentalSetups/arm-v3/hardware/motorControl/left_arm-j12_15-mc.xml
@@ -4,19 +4,19 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-j12_15-mc" type="embObjMotionControl">
-    
+
         <xi:include href="../../general.xml" />
         <xi:include href="../../hardware/electronics/left_arm-j12_15-eln.xml" />
         <xi:include href="../../hardware/mechanicals/left_arm-j12_15-mec.xml" />
-        
+
         <xi:include href="hardware/motorControl/left_arm-j12_15-mc-service.xml" />
 
         <!-- joint number in sub-part           0               1               2               3          -->
-        <!-- joint name                    index_distal   middle-proximal   middle-distal   little-fingers -->     
+        <!-- joint name                    index_distal   middle_proximal   middle_distal   pinky -->
         <group name="LIMITS">
             <param name="jntPosMax">              180          90              180             270          </param>
-            <param name="jntPosMin">                0           0                0               0           </param> 
-            <param name="rotorPosMin">         -55040       -5120            -5120           -69120       </param> 
+            <param name="jntPosMin">                0           0                0               0           </param>
+            <param name="rotorPosMin">         -55040       -5120            -5120           -69120       </param>
             <param name="rotorPosMax">           5120       32000            55040             2048       </param>
             <param name="jntVelMax">                1000        1000            1000           1000         </param>
             <param name="motorOverloadCurrents">    2000        2000            2000           2000       </param>
@@ -24,7 +24,7 @@
             <param name="motorPeakCurrents">        1000        1000            1000           1000        </param>
             <param name="motorPwmLimit">            3360        3360            3360            3360       </param>
         </group>
-    
+
 
         <group name="IMPEDANCE">
             <param name="stiffness">            0.0         0.0     0.0         0.0             </param>
@@ -37,27 +37,27 @@
 
 
         <group name="CONTROLS">
-           <param name="positionControl">           JOINT_PID_V1   JOINT_PID_V1    JOINT_PID_V1    JOINT_PID_V1    </param> 
-           <param name="velocityControl">           none           none            none            none            </param> 
-           <param name="torqueControl">             none           none            none            none            </param> 
+           <param name="positionControl">           JOINT_PID_V1   JOINT_PID_V1    JOINT_PID_V1    JOINT_PID_V1    </param>
+           <param name="velocityControl">           none           none            none            none            </param>
+           <param name="torqueControl">             none           none            none            none            </param>
            <param name="currentPid">                none           none            none            none            </param>
         </group>
 
 	    <group name="JOINT_PID_V1">
-	        <param name="controlLaw">    Pid_inPos_outPwm                          </param> 
-            <param name="controlUnits">     metric_units                                        </param> 
+	        <param name="controlLaw">    Pid_inPos_outPwm                          </param>
+            <param name="controlUnits">     metric_units                                        </param>
             <param name="pos_kp">                  -500.00    500.00      500.00     -200.00      </param>
-            <param name="pos_kd">                   0.0         0.0         0.0         0.0         </param>     
-            <param name="pos_ki">                   0.0         0.0         0.0         0.0         </param>       
-            <param name="pos_maxOutput">            1500        3360        3360        3360        </param>  
-            <param name="pos_maxInt">               1500        3360        3360        3360        </param> 
-            <param name="pos_shift">                0           0           0           0           </param>       
-            <param name="pos_ko">                   0           0           0           0           </param>  
-            <param name="pos_stictionUp">           0           0           0           0           </param> 
-            <param name="pos_stictionDwn">          0           0           0           0           </param> 
-            <param name="pos_kff">                  0           0           0           0           </param> 
+            <param name="pos_kd">                   0.0         0.0         0.0         0.0         </param>
+            <param name="pos_ki">                   0.0         0.0         0.0         0.0         </param>
+            <param name="pos_maxOutput">            1500        3360        3360        3360        </param>
+            <param name="pos_maxInt">               1500        3360        3360        3360        </param>
+            <param name="pos_shift">                0           0           0           0           </param>
+            <param name="pos_ko">                   0           0           0           0           </param>
+            <param name="pos_stictionUp">           0           0           0           0           </param>
+            <param name="pos_stictionDwn">          0           0           0           0           </param>
+            <param name="pos_kff">                  0           0           0           0           </param>
         </group>
 
-    </device> 
-    
+    </device>
+
 

--- a/experimentalSetups/arm-v3/hardware/motorControl/left_lower_arm-j12_15-mc.xml
+++ b/experimentalSetups/arm-v3/hardware/motorControl/left_lower_arm-j12_15-mc.xml
@@ -4,18 +4,18 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_lower_arm-j12_15-mc" type="embObjMotionControl">
-    
+
         <xi:include href="../../general.xml" />
         <xi:include href="../../hardware/electronics/left_lower_arm-j12_15-eln.xml" />
         <xi:include href="../../hardware/mechanicals/left_lower_arm-j12_15-mec.xml" />
         <xi:include href="hardware/motorControl/left_arm-j12_15-mc-service.xml"/>
 
         <!-- joint number in sub-part           0               1               2               3          -->
-        <!-- joint name                    index_distal   middle-proximal   middle-distal   little-fingers -->     
+        <!-- joint name                    index_distal   middle_proximal   middle_distal   pinky -->
         <group name="LIMITS">
             <param name="jntPosMax">              180          90              180             270          </param>
-            <param name="jntPosMin">                0           0                0               0           </param> 
-            <param name="rotorPosMin">           -64000        -1280          -2560           -53760          </param> 
+            <param name="jntPosMin">                0           0                0               0           </param>
+            <param name="rotorPosMin">           -64000        -1280          -2560           -53760          </param>
             <param name="rotorPosMax">             1280        30720           59648           1280            </param>
             <param name="jntVelMax">                1000        1000            1000           1000         </param>
             <param name="motorOverloadCurrents">    2000        2000            2000           2000       </param>
@@ -23,7 +23,7 @@
             <param name="motorPeakCurrents">        1000        1000            1000           1000        </param>
             <param name="motorPwmLimit">            3360        3360            3360            3360       </param>
         </group>
-    
+
 
         <group name="IMPEDANCE">
             <param name="stiffness">            0.0         0.0     0.0         0.0             </param>
@@ -31,38 +31,38 @@
         </group>
 
         <group name="POSITION_CONTROL">
-            <param name="controlLaw">       joint_pid_v1                                        </param>    
-            <param name="controlUnits">     metric_units                                        </param> 
+            <param name="controlLaw">       joint_pid_v1                                        </param>
+            <param name="controlUnits">     metric_units                                        </param>
             <param name="kp">                  -500.00    500.00      500.00     -200.00      </param>
-            <param name="kd">                   0.0         0.0         0.0         0.0         </param>     
-            <param name="ki">                   0.0         0.0         0.0         0.0         </param>       
-            <param name="maxOutput">            1500        3360        3360        3360        </param>  
-            <param name="maxInt">               1500        3360        3360        3360        </param> 
-            <param name="shift">                0           0           0           0           </param>       
-            <param name="ko">                   0           0           0           0           </param>  
-            <param name="stictionUp">           0           0           0           0           </param> 
-            <param name="stictionDwn">          0           0           0           0           </param> 
-            <param name="kff">                  0           0           0           0           </param> 
+            <param name="kd">                   0.0         0.0         0.0         0.0         </param>
+            <param name="ki">                   0.0         0.0         0.0         0.0         </param>
+            <param name="maxOutput">            1500        3360        3360        3360        </param>
+            <param name="maxInt">               1500        3360        3360        3360        </param>
+            <param name="shift">                0           0           0           0           </param>
+            <param name="ko">                   0           0           0           0           </param>
+            <param name="stictionUp">           0           0           0           0           </param>
+            <param name="stictionDwn">          0           0           0           0           </param>
+            <param name="kff">                  0           0           0           0           </param>
         </group>
-    
+
         <group name="TORQUE_CONTROL">
-            <param name="controlLaw">       motor_pid_with_friction_v1                   </param>    
-            <param name="controlUnits">     metric_units                                 </param> 
-            <param name="kp">                   0           0           0           0    </param>    
-            <param name="kd">                   0           0           0           0    </param>        
-            <param name="ki">                   0           0           0           0    </param>        
-            <param name="maxOutput">            0           0           0           0    </param>       
-            <param name="maxInt">               0           0           0           0    </param>       
-            <param name="shift">                0           0           0           0    </param>        
-            <param name="ko">                   0           0           0           0    </param>        
-            <param name="stictionUp">           0           0           0           0    </param>        
-            <param name="stictionDwn">          0           0           0           0    </param>        
-            <param name="kff">                  0           0           0           0    </param>    
-            <param name="kbemf">                0           0           0           0    </param>     
-            <param name="filterType">           0           0           0           0    </param>            
-            <param name="ktau">                 0           0           0           0    </param>   
+            <param name="controlLaw">       motor_pid_with_friction_v1                   </param>
+            <param name="controlUnits">     metric_units                                 </param>
+            <param name="kp">                   0           0           0           0    </param>
+            <param name="kd">                   0           0           0           0    </param>
+            <param name="ki">                   0           0           0           0    </param>
+            <param name="maxOutput">            0           0           0           0    </param>
+            <param name="maxInt">               0           0           0           0    </param>
+            <param name="shift">                0           0           0           0    </param>
+            <param name="ko">                   0           0           0           0    </param>
+            <param name="stictionUp">           0           0           0           0    </param>
+            <param name="stictionDwn">          0           0           0           0    </param>
+            <param name="kff">                  0           0           0           0    </param>
+            <param name="kbemf">                0           0           0           0    </param>
+            <param name="filterType">           0           0           0           0    </param>
+            <param name="ktau">                 0           0           0           0    </param>
         </group>
-       
-    </device> 
-    
+
+    </device>
+
 

--- a/experimentalSetups/iCubGenovaV3-VelCtrl/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
+++ b/experimentalSetups/iCubGenovaV3-VelCtrl/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
@@ -4,25 +4,25 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-eb26-j12_15-mc" type="embObjMotionControl">
-    
+
         <xi:include href="../../general.xml" />
         <xi:include href="../../hardware/electronics/left_arm-eb26-j12_15-eln.xml" />
         <xi:include href="../../hardware/mechanicals/left_arm-eb26-j12_15-mec.xml" />
-        
+
         <xi:include href="./left_arm-eb26-j12_15-mc_service.xml" />
 
         <!-- joint number in sub-part           0               1               2               3          -->
-        <!-- joint name                    index_distal   middle-proximal   middle-distal   little-fingers -->     
+        <!-- joint name                    index_distal   middle_proximal   middle_distal   pinky -->
         <group name="LIMITS">
             <param name="jntPosMax">              180          90              180             270        </param>
-            <param name="jntPosMin">                0           0                0               0        </param> 
+            <param name="jntPosMin">                0           0                0               0        </param>
             <param name="jntVelMax">                1000        1000            1000           1000       </param>
             <param name="motorOverloadCurrents">    2000        2000            2000           2000       </param>
             <param name="motorNominalCurrents">      600         600             600            600        </param>
             <param name="motorPeakCurrents">        1000        1000            1000           1000        </param>
             <param name="motorPwmLimit">            3360        3360            3360            3360       </param>
         </group>
-    
+
 
         <group name="IMPEDANCE">
             <param name="stiffness">            0.0         0.0     0.0         0.0             </param>
@@ -35,28 +35,28 @@
 
 
         <group name="CONTROLS">
-           <param name="positionControl">           POS_PID_DEFAULT   POS_PID_DEFAULT    POS_PID_DEFAULT    POS_PID_DEFAULT    </param> 
-           <param name="velocityControl">           none           none            none            none            </param> 
-           <param name="torqueControl">             none           none            none            none            </param> 
+           <param name="positionControl">           POS_PID_DEFAULT   POS_PID_DEFAULT    POS_PID_DEFAULT    POS_PID_DEFAULT    </param>
+           <param name="velocityControl">           none           none            none            none            </param>
+           <param name="torqueControl">             none           none            none            none            </param>
            <param name="currentPid">                none           none            none            none            </param>
         </group>
 
 	    <group name="POS_PID_DEFAULT">
-	        <param name="controlLaw">    Pid_inPos_outPwm                          </param> 
-            <param name="fbkControlUnits">     metric_units       </param> 
+	        <param name="controlLaw">    Pid_inPos_outPwm                          </param>
+            <param name="fbkControlUnits">     metric_units       </param>
             <param name="outputControlUnits">  machine_units      </param>
             <param name="pos_kp">                  -500.0       500.0       500.0      -200.0       </param>
-            <param name="pos_kd">                   0.0         0.0         0.0         0.0         </param>      
-            <param name="pos_ki">                  -50.0        50.0        50.0       -20.0        </param>        
-            <param name="pos_maxOutput">            3360        3360        3360        3360        </param>   
-            <param name="pos_maxInt">               3360        3360        3360        3360        </param> 
-            <param name="pos_shift">                0           0           0           0           </param>        
-            <param name="pos_ko">                   0           0           0           0           </param>   
-            <param name="pos_stictionUp">           0           0           0           0           </param> 
-            <param name="pos_stictionDwn">          0           0           0           0           </param> 
-            <param name="pos_kff">                  0           0           0           0           </param> 
+            <param name="pos_kd">                   0.0         0.0         0.0         0.0         </param>
+            <param name="pos_ki">                  -50.0        50.0        50.0       -20.0        </param>
+            <param name="pos_maxOutput">            3360        3360        3360        3360        </param>
+            <param name="pos_maxInt">               3360        3360        3360        3360        </param>
+            <param name="pos_shift">                0           0           0           0           </param>
+            <param name="pos_ko">                   0           0           0           0           </param>
+            <param name="pos_stictionUp">           0           0           0           0           </param>
+            <param name="pos_stictionDwn">          0           0           0           0           </param>
+            <param name="pos_kff">                  0           0           0           0           </param>
         </group>
 
-    </device> 
-    
+    </device>
+
 

--- a/experimentalSetups/iCubGenovaV3-VelCtrl/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
+++ b/experimentalSetups/iCubGenovaV3-VelCtrl/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
@@ -4,25 +4,25 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-eb29-j12_15-mc" type="embObjMotionControl">
-    
+
         <xi:include href="../../general.xml" />
         <xi:include href="../../hardware/electronics/right_arm-eb29-j12_15-eln.xml" />
         <xi:include href="../../hardware/mechanicals/right_arm-eb29-j12_15-mec.xml" />
-        
+
         <xi:include href="./right_arm-eb29-j12_15-mc_service.xml" />
 
         <!-- joint number in sub-part           0               1               2               3          -->
-        <!-- joint name                    index_distal   middle-proximal   middle-distal   little-fingers -->     
+        <!-- joint name                    index_distal   middle_proximal   middle_distal   pinky -->
         <group name="LIMITS">
             <param name="jntPosMax">              180          90              180             270          </param>
-            <param name="jntPosMin">                0           0                0               0           </param> 
+            <param name="jntPosMin">                0           0                0               0           </param>
             <param name="jntVelMax">                1000        1000            1000           1000         </param>
             <param name="motorOverloadCurrents">    2000        2000            2000           2000       </param>
             <param name="motorNominalCurrents">      600         600             600            600        </param>
             <param name="motorPeakCurrents">        1000        1000            1000           1000        </param>
             <param name="motorPwmLimit">            3360        3360            3360            3360       </param>
         </group>
-    
+
         <group name="IMPEDANCE">
             <param name="stiffness">            0.0         0.0     0.0         0.0             </param>
             <param name="damping">              0.0         0.0     0.0         0.0             </param>
@@ -34,28 +34,28 @@
 
 
         <group name="CONTROLS">
-           <param name="positionControl">           POS_PID_DEFAULT   POS_PID_DEFAULT    POS_PID_DEFAULT    POS_PID_DEFAULT    </param> 
-           <param name="velocityControl">           none           none            none            none            </param> 
-           <param name="torqueControl">             none           none            none            none            </param> 
+           <param name="positionControl">           POS_PID_DEFAULT   POS_PID_DEFAULT    POS_PID_DEFAULT    POS_PID_DEFAULT    </param>
+           <param name="velocityControl">           none           none            none            none            </param>
+           <param name="torqueControl">             none           none            none            none            </param>
            <param name="currentPid">                none           none            none            none            </param>
         </group>
 
 	    <group name="POS_PID_DEFAULT">
-	        <param name="controlLaw">    Pid_inPos_outPwm                          </param> 
-        <param name="fbkControlUnits">     metric_units       </param> 
+	        <param name="controlLaw">    Pid_inPos_outPwm                          </param>
+        <param name="fbkControlUnits">     metric_units       </param>
         <param name="outputControlUnits">  machine_units      </param>
             <param name="pos_kp">                500.0       500.0      -500.0       200.0       </param>
-            <param name="pos_kd">                0.0         0.0         0.0         0.0         </param>  
-            <param name="pos_ki">                50.0        50.0       -50.0        20.0        </param>    
-            <param name="pos_maxOutput">         3360        3360        3360        3360        </param>  
-            <param name="pos_maxInt">            3360        3360        3360        3360        </param> 
-            <param name="pos_shift">             0           0           0           0           </param>    
-            <param name="pos_ko">                0           0           0           0           </param>  
-            <param name="pos_stictionUp">        0           0           0           0           </param> 
-            <param name="pos_stictionDwn">       0           0           0           0           </param> 
-            <param name="pos_kff">               0           0           0           0           </param> 
+            <param name="pos_kd">                0.0         0.0         0.0         0.0         </param>
+            <param name="pos_ki">                50.0        50.0       -50.0        20.0        </param>
+            <param name="pos_maxOutput">         3360        3360        3360        3360        </param>
+            <param name="pos_maxInt">            3360        3360        3360        3360        </param>
+            <param name="pos_shift">             0           0           0           0           </param>
+            <param name="pos_ko">                0           0           0           0           </param>
+            <param name="pos_stictionUp">        0           0           0           0           </param>
+            <param name="pos_stictionDwn">       0           0           0           0           </param>
+            <param name="pos_kff">               0           0           0           0           </param>
         </group>
-       
-    </device> 
-    
+
+    </device>
+
 

--- a/experimentalSetups/iCubGenovaV3/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
+++ b/experimentalSetups/iCubGenovaV3/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
@@ -4,25 +4,25 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-eb26-j12_15-mc" type="embObjMotionControl">
-    
+
         <xi:include href="../../general.xml" />
         <xi:include href="../../hardware/electronics/left_arm-eb26-j12_15-eln.xml" />
         <xi:include href="../../hardware/mechanicals/left_arm-eb26-j12_15-mec.xml" />
-        
+
         <xi:include href="./left_arm-eb26-j12_15-mc_service.xml" />
 
         <!-- joint number in sub-part           0               1               2               3          -->
-        <!-- joint name                    index_distal   middle-proximal   middle-distal   little-fingers -->     
+        <!-- joint name                    index_distal   middle_proximal   middle_distal   pinky -->
         <group name="LIMITS">
             <param name="jntPosMax">              180          90              180             270        </param>
-            <param name="jntPosMin">                0           0                0               0        </param> 
+            <param name="jntPosMin">                0           0                0               0        </param>
             <param name="jntVelMax">                1000        1000            1000           1000       </param>
             <param name="motorOverloadCurrents">    2000        2000            2000           2000       </param>
             <param name="motorNominalCurrents">      600         600             600            600        </param>
             <param name="motorPeakCurrents">        1000        1000            1000           1000        </param>
             <param name="motorPwmLimit">            3360        3360            3360            3360       </param>
         </group>
-    
+
 
         <group name="IMPEDANCE">
             <param name="stiffness">            0.0         0.0     0.0         0.0             </param>
@@ -35,28 +35,28 @@
 
 
         <group name="CONTROLS">
-           <param name="positionControl">           POS_PID_DEFAULT   POS_PID_DEFAULT    POS_PID_DEFAULT    POS_PID_DEFAULT    </param> 
-           <param name="velocityControl">           none           none            none            none            </param> 
-           <param name="torqueControl">             none           none            none            none            </param> 
+           <param name="positionControl">           POS_PID_DEFAULT   POS_PID_DEFAULT    POS_PID_DEFAULT    POS_PID_DEFAULT    </param>
+           <param name="velocityControl">           none           none            none            none            </param>
+           <param name="torqueControl">             none           none            none            none            </param>
            <param name="currentPid">                none           none            none            none            </param>
         </group>
 
 	    <group name="POS_PID_DEFAULT">
-	        <param name="controlLaw">    Pid_inPos_outPwm                          </param> 
-            <param name="fbkControlUnits">     metric_units       </param> 
+	        <param name="controlLaw">    Pid_inPos_outPwm                          </param>
+            <param name="fbkControlUnits">     metric_units       </param>
             <param name="outputControlUnits">  machine_units      </param>
             <param name="pos_kp">                  -500.0       500.0       500.0      -200.0       </param>
-            <param name="pos_kd">                   0.0         0.0         0.0         0.0         </param>      
-            <param name="pos_ki">                  -50.0        50.0        50.0       -20.0        </param>        
-            <param name="pos_maxOutput">            3360        3360        3360        3360        </param>   
-            <param name="pos_maxInt">               3360        3360        3360        3360        </param> 
-            <param name="pos_shift">                0           0           0           0           </param>        
-            <param name="pos_ko">                   0           0           0           0           </param>   
-            <param name="pos_stictionUp">           0           0           0           0           </param> 
-            <param name="pos_stictionDwn">          0           0           0           0           </param> 
-            <param name="pos_kff">                  0           0           0           0           </param> 
+            <param name="pos_kd">                   0.0         0.0         0.0         0.0         </param>
+            <param name="pos_ki">                  -50.0        50.0        50.0       -20.0        </param>
+            <param name="pos_maxOutput">            3360        3360        3360        3360        </param>
+            <param name="pos_maxInt">               3360        3360        3360        3360        </param>
+            <param name="pos_shift">                0           0           0           0           </param>
+            <param name="pos_ko">                   0           0           0           0           </param>
+            <param name="pos_stictionUp">           0           0           0           0           </param>
+            <param name="pos_stictionDwn">          0           0           0           0           </param>
+            <param name="pos_kff">                  0           0           0           0           </param>
         </group>
 
-    </device> 
-    
+    </device>
+
 

--- a/experimentalSetups/iCubGenovaV3/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
+++ b/experimentalSetups/iCubGenovaV3/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
@@ -4,25 +4,25 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-eb29-j12_15-mc" type="embObjMotionControl">
-    
+
         <xi:include href="../../general.xml" />
         <xi:include href="../../hardware/electronics/right_arm-eb29-j12_15-eln.xml" />
         <xi:include href="../../hardware/mechanicals/right_arm-eb29-j12_15-mec.xml" />
-        
+
         <xi:include href="./right_arm-eb29-j12_15-mc_service.xml" />
 
         <!-- joint number in sub-part           0               1               2               3          -->
-        <!-- joint name                    index_distal   middle-proximal   middle-distal   little-fingers -->     
+        <!-- joint name                    index_distal   middle_proximal   middle_distal   pinky -->
         <group name="LIMITS">
             <param name="jntPosMax">              180          90              180             270          </param>
-            <param name="jntPosMin">                0           0                0               0           </param> 
+            <param name="jntPosMin">                0           0                0               0           </param>
             <param name="jntVelMax">                1000        1000            1000           1000         </param>
             <param name="motorOverloadCurrents">    2000        2000            2000           2000       </param>
             <param name="motorNominalCurrents">      600         600             600            600        </param>
             <param name="motorPeakCurrents">        1000        1000            1000           1000        </param>
             <param name="motorPwmLimit">            3360        3360            3360            3360       </param>
         </group>
-    
+
         <group name="IMPEDANCE">
             <param name="stiffness">            0.0         0.0     0.0         0.0             </param>
             <param name="damping">              0.0         0.0     0.0         0.0             </param>
@@ -34,28 +34,28 @@
 
 
         <group name="CONTROLS">
-           <param name="positionControl">           POS_PID_DEFAULT   POS_PID_DEFAULT    POS_PID_DEFAULT    POS_PID_DEFAULT    </param> 
-           <param name="velocityControl">           none           none            none            none            </param> 
-           <param name="torqueControl">             none           none            none            none            </param> 
+           <param name="positionControl">           POS_PID_DEFAULT   POS_PID_DEFAULT    POS_PID_DEFAULT    POS_PID_DEFAULT    </param>
+           <param name="velocityControl">           none           none            none            none            </param>
+           <param name="torqueControl">             none           none            none            none            </param>
            <param name="currentPid">                none           none            none            none            </param>
         </group>
 
 	    <group name="POS_PID_DEFAULT">
-	        <param name="controlLaw">    Pid_inPos_outPwm                          </param> 
-        <param name="fbkControlUnits">     metric_units       </param> 
+	        <param name="controlLaw">    Pid_inPos_outPwm                          </param>
+        <param name="fbkControlUnits">     metric_units       </param>
         <param name="outputControlUnits">  machine_units      </param>
             <param name="pos_kp">                500.0       500.0      -500.0       200.0       </param>
-            <param name="pos_kd">                0.0         0.0         0.0         0.0         </param>  
-            <param name="pos_ki">                50.0        50.0       -50.0        20.0        </param>    
-            <param name="pos_maxOutput">         3360        3360        3360        3360        </param>  
-            <param name="pos_maxInt">            3360        3360        3360        3360        </param> 
-            <param name="pos_shift">             0           0           0           0           </param>    
-            <param name="pos_ko">                0           0           0           0           </param>  
-            <param name="pos_stictionUp">        0           0           0           0           </param> 
-            <param name="pos_stictionDwn">       0           0           0           0           </param> 
-            <param name="pos_kff">               0           0           0           0           </param> 
+            <param name="pos_kd">                0.0         0.0         0.0         0.0         </param>
+            <param name="pos_ki">                50.0        50.0       -50.0        20.0        </param>
+            <param name="pos_maxOutput">         3360        3360        3360        3360        </param>
+            <param name="pos_maxInt">            3360        3360        3360        3360        </param>
+            <param name="pos_shift">             0           0           0           0           </param>
+            <param name="pos_ko">                0           0           0           0           </param>
+            <param name="pos_stictionUp">        0           0           0           0           </param>
+            <param name="pos_stictionDwn">       0           0           0           0           </param>
+            <param name="pos_kff">               0           0           0           0           </param>
         </group>
-       
-    </device> 
-    
+
+    </device>
+
 

--- a/iCubChemnitz01/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
+++ b/iCubChemnitz01/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
@@ -6,14 +6,14 @@
 
     <xi:include href="../../general.xml" />
     <xi:include href="../../hardware/electronics/right_arm-eb29-j12_15-eln.xml" />
-    <xi:include href="../../hardware/mechanicals/right_arm-eb29-j12_15-mec.xml" />   
+    <xi:include href="../../hardware/mechanicals/right_arm-eb29-j12_15-mec.xml" />
     <xi:include href="./right_arm-eb29-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3               -->
-    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers  -->     
+    <!-- joint name                             index_distal        middle_proximal     middle_distal       pinky  -->
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270             </param>
-        <param name="jntPosMin">                0                   0                   0                   0               </param> 
+        <param name="jntPosMin">                0                   0                   0                   0               </param>
         <param name="jntVelMax">                1000                1000                1000                1000            </param>
         <param name="motorOverloadCurrents">    2000                2000                2000                2000            </param>
         <param name="motorNominalCurrents">     600                 600                 600                 600             </param>
@@ -31,18 +31,18 @@
     </group>
 
     <group name="CONTROLS">
-        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="torqueControl">            none                none                none                none                </param> 
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="torqueControl">            none                none                none                none                </param>
         <param name="currentPid">               none                none                none                none                </param>
-        <param name="speedPid">                 none                none                none                none                </param> 
+        <param name="speedPid">                 none                none                none                none                </param>
     </group>
 
     <group name="POS_PID_DEFAULT">
         <param name="controlLaw">             minjerk                   </param>
         <param name="outputType">             pwm                       </param>
-        <param name="fbkControlUnits">        metric_units              </param> 
+        <param name="fbkControlUnits">        metric_units              </param>
         <param name="outputControlUnits">     machine_units             </param>
         <param name="kp">                500.0       500.0      -500.0       200.0       </param>
         <param name="kd">                0.0         0.0         0.0         0.0         </param>
@@ -55,9 +55,9 @@
     </group>
 
     <!-- begin of reserved section. this section is reserved for custom PIDs -->
-    
+
     <!-- end of reserved section. this section is reserved for custom PIDs -->
-    
-</device> 
-    
+
+</device>
+
 

--- a/iCubEdinburgh01/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
+++ b/iCubEdinburgh01/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
@@ -4,25 +4,25 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-eb26-j12_15-mc" type="embObjMotionControl">
-    
+
         <xi:include href="../../general.xml" />
         <xi:include href="../../hardware/electronics/left_arm-eb26-j12_15-eln.xml" />
         <xi:include href="../../hardware/mechanicals/left_arm-eb26-j12_15-mec.xml" />
-        
+
         <xi:include href="./left_arm-eb26-j12_15-mc_service.xml" />
 
         <!-- joint number in sub-part           0               1               2               3          -->
-        <!-- joint name                    index_distal   middle-proximal   middle-distal   little-fingers -->     
+        <!-- joint name                    index_distal   middle_proximal   middle_distal   pinky -->
         <group name="LIMITS">
             <param name="jntPosMax">              180          90              180             270        </param>
-            <param name="jntPosMin">                0           0                0               0        </param> 
+            <param name="jntPosMin">                0           0                0               0        </param>
             <param name="jntVelMax">                1000        1000            1000           1000       </param>
             <param name="motorOverloadCurrents">    2000        2000            2000           2000       </param>
             <param name="motorNominalCurrents">      600         600             600            600        </param>
             <param name="motorPeakCurrents">        1000        1000            1000           1000        </param>
             <param name="motorPwmLimit">            3360        3360            3360            3360       </param>
         </group>
-    
+
 
         <group name="IMPEDANCE">
             <param name="stiffness">            0.0         0.0     0.0         0.0             </param>
@@ -35,29 +35,29 @@
 
 
         <group name="CONTROLS">
-           <param name="positionControl">           POS_PID_DEFAULT   POS_PID_DEFAULT    POS_PID_DEFAULT    POS_PID_DEFAULT    </param> 
+           <param name="positionControl">           POS_PID_DEFAULT   POS_PID_DEFAULT    POS_PID_DEFAULT    POS_PID_DEFAULT    </param>
            <param name="velocityControl"> POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT</param>
-           <param name="mixedControl"> POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT</param> 
-           <param name="torqueControl">             none           none            none            none            </param> 
+           <param name="mixedControl"> POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT</param>
+           <param name="torqueControl">             none           none            none            none            </param>
            <param name="currentPid"> none none none none</param>
        <param name="speedPid"> none none none none</param>
         </group>
 
         <group name="POS_PID_DEFAULT">
             <param name="controlLaw">             minjerk                   </param>
-           <param name="outputType">             pwm                       </param> 
+           <param name="outputType">             pwm                       </param>
             <param name="fbkControlUnits">  metric_units   </param>
-            <param name="outputControlUnits">  machine_units      </param> 
+            <param name="outputControlUnits">  machine_units      </param>
             <param name="kp">                  -500.0       500.0       500.0      -200.0       </param>
-            <param name="kd">                   0.0         0.0         0.0         0.0         </param>      
-            <param name="ki">                  -50.0        50.0        50.0       -20.0        </param>        
-            <param name="maxOutput">            3360        3360        3360        3360        </param>   
-            <param name="maxInt">               3360        3360        3360        3360        </param> 
-            <param name="stictionUp">           0           0           0           0           </param> 
-            <param name="stictionDown">          0           0           0           0           </param> 
-            <param name="kff">                  0           0           0           0           </param> 
+            <param name="kd">                   0.0         0.0         0.0         0.0         </param>
+            <param name="ki">                  -50.0        50.0        50.0       -20.0        </param>
+            <param name="maxOutput">            3360        3360        3360        3360        </param>
+            <param name="maxInt">               3360        3360        3360        3360        </param>
+            <param name="stictionUp">           0           0           0           0           </param>
+            <param name="stictionDown">          0           0           0           0           </param>
+            <param name="kff">                  0           0           0           0           </param>
         </group>
 
-    </device> 
-    
+    </device>
+
 

--- a/iCubEdinburgh01/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
+++ b/iCubEdinburgh01/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
@@ -4,25 +4,25 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-eb29-j12_15-mc" type="embObjMotionControl">
-    
+
         <xi:include href="../../general.xml" />
         <xi:include href="../../hardware/electronics/right_arm-eb29-j12_15-eln.xml" />
         <xi:include href="../../hardware/mechanicals/right_arm-eb29-j12_15-mec.xml" />
-        
+
         <xi:include href="./right_arm-eb29-j12_15-mc_service.xml" />
 
         <!-- joint number in sub-part           0               1               2               3          -->
-        <!-- joint name                    index_distal   middle-proximal   middle-distal   little-fingers -->     
+        <!-- joint name                    index_distal   middle_proximal   middle_distal   pinky -->
         <group name="LIMITS">
             <param name="jntPosMax">              180          90              180             270          </param>
-            <param name="jntPosMin">                0           0                0               0           </param> 
+            <param name="jntPosMin">                0           0                0               0           </param>
             <param name="jntVelMax">                1000        1000            1000           1000         </param>
             <param name="motorOverloadCurrents">    2000        2000            2000           2000       </param>
             <param name="motorNominalCurrents">      600         600             600            600        </param>
             <param name="motorPeakCurrents">        1000        1000            1000           1000        </param>
             <param name="motorPwmLimit">            3360        3360            3360            3360       </param>
         </group>
-    
+
         <group name="IMPEDANCE">
             <param name="stiffness">            0.0         0.0     0.0         0.0             </param>
             <param name="damping">              0.0         0.0     0.0         0.0             </param>
@@ -34,29 +34,29 @@
 
 
         <group name="CONTROLS">
-           <param name="positionControl">           POS_PID_DEFAULT   POS_PID_DEFAULT    POS_PID_DEFAULT    POS_PID_DEFAULT    </param> 
+           <param name="positionControl">           POS_PID_DEFAULT   POS_PID_DEFAULT    POS_PID_DEFAULT    POS_PID_DEFAULT    </param>
            <param name="velocityControl"> POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT</param>
-           <param name="mixedControl"> POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT</param> 
-           <param name="torqueControl">             none           none            none            none            </param> 
+           <param name="mixedControl"> POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT</param>
+           <param name="torqueControl">             none           none            none            none            </param>
            <param name="currentPid"> none none none none</param>
        <param name="speedPid"> none none none none</param>
         </group>
 
 	    <group name="POS_PID_DEFAULT">
 	        <param name="controlLaw">             minjerk                   </param>
-           <param name="outputType">             pwm                       </param> 
+           <param name="outputType">             pwm                       </param>
             <param name="fbkControlUnits">  metric_units   </param>
-            <param name="outputControlUnits">  machine_units      </param> 
+            <param name="outputControlUnits">  machine_units      </param>
             <param name="kp">                500.0       500.0      -500.0       200.0       </param>
-            <param name="kd">                0.0         0.0         0.0         0.0         </param>  
-            <param name="ki">                50.0        50.0       -50.0        20.0        </param>    
-            <param name="maxOutput">         3360        3360        3360        3360        </param>  
-            <param name="maxInt">            3360        3360        3360        3360        </param> 
-            <param name="stictionUp">        0           0           0           0           </param> 
-            <param name="stictionDown">       0           0           0           0           </param> 
-            <param name="kff">               0           0           0           0           </param> 
+            <param name="kd">                0.0         0.0         0.0         0.0         </param>
+            <param name="ki">                50.0        50.0       -50.0        20.0        </param>
+            <param name="maxOutput">         3360        3360        3360        3360        </param>
+            <param name="maxInt">            3360        3360        3360        3360        </param>
+            <param name="stictionUp">        0           0           0           0           </param>
+            <param name="stictionDown">       0           0           0           0           </param>
+            <param name="kff">               0           0           0           0           </param>
         </group>
-       
-    </device> 
-    
+
+    </device>
+
 

--- a/iCubErzelli01/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
+++ b/iCubErzelli01/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
@@ -6,14 +6,14 @@
 
     <xi:include href="../../general.xml" />
     <xi:include href="../../hardware/electronics/left_arm-eb26-j12_15-eln.xml" />
-    <xi:include href="../../hardware/mechanicals/left_arm-eb26-j12_15-mec.xml" />   
+    <xi:include href="../../hardware/mechanicals/left_arm-eb26-j12_15-mec.xml" />
     <xi:include href="./left_arm-eb26-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3                   -->
-    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers      -->     
+    <!-- joint name                             index_distal        middle_proximal     middle_distal       pinky      -->
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270                 </param>
-        <param name="jntPosMin">                0                   0                   0                   0                   </param> 
+        <param name="jntPosMin">                0                   0                   0                   0                   </param>
         <param name="jntVelMax">                1000                1000                1000                1000                </param>
         <param name="motorOverloadCurrents">    2000                2000                2000                2000                </param>
         <param name="motorNominalCurrents">     600                 600                 600                 600                 </param>
@@ -31,21 +31,21 @@
     </group>
 
     <group name="CONTROLS">
-        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="torqueControl">            none                none                none                none                </param> 
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="torqueControl">            none                none                none                none                </param>
         <param name="currentPid">               none                none                none                none                </param>
-        <param name="speedPid">                 none                none                none                none                </param> 
+        <param name="speedPid">                 none                none                none                none                </param>
     </group>
 
 
     <!-- default position PID: begin -->
-    
+
     <group name="POS_PID_DEFAULT">
         <param name="controlLaw">             minjerk                   </param>
         <param name="outputType">             pwm                       </param>
-        <param name="fbkControlUnits">        metric_units              </param> 
+        <param name="fbkControlUnits">        metric_units              </param>
         <param name="outputControlUnits">     machine_units             </param>
         <param name="kp">                  -500.0       500.0       500.0      -200.0       </param>
         <param name="kd">                   0.0         0.0         0.0         0.0         </param>
@@ -60,13 +60,13 @@
     <!-- default position PID: end -->
 
 
-    <!-- other default PIDs: begin -->   
+    <!-- other default PIDs: begin -->
     <!-- other default PIDs: end -->
 
 
-    <!-- custom PIDs: begin -->    
+    <!-- custom PIDs: begin -->
     <!-- custom PIDs: end -->
-    
-</device> 
-    
+
+</device>
+
 

--- a/iCubErzelli01/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
+++ b/iCubErzelli01/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
@@ -6,14 +6,14 @@
 
     <xi:include href="../../general.xml" />
     <xi:include href="../../hardware/electronics/right_arm-eb29-j12_15-eln.xml" />
-    <xi:include href="../../hardware/mechanicals/right_arm-eb29-j12_15-mec.xml" />   
+    <xi:include href="../../hardware/mechanicals/right_arm-eb29-j12_15-mec.xml" />
     <xi:include href="./right_arm-eb29-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3               -->
-    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers  -->     
+    <!-- joint name                             index_distal        middle_proximal     middle_distal       pinky  -->
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270             </param>
-        <param name="jntPosMin">                0                   0                   0                   0               </param> 
+        <param name="jntPosMin">                0                   0                   0                   0               </param>
         <param name="jntVelMax">                1000                1000                1000                1000            </param>
         <param name="motorOverloadCurrents">    2000                2000                2000                2000            </param>
         <param name="motorNominalCurrents">     600                 600                 600                 600             </param>
@@ -31,18 +31,18 @@
     </group>
 
     <group name="CONTROLS">
-        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="torqueControl">            none                none                none                none                </param> 
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="torqueControl">            none                none                none                none                </param>
         <param name="currentPid">               none                none                none                none                </param>
-        <param name="speedPid">                 none                none                none                none                </param> 
+        <param name="speedPid">                 none                none                none                none                </param>
     </group>
 
     <group name="POS_PID_DEFAULT">
         <param name="controlLaw">             minjerk                   </param>
         <param name="outputType">             pwm                       </param>
-        <param name="fbkControlUnits">        metric_units              </param> 
+        <param name="fbkControlUnits">        metric_units              </param>
         <param name="outputControlUnits">     machine_units             </param>
         <param name="kp">                500.0       500.0      -500.0       200.0       </param>
         <param name="kd">                0.0         0.0         0.0         0.0         </param>
@@ -55,9 +55,9 @@
     </group>
 
     <!-- begin of reserved section. this section is reserved for custom PIDs -->
-    
+
     <!-- end of reserved section. this section is reserved for custom PIDs -->
-    
-</device> 
-    
+
+</device>
+
 

--- a/iCubErzelli02/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
@@ -6,14 +6,14 @@
 
     <xi:include href="../../general.xml" />
     <xi:include href="../../hardware/electronics/left_arm-eb26-j12_15-eln.xml" />
-    <xi:include href="../../hardware/mechanicals/left_arm-eb26-j12_15-mec.xml" />   
+    <xi:include href="../../hardware/mechanicals/left_arm-eb26-j12_15-mec.xml" />
     <xi:include href="./left_arm-eb26-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3                   -->
-    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers      -->     
+    <!-- joint name                             index_distal        middle_proximal     middle_distal       pinky      -->
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270                 </param>
-        <param name="jntPosMin">                0                   0                   0                   0                   </param> 
+        <param name="jntPosMin">                0                   0                   0                   0                   </param>
         <param name="jntVelMax">                1000                1000                1000                1000                </param>
         <param name="motorOverloadCurrents">    2000                2000                2000                2000                </param>
         <param name="motorNominalCurrents">     600                 600                 600                 600                 </param>
@@ -31,21 +31,21 @@
     </group>
 
     <group name="CONTROLS">
-        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="torqueControl">            none                none                none                none                </param> 
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="torqueControl">            none                none                none                none                </param>
         <param name="currentPid">               none                none                none                none                </param>
-        <param name="speedPid">                 none                none                none                none                </param> 
+        <param name="speedPid">                 none                none                none                none                </param>
     </group>
 
 
     <!-- default position PID: begin -->
-    
+
     <group name="POS_PID_DEFAULT">
         <param name="controlLaw">             minjerk                   </param>
         <param name="outputType">             pwm                       </param>
-        <param name="fbkControlUnits">        metric_units              </param> 
+        <param name="fbkControlUnits">        metric_units              </param>
         <param name="outputControlUnits">     machine_units             </param>
         <param name="kp">                  -500.0       500.0       500.0      -200.0       </param>
         <param name="kd">                   0.0         0.0         0.0         0.0         </param>
@@ -60,13 +60,13 @@
     <!-- default position PID: end -->
 
 
-    <!-- other default PIDs: begin -->   
+    <!-- other default PIDs: begin -->
     <!-- other default PIDs: end -->
 
 
-    <!-- custom PIDs: begin -->    
+    <!-- custom PIDs: begin -->
     <!-- custom PIDs: end -->
-    
-</device> 
-    
+
+</device>
+
 

--- a/iCubErzelli02/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
@@ -6,14 +6,14 @@
 
     <xi:include href="../../general.xml" />
     <xi:include href="../../hardware/electronics/right_arm-eb29-j12_15-eln.xml" />
-    <xi:include href="../../hardware/mechanicals/right_arm-eb29-j12_15-mec.xml" />   
+    <xi:include href="../../hardware/mechanicals/right_arm-eb29-j12_15-mec.xml" />
     <xi:include href="./right_arm-eb29-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3               -->
-    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers  -->     
+    <!-- joint name                             index_distal        middle_proximal     middle_distal       pinky  -->
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270             </param>
-        <param name="jntPosMin">                0                   0                   0                   0               </param> 
+        <param name="jntPosMin">                0                   0                   0                   0               </param>
         <param name="jntVelMax">                1000                1000                1000                1000            </param>
         <param name="motorOverloadCurrents">    2000                2000                2000                2000            </param>
         <param name="motorNominalCurrents">     600                 600                 600                 600             </param>
@@ -31,18 +31,18 @@
     </group>
 
     <group name="CONTROLS">
-        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="torqueControl">            none                none                none                none                </param> 
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="torqueControl">            none                none                none                none                </param>
         <param name="currentPid">               none                none                none                none                </param>
-        <param name="speedPid">                 none                none                none                none                </param> 
+        <param name="speedPid">                 none                none                none                none                </param>
     </group>
 
     <group name="POS_PID_DEFAULT">
         <param name="controlLaw">             minjerk                   </param>
         <param name="outputType">             pwm                       </param>
-        <param name="fbkControlUnits">        metric_units              </param> 
+        <param name="fbkControlUnits">        metric_units              </param>
         <param name="outputControlUnits">     machine_units             </param>
         <param name="kp">                500.0       500.0      -500.0       200.0       </param>
         <param name="kd">                0.0         0.0         0.0         0.0         </param>
@@ -55,9 +55,9 @@
     </group>
 
     <!-- begin of reserved section. this section is reserved for custom PIDs -->
-    
+
     <!-- end of reserved section. this section is reserved for custom PIDs -->
-    
-</device> 
-    
+
+</device>
+
 

--- a/iCubGenova04/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
+++ b/iCubGenova04/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
@@ -6,14 +6,14 @@
 
     <xi:include href="../../general.xml" />
     <xi:include href="../../hardware/electronics/left_arm-eb26-j12_15-eln.xml" />
-    <xi:include href="../../hardware/mechanicals/left_arm-eb26-j12_15-mec.xml" />   
+    <xi:include href="../../hardware/mechanicals/left_arm-eb26-j12_15-mec.xml" />
     <xi:include href="./left_arm-eb26-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3                   -->
-    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers      -->     
+    <!-- joint name                             index_distal        middle_proximal     middle_distal       pinky      -->
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270                 </param>
-        <param name="jntPosMin">                0                   0                   0                   0                   </param> 
+        <param name="jntPosMin">                0                   0                   0                   0                   </param>
         <param name="jntVelMax">                1000                1000                1000                1000                </param>
         <param name="motorOverloadCurrents">    2000                2000                2000                2000                </param>
         <param name="motorNominalCurrents">     600                 600                 600                 600                 </param>
@@ -31,21 +31,21 @@
     </group>
 
     <group name="CONTROLS">
-        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="torqueControl">            none                none                none                none                </param> 
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="torqueControl">            none                none                none                none                </param>
         <param name="currentPid">               none                none                none                none                </param>
-        <param name="speedPid">                 none                none                none                none                </param> 
+        <param name="speedPid">                 none                none                none                none                </param>
     </group>
 
 
     <!-- default position PID: begin -->
-    
+
     <group name="POS_PID_DEFAULT">
         <param name="controlLaw">             minjerk                   </param>
         <param name="outputType">             pwm                       </param>
-        <param name="fbkControlUnits">        metric_units              </param> 
+        <param name="fbkControlUnits">        metric_units              </param>
         <param name="outputControlUnits">     machine_units             </param>
         <param name="kp">                  -500.0       500.0       500.0      -200.0       </param>
         <param name="kd">                   0.0         0.0         0.0         0.0         </param>
@@ -60,13 +60,13 @@
     <!-- default position PID: end -->
 
 
-    <!-- other default PIDs: begin -->   
+    <!-- other default PIDs: begin -->
     <!-- other default PIDs: end -->
 
 
-    <!-- custom PIDs: begin -->    
+    <!-- custom PIDs: begin -->
     <!-- custom PIDs: end -->
-    
-</device> 
-    
+
+</device>
+
 

--- a/iCubGenova04/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
+++ b/iCubGenova04/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
@@ -6,14 +6,14 @@
 
     <xi:include href="../../general.xml" />
     <xi:include href="../../hardware/electronics/right_arm-eb29-j12_15-eln.xml" />
-    <xi:include href="../../hardware/mechanicals/right_arm-eb29-j12_15-mec.xml" />   
+    <xi:include href="../../hardware/mechanicals/right_arm-eb29-j12_15-mec.xml" />
     <xi:include href="./right_arm-eb29-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3               -->
-    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers  -->     
+    <!-- joint name                             index_distal        middle_proximal     middle_distal       pinky  -->
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270             </param>
-        <param name="jntPosMin">                0                   0                   0                   0               </param> 
+        <param name="jntPosMin">                0                   0                   0                   0               </param>
         <param name="jntVelMax">                1000                1000                1000                1000            </param>
         <param name="motorOverloadCurrents">    2000                2000                2000                2000            </param>
         <param name="motorNominalCurrents">     600                 600                 600                 600             </param>
@@ -31,18 +31,18 @@
     </group>
 
     <group name="CONTROLS">
-        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="torqueControl">            none                none                none                none                </param> 
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="torqueControl">            none                none                none                none                </param>
         <param name="currentPid">               none                none                none                none                </param>
-        <param name="speedPid">                 none                none                none                none                </param> 
+        <param name="speedPid">                 none                none                none                none                </param>
     </group>
 
     <group name="POS_PID_DEFAULT">
         <param name="controlLaw">             minjerk                   </param>
         <param name="outputType">             pwm                       </param>
-        <param name="fbkControlUnits">        metric_units              </param> 
+        <param name="fbkControlUnits">        metric_units              </param>
         <param name="outputControlUnits">     machine_units             </param>
         <param name="kp">                500.0       500.0      -500.0       200.0       </param>
         <param name="kd">                0.0         0.0         0.0         0.0         </param>
@@ -55,9 +55,9 @@
     </group>
 
     <!-- begin of reserved section. this section is reserved for custom PIDs -->
-    
+
     <!-- end of reserved section. this section is reserved for custom PIDs -->
-    
-</device> 
-    
+
+</device>
+
 

--- a/iCubGenova07/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
+++ b/iCubGenova07/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
@@ -6,14 +6,14 @@
 
     <xi:include href="../../general.xml" />
     <xi:include href="../../hardware/electronics/left_arm-eb26-j12_15-eln.xml" />
-    <xi:include href="../../hardware/mechanicals/left_arm-eb26-j12_15-mec.xml" />   
+    <xi:include href="../../hardware/mechanicals/left_arm-eb26-j12_15-mec.xml" />
     <xi:include href="./left_arm-eb26-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3                   -->
-    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers      -->     
+    <!-- joint name                             index_distal        middle_proximal     middle_distal       pinky      -->
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270                 </param>
-        <param name="jntPosMin">                0                   0                   0                   0                   </param> 
+        <param name="jntPosMin">                0                   0                   0                   0                   </param>
         <param name="jntVelMax">                1000                1000                1000                1000                </param>
         <param name="motorOverloadCurrents">    2000                2000                2000                2000                </param>
         <param name="motorNominalCurrents">     600                 600                 600                 500                 </param>
@@ -31,21 +31,21 @@
     </group>
 
     <group name="CONTROLS">
-        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="torqueControl">            none                none                none                none                </param> 
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="torqueControl">            none                none                none                none                </param>
         <param name="currentPid">               none                none                none                none                </param>
-        <param name="speedPid">                 none                none                none                none                </param> 
+        <param name="speedPid">                 none                none                none                none                </param>
     </group>
 
 
     <!-- default position PID: begin -->
-    
+
     <group name="POS_PID_DEFAULT">
         <param name="controlLaw">             minjerk                   </param>
         <param name="outputType">             pwm                       </param>
-        <param name="fbkControlUnits">        metric_units              </param> 
+        <param name="fbkControlUnits">        metric_units              </param>
         <param name="outputControlUnits">     machine_units             </param>
         <param name="kp">                  -500.0       500.0       500.0      -200.0       </param>
         <param name="kd">                   0.0         0.0         0.0         0.0         </param>
@@ -60,13 +60,13 @@
     <!-- default position PID: end -->
 
 
-    <!-- other default PIDs: begin -->   
+    <!-- other default PIDs: begin -->
     <!-- other default PIDs: end -->
 
 
-    <!-- custom PIDs: begin -->    
+    <!-- custom PIDs: begin -->
     <!-- custom PIDs: end -->
-    
-</device> 
-    
+
+</device>
+
 

--- a/iCubGenova07/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
+++ b/iCubGenova07/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
@@ -6,14 +6,14 @@
 
     <xi:include href="../../general.xml" />
     <xi:include href="../../hardware/electronics/right_arm-eb29-j12_15-eln.xml" />
-    <xi:include href="../../hardware/mechanicals/right_arm-eb29-j12_15-mec.xml" />   
+    <xi:include href="../../hardware/mechanicals/right_arm-eb29-j12_15-mec.xml" />
     <xi:include href="./right_arm-eb29-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3               -->
-    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers  -->     
+    <!-- joint name                             index_distal        middle_proximal     middle_distal       pinky  -->
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270             </param>
-        <param name="jntPosMin">                0                   0                   0                   0               </param> 
+        <param name="jntPosMin">                0                   0                   0                   0               </param>
         <param name="jntVelMax">                1000                1000                1000                1000            </param>
         <param name="motorOverloadCurrents">    2000                2000                2000                2000            </param>
         <param name="motorNominalCurrents">     600                 600                 600                 500             </param>
@@ -31,18 +31,18 @@
     </group>
 
     <group name="CONTROLS">
-        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="torqueControl">            none                none                none                none                </param> 
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="torqueControl">            none                none                none                none                </param>
         <param name="currentPid">               none                none                none                none                </param>
-        <param name="speedPid">                 none                none                none                none                </param> 
+        <param name="speedPid">                 none                none                none                none                </param>
     </group>
 
     <group name="POS_PID_DEFAULT">
         <param name="controlLaw">             minjerk                   </param>
         <param name="outputType">             pwm                       </param>
-        <param name="fbkControlUnits">        metric_units              </param> 
+        <param name="fbkControlUnits">        metric_units              </param>
         <param name="outputControlUnits">     machine_units             </param>
         <param name="kp">                500.0       500.0      -500.0       200.0       </param>
         <param name="kd">                0.0         0.0         0.0         0.0         </param>
@@ -55,9 +55,9 @@
     </group>
 
     <!-- begin of reserved section. this section is reserved for custom PIDs -->
-    
+
     <!-- end of reserved section. this section is reserved for custom PIDs -->
-    
-</device> 
-    
+
+</device>
+
 

--- a/iCubGenova08/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
+++ b/iCubGenova08/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
@@ -6,14 +6,14 @@
 
     <xi:include href="../../general.xml" />
     <xi:include href="../../hardware/electronics/left_arm-eb26-j12_15-eln.xml" />
-    <xi:include href="../../hardware/mechanicals/left_arm-eb26-j12_15-mec.xml" />   
+    <xi:include href="../../hardware/mechanicals/left_arm-eb26-j12_15-mec.xml" />
     <xi:include href="./left_arm-eb26-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3                   -->
-    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers      -->     
+    <!-- joint name                             index_distal        middle_proximal     middle_distal       pinky      -->
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270                 </param>
-        <param name="jntPosMin">                0                   0                   0                   0                   </param> 
+        <param name="jntPosMin">                0                   0                   0                   0                   </param>
         <param name="jntVelMax">                1000                1000                1000                1000                </param>
         <param name="motorOverloadCurrents">    2000                2000                2000                2000                </param>
         <param name="motorNominalCurrents">     600                 600                 600                 600                 </param>
@@ -31,21 +31,21 @@
     </group>
 
     <group name="CONTROLS">
-        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="torqueControl">            none                none                none                none                </param> 
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="torqueControl">            none                none                none                none                </param>
         <param name="currentPid">               none                none                none                none                </param>
-        <param name="speedPid">                 none                none                none                none                </param> 
+        <param name="speedPid">                 none                none                none                none                </param>
     </group>
 
 
     <!-- default position PID: begin -->
-    
+
     <group name="POS_PID_DEFAULT">
         <param name="controlLaw">             minjerk                   </param>
         <param name="outputType">             pwm                       </param>
-        <param name="fbkControlUnits">        metric_units              </param> 
+        <param name="fbkControlUnits">        metric_units              </param>
         <param name="outputControlUnits">     machine_units             </param>
         <param name="kp">                  -500.0       500.0       500.0      -200.0       </param>
         <param name="kd">                   0.0         0.0         0.0         0.0         </param>
@@ -60,13 +60,13 @@
     <!-- default position PID: end -->
 
 
-    <!-- other default PIDs: begin -->   
+    <!-- other default PIDs: begin -->
     <!-- other default PIDs: end -->
 
 
-    <!-- custom PIDs: begin -->    
+    <!-- custom PIDs: begin -->
     <!-- custom PIDs: end -->
-    
-</device> 
-    
+
+</device>
+
 

--- a/iCubGenova08/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
+++ b/iCubGenova08/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
@@ -6,14 +6,14 @@
 
     <xi:include href="../../general.xml" />
     <xi:include href="../../hardware/electronics/right_arm-eb29-j12_15-eln.xml" />
-    <xi:include href="../../hardware/mechanicals/right_arm-eb29-j12_15-mec.xml" />   
+    <xi:include href="../../hardware/mechanicals/right_arm-eb29-j12_15-mec.xml" />
     <xi:include href="./right_arm-eb29-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3               -->
-    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers  -->     
+    <!-- joint name                             index_distal        middle_proximal     middle_distal       pinky  -->
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270             </param>
-        <param name="jntPosMin">                0                   0                   0                   0               </param> 
+        <param name="jntPosMin">                0                   0                   0                   0               </param>
         <param name="jntVelMax">                1000                1000                1000                1000            </param>
         <param name="motorOverloadCurrents">    2000                2000                2000                2000            </param>
         <param name="motorNominalCurrents">     600                 600                 600                 600             </param>
@@ -31,18 +31,18 @@
     </group>
 
     <group name="CONTROLS">
-        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="torqueControl">            none                none                none                none                </param> 
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="torqueControl">            none                none                none                none                </param>
         <param name="currentPid">               none                none                none                none                </param>
-        <param name="speedPid">                 none                none                none                none                </param> 
+        <param name="speedPid">                 none                none                none                none                </param>
     </group>
 
     <group name="POS_PID_DEFAULT">
         <param name="controlLaw">             minjerk                   </param>
         <param name="outputType">             pwm                       </param>
-        <param name="fbkControlUnits">        metric_units              </param> 
+        <param name="fbkControlUnits">        metric_units              </param>
         <param name="outputControlUnits">     machine_units             </param>
         <param name="kp">                500.0       500.0      -500.0       200.0       </param>
         <param name="kd">                0.0         0.0         0.0         0.0         </param>
@@ -55,9 +55,9 @@
     </group>
 
     <!-- begin of reserved section. this section is reserved for custom PIDs -->
-    
+
     <!-- end of reserved section. this section is reserved for custom PIDs -->
-    
-</device> 
-    
+
+</device>
+
 

--- a/iCubGenova09/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
+++ b/iCubGenova09/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
@@ -6,14 +6,14 @@
 
     <xi:include href="../../general.xml" />
     <xi:include href="../../hardware/electronics/left_arm-eb26-j12_15-eln.xml" />
-    <xi:include href="../../hardware/mechanicals/left_arm-eb26-j12_15-mec.xml" />   
+    <xi:include href="../../hardware/mechanicals/left_arm-eb26-j12_15-mec.xml" />
     <xi:include href="./left_arm-eb26-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3                   -->
-    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers      -->     
+    <!-- joint name                             index_distal        middle_proximal     middle_distal       pinky      -->
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270                 </param>
-        <param name="jntPosMin">                0                   0                   0                   0                   </param> 
+        <param name="jntPosMin">                0                   0                   0                   0                   </param>
         <param name="jntVelMax">                1000                1000                1000                1000                </param>
         <param name="motorOverloadCurrents">    2000                2000                2000                2000                </param>
         <param name="motorNominalCurrents">     600                 600                 600                 600                 </param>
@@ -31,21 +31,21 @@
     </group>
 
     <group name="CONTROLS">
-        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="torqueControl">            none                none                none                none                </param> 
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="torqueControl">            none                none                none                none                </param>
         <param name="currentPid">               none                none                none                none                </param>
-        <param name="speedPid">                 none                none                none                none                </param> 
+        <param name="speedPid">                 none                none                none                none                </param>
     </group>
 
 
     <!-- default position PID: begin -->
-    
+
     <group name="POS_PID_DEFAULT">
         <param name="controlLaw">             minjerk                   </param>
         <param name="outputType">             pwm                       </param>
-        <param name="fbkControlUnits">        metric_units              </param> 
+        <param name="fbkControlUnits">        metric_units              </param>
         <param name="outputControlUnits">     machine_units             </param>
         <param name="kp">                   -500        300         500        -200         </param>
         <param name="kd">                   0           0           0           0           </param>
@@ -60,13 +60,13 @@
     <!-- default position PID: end -->
 
 
-    <!-- other default PIDs: begin -->   
+    <!-- other default PIDs: begin -->
     <!-- other default PIDs: end -->
 
 
-    <!-- custom PIDs: begin -->    
+    <!-- custom PIDs: begin -->
     <!-- custom PIDs: end -->
-    
-</device> 
-    
+
+</device>
+
 

--- a/iCubGenova09/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
+++ b/iCubGenova09/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
@@ -6,14 +6,14 @@
 
     <xi:include href="../../general.xml" />
     <xi:include href="../../hardware/electronics/right_arm-eb29-j12_15-eln.xml" />
-    <xi:include href="../../hardware/mechanicals/right_arm-eb29-j12_15-mec.xml" />   
+    <xi:include href="../../hardware/mechanicals/right_arm-eb29-j12_15-mec.xml" />
     <xi:include href="./right_arm-eb29-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3               -->
-    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers  -->     
+    <!-- joint name                             index_distal        middle_proximal     middle_distal       pinky  -->
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270             </param>
-        <param name="jntPosMin">                0                   0                   0                   0               </param> 
+        <param name="jntPosMin">                0                   0                   0                   0               </param>
         <param name="jntVelMax">                1000                1000                1000                1000            </param>
         <param name="motorOverloadCurrents">    2000                2000                2000                2000            </param>
         <param name="motorNominalCurrents">     600                 600                 600                 600             </param>
@@ -31,18 +31,18 @@
     </group>
 
     <group name="CONTROLS">
-        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="torqueControl">            none                none                none                none                </param> 
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="torqueControl">            none                none                none                none                </param>
         <param name="currentPid">               none                none                none                none                </param>
-        <param name="speedPid">                 none                none                none                none                </param> 
+        <param name="speedPid">                 none                none                none                none                </param>
     </group>
 
     <group name="POS_PID_DEFAULT">
         <param name="controlLaw">             minjerk                   </param>
         <param name="outputType">             pwm                       </param>
-        <param name="fbkControlUnits">        metric_units              </param> 
+        <param name="fbkControlUnits">        metric_units              </param>
         <param name="outputControlUnits">     machine_units             </param>
         <param name="kp">                500         500         -500        200         </param>
         <param name="kd">                0           0           0           0           </param>
@@ -55,9 +55,9 @@
     </group>
 
     <!-- begin of reserved section. this section is reserved for custom PIDs -->
-    
+
     <!-- end of reserved section. this section is reserved for custom PIDs -->
-    
-</device> 
-    
+
+</device>
+
 

--- a/iCubGenova10/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
+++ b/iCubGenova10/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
@@ -6,14 +6,14 @@
 
     <xi:include href="../../general.xml" />
     <xi:include href="../../hardware/electronics/left_arm-eb26-j12_15-eln.xml" />
-    <xi:include href="../../hardware/mechanicals/left_arm-eb26-j12_15-mec.xml" />   
+    <xi:include href="../../hardware/mechanicals/left_arm-eb26-j12_15-mec.xml" />
     <xi:include href="./left_arm-eb26-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3                   -->
-    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers      -->     
+    <!-- joint name                             index_distal        middle_proximal     middle_distal       pinky      -->
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270                 </param>
-        <param name="jntPosMin">                0                   0                   0                   0                   </param> 
+        <param name="jntPosMin">                0                   0                   0                   0                   </param>
         <param name="jntVelMax">                1000                1000                1000                1000                </param>
         <param name="motorOverloadCurrents">    2000                2000                2000                2000                </param>
         <param name="motorNominalCurrents">     600                 600                 600                 600                 </param>
@@ -31,21 +31,21 @@
     </group>
 
     <group name="CONTROLS">
-        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="torqueControl">            none                none                none                none                </param> 
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="torqueControl">            none                none                none                none                </param>
         <param name="currentPid">               none                none                none                none                </param>
-        <param name="speedPid">                 none                none                none                none                </param> 
+        <param name="speedPid">                 none                none                none                none                </param>
     </group>
 
 
     <!-- default position PID: begin -->
-    
+
     <group name="POS_PID_DEFAULT">
         <param name="controlLaw">             minjerk                   </param>
         <param name="outputType">             pwm                       </param>
-        <param name="fbkControlUnits">        metric_units              </param> 
+        <param name="fbkControlUnits">        metric_units              </param>
         <param name="outputControlUnits">     machine_units             </param>
         <param name="kp">                  -500.0       500.0       500.0      -200.0       </param>
         <param name="kd">                   0.0         0.0         0.0         0.0         </param>
@@ -60,13 +60,13 @@
     <!-- default position PID: end -->
 
 
-    <!-- other default PIDs: begin -->   
+    <!-- other default PIDs: begin -->
     <!-- other default PIDs: end -->
 
 
-    <!-- custom PIDs: begin -->    
+    <!-- custom PIDs: begin -->
     <!-- custom PIDs: end -->
-    
-</device> 
-    
+
+</device>
+
 

--- a/iCubGenova10/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
+++ b/iCubGenova10/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
@@ -6,14 +6,14 @@
 
     <xi:include href="../../general.xml" />
     <xi:include href="../../hardware/electronics/right_arm-eb29-j12_15-eln.xml" />
-    <xi:include href="../../hardware/mechanicals/right_arm-eb29-j12_15-mec.xml" />   
+    <xi:include href="../../hardware/mechanicals/right_arm-eb29-j12_15-mec.xml" />
     <xi:include href="./right_arm-eb29-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3               -->
-    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers  -->     
+    <!-- joint name                             index_distal        middle_proximal     middle_distal       pinky  -->
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270             </param>
-        <param name="jntPosMin">                0                   0                   0                   0               </param> 
+        <param name="jntPosMin">                0                   0                   0                   0               </param>
         <param name="jntVelMax">                1000                1000                1000                1000            </param>
         <param name="motorOverloadCurrents">    2000                2000                2000                2000            </param>
         <param name="motorNominalCurrents">     600                 600                 600                 600             </param>
@@ -31,18 +31,18 @@
     </group>
 
     <group name="CONTROLS">
-        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="torqueControl">            none                none                none                none                </param> 
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="torqueControl">            none                none                none                none                </param>
         <param name="currentPid">               none                none                none                none                </param>
-        <param name="speedPid">                 none                none                none                none                </param> 
+        <param name="speedPid">                 none                none                none                none                </param>
     </group>
 
     <group name="POS_PID_DEFAULT">
         <param name="controlLaw">             minjerk                   </param>
         <param name="outputType">             pwm                       </param>
-        <param name="fbkControlUnits">        metric_units              </param> 
+        <param name="fbkControlUnits">        metric_units              </param>
         <param name="outputControlUnits">     machine_units             </param>
         <param name="kp">                500.0       500.0      -500.0       200.0       </param>
         <param name="kd">                0.0         0.0         0.0         0.0         </param>
@@ -55,9 +55,9 @@
     </group>
 
     <!-- begin of reserved section. this section is reserved for custom PIDs -->
-    
+
     <!-- end of reserved section. this section is reserved for custom PIDs -->
-    
-</device> 
-    
+
+</device>
+
 

--- a/iCubGenova11/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubGenova11/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
- 
+
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="iCubGenova11" build="1">
     <group name="GENERAL">
         <param name="MotioncontrolVersion"> 6 </param>
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_little-fingers"  </param> 
+        <param name="AxisName">                 "l_index_distal" "l_middle_proximal" "l_middle_distal" "l_pinky"  </param>
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
-        <param name="AxisMap">                  0                1                   2                  3               </param>   
-        <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    
+        <param name="AxisMap">                  0                1                   2                  3               </param>
+        <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>
         <param name="fullscalePWM">             3360             3360               3360                3360            </param>
         <param name="ampsToSensor">             1000.0           1000.0             1000.0              1000.0          </param>
         <param name="Gearbox_M2J">              256              256                 256                256             </param>
@@ -19,64 +19,64 @@
         <param name="MotorType">               "DC"              "DC"                "DC"           "DC"               </param>
         <param name="Verbose">                  0                                                                       </param>
     </group>
-    
+
     <group name="LIMITS">
         <param name="hardwareJntPosMax">     180          90              180             270        </param>
-        <param name="hardwareJntPosMin">       0           0                0               0        </param> 
-        <param name="rotorPosMin">         -5120       -5120              -65000          -5120     </param> 
+        <param name="hardwareJntPosMin">       0           0                0               0        </param>
+        <param name="rotorPosMin">         -5120       -5120              -65000          -5120     </param>
         <param name="rotorPosMax">          65000       32000              5120           65000      </param>
     </group>
 
-    <group name="COUPLINGS"> 
-                            
-        <param name ="matrixJ2M"> 
+    <group name="COUPLINGS">
+
+        <param name ="matrixJ2M">
             1.000   0.000   0.000   0.000
             0.000   1.000   0.000   0.000
             0.000   0.000   1.000   0.000
-            0.000   0.000   0.000   1.000   
+            0.000   0.000   0.000   1.000
         </param>
 
-        <param name ="matrixM2J"> 
+        <param name ="matrixM2J">
             1.000   0.000   0.000   0.000
             1.000   1.000   0.000   0.000
             0.000   0.000   1.000   0.000
-            0.000   0.000   0.000   1.000   
+            0.000   0.000   0.000   1.000
         </param>
-       
-         <param name ="matrixE2J">  
+
+         <param name ="matrixE2J">
             1.000   0.000   0.000   0.000   0.000   0.000
             0.000   1.000   0.000   0.000   0.000   0.000
             0.000   0.000   1.000   0.000   0.000   0.000
-            0.000   0.000   0.000   1.000   0.000   0.000   
+            0.000   0.000   0.000   1.000   0.000   0.000
         </param>
-  
-    </group>                
 
-    <group name="JOINTSET_CFG"> 
+    </group>
+
+    <group name="JOINTSET_CFG">
         <param name= "numberofsets"> 4</param>
          <group name="JOINTSET_0">
                     <param name="listofjoints">  0             </param>
                     <param name="constraint">    none          </param>
                     <param name="param1">        0             </param>
                     <param name="param2">        0             </param>
-            </group> 
+            </group>
             <group name="JOINTSET_1">
                     <param name="listofjoints">   1             </param>
                     <param name="constraint">      none          </param>
                     <param name="param1">         0             </param>
                     <param name="param2">         0             </param>
-            </group> 
+            </group>
             <group name="JOINTSET_2">
                     <param name="listofjoints">   2             </param>
                     <param name="constraint">      none          </param>
                     <param name="param1">         0             </param>
                     <param name="param2">         0             </param>
-            </group> 
+            </group>
             <group name="JOINTSET_3">
                     <param name="listofjoints">   3             </param>
                     <param name="constraint">     none         </param>
                     <param name="param1">         0            </param>
                     <param name="param2">         0            </param>
-            </group> 
-    </group>                            
+            </group>
+    </group>
 </params>

--- a/iCubGenova11/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubGenova11/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
- 
+
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="iCubGenova11" build="1">
     <group name="GENERAL">
         <param name="MotioncontrolVersion"> 6 </param>
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle-proximal" "r_middle-distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index_distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param>
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
-        <param name="AxisMap">                  0                1                   2                  3                </param>   
-         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   
+        <param name="AxisMap">                  0                1                   2                  3                </param>
+         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>
         <param name="fullscalePWM">             3360              3360                3360             3360              </param>
         <param name="ampsToSensor">             1000.0            1000.0              1000.0           1000.0            </param>
         <param name="Gearbox_M2J">               256              256                 256                256             </param>
@@ -19,65 +19,65 @@
         <param name="MotorType">                  "DC"             "DC"                "DC"               "DC"           </param>
         <param name="Verbose">                  0                                                                        </param>
     </group>
-    
+
     <group name="LIMITS">
         <param name="hardwareJntPosMax">        180                 90                180                 270          </param>
-        <param name="hardwareJntPosMin">          0                  0                  0                   0          </param> 
-        <param name="rotorPosMin">           -65000              -5120              -5120               -65000          </param> 
+        <param name="hardwareJntPosMin">          0                  0                  0                   0          </param>
+        <param name="rotorPosMin">           -65000              -5120              -5120               -65000          </param>
         <param name="rotorPosMax">             5120              42000              65000               5120          </param>
 
 </group>
 
-    <group name="COUPLINGS"> 
-                            
-        <param name ="matrixJ2M"> 
+    <group name="COUPLINGS">
+
+        <param name ="matrixJ2M">
             1.000   0.000   0.000   0.000
             0.000   1.000   0.000   0.000
             0.000   0.000   1.000   0.000
-            0.000   0.000   0.000   1.000   
+            0.000   0.000   0.000   1.000
         </param>
 
-        <param name ="matrixM2J"> 
+        <param name ="matrixM2J">
             1.000   0.000   0.000   0.000
             1.000   1.000   0.000   0.000
             0.000   0.000   1.000   0.000
-            0.000   0.000   0.000   1.000   
+            0.000   0.000   0.000   1.000
         </param>
-       
-         <param name ="matrixE2J">  
+
+         <param name ="matrixE2J">
             1.000   0.000   0.000   0.000   0.000   0.000
             0.000   1.000   0.000   0.000   0.000   0.000
             0.000   0.000   1.000   0.000   0.000   0.000
-            0.000   0.000   0.000   1.000   0.000   0.000   
+            0.000   0.000   0.000   1.000   0.000   0.000
         </param>
-  
-    </group>                
 
-    <group name="JOINTSET_CFG"> 
+    </group>
+
+    <group name="JOINTSET_CFG">
         <param name= "numberofsets"> 4</param>
          <group name="JOINTSET_0">
                     <param name="listofjoints">  0             </param>
                     <param name="constraint">    none          </param>
                     <param name="param1">        0             </param>
                     <param name="param2">        0             </param>
-            </group> 
+            </group>
             <group name="JOINTSET_1">
                     <param name="listofjoints">   1             </param>
                     <param name="constraint">      none          </param>
                     <param name="param1">         0             </param>
                     <param name="param2">         0             </param>
-            </group> 
+            </group>
             <group name="JOINTSET_2">
                     <param name="listofjoints">   2             </param>
                     <param name="constraint">      none          </param>
                     <param name="param1">         0             </param>
                     <param name="param2">         0             </param>
-            </group> 
+            </group>
             <group name="JOINTSET_3">
                     <param name="listofjoints">   3             </param>
                     <param name="constraint">     none         </param>
                     <param name="param1">         0            </param>
                     <param name="param2">         0            </param>
-            </group> 
-    </group>                            
+            </group>
+    </group>
 </params>

--- a/iCubGenova11/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
+++ b/iCubGenova11/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
@@ -6,14 +6,14 @@
 
     <xi:include href="../../general.xml" />
     <xi:include href="../../hardware/electronics/left_arm-eb26-j12_15-eln.xml" />
-    <xi:include href="../../hardware/mechanicals/left_arm-eb26-j12_15-mec.xml" />   
+    <xi:include href="../../hardware/mechanicals/left_arm-eb26-j12_15-mec.xml" />
     <xi:include href="./left_arm-eb26-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3                   -->
-    <!-- joint name                             index-distal        middle-proximal     middle-distal       little-fingers      -->     
+    <!-- joint name                             index_distal        middle_proximal     middle_distal       pinky      -->
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270                 </param>
-        <param name="jntPosMin">                0                   0                   0                   0                   </param> 
+        <param name="jntPosMin">                0                   0                   0                   0                   </param>
         <param name="jntVelMax">                1000                1000                1000                1000                </param>
         <param name="motorOverloadCurrents">    2000                2000                2000                2000                </param>
         <param name="motorNominalCurrents">     600                 600                 600                 600                 </param>
@@ -31,21 +31,21 @@
     </group>
 
     <group name="CONTROLS">
-        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="torqueControl">            none                none                none                none                </param> 
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="torqueControl">            none                none                none                none                </param>
         <param name="currentPid">               none                none                none                none                </param>
-        <param name="speedPid">                 none                none                none                none                </param> 
+        <param name="speedPid">                 none                none                none                none                </param>
     </group>
 
 
     <!-- default position PID: begin -->
-    
+
     <group name="POS_PID_DEFAULT">
         <param name="controlLaw">             minjerk                   </param>
         <param name="outputType">             pwm                       </param>
-        <param name="fbkControlUnits">        metric_units              </param> 
+        <param name="fbkControlUnits">        metric_units              </param>
         <param name="outputControlUnits">     machine_units             </param>
         <param name="kp">                  -500.0       500.0       500.0      -200.0       </param>
         <param name="kd">                   0.0         0.0         0.0         0.0         </param>
@@ -60,13 +60,13 @@
     <!-- default position PID: end -->
 
 
-    <!-- other default PIDs: begin -->   
+    <!-- other default PIDs: begin -->
     <!-- other default PIDs: end -->
 
 
-    <!-- custom PIDs: begin -->    
+    <!-- custom PIDs: begin -->
     <!-- custom PIDs: end -->
-    
-</device> 
-    
+
+</device>
+
 

--- a/iCubGenova11/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
+++ b/iCubGenova11/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
@@ -6,14 +6,14 @@
 
     <xi:include href="../../general.xml" />
     <xi:include href="../../hardware/electronics/right_arm-eb29-j12_15-eln.xml" />
-    <xi:include href="../../hardware/mechanicals/right_arm-eb29-j12_15-mec.xml" />   
+    <xi:include href="../../hardware/mechanicals/right_arm-eb29-j12_15-mec.xml" />
     <xi:include href="./right_arm-eb29-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3               -->
-    <!-- joint name                             index-distal        middle-proximal     middle-distal       little-fingers  -->     
+    <!-- joint name                             index_distal        middle_proximal     middle_distal       pinky  -->
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270             </param>
-        <param name="jntPosMin">                0                   0                   0                   0               </param> 
+        <param name="jntPosMin">                0                   0                   0                   0               </param>
         <param name="jntVelMax">                1000                1000                1000                1000            </param>
         <param name="motorOverloadCurrents">    2000                2000                2000                2000            </param>
         <param name="motorNominalCurrents">     600                 600                 600                 600             </param>
@@ -31,18 +31,18 @@
     </group>
 
     <group name="CONTROLS">
-        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="torqueControl">            none                none                none                none                </param> 
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="torqueControl">            none                none                none                none                </param>
         <param name="currentPid">               none                none                none                none                </param>
-        <param name="speedPid">                 none                none                none                none                </param> 
+        <param name="speedPid">                 none                none                none                none                </param>
     </group>
 
     <group name="POS_PID_DEFAULT">
         <param name="controlLaw">             minjerk                   </param>
         <param name="outputType">             pwm                       </param>
-        <param name="fbkControlUnits">        metric_units              </param> 
+        <param name="fbkControlUnits">        metric_units              </param>
         <param name="outputControlUnits">     machine_units             </param>
         <param name="kp">                500.0       500.0      -500.0       200.0       </param>
         <param name="kd">                0.0         0.0         0.0         0.0         </param>
@@ -55,9 +55,9 @@
     </group>
 
     <!-- begin of reserved section. this section is reserved for custom PIDs -->
-    
+
     <!-- end of reserved section. this section is reserved for custom PIDs -->
-    
-</device> 
-    
+
+</device>
+
 

--- a/iCubHongKong01/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
+++ b/iCubHongKong01/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
@@ -6,14 +6,14 @@
 
     <xi:include href="../../general.xml" />
     <xi:include href="../../hardware/electronics/left_arm-eb26-j12_15-eln.xml" />
-    <xi:include href="../../hardware/mechanicals/left_arm-eb26-j12_15-mec.xml" />   
+    <xi:include href="../../hardware/mechanicals/left_arm-eb26-j12_15-mec.xml" />
     <xi:include href="./left_arm-eb26-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3                   -->
-    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers      -->     
+    <!-- joint name                             index_distal        middle_proximal     middle_distal       pinky      -->
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270                 </param>
-        <param name="jntPosMin">                0                   0                   0                   0                   </param> 
+        <param name="jntPosMin">                0                   0                   0                   0                   </param>
         <param name="jntVelMax">                1000                1000                1000                1000                </param>
         <param name="motorOverloadCurrents">    2000                2000                2000                2000                </param>
         <param name="motorNominalCurrents">     600                 600                 600                 600                 </param>
@@ -31,21 +31,21 @@
     </group>
 
     <group name="CONTROLS">
-        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="torqueControl">            none                none                none                none                </param> 
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="torqueControl">            none                none                none                none                </param>
         <param name="currentPid">               none                none                none                none                </param>
-        <param name="speedPid">                 none                none                none                none                </param> 
+        <param name="speedPid">                 none                none                none                none                </param>
     </group>
 
 
     <!-- default position PID: begin -->
-    
+
     <group name="POS_PID_DEFAULT">
         <param name="controlLaw">             minjerk                   </param>
         <param name="outputType">             pwm                       </param>
-        <param name="fbkControlUnits">        metric_units              </param> 
+        <param name="fbkControlUnits">        metric_units              </param>
         <param name="outputControlUnits">     machine_units             </param>
         <param name="kp">                  -500.0       500.0       500.0      -200.0       </param>
         <param name="kd">                   0.0         0.0         0.0         0.0         </param>
@@ -60,13 +60,13 @@
     <!-- default position PID: end -->
 
 
-    <!-- other default PIDs: begin -->   
+    <!-- other default PIDs: begin -->
     <!-- other default PIDs: end -->
 
 
-    <!-- custom PIDs: begin -->    
+    <!-- custom PIDs: begin -->
     <!-- custom PIDs: end -->
-    
-</device> 
-    
+
+</device>
+
 

--- a/iCubHongKong01/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
+++ b/iCubHongKong01/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
@@ -6,14 +6,14 @@
 
     <xi:include href="../../general.xml" />
     <xi:include href="../../hardware/electronics/right_arm-eb29-j12_15-eln.xml" />
-    <xi:include href="../../hardware/mechanicals/right_arm-eb29-j12_15-mec.xml" />   
+    <xi:include href="../../hardware/mechanicals/right_arm-eb29-j12_15-mec.xml" />
     <xi:include href="./right_arm-eb29-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3               -->
-    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers  -->     
+    <!-- joint name                             index_distal        middle_proximal     middle_distal       pinky  -->
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270             </param>
-        <param name="jntPosMin">                0                   0                   0                   0               </param> 
+        <param name="jntPosMin">                0                   0                   0                   0               </param>
         <param name="jntVelMax">                1000                1000                1000                1000            </param>
         <param name="motorOverloadCurrents">    2000                2000                2000                2000            </param>
         <param name="motorNominalCurrents">     600                 600                 600                 600             </param>
@@ -31,18 +31,18 @@
     </group>
 
     <group name="CONTROLS">
-        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="torqueControl">            none                none                none                none                </param> 
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="torqueControl">            none                none                none                none                </param>
         <param name="currentPid">               none                none                none                none                </param>
-        <param name="speedPid">                 none                none                none                none                </param> 
+        <param name="speedPid">                 none                none                none                none                </param>
     </group>
 
     <group name="POS_PID_DEFAULT">
         <param name="controlLaw">             minjerk                   </param>
         <param name="outputType">             pwm                       </param>
-        <param name="fbkControlUnits">        metric_units              </param> 
+        <param name="fbkControlUnits">        metric_units              </param>
         <param name="outputControlUnits">     machine_units             </param>
         <param name="kp">                500.0       500.0      -500.0       200.0       </param>
         <param name="kd">                0.0         0.0         0.0         0.0         </param>
@@ -55,9 +55,9 @@
     </group>
 
     <!-- begin of reserved section. this section is reserved for custom PIDs -->
-    
+
     <!-- end of reserved section. this section is reserved for custom PIDs -->
-    
-</device> 
-    
+
+</device>
+
 

--- a/iCubLausanne02/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
+++ b/iCubLausanne02/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
@@ -4,25 +4,25 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-eb26-j12_15-mc" type="embObjMotionControl">
-    
+
         <xi:include href="../../general.xml" />
         <xi:include href="../../hardware/electronics/left_arm-eb26-j12_15-eln.xml" />
         <xi:include href="../../hardware/mechanicals/left_arm-eb26-j12_15-mec.xml" />
-        
+
         <xi:include href="./left_arm-eb26-j12_15-mc_service.xml" />
 
         <!-- joint number in sub-part           0               1               2               3          -->
-        <!-- joint name                    index_distal   middle-proximal   middle-distal   little-fingers -->     
+        <!-- joint name                    index_distal   middle_proximal   middle_distal   pinky -->
         <group name="LIMITS">
             <param name="jntPosMax">              180          90              180             270        </param>
-            <param name="jntPosMin">                0           0                0               0        </param> 
+            <param name="jntPosMin">                0           0                0               0        </param>
             <param name="jntVelMax">                1000        1000            1000           1000       </param>
             <param name="motorOverloadCurrents">    2000        2000            2000           2000       </param>
             <param name="motorNominalCurrents">      600         600             600            600        </param>
             <param name="motorPeakCurrents">        1000        1000            1000           1000        </param>
             <param name="motorPwmLimit">            3360        3360            3360            3360       </param>
         </group>
-    
+
 
         <group name="IMPEDANCE">
             <param name="stiffness">            0.0         0.0     0.0         0.0             </param>
@@ -35,29 +35,29 @@
 
 
         <group name="CONTROLS">
-           <param name="positionControl">           POS_PID_DEFAULT   POS_PID_DEFAULT    POS_PID_DEFAULT    POS_PID_DEFAULT    </param> 
+           <param name="positionControl">           POS_PID_DEFAULT   POS_PID_DEFAULT    POS_PID_DEFAULT    POS_PID_DEFAULT    </param>
            <param name="velocityControl"> POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT</param>
-           <param name="mixedControl"> POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT</param> 
-           <param name="torqueControl">             none           none            none            none            </param> 
+           <param name="mixedControl"> POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT</param>
+           <param name="torqueControl">             none           none            none            none            </param>
            <param name="currentPid"> none none none none</param>
        <param name="speedPid"> none none none none</param>
         </group>
 
 	    <group name="POS_PID_DEFAULT">
 	        <param name="controlLaw">             minjerk                   </param>
-           <param name="outputType">             pwm                       </param> 
+           <param name="outputType">             pwm                       </param>
             <param name="fbkControlUnits">  metric_units   </param>
-            <param name="outputControlUnits">  machine_units      </param> 
+            <param name="outputControlUnits">  machine_units      </param>
             <param name="kp">                  -500.0       500.0       500.0      -200.0       </param>
-            <param name="kd">                   0.0         0.0         0.0         0.0         </param>      
-            <param name="ki">                  -50.0        50.0        50.0       -20.0        </param>        
-            <param name="maxOutput">            3360        3360        3360        3360        </param>   
-            <param name="maxInt">               3360        3360        3360        3360        </param> 
-            <param name="stictionUp">           0           0           0           0           </param> 
-            <param name="stictionDown">          0           0           0           0           </param> 
-            <param name="kff">                  0           0           0           0           </param> 
+            <param name="kd">                   0.0         0.0         0.0         0.0         </param>
+            <param name="ki">                  -50.0        50.0        50.0       -20.0        </param>
+            <param name="maxOutput">            3360        3360        3360        3360        </param>
+            <param name="maxInt">               3360        3360        3360        3360        </param>
+            <param name="stictionUp">           0           0           0           0           </param>
+            <param name="stictionDown">          0           0           0           0           </param>
+            <param name="kff">                  0           0           0           0           </param>
         </group>
 
-    </device> 
-    
+    </device>
+
 

--- a/iCubLausanne02/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
+++ b/iCubLausanne02/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
@@ -4,25 +4,25 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-eb29-j12_15-mc" type="embObjMotionControl">
-    
+
         <xi:include href="../../general.xml" />
         <xi:include href="../../hardware/electronics/right_arm-eb29-j12_15-eln.xml" />
         <xi:include href="../../hardware/mechanicals/right_arm-eb29-j12_15-mec.xml" />
-        
+
         <xi:include href="./right_arm-eb29-j12_15-mc_service.xml" />
 
         <!-- joint number in sub-part           0               1               2               3          -->
-        <!-- joint name                    index_distal   middle-proximal   middle-distal   little-fingers -->     
+        <!-- joint name                    index_distal   middle_proximal   middle_distal   pinky -->
         <group name="LIMITS">
             <param name="jntPosMax">              180          90              180             270          </param>
-            <param name="jntPosMin">                0           0                0               0           </param> 
+            <param name="jntPosMin">                0           0                0               0           </param>
             <param name="jntVelMax">                1000        1000            1000           1000         </param>
             <param name="motorOverloadCurrents">    2000        2000            2000           2000       </param>
             <param name="motorNominalCurrents">      600         600             600            600        </param>
             <param name="motorPeakCurrents">        1000        1000            1000           1000        </param>
             <param name="motorPwmLimit">            3360        3360            3360            3360       </param>
         </group>
-    
+
         <group name="IMPEDANCE">
             <param name="stiffness">            0.0         0.0     0.0         0.0             </param>
             <param name="damping">              0.0         0.0     0.0         0.0             </param>
@@ -34,29 +34,29 @@
 
 
         <group name="CONTROLS">
-           <param name="positionControl">           POS_PID_DEFAULT   POS_PID_DEFAULT    POS_PID_DEFAULT    POS_PID_DEFAULT    </param> 
+           <param name="positionControl">           POS_PID_DEFAULT   POS_PID_DEFAULT    POS_PID_DEFAULT    POS_PID_DEFAULT    </param>
            <param name="velocityControl"> POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT</param>
-           <param name="mixedControl"> POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT</param> 
-           <param name="torqueControl">             none           none            none            none            </param> 
+           <param name="mixedControl"> POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT POS_PID_DEFAULT</param>
+           <param name="torqueControl">             none           none            none            none            </param>
            <param name="currentPid"> none none none none</param>
        <param name="speedPid"> none none none none</param>
         </group>
 
 	    <group name="POS_PID_DEFAULT">
 	        <param name="controlLaw">             minjerk                   </param>
-           <param name="outputType">             pwm                       </param> 
+           <param name="outputType">             pwm                       </param>
             <param name="fbkControlUnits">  metric_units   </param>
-            <param name="outputControlUnits">  machine_units      </param> 
+            <param name="outputControlUnits">  machine_units      </param>
             <param name="kp">                500.0       500.0      -500.0       200.0       </param>
-            <param name="kd">                0.0         0.0         0.0         0.0         </param>  
-            <param name="ki">                50.0        50.0       -50.0        20.0        </param>    
-            <param name="maxOutput">         3360        3360        3360        3360        </param>  
-            <param name="maxInt">            3360        3360        3360        3360        </param> 
-            <param name="stictionUp">        0           0           0           0           </param> 
-            <param name="stictionDown">       0           0           0           0           </param> 
-            <param name="kff">               0           0           0           0           </param> 
+            <param name="kd">                0.0         0.0         0.0         0.0         </param>
+            <param name="ki">                50.0        50.0       -50.0        20.0        </param>
+            <param name="maxOutput">         3360        3360        3360        3360        </param>
+            <param name="maxInt">            3360        3360        3360        3360        </param>
+            <param name="stictionUp">        0           0           0           0           </param>
+            <param name="stictionDown">       0           0           0           0           </param>
+            <param name="kff">               0           0           0           0           </param>
         </group>
-       
-    </device> 
-    
+
+    </device>
+
 

--- a/iCubLisboa01/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
+++ b/iCubLisboa01/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
@@ -6,14 +6,14 @@
 
     <xi:include href="../../general.xml" />
     <xi:include href="../../hardware/electronics/left_arm-eb26-j12_15-eln.xml" />
-    <xi:include href="../../hardware/mechanicals/left_arm-eb26-j12_15-mec.xml" />   
+    <xi:include href="../../hardware/mechanicals/left_arm-eb26-j12_15-mec.xml" />
     <xi:include href="./left_arm-eb26-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3                   -->
-    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers      -->     
+    <!-- joint name                             index_distal        middle_proximal     middle_distal       pinky      -->
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270                 </param>
-        <param name="jntPosMin">                0                   0                   0                   0                   </param> 
+        <param name="jntPosMin">                0                   0                   0                   0                   </param>
         <param name="jntVelMax">                1000                1000                1000                1000                </param>
         <param name="motorOverloadCurrents">    2000                2000                2000                2000                </param>
         <param name="motorNominalCurrents">     600                 600                 600                 600                 </param>
@@ -31,21 +31,21 @@
     </group>
 
     <group name="CONTROLS">
-        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="torqueControl">            none                none                none                none                </param> 
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="torqueControl">            none                none                none                none                </param>
         <param name="currentPid">               none                none                none                none                </param>
-        <param name="speedPid">                 none                none                none                none                </param> 
+        <param name="speedPid">                 none                none                none                none                </param>
     </group>
 
 
     <!-- default position PID: begin -->
-    
+
     <group name="POS_PID_DEFAULT">
         <param name="controlLaw">             minjerk                   </param>
         <param name="outputType">             pwm                       </param>
-        <param name="fbkControlUnits">        metric_units              </param> 
+        <param name="fbkControlUnits">        metric_units              </param>
         <param name="outputControlUnits">     machine_units             </param>
         <param name="kp">                  -500.0       500.0       500.0      -200.0       </param>
         <param name="kd">                   0.0         0.0         0.0         0.0         </param>
@@ -60,12 +60,12 @@
     <!-- default position PID: end -->
 
 
-    <!-- other default PIDs: begin -->   
+    <!-- other default PIDs: begin -->
     <!-- other default PIDs: end -->
 
 
-    <!-- custom PIDs: begin -->    
+    <!-- custom PIDs: begin -->
     <!-- custom PIDs: end -->
-    
-</device> 
-    
+
+</device>
+

--- a/iCubLisboa01/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
+++ b/iCubLisboa01/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
@@ -6,14 +6,14 @@
 
     <xi:include href="../../general.xml" />
     <xi:include href="../../hardware/electronics/right_arm-eb29-j12_15-eln.xml" />
-    <xi:include href="../../hardware/mechanicals/right_arm-eb29-j12_15-mec.xml" />   
+    <xi:include href="../../hardware/mechanicals/right_arm-eb29-j12_15-mec.xml" />
     <xi:include href="./right_arm-eb29-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3               -->
-    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers  -->     
+    <!-- joint name                             index_distal        middle_proximal     middle_distal       pinky  -->
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270             </param>
-        <param name="jntPosMin">                0                   0                   0                   0               </param> 
+        <param name="jntPosMin">                0                   0                   0                   0               </param>
         <param name="jntVelMax">                1000                1000                1000                1000            </param>
         <param name="motorOverloadCurrents">    2000                2000                2000                2000            </param>
         <param name="motorNominalCurrents">     600                 600                 600                 600             </param>
@@ -31,18 +31,18 @@
     </group>
 
     <group name="CONTROLS">
-        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="torqueControl">            none                none                none                none                </param> 
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="torqueControl">            none                none                none                none                </param>
         <param name="currentPid">               none                none                none                none                </param>
-        <param name="speedPid">                 none                none                none                none                </param> 
+        <param name="speedPid">                 none                none                none                none                </param>
     </group>
 
     <group name="POS_PID_DEFAULT">
         <param name="controlLaw">             minjerk                   </param>
         <param name="outputType">             pwm                       </param>
-        <param name="fbkControlUnits">        metric_units              </param> 
+        <param name="fbkControlUnits">        metric_units              </param>
         <param name="outputControlUnits">     machine_units             </param>
         <param name="kp">                500.0       500.0      -500.0       200.0       </param>
         <param name="kd">                0.0         0.0         0.0         0.0         </param>
@@ -55,9 +55,9 @@
     </group>
 
     <!-- begin of reserved section. this section is reserved for custom PIDs -->
-    
+
     <!-- end of reserved section. this section is reserved for custom PIDs -->
-    
-</device> 
-    
+
+</device>
+
 

--- a/iCubMoscow01/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
+++ b/iCubMoscow01/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
@@ -6,14 +6,14 @@
 
     <xi:include href="../../general.xml" />
     <xi:include href="../../hardware/electronics/left_arm-eb26-j12_15-eln.xml" />
-    <xi:include href="../../hardware/mechanicals/left_arm-eb26-j12_15-mec.xml" />   
+    <xi:include href="../../hardware/mechanicals/left_arm-eb26-j12_15-mec.xml" />
     <xi:include href="./left_arm-eb26-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3                   -->
-    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers      -->     
+    <!-- joint name                             index_distal        middle_proximal     middle_distal       pinky      -->
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270                 </param>
-        <param name="jntPosMin">                0                   0                   0                   0                   </param> 
+        <param name="jntPosMin">                0                   0                   0                   0                   </param>
         <param name="jntVelMax">                1000                1000                1000                1000                </param>
         <param name="motorOverloadCurrents">    2000                2000                2000                2000                </param>
         <param name="motorNominalCurrents">     600                 600                 600                 600                 </param>
@@ -31,21 +31,21 @@
     </group>
 
     <group name="CONTROLS">
-        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="torqueControl">            none                none                none                none                </param> 
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="torqueControl">            none                none                none                none                </param>
         <param name="currentPid">               none                none                none                none                </param>
-        <param name="speedPid">                 none                none                none                none                </param> 
+        <param name="speedPid">                 none                none                none                none                </param>
     </group>
 
 
     <!-- default position PID: begin -->
-    
+
     <group name="POS_PID_DEFAULT">
         <param name="controlLaw">             minjerk                   </param>
         <param name="outputType">             pwm                       </param>
-        <param name="fbkControlUnits">        metric_units              </param> 
+        <param name="fbkControlUnits">        metric_units              </param>
         <param name="outputControlUnits">     machine_units             </param>
         <param name="kp">                  -500.0       500.0       500.0      -200.0       </param>
         <param name="kd">                   0.0         0.0         0.0         0.0         </param>
@@ -60,13 +60,13 @@
     <!-- default position PID: end -->
 
 
-    <!-- other default PIDs: begin -->   
+    <!-- other default PIDs: begin -->
     <!-- other default PIDs: end -->
 
 
-    <!-- custom PIDs: begin -->    
+    <!-- custom PIDs: begin -->
     <!-- custom PIDs: end -->
-    
-</device> 
-    
+
+</device>
+
 

--- a/iCubMoscow01/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
+++ b/iCubMoscow01/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
@@ -6,14 +6,14 @@
 
     <xi:include href="../../general.xml" />
     <xi:include href="../../hardware/electronics/right_arm-eb29-j12_15-eln.xml" />
-    <xi:include href="../../hardware/mechanicals/right_arm-eb29-j12_15-mec.xml" />   
+    <xi:include href="../../hardware/mechanicals/right_arm-eb29-j12_15-mec.xml" />
     <xi:include href="./right_arm-eb29-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3               -->
-    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers  -->     
+    <!-- joint name                             index_distal        middle_proximal     middle_distal       pinky  -->
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270             </param>
-        <param name="jntPosMin">                0                   0                   0                   0               </param> 
+        <param name="jntPosMin">                0                   0                   0                   0               </param>
         <param name="jntVelMax">                1000                1000                1000                1000            </param>
         <param name="motorOverloadCurrents">    2000                2000                2000                2000            </param>
         <param name="motorNominalCurrents">     600                 600                 600                 600             </param>
@@ -31,18 +31,18 @@
     </group>
 
     <group name="CONTROLS">
-        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="torqueControl">            none                none                none                none                </param> 
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="torqueControl">            none                none                none                none                </param>
         <param name="currentPid">               none                none                none                none                </param>
-        <param name="speedPid">                 none                none                none                none                </param> 
+        <param name="speedPid">                 none                none                none                none                </param>
     </group>
 
     <group name="POS_PID_DEFAULT">
         <param name="controlLaw">             minjerk                   </param>
         <param name="outputType">             pwm                       </param>
-        <param name="fbkControlUnits">        metric_units              </param> 
+        <param name="fbkControlUnits">        metric_units              </param>
         <param name="outputControlUnits">     machine_units             </param>
         <param name="kp">                500.0       500.0      -500.0       200.0       </param>
         <param name="kd">                0.0         0.0         0.0         0.0         </param>
@@ -55,9 +55,9 @@
     </group>
 
     <!-- begin of reserved section. this section is reserved for custom PIDs -->
-    
+
     <!-- end of reserved section. this section is reserved for custom PIDs -->
-    
-</device> 
-    
+
+</device>
+
 

--- a/iCubPrague01/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
+++ b/iCubPrague01/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
@@ -6,14 +6,14 @@
 
     <xi:include href="../../general.xml" />
     <xi:include href="../../hardware/electronics/left_arm-eb26-j12_15-eln.xml" />
-    <xi:include href="../../hardware/mechanicals/left_arm-eb26-j12_15-mec.xml" />   
+    <xi:include href="../../hardware/mechanicals/left_arm-eb26-j12_15-mec.xml" />
     <xi:include href="./left_arm-eb26-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3                   -->
-    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers      -->     
+    <!-- joint name                             index_distal        middle_proximal     middle_distal       pinky      -->
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270                 </param>
-        <param name="jntPosMin">                0                   0                   0                   0                   </param> 
+        <param name="jntPosMin">                0                   0                   0                   0                   </param>
         <param name="jntVelMax">                1000                1000                1000                1000                </param>
         <param name="motorOverloadCurrents">    2000                2000                2000                2000                </param>
         <param name="motorNominalCurrents">     600                 600                 600                 600                 </param>
@@ -31,21 +31,21 @@
     </group>
 
     <group name="CONTROLS">
-        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="torqueControl">            none                none                none                none                </param> 
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="torqueControl">            none                none                none                none                </param>
         <param name="currentPid">               none                none                none                none                </param>
-        <param name="speedPid">                 none                none                none                none                </param> 
+        <param name="speedPid">                 none                none                none                none                </param>
     </group>
 
 
     <!-- default position PID: begin -->
-    
+
     <group name="POS_PID_DEFAULT">
         <param name="controlLaw">             minjerk                   </param>
         <param name="outputType">             pwm                       </param>
-        <param name="fbkControlUnits">        metric_units              </param> 
+        <param name="fbkControlUnits">        metric_units              </param>
         <param name="outputControlUnits">     machine_units             </param>
         <param name="kp">                  -500.0       500.0       500.0      -200.0       </param>
         <param name="kd">                   0.0         0.0         0.0         0.0         </param>
@@ -60,13 +60,13 @@
     <!-- default position PID: end -->
 
 
-    <!-- other default PIDs: begin -->   
+    <!-- other default PIDs: begin -->
     <!-- other default PIDs: end -->
 
 
-    <!-- custom PIDs: begin -->    
+    <!-- custom PIDs: begin -->
     <!-- custom PIDs: end -->
-    
-</device> 
-    
+
+</device>
+
 

--- a/iCubPrague01/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
+++ b/iCubPrague01/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
@@ -6,14 +6,14 @@
 
     <xi:include href="../../general.xml" />
     <xi:include href="../../hardware/electronics/right_arm-eb29-j12_15-eln.xml" />
-    <xi:include href="../../hardware/mechanicals/right_arm-eb29-j12_15-mec.xml" />   
+    <xi:include href="../../hardware/mechanicals/right_arm-eb29-j12_15-mec.xml" />
     <xi:include href="./right_arm-eb29-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3               -->
-    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers  -->     
+    <!-- joint name                             index_distal        middle_proximal     middle_distal       pinky  -->
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270             </param>
-        <param name="jntPosMin">                0                   0                   0                   0               </param> 
+        <param name="jntPosMin">                0                   0                   0                   0               </param>
         <param name="jntVelMax">                1000                1000                1000                1000            </param>
         <param name="motorOverloadCurrents">    2000                2000                2000                2000            </param>
         <param name="motorNominalCurrents">     600                 600                 600                 600             </param>
@@ -31,18 +31,18 @@
     </group>
 
     <group name="CONTROLS">
-        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="torqueControl">            none                none                none                none                </param> 
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="torqueControl">            none                none                none                none                </param>
         <param name="currentPid">               none                none                none                none                </param>
-        <param name="speedPid">                 none                none                none                none                </param> 
+        <param name="speedPid">                 none                none                none                none                </param>
     </group>
 
     <group name="POS_PID_DEFAULT">
         <param name="controlLaw">             minjerk                   </param>
         <param name="outputType">             pwm                       </param>
-        <param name="fbkControlUnits">        metric_units              </param> 
+        <param name="fbkControlUnits">        metric_units              </param>
         <param name="outputControlUnits">     machine_units             </param>
         <param name="kp">                500.0       500.0      -500.0       200.0       </param>
         <param name="kd">                0.0         0.0         0.0         0.0         </param>
@@ -55,9 +55,9 @@
     </group>
 
     <!-- begin of reserved section. this section is reserved for custom PIDs -->
-    
+
     <!-- end of reserved section. this section is reserved for custom PIDs -->
-    
-</device> 
-    
+
+</device>
+
 

--- a/iCubShanghai01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubShanghai01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
- 
+
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="iCubShanghai01" build="1">
     <group name="GENERAL">
         <param name="MotioncontrolVersion"> 6 </param>
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_little-fingers"  </param> 
+        <param name="AxisName">                 "l_index_distal" "l_middle_proximal" "l_middle_distal" "l_pinky"  </param>
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
-        <param name="AxisMap">                  0                1                   2                  3               </param>   
-        <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    
+        <param name="AxisMap">                  0                1                   2                  3               </param>
+        <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>
         <param name="fullscalePWM">             3360             3360               3360                3360            </param>
         <param name="ampsToSensor">             1000.0           1000.0             1000.0              1000.0          </param>
         <param name="Gearbox_M2J">              256              256                 256                256             </param>
@@ -19,64 +19,64 @@
         <param name="MotorType">               "DC"              "DC"                "DC"           "DC"               </param>
         <param name="Verbose">                  0                                                                       </param>
     </group>
-    
+
     <group name="LIMITS">
         <param name="hardwareJntPosMax">     180          90              180             270        </param>
-        <param name="hardwareJntPosMin">       0           0                0               0        </param> 
-        <param name="rotorPosMin">         -5120       -5120              -65000          -5120     </param> 
+        <param name="hardwareJntPosMin">       0           0                0               0        </param>
+        <param name="rotorPosMin">         -5120       -5120              -65000          -5120     </param>
         <param name="rotorPosMax">          65000       32000              5120           65000      </param>
     </group>
 
-    <group name="COUPLINGS"> 
-                            
-        <param name ="matrixJ2M"> 
+    <group name="COUPLINGS">
+
+        <param name ="matrixJ2M">
             1.000   0.000   0.000   0.000
             0.000   1.000   0.000   0.000
             0.000   0.000   1.000   0.000
-            0.000   0.000   0.000   1.000   
+            0.000   0.000   0.000   1.000
         </param>
 
-        <param name ="matrixM2J"> 
+        <param name ="matrixM2J">
             1.000   0.000   0.000   0.000
             1.000   1.000   0.000   0.000
             0.000   0.000   1.000   0.000
-            0.000   0.000   0.000   1.000   
+            0.000   0.000   0.000   1.000
         </param>
-       
-         <param name ="matrixE2J">  
+
+         <param name ="matrixE2J">
             1.000   0.000   0.000   0.000   0.000   0.000
             0.000   1.000   0.000   0.000   0.000   0.000
             0.000   0.000   1.000   0.000   0.000   0.000
-            0.000   0.000   0.000   1.000   0.000   0.000   
+            0.000   0.000   0.000   1.000   0.000   0.000
         </param>
-  
-    </group>                
 
-    <group name="JOINTSET_CFG"> 
+    </group>
+
+    <group name="JOINTSET_CFG">
         <param name= "numberofsets"> 4</param>
          <group name="JOINTSET_0">
                     <param name="listofjoints">  0             </param>
                     <param name="constraint">    none          </param>
                     <param name="param1">        0             </param>
                     <param name="param2">        0             </param>
-            </group> 
+            </group>
             <group name="JOINTSET_1">
                     <param name="listofjoints">   1             </param>
                     <param name="constraint">      none          </param>
                     <param name="param1">         0             </param>
                     <param name="param2">         0             </param>
-            </group> 
+            </group>
             <group name="JOINTSET_2">
                     <param name="listofjoints">   2             </param>
                     <param name="constraint">      none          </param>
                     <param name="param1">         0             </param>
                     <param name="param2">         0             </param>
-            </group> 
+            </group>
             <group name="JOINTSET_3">
                     <param name="listofjoints">   3             </param>
                     <param name="constraint">     none         </param>
                     <param name="param1">         0            </param>
                     <param name="param2">         0            </param>
-            </group> 
-    </group>                            
+            </group>
+    </group>
 </params>

--- a/iCubShanghai01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubShanghai01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
- 
+
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="iCubShanghai01" build="1">
     <group name="GENERAL">
         <param name="MotioncontrolVersion"> 6 </param>
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle-proximal" "r_middle-distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index_distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param>
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
-        <param name="AxisMap">                  0                1                   2                  3                </param>   
-         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   
+        <param name="AxisMap">                  0                1                   2                  3                </param>
+         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>
         <param name="fullscalePWM">             3360              3360                3360             3360              </param>
         <param name="ampsToSensor">             1000.0            1000.0              1000.0           1000.0            </param>
         <param name="Gearbox_M2J">               256              256                 256                256             </param>
@@ -19,65 +19,65 @@
         <param name="MotorType">                  "DC"             "DC"                "DC"               "DC"           </param>
         <param name="Verbose">                  0                                                                        </param>
     </group>
-    
+
     <group name="LIMITS">
         <param name="hardwareJntPosMax">        180                 90                180                 270          </param>
-        <param name="hardwareJntPosMin">          0                  0                  0                   0          </param> 
-        <param name="rotorPosMin">           -65000              -5120              -5120               -65000          </param> 
+        <param name="hardwareJntPosMin">          0                  0                  0                   0          </param>
+        <param name="rotorPosMin">           -65000              -5120              -5120               -65000          </param>
         <param name="rotorPosMax">             5120              32000              65000               5120          </param>
 
 </group>
 
-    <group name="COUPLINGS"> 
-                            
-        <param name ="matrixJ2M"> 
+    <group name="COUPLINGS">
+
+        <param name ="matrixJ2M">
             1.000   0.000   0.000   0.000
             0.000   1.000   0.000   0.000
             0.000   0.000   1.000   0.000
-            0.000   0.000   0.000   1.000   
+            0.000   0.000   0.000   1.000
         </param>
 
-        <param name ="matrixM2J"> 
+        <param name ="matrixM2J">
             1.000   0.000   0.000   0.000
             1.000   1.000   0.000   0.000
             0.000   0.000   1.000   0.000
-            0.000   0.000   0.000   1.000   
+            0.000   0.000   0.000   1.000
         </param>
-       
-         <param name ="matrixE2J">  
+
+         <param name ="matrixE2J">
             1.000   0.000   0.000   0.000   0.000   0.000
             0.000   1.000   0.000   0.000   0.000   0.000
             0.000   0.000   1.000   0.000   0.000   0.000
-            0.000   0.000   0.000   1.000   0.000   0.000   
+            0.000   0.000   0.000   1.000   0.000   0.000
         </param>
-  
-    </group>                
 
-    <group name="JOINTSET_CFG"> 
+    </group>
+
+    <group name="JOINTSET_CFG">
         <param name= "numberofsets"> 4</param>
          <group name="JOINTSET_0">
                     <param name="listofjoints">  0             </param>
                     <param name="constraint">    none          </param>
                     <param name="param1">        0             </param>
                     <param name="param2">        0             </param>
-            </group> 
+            </group>
             <group name="JOINTSET_1">
                     <param name="listofjoints">   1             </param>
                     <param name="constraint">      none          </param>
                     <param name="param1">         0             </param>
                     <param name="param2">         0             </param>
-            </group> 
+            </group>
             <group name="JOINTSET_2">
                     <param name="listofjoints">   2             </param>
                     <param name="constraint">      none          </param>
                     <param name="param1">         0             </param>
                     <param name="param2">         0             </param>
-            </group> 
+            </group>
             <group name="JOINTSET_3">
                     <param name="listofjoints">   3             </param>
                     <param name="constraint">     none         </param>
                     <param name="param1">         0            </param>
                     <param name="param2">         0            </param>
-            </group> 
-    </group>                            
+            </group>
+    </group>
 </params>

--- a/iCubShanghai01/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
+++ b/iCubShanghai01/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
@@ -6,14 +6,14 @@
 
     <xi:include href="../../general.xml" />
     <xi:include href="../../hardware/electronics/left_arm-eb26-j12_15-eln.xml" />
-    <xi:include href="../../hardware/mechanicals/left_arm-eb26-j12_15-mec.xml" />   
+    <xi:include href="../../hardware/mechanicals/left_arm-eb26-j12_15-mec.xml" />
     <xi:include href="./left_arm-eb26-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3                   -->
-    <!-- joint name                             index-distal        middle-proximal     middle-distal       little-fingers      -->     
+    <!-- joint name                             index_distal        middle_proximal     middle_distal       pinky      -->
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270                 </param>
-        <param name="jntPosMin">                0                   0                   0                   0                   </param> 
+        <param name="jntPosMin">                0                   0                   0                   0                   </param>
         <param name="jntVelMax">                1000                1000                1000                1000                </param>
         <param name="motorOverloadCurrents">    2000                2000                2000                2000                </param>
         <param name="motorNominalCurrents">     600                 600                 600                 600                 </param>
@@ -31,21 +31,21 @@
     </group>
 
     <group name="CONTROLS">
-        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="torqueControl">            none                none                none                none                </param> 
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="torqueControl">            none                none                none                none                </param>
         <param name="currentPid">               none                none                none                none                </param>
-        <param name="speedPid">                 none                none                none                none                </param> 
+        <param name="speedPid">                 none                none                none                none                </param>
     </group>
 
 
     <!-- default position PID: begin -->
-    
+
     <group name="POS_PID_DEFAULT">
         <param name="controlLaw">             minjerk                   </param>
         <param name="outputType">             pwm                       </param>
-        <param name="fbkControlUnits">        metric_units              </param> 
+        <param name="fbkControlUnits">        metric_units              </param>
         <param name="outputControlUnits">     machine_units             </param>
         <param name="kp">                  -500.0       500.0       500.0      -200.0       </param>
         <param name="kd">                   0.0         0.0         0.0         0.0         </param>
@@ -60,13 +60,13 @@
     <!-- default position PID: end -->
 
 
-    <!-- other default PIDs: begin -->   
+    <!-- other default PIDs: begin -->
     <!-- other default PIDs: end -->
 
 
-    <!-- custom PIDs: begin -->    
+    <!-- custom PIDs: begin -->
     <!-- custom PIDs: end -->
-    
-</device> 
-    
+
+</device>
+
 

--- a/iCubShanghai01/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
+++ b/iCubShanghai01/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
@@ -6,14 +6,14 @@
 
     <xi:include href="../../general.xml" />
     <xi:include href="../../hardware/electronics/right_arm-eb29-j12_15-eln.xml" />
-    <xi:include href="../../hardware/mechanicals/right_arm-eb29-j12_15-mec.xml" />   
+    <xi:include href="../../hardware/mechanicals/right_arm-eb29-j12_15-mec.xml" />
     <xi:include href="./right_arm-eb29-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3               -->
-    <!-- joint name                             index-distal        middle-proximal     middle-distal       little-fingers  -->     
+    <!-- joint name                             index_distal        middle_proximal     middle_distal       pinky  -->
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270             </param>
-        <param name="jntPosMin">                0                   0                   0                   0               </param> 
+        <param name="jntPosMin">                0                   0                   0                   0               </param>
         <param name="jntVelMax">                1000                1000                1000                1000            </param>
         <param name="motorOverloadCurrents">    2000                2000                2000                2000            </param>
         <param name="motorNominalCurrents">     600                 600                 600                 600             </param>
@@ -31,18 +31,18 @@
     </group>
 
     <group name="CONTROLS">
-        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="torqueControl">            none                none                none                none                </param> 
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="torqueControl">            none                none                none                none                </param>
         <param name="currentPid">               none                none                none                none                </param>
-        <param name="speedPid">                 none                none                none                none                </param> 
+        <param name="speedPid">                 none                none                none                none                </param>
     </group>
 
     <group name="POS_PID_DEFAULT">
         <param name="controlLaw">             minjerk                   </param>
         <param name="outputType">             pwm                       </param>
-        <param name="fbkControlUnits">        metric_units              </param> 
+        <param name="fbkControlUnits">        metric_units              </param>
         <param name="outputControlUnits">     machine_units             </param>
         <param name="kp">                500.0       500.0      -500.0       200.0       </param>
         <param name="kd">                0.0         0.0         0.0         0.0         </param>
@@ -55,9 +55,9 @@
     </group>
 
     <!-- begin of reserved section. this section is reserved for custom PIDs -->
-    
+
     <!-- end of reserved section. this section is reserved for custom PIDs -->
-    
-</device> 
-    
+
+</device>
+
 

--- a/iCubShenzhen01/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
+++ b/iCubShenzhen01/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
@@ -6,14 +6,14 @@
 
     <xi:include href="../../general.xml" />
     <xi:include href="../../hardware/electronics/left_arm-eb26-j12_15-eln.xml" />
-    <xi:include href="../../hardware/mechanicals/left_arm-eb26-j12_15-mec.xml" />   
+    <xi:include href="../../hardware/mechanicals/left_arm-eb26-j12_15-mec.xml" />
     <xi:include href="./left_arm-eb26-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3                   -->
-    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers      -->     
+    <!-- joint name                             index_distal        middle_proximal     middle_distal       pinky      -->
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270                 </param>
-        <param name="jntPosMin">                0                   0                   0                   0                   </param> 
+        <param name="jntPosMin">                0                   0                   0                   0                   </param>
         <param name="jntVelMax">                1000                1000                1000                1000                </param>
         <param name="motorOverloadCurrents">    2000                2000                2000                2000                </param>
         <param name="motorNominalCurrents">     600                 600                 600                 600                 </param>
@@ -31,21 +31,21 @@
     </group>
 
     <group name="CONTROLS">
-        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="torqueControl">            none                none                none                none                </param> 
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="torqueControl">            none                none                none                none                </param>
         <param name="currentPid">               none                none                none                none                </param>
-        <param name="speedPid">                 none                none                none                none                </param> 
+        <param name="speedPid">                 none                none                none                none                </param>
     </group>
 
 
     <!-- default position PID: begin -->
-    
+
     <group name="POS_PID_DEFAULT">
         <param name="controlLaw">             minjerk                   </param>
         <param name="outputType">             pwm                       </param>
-        <param name="fbkControlUnits">        metric_units              </param> 
+        <param name="fbkControlUnits">        metric_units              </param>
         <param name="outputControlUnits">     machine_units             </param>
         <param name="kp">                  -500.0       500.0       500.0      -200.0       </param>
         <param name="kd">                   0.0         0.0         0.0         0.0         </param>
@@ -60,13 +60,13 @@
     <!-- default position PID: end -->
 
 
-    <!-- other default PIDs: begin -->   
+    <!-- other default PIDs: begin -->
     <!-- other default PIDs: end -->
 
 
-    <!-- custom PIDs: begin -->    
+    <!-- custom PIDs: begin -->
     <!-- custom PIDs: end -->
-    
-</device> 
-    
+
+</device>
+
 

--- a/iCubShenzhen01/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
+++ b/iCubShenzhen01/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
@@ -6,14 +6,14 @@
 
     <xi:include href="../../general.xml" />
     <xi:include href="../../hardware/electronics/right_arm-eb29-j12_15-eln.xml" />
-    <xi:include href="../../hardware/mechanicals/right_arm-eb29-j12_15-mec.xml" />   
+    <xi:include href="../../hardware/mechanicals/right_arm-eb29-j12_15-mec.xml" />
     <xi:include href="./right_arm-eb29-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3               -->
-    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers  -->     
+    <!-- joint name                             index_distal        middle_proximal     middle_distal       pinky  -->
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270             </param>
-        <param name="jntPosMin">                0                   0                   0                   0               </param> 
+        <param name="jntPosMin">                0                   0                   0                   0               </param>
         <param name="jntVelMax">                1000                1000                1000                1000            </param>
         <param name="motorOverloadCurrents">    2000                2000                2000                2000            </param>
         <param name="motorNominalCurrents">     600                 600                 600                 600             </param>
@@ -31,18 +31,18 @@
     </group>
 
     <group name="CONTROLS">
-        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="torqueControl">            none                none                none                none                </param> 
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="torqueControl">            none                none                none                none                </param>
         <param name="currentPid">               none                none                none                none                </param>
-        <param name="speedPid">                 none                none                none                none                </param> 
+        <param name="speedPid">                 none                none                none                none                </param>
     </group>
 
     <group name="POS_PID_DEFAULT">
         <param name="controlLaw">             minjerk                   </param>
         <param name="outputType">             pwm                       </param>
-        <param name="fbkControlUnits">        metric_units              </param> 
+        <param name="fbkControlUnits">        metric_units              </param>
         <param name="outputControlUnits">     machine_units             </param>
         <param name="kp">                500.0       500.0      -500.0       200.0       </param>
         <param name="kd">                0.0         0.0         0.0         0.0         </param>
@@ -55,9 +55,9 @@
     </group>
 
     <!-- begin of reserved section. this section is reserved for custom PIDs -->
-    
+
     <!-- end of reserved section. this section is reserved for custom PIDs -->
-    
-</device> 
-    
+
+</device>
+
 

--- a/iCubSingapore01/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
+++ b/iCubSingapore01/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
@@ -6,14 +6,14 @@
 
     <xi:include href="../../general.xml" />
     <xi:include href="../../hardware/electronics/left_arm-eb26-j12_15-eln.xml" />
-    <xi:include href="../../hardware/mechanicals/left_arm-eb26-j12_15-mec.xml" />   
+    <xi:include href="../../hardware/mechanicals/left_arm-eb26-j12_15-mec.xml" />
     <xi:include href="./left_arm-eb26-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3                   -->
-    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers      -->     
+    <!-- joint name                             index_distal        middle_proximal     middle_distal       pinky      -->
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270                 </param>
-        <param name="jntPosMin">                0                   0                   0                   0                   </param> 
+        <param name="jntPosMin">                0                   0                   0                   0                   </param>
         <param name="jntVelMax">                1000                1000                1000                1000                </param>
         <param name="motorOverloadCurrents">    2000                2000                2000                2000                </param>
         <param name="motorNominalCurrents">     600                 600                 600                 600                 </param>
@@ -31,21 +31,21 @@
     </group>
 
     <group name="CONTROLS">
-        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="torqueControl">            none                none                none                none                </param> 
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="torqueControl">            none                none                none                none                </param>
         <param name="currentPid">               none                none                none                none                </param>
-        <param name="speedPid">                 none                none                none                none                </param> 
+        <param name="speedPid">                 none                none                none                none                </param>
     </group>
 
 
     <!-- default position PID: begin -->
-    
+
     <group name="POS_PID_DEFAULT">
         <param name="controlLaw">             minjerk                   </param>
         <param name="outputType">             pwm                       </param>
-        <param name="fbkControlUnits">        metric_units              </param> 
+        <param name="fbkControlUnits">        metric_units              </param>
         <param name="outputControlUnits">     machine_units             </param>
         <param name="kp">                  -500.0       500.0       500.0      -500.0       </param>
         <param name="kd">                   0.0         0.0         0.0         0.0         </param>
@@ -60,13 +60,13 @@
     <!-- default position PID: end -->
 
 
-    <!-- other default PIDs: begin -->   
+    <!-- other default PIDs: begin -->
     <!-- other default PIDs: end -->
 
 
-    <!-- custom PIDs: begin -->    
+    <!-- custom PIDs: begin -->
     <!-- custom PIDs: end -->
-    
-</device> 
-    
+
+</device>
+
 

--- a/iCubSingapore01/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
+++ b/iCubSingapore01/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
@@ -6,14 +6,14 @@
 
     <xi:include href="../../general.xml" />
     <xi:include href="../../hardware/electronics/right_arm-eb29-j12_15-eln.xml" />
-    <xi:include href="../../hardware/mechanicals/right_arm-eb29-j12_15-mec.xml" />   
+    <xi:include href="../../hardware/mechanicals/right_arm-eb29-j12_15-mec.xml" />
     <xi:include href="./right_arm-eb29-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3               -->
-    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers  -->     
+    <!-- joint name                             index_distal        middle_proximal     middle_distal       pinky  -->
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270             </param>
-        <param name="jntPosMin">                0                   0                   0                   0               </param> 
+        <param name="jntPosMin">                0                   0                   0                   0               </param>
         <param name="jntVelMax">                1000                1000                1000                1000            </param>
         <param name="motorOverloadCurrents">    2000                2000                2000                2000            </param>
         <param name="motorNominalCurrents">     600                 600                 600                 600             </param>
@@ -31,18 +31,18 @@
     </group>
 
     <group name="CONTROLS">
-        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="torqueControl">            none                none                none                none                </param> 
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="torqueControl">            none                none                none                none                </param>
         <param name="currentPid">               none                none                none                none                </param>
-        <param name="speedPid">                 none                none                none                none                </param> 
+        <param name="speedPid">                 none                none                none                none                </param>
     </group>
 
     <group name="POS_PID_DEFAULT">
         <param name="controlLaw">             minjerk                   </param>
         <param name="outputType">             pwm                       </param>
-        <param name="fbkControlUnits">        metric_units              </param> 
+        <param name="fbkControlUnits">        metric_units              </param>
         <param name="outputControlUnits">     machine_units             </param>
         <param name="kp">                500.0       500.0      -500.0       200.0       </param>
         <param name="kd">                0.0         0.0         0.0         0.0         </param>
@@ -55,9 +55,9 @@
     </group>
 
     <!-- begin of reserved section. this section is reserved for custom PIDs -->
-    
+
     <!-- end of reserved section. this section is reserved for custom PIDs -->
-    
-</device> 
-    
+
+</device>
+
 

--- a/iCubValparaiso01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
+++ b/iCubValparaiso01/hardware/mechanicals/left_arm-eb26-j12_15-mec.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
- 
+
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="iCubValparaiso01" build="1">
     <group name="GENERAL">
         <param name="MotioncontrolVersion"> 6 </param>
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "l_index-distal" "l_middle-proximal" "l_middle-distal" "l_little-fingers"  </param> 
+        <param name="AxisName">                 "l_index_distal" "l_middle_proximal" "l_middle_distal" "l_pinky"  </param>
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"      </param>
-        <param name="AxisMap">                  0                1                   2                  3               </param>   
-        <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>    
+        <param name="AxisMap">                  0                1                   2                  3               </param>
+        <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>
         <param name="fullscalePWM">             3360             3360               3360                3360            </param>
         <param name="ampsToSensor">             1000.0           1000.0             1000.0              1000.0          </param>
         <param name="Gearbox_M2J">              256              256                 256                256             </param>
@@ -19,64 +19,64 @@
         <param name="MotorType">               "DC"              "DC"                "DC"           "DC"               </param>
         <param name="Verbose">                  0                                                                       </param>
     </group>
-    
+
     <group name="LIMITS">
         <param name="hardwareJntPosMax">     180          90              180             270        </param>
-        <param name="hardwareJntPosMin">       0           0                0               0        </param> 
-        <param name="rotorPosMin">         -5120       -5120              -65000          -5120     </param> 
+        <param name="hardwareJntPosMin">       0           0                0               0        </param>
+        <param name="rotorPosMin">         -5120       -5120              -65000          -5120     </param>
         <param name="rotorPosMax">          65000       32000              5120           65000      </param>
     </group>
 
-    <group name="COUPLINGS"> 
-                            
-        <param name ="matrixJ2M"> 
+    <group name="COUPLINGS">
+
+        <param name ="matrixJ2M">
             1.000   0.000   0.000   0.000
             0.000   1.000   0.000   0.000
             0.000   0.000   1.000   0.000
-            0.000   0.000   0.000   1.000   
+            0.000   0.000   0.000   1.000
         </param>
 
-        <param name ="matrixM2J"> 
+        <param name ="matrixM2J">
             1.000   0.000   0.000   0.000
             1.000   1.000   0.000   0.000
             0.000   0.000   1.000   0.000
-            0.000   0.000   0.000   1.000   
+            0.000   0.000   0.000   1.000
         </param>
-       
-         <param name ="matrixE2J">  
+
+         <param name ="matrixE2J">
             1.000   0.000   0.000   0.000   0.000   0.000
             0.000   1.000   0.000   0.000   0.000   0.000
             0.000   0.000   1.000   0.000   0.000   0.000
-            0.000   0.000   0.000   1.000   0.000   0.000   
+            0.000   0.000   0.000   1.000   0.000   0.000
         </param>
-  
-    </group>                
 
-    <group name="JOINTSET_CFG"> 
+    </group>
+
+    <group name="JOINTSET_CFG">
         <param name= "numberofsets"> 4</param>
          <group name="JOINTSET_0">
                     <param name="listofjoints">  0             </param>
                     <param name="constraint">    none          </param>
                     <param name="param1">        0             </param>
                     <param name="param2">        0             </param>
-            </group> 
+            </group>
             <group name="JOINTSET_1">
                     <param name="listofjoints">   1             </param>
                     <param name="constraint">      none          </param>
                     <param name="param1">         0             </param>
                     <param name="param2">         0             </param>
-            </group> 
+            </group>
             <group name="JOINTSET_2">
                     <param name="listofjoints">   2             </param>
                     <param name="constraint">      none          </param>
                     <param name="param1">         0             </param>
                     <param name="param2">         0             </param>
-            </group> 
+            </group>
             <group name="JOINTSET_3">
                     <param name="listofjoints">   3             </param>
                     <param name="constraint">     none         </param>
                     <param name="param1">         0            </param>
                     <param name="param2">         0            </param>
-            </group> 
-    </group>                            
+            </group>
+    </group>
 </params>

--- a/iCubValparaiso01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubValparaiso01/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
- 
+
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="iCubValparaiso01" build="1">
     <group name="GENERAL">
         <param name="MotioncontrolVersion"> 6 </param>
         <param name="Joints"> 4 </param> <!-- the number of joints of the robot part -->
 
         <!-- joint number in sub-part           0                 1                  2                 3           -->
-        <param name="AxisName">                 "r_index-distal" "r_middle-proximal" "r_middle-distal" "r_little-fingers"  </param> 
+        <param name="AxisName">                 "r_index_distal" "r_middle_proximal" "r_middle_distal" "r_pinky"  </param>
         <param name="AxisType">                 "revolute"       "revolute"           "revolute"        "revolute"       </param>
-        <param name="AxisMap">                  0                1                   2                  3                </param>   
-         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>   
+        <param name="AxisMap">                  0                1                   2                  3                </param>
+         <param name="Encoder">                  182.044          182.044             182.044            182.044         </param>
         <param name="fullscalePWM">             3360              3360                3360             3360              </param>
         <param name="ampsToSensor">             1000.0            1000.0              1000.0           1000.0            </param>
         <param name="Gearbox_M2J">               256              256                 256                256             </param>
@@ -19,65 +19,65 @@
         <param name="MotorType">                  "DC"             "DC"                "DC"               "DC"           </param>
         <param name="Verbose">                  0                                                                        </param>
     </group>
-    
+
     <group name="LIMITS">
         <param name="hardwareJntPosMax">        180                 90                180                 270          </param>
-        <param name="hardwareJntPosMin">          0                  0                  0                   0          </param> 
-        <param name="rotorPosMin">           -65000              -5120              -5120               -65000          </param> 
+        <param name="hardwareJntPosMin">          0                  0                  0                   0          </param>
+        <param name="rotorPosMin">           -65000              -5120              -5120               -65000          </param>
         <param name="rotorPosMax">             5120              32000              65000               5120          </param>
 
 </group>
 
-    <group name="COUPLINGS"> 
-                            
-        <param name ="matrixJ2M"> 
+    <group name="COUPLINGS">
+
+        <param name ="matrixJ2M">
             1.000   0.000   0.000   0.000
             0.000   1.000   0.000   0.000
             0.000   0.000   1.000   0.000
-            0.000   0.000   0.000   1.000   
+            0.000   0.000   0.000   1.000
         </param>
 
-        <param name ="matrixM2J"> 
+        <param name ="matrixM2J">
             1.000   0.000   0.000   0.000
             1.000   1.000   0.000   0.000
             0.000   0.000   1.000   0.000
-            0.000   0.000   0.000   1.000   
+            0.000   0.000   0.000   1.000
         </param>
-       
-         <param name ="matrixE2J">  
+
+         <param name ="matrixE2J">
             1.000   0.000   0.000   0.000   0.000   0.000
             0.000   1.000   0.000   0.000   0.000   0.000
             0.000   0.000   1.000   0.000   0.000   0.000
-            0.000   0.000   0.000   1.000   0.000   0.000   
+            0.000   0.000   0.000   1.000   0.000   0.000
         </param>
-  
-    </group>                
 
-    <group name="JOINTSET_CFG"> 
+    </group>
+
+    <group name="JOINTSET_CFG">
         <param name= "numberofsets"> 4</param>
          <group name="JOINTSET_0">
                     <param name="listofjoints">  0             </param>
                     <param name="constraint">    none          </param>
                     <param name="param1">        0             </param>
                     <param name="param2">        0             </param>
-            </group> 
+            </group>
             <group name="JOINTSET_1">
                     <param name="listofjoints">   1             </param>
                     <param name="constraint">      none          </param>
                     <param name="param1">         0             </param>
                     <param name="param2">         0             </param>
-            </group> 
+            </group>
             <group name="JOINTSET_2">
                     <param name="listofjoints">   2             </param>
                     <param name="constraint">      none          </param>
                     <param name="param1">         0             </param>
                     <param name="param2">         0             </param>
-            </group> 
+            </group>
             <group name="JOINTSET_3">
                     <param name="listofjoints">   3             </param>
                     <param name="constraint">     none         </param>
                     <param name="param1">         0            </param>
                     <param name="param2">         0            </param>
-            </group> 
-    </group>                            
+            </group>
+    </group>
 </params>

--- a/iCubValparaiso01/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
+++ b/iCubValparaiso01/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
@@ -6,14 +6,14 @@
 
     <xi:include href="../../general.xml" />
     <xi:include href="../../hardware/electronics/left_arm-eb26-j12_15-eln.xml" />
-    <xi:include href="../../hardware/mechanicals/left_arm-eb26-j12_15-mec.xml" />   
+    <xi:include href="../../hardware/mechanicals/left_arm-eb26-j12_15-mec.xml" />
     <xi:include href="./left_arm-eb26-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3                   -->
-    <!-- joint name                             index-distal        middle-proximal     middle-distal       little-fingers      -->     
+    <!-- joint name                             index_distal        middle_proximal     middle_distal       pinky      -->
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270                 </param>
-        <param name="jntPosMin">                0                   0                   0                   0                   </param> 
+        <param name="jntPosMin">                0                   0                   0                   0                   </param>
         <param name="jntVelMax">                1000                1000                1000                1000                </param>
         <param name="motorOverloadCurrents">    2000                2000                2000                2000                </param>
         <param name="motorNominalCurrents">     600                 600                 600                 600                 </param>
@@ -31,21 +31,21 @@
     </group>
 
     <group name="CONTROLS">
-        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="torqueControl">            none                none                none                none                </param> 
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="torqueControl">            none                none                none                none                </param>
         <param name="currentPid">               none                none                none                none                </param>
-        <param name="speedPid">                 none                none                none                none                </param> 
+        <param name="speedPid">                 none                none                none                none                </param>
     </group>
 
 
     <!-- default position PID: begin -->
-    
+
     <group name="POS_PID_DEFAULT">
         <param name="controlLaw">             minjerk                   </param>
         <param name="outputType">             pwm                       </param>
-        <param name="fbkControlUnits">        metric_units              </param> 
+        <param name="fbkControlUnits">        metric_units              </param>
         <param name="outputControlUnits">     machine_units             </param>
         <param name="kp">                  -500.0       500.0       500.0      -200.0       </param>
         <param name="kd">                   0.0         0.0         0.0         0.0         </param>
@@ -60,13 +60,13 @@
     <!-- default position PID: end -->
 
 
-    <!-- other default PIDs: begin -->   
+    <!-- other default PIDs: begin -->
     <!-- other default PIDs: end -->
 
 
-    <!-- custom PIDs: begin -->    
+    <!-- custom PIDs: begin -->
     <!-- custom PIDs: end -->
-    
-</device> 
-    
+
+</device>
+
 

--- a/iCubValparaiso01/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
+++ b/iCubValparaiso01/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
@@ -6,14 +6,14 @@
 
     <xi:include href="../../general.xml" />
     <xi:include href="../../hardware/electronics/right_arm-eb29-j12_15-eln.xml" />
-    <xi:include href="../../hardware/mechanicals/right_arm-eb29-j12_15-mec.xml" />   
+    <xi:include href="../../hardware/mechanicals/right_arm-eb29-j12_15-mec.xml" />
     <xi:include href="./right_arm-eb29-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3               -->
-    <!-- joint name                             index-distal        middle-proximal     middle-distal       little-fingers  -->     
+    <!-- joint name                             index_distal        middle_proximal     middle_distal       pinky  -->
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270             </param>
-        <param name="jntPosMin">                0                   0                   0                   0               </param> 
+        <param name="jntPosMin">                0                   0                   0                   0               </param>
         <param name="jntVelMax">                1000                1000                1000                1000            </param>
         <param name="motorOverloadCurrents">    2000                2000                2000                2000            </param>
         <param name="motorNominalCurrents">     600                 600                 600                 600             </param>
@@ -31,18 +31,18 @@
     </group>
 
     <group name="CONTROLS">
-        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="torqueControl">            none                none                none                none                </param> 
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="torqueControl">            none                none                none                none                </param>
         <param name="currentPid">               none                none                none                none                </param>
-        <param name="speedPid">                 none                none                none                none                </param> 
+        <param name="speedPid">                 none                none                none                none                </param>
     </group>
 
     <group name="POS_PID_DEFAULT">
         <param name="controlLaw">             minjerk                   </param>
         <param name="outputType">             pwm                       </param>
-        <param name="fbkControlUnits">        metric_units              </param> 
+        <param name="fbkControlUnits">        metric_units              </param>
         <param name="outputControlUnits">     machine_units             </param>
         <param name="kp">                500.0       500.0      -500.0       200.0       </param>
         <param name="kd">                0.0         0.0         0.0         0.0         </param>
@@ -55,9 +55,9 @@
     </group>
 
     <!-- begin of reserved section. this section is reserved for custom PIDs -->
-    
+
     <!-- end of reserved section. this section is reserved for custom PIDs -->
-    
-</device> 
-    
+
+</device>
+
 

--- a/iCubWaterloo01/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
+++ b/iCubWaterloo01/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
@@ -6,14 +6,14 @@
 
     <xi:include href="../../general.xml" />
     <xi:include href="../../hardware/electronics/left_arm-eb26-j12_15-eln.xml" />
-    <xi:include href="../../hardware/mechanicals/left_arm-eb26-j12_15-mec.xml" />   
+    <xi:include href="../../hardware/mechanicals/left_arm-eb26-j12_15-mec.xml" />
     <xi:include href="./left_arm-eb26-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3                   -->
-    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers      -->     
+    <!-- joint name                             index_distal        middle_proximal     middle_distal       pinky      -->
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270                 </param>
-        <param name="jntPosMin">                0                   0                   0                   0                   </param> 
+        <param name="jntPosMin">                0                   0                   0                   0                   </param>
         <param name="jntVelMax">                1000                1000                1000                1000                </param>
         <param name="motorOverloadCurrents">    2000                2000                2000                2000                </param>
         <param name="motorNominalCurrents">     600                 600                 600                 600                 </param>
@@ -31,21 +31,21 @@
     </group>
 
     <group name="CONTROLS">
-        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="torqueControl">            none                none                none                none                </param> 
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="torqueControl">            none                none                none                none                </param>
         <param name="currentPid">               none                none                none                none                </param>
-        <param name="speedPid">                 none                none                none                none                </param> 
+        <param name="speedPid">                 none                none                none                none                </param>
     </group>
 
 
     <!-- default position PID: begin -->
-    
+
     <group name="POS_PID_DEFAULT">
         <param name="controlLaw">             minjerk                   </param>
         <param name="outputType">             pwm                       </param>
-        <param name="fbkControlUnits">        metric_units              </param> 
+        <param name="fbkControlUnits">        metric_units              </param>
         <param name="outputControlUnits">     machine_units             </param>
         <param name="kp">                  -500.0       500.0       500.0      -200.0       </param>
         <param name="kd">                   0.0         0.0         0.0         0.0         </param>
@@ -60,13 +60,13 @@
     <!-- default position PID: end -->
 
 
-    <!-- other default PIDs: begin -->   
+    <!-- other default PIDs: begin -->
     <!-- other default PIDs: end -->
 
 
-    <!-- custom PIDs: begin -->    
+    <!-- custom PIDs: begin -->
     <!-- custom PIDs: end -->
-    
-</device> 
-    
+
+</device>
+
 

--- a/iCubWaterloo01/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
+++ b/iCubWaterloo01/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
@@ -6,14 +6,14 @@
 
     <xi:include href="../../general.xml" />
     <xi:include href="../../hardware/electronics/right_arm-eb29-j12_15-eln.xml" />
-    <xi:include href="../../hardware/mechanicals/right_arm-eb29-j12_15-mec.xml" />   
+    <xi:include href="../../hardware/mechanicals/right_arm-eb29-j12_15-mec.xml" />
     <xi:include href="./right_arm-eb29-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3               -->
-    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers  -->     
+    <!-- joint name                             index_distal        middle_proximal     middle_distal       pinky  -->
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270             </param>
-        <param name="jntPosMin">                0                   0                   0                   0               </param> 
+        <param name="jntPosMin">                0                   0                   0                   0               </param>
         <param name="jntVelMax">                1000                1000                1000                1000            </param>
         <param name="motorOverloadCurrents">    2000                2000                2000                2000            </param>
         <param name="motorNominalCurrents">     600                 600                 600                 600             </param>
@@ -31,18 +31,18 @@
     </group>
 
     <group name="CONTROLS">
-        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="torqueControl">            none                none                none                none                </param> 
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="torqueControl">            none                none                none                none                </param>
         <param name="currentPid">               none                none                none                none                </param>
-        <param name="speedPid">                 none                none                none                none                </param> 
+        <param name="speedPid">                 none                none                none                none                </param>
     </group>
 
     <group name="POS_PID_DEFAULT">
         <param name="controlLaw">             minjerk                   </param>
         <param name="outputType">             pwm                       </param>
-        <param name="fbkControlUnits">        metric_units              </param> 
+        <param name="fbkControlUnits">        metric_units              </param>
         <param name="outputControlUnits">     machine_units             </param>
         <param name="kp">                500.0       500.0      -500.0       200.0       </param>
         <param name="kd">                0.0         0.0         0.0         0.0         </param>
@@ -55,9 +55,9 @@
     </group>
 
     <!-- begin of reserved section. this section is reserved for custom PIDs -->
-    
+
     <!-- end of reserved section. this section is reserved for custom PIDs -->
-    
-</device> 
-    
+
+</device>
+
 

--- a/iCubZagreb01/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
+++ b/iCubZagreb01/hardware/motorControl/left_arm-eb26-j12_15-mc.xml
@@ -6,14 +6,14 @@
 
     <xi:include href="../../general.xml" />
     <xi:include href="../../hardware/electronics/left_arm-eb26-j12_15-eln.xml" />
-    <xi:include href="../../hardware/mechanicals/left_arm-eb26-j12_15-mec.xml" />   
+    <xi:include href="../../hardware/mechanicals/left_arm-eb26-j12_15-mec.xml" />
     <xi:include href="./left_arm-eb26-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3                   -->
-    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers      -->     
+    <!-- joint name                             index_distal        middle_proximal     middle_distal       pinky      -->
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270                 </param>
-        <param name="jntPosMin">                0                   0                   0                   0                   </param> 
+        <param name="jntPosMin">                0                   0                   0                   0                   </param>
         <param name="jntVelMax">                1000                1000                1000                1000                </param>
         <param name="motorOverloadCurrents">    2000                2000                2000                2000                </param>
         <param name="motorNominalCurrents">     600                 600                 600                 600                 </param>
@@ -31,21 +31,21 @@
     </group>
 
     <group name="CONTROLS">
-        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="torqueControl">            none                none                none                none                </param> 
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="torqueControl">            none                none                none                none                </param>
         <param name="currentPid">               none                none                none                none                </param>
-        <param name="speedPid">                 none                none                none                none                </param> 
+        <param name="speedPid">                 none                none                none                none                </param>
     </group>
 
 
     <!-- default position PID: begin -->
-    
+
     <group name="POS_PID_DEFAULT">
         <param name="controlLaw">             minjerk                   </param>
         <param name="outputType">             pwm                       </param>
-        <param name="fbkControlUnits">        metric_units              </param> 
+        <param name="fbkControlUnits">        metric_units              </param>
         <param name="outputControlUnits">     machine_units             </param>
         <param name="kp">                  -500.0       500.0       500.0      -200.0       </param>
         <param name="kd">                   0.0         0.0         0.0         0.0         </param>
@@ -60,13 +60,13 @@
     <!-- default position PID: end -->
 
 
-    <!-- other default PIDs: begin -->   
+    <!-- other default PIDs: begin -->
     <!-- other default PIDs: end -->
 
 
-    <!-- custom PIDs: begin -->    
+    <!-- custom PIDs: begin -->
     <!-- custom PIDs: end -->
-    
-</device> 
-    
+
+</device>
+
 

--- a/iCubZagreb01/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
+++ b/iCubZagreb01/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
@@ -6,14 +6,14 @@
 
     <xi:include href="../../general.xml" />
     <xi:include href="../../hardware/electronics/right_arm-eb29-j12_15-eln.xml" />
-    <xi:include href="../../hardware/mechanicals/right_arm-eb29-j12_15-mec.xml" />   
+    <xi:include href="../../hardware/mechanicals/right_arm-eb29-j12_15-mec.xml" />
     <xi:include href="./right_arm-eb29-j12_15-mc_service.xml" />
 
     <!-- joint number                           0                   1                   2                   3               -->
-    <!-- joint name                             index_distal        middle-proximal     middle-distal       little-fingers  -->     
+    <!-- joint name                             index_distal        middle_proximal     middle_distal       pinky  -->
     <group name="LIMITS">
         <param name="jntPosMax">                180                 90                  180                 270             </param>
-        <param name="jntPosMin">                0                   0                   0                   0               </param> 
+        <param name="jntPosMin">                0                   0                   0                   0               </param>
         <param name="jntVelMax">                1000                1000                1000                1000            </param>
         <param name="motorOverloadCurrents">    2000                2000                2000                2000            </param>
         <param name="motorNominalCurrents">     600                 600                 600                 600             </param>
@@ -31,18 +31,18 @@
     </group>
 
     <group name="CONTROLS">
-        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param> 
-        <param name="torqueControl">            none                none                none                none                </param> 
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="torqueControl">            none                none                none                none                </param>
         <param name="currentPid">               none                none                none                none                </param>
-        <param name="speedPid">                 none                none                none                none                </param> 
+        <param name="speedPid">                 none                none                none                none                </param>
     </group>
 
     <group name="POS_PID_DEFAULT">
         <param name="controlLaw">             minjerk                   </param>
         <param name="outputType">             pwm                       </param>
-        <param name="fbkControlUnits">        metric_units              </param> 
+        <param name="fbkControlUnits">        metric_units              </param>
         <param name="outputControlUnits">     machine_units             </param>
         <param name="kp">                500.0       500.0      -500.0       200.0       </param>
         <param name="kd">                0.0         0.0         0.0         0.0         </param>
@@ -55,9 +55,9 @@
     </group>
 
     <!-- begin of reserved section. this section is reserved for custom PIDs -->
-    
+
     <!-- end of reserved section. this section is reserved for custom PIDs -->
-    
-</device> 
-    
+
+</device>
+
 


### PR DESCRIPTION
The names have been fixed according to https://icub-tech-iit.github.io/documentation/icub_kinematics/icub-joints/icub-joints/#left-arm


These are the names also used in the urdf.

It is important that the template used for new robot is rebased also over these changes

cc @pattacini @AntonioConsilvio @xEnVrE 