### PR TITLE
Add framename for the FT sensors

### DIFF
--- a/R1SN000/hardware/FT/cer_left_upper_arm-ems17-strain.xml
+++ b/R1SN000/hardware/FT/cer_left_upper_arm-ems17-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_upper_arm_strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../electronics/cer_left_upper_arm-ems17-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_arm_strain   </param>
+                    <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_arm_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/R1SN000/hardware/FT/cer_right_upper_arm-ems19-strain.xml
+++ b/R1SN000/hardware/FT/cer_right_upper_arm-ems19-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_upper_arm_strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../electronics/cer_right_upper_arm-ems19-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_arm_strain   </param>
+                    <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_arm_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/R1SN001/hardware/FT/cer_left_shoulder-ems5-strain.xml
+++ b/R1SN001/hardware/FT/cer_left_shoulder-ems5-strain.xml
@@ -4,49 +4,50 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_left_arm-eb5-strain" type="embObjStrain">
-    
+
       <xi:include href="../../general.xml" />
       <xi:include href="../electronics/cer_left_shoulder-ems5-eln.xml" />
 
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_arm_strain   </param>
+                    <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_arm_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
 </device>
 
 

--- a/R1SN001/hardware/FT/cer_right_shoulder-ems4-strain.xml
+++ b/R1SN001/hardware/FT/cer_right_shoulder-ems4-strain.xml
@@ -4,49 +4,50 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_right_arm-eb4-strain" type="embObjStrain">
-    
+
       <xi:include href="../../general.xml" />
       <xi:include href="../electronics/cer_right_shoulder-ems4-eln.xml" />
 
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_arm_strain   </param>
+                    <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_arm_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
 </device>
 
 

--- a/R1SN002/hardware/FT/cer_left_shoulder-ems5-strain.xml
+++ b/R1SN002/hardware/FT/cer_left_shoulder-ems5-strain.xml
@@ -4,49 +4,50 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_left_arm-eb5-strain" type="embObjStrain">
-    
+
       <xi:include href="../../general.xml" />
       <xi:include href="../electronics/cer_left_shoulder-ems5-eln.xml" />
 
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_arm_strain   </param>
+                    <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_arm_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
 </device>
 
 

--- a/R1SN002/hardware/FT/cer_right_shoulder-ems4-strain.xml
+++ b/R1SN002/hardware/FT/cer_right_shoulder-ems4-strain.xml
@@ -4,49 +4,50 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_right_arm-eb4-strain" type="embObjStrain">
-    
+
       <xi:include href="../../general.xml" />
       <xi:include href="../electronics/cer_right_shoulder-ems4-eln.xml" />
 
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_arm_strain   </param>
+                    <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_arm_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
 </device>
 
 

--- a/R1SN003/hardware/FT/cer_left_shoulder-ems5-strain.xml
+++ b/R1SN003/hardware/FT/cer_left_shoulder-ems5-strain.xml
@@ -4,49 +4,50 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_left_arm-eb5-strain" type="embObjStrain">
-    
+
       <xi:include href="../../general.xml" />
       <xi:include href="../electronics/cer_left_shoulder-ems5-eln.xml" />
 
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_arm_strain   </param>
+                    <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_arm_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
 </device>
 
 

--- a/R1SN003/hardware/FT/cer_right_shoulder-ems4-strain.xml
+++ b/R1SN003/hardware/FT/cer_right_shoulder-ems4-strain.xml
@@ -4,49 +4,50 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_right_arm-eb4-strain" type="embObjStrain">
-    
+
       <xi:include href="../../general.xml" />
       <xi:include href="../electronics/cer_right_shoulder-ems4-eln.xml" />
 
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_arm_strain   </param>
+                    <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_arm_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
 </device>
 
 

--- a/experimentalSetups/iCubGenova02-VelCtrl/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/experimentalSetups/iCubGenova02-VelCtrl/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-eb1-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_arm-eb1-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_arm_strain   </param>
+                    <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_arm_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/experimentalSetups/iCubGenova02-VelCtrl/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/experimentalSetups/iCubGenova02-VelCtrl/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb6-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb6-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_leg_strain   </param>
+                    <param name="framename">            l_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_leg_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/experimentalSetups/iCubGenova02-VelCtrl/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/experimentalSetups/iCubGenova02-VelCtrl/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb7-j4_5-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb7-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_lower_leg_strain   </param>
+                    <param name="framename">            l_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_l_lower_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/experimentalSetups/iCubGenova02-VelCtrl/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/experimentalSetups/iCubGenova02-VelCtrl/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-eb3-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_arm-eb3-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_arm_strain   </param>
+                    <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_arm_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/experimentalSetups/iCubGenova02-VelCtrl/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/experimentalSetups/iCubGenova02-VelCtrl/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb8-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb8-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_leg_strain   </param>
+                    <param name="framename">            r_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/experimentalSetups/iCubGenova02-VelCtrl/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/experimentalSetups/iCubGenova02-VelCtrl/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb9-j4_5-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb9-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_lower_leg_strain   </param>
+                    <param name="framename">            r_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                  </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_lower_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/experimentalSetups/iCubGenovaV3-VelCtrl/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/experimentalSetups/iCubGenovaV3-VelCtrl/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-eb1-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_arm-eb1-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_arm_strain   </param>
+                    <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_arm_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/experimentalSetups/iCubGenovaV3-VelCtrl/hardware/FT/left_leg-eb6-j0_1-strain.xml
+++ b/experimentalSetups/iCubGenovaV3-VelCtrl/hardware/FT/left_leg-eb6-j0_1-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb6-j0_1-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb6-j0_1-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_leg_strain   </param>
+                    <param name="framename">            l_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_leg_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/experimentalSetups/iCubGenovaV3-VelCtrl/hardware/FT/left_leg-eb8-j4_5-strain.xml
+++ b/experimentalSetups/iCubGenovaV3-VelCtrl/hardware/FT/left_leg-eb8-j4_5-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb8-j4_5-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb8-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_lower_leg_strain   </param>
+                    <param name="framename">            l_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_l_lower_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/experimentalSetups/iCubGenovaV3-VelCtrl/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/experimentalSetups/iCubGenovaV3-VelCtrl/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-eb3-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_arm-eb3-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_arm_strain   </param>
+                    <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_arm_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/experimentalSetups/iCubGenovaV3-VelCtrl/hardware/FT/right_leg-eb10-j0_1-strain.xml
+++ b/experimentalSetups/iCubGenovaV3-VelCtrl/hardware/FT/right_leg-eb10-j0_1-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb10-j0_1-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb10-j0_1-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_leg_strain   </param>
+                    <param name="framename">            r_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/experimentalSetups/iCubGenovaV3-VelCtrl/hardware/FT/right_leg-eb12-j4_5-strain.xml
+++ b/experimentalSetups/iCubGenovaV3-VelCtrl/hardware/FT/right_leg-eb12-j4_5-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb12-j4_5-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb12-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_lower_leg_strain   </param>
+                    <param name="framename">            r_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_lower_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/experimentalSetups/iCubGenovaV3/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/experimentalSetups/iCubGenovaV3/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-eb1-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_arm-eb1-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_arm_strain   </param>
+                    <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_arm_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/experimentalSetups/iCubGenovaV3/hardware/FT/left_leg-eb6-j0_1-strain.xml
+++ b/experimentalSetups/iCubGenovaV3/hardware/FT/left_leg-eb6-j0_1-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb6-j0_1-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb6-j0_1-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_leg_strain   </param>
+                    <param name="framename">            l_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_leg_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/experimentalSetups/iCubGenovaV3/hardware/FT/left_leg-eb8-j4_5-strain.xml
+++ b/experimentalSetups/iCubGenovaV3/hardware/FT/left_leg-eb8-j4_5-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb8-j4_5-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb8-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_lower_leg_strain   </param>
+                    <param name="framename">            l_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_l_lower_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/experimentalSetups/iCubGenovaV3/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/experimentalSetups/iCubGenovaV3/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-eb3-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_arm-eb3-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_arm_strain   </param>
+                    <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_arm_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/experimentalSetups/iCubGenovaV3/hardware/FT/right_leg-eb10-j0_1-strain.xml
+++ b/experimentalSetups/iCubGenovaV3/hardware/FT/right_leg-eb10-j0_1-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb10-j0_1-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb10-j0_1-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_leg_strain   </param>
+                    <param name="framename">            r_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/experimentalSetups/iCubGenovaV3/hardware/FT/right_leg-eb12-j4_5-strain.xml
+++ b/experimentalSetups/iCubGenovaV3/hardware/FT/right_leg-eb12-j4_5-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb12-j4_5-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb12-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_lower_leg_strain   </param>
+                    <param name="framename">            r_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_lower_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/experimentalSetups/singleETHboard/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/experimentalSetups/singleETHboard/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-eb1-j0_3-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_arm-eb1-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2                 </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                   </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_arm_strain   </param>
+                    <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:2                  </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_arm_strain   </param>    
-                <param name="temperature-acquisitionRate"> 1000 </param> <!-- 1 seconds -->            
+                <param name="enabledSensors">           id_l_upper_arm_strain   </param>
+                <param name="temperature-acquisitionRate"> 1000 </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubChemnitz01/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/iCubChemnitz01/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-eb3-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_arm-eb3-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_arm_strain   </param>
+                    <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_arm_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubDarmstadt01/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/iCubDarmstadt01/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-eb1-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_arm-eb1-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_arm_strain   </param>
+                    <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_arm_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubDarmstadt01/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/iCubDarmstadt01/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb6-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb6-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_leg_strain   </param>
+                    <param name="framename">            l_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_leg_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubDarmstadt01/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/iCubDarmstadt01/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb7-j4_5-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb7-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_lower_leg_strain   </param>
+                    <param name="framename">            l_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:1                  </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_l_lower_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubDarmstadt01/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/iCubDarmstadt01/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-eb3-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_arm-eb3-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_arm_strain   </param>
+                    <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_arm_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubDarmstadt01/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/iCubDarmstadt01/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb8-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb8-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_leg_strain   </param>
+                    <param name="framename">            r_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubDarmstadt01/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/iCubDarmstadt01/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb9-j4_5-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb9-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_lower_leg_strain   </param>
+                    <param name="framename">            r_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:1                  </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_lower_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubEdinburgh01/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/iCubEdinburgh01/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-eb1-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_arm-eb1-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_arm_strain   </param>
+                    <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_arm_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubEdinburgh01/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/iCubEdinburgh01/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb6-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb6-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            4                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_leg_strain   </param>
+                    <param name="framename">            l_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_leg_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubEdinburgh01/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/iCubEdinburgh01/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb7-j4_5-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb7-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            4                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_lower_leg_strain   </param>
+                    <param name="framename">            l_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:1                  </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_l_lower_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubEdinburgh01/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/iCubEdinburgh01/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-eb3-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_arm-eb3-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_arm_strain   </param>
+                    <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_arm_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubEdinburgh01/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/iCubEdinburgh01/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb8-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb8-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            4                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_leg_strain   </param>
+                    <param name="framename">            r_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubEdinburgh01/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/iCubEdinburgh01/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb9-j4_5-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb9-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            4                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_lower_leg_strain   </param>
+                    <param name="framename">            r_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:1                  </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_lower_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubErzelli01/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/iCubErzelli01/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-eb1-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_arm-eb1-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_arm_strain   </param>
+                    <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_arm_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubErzelli01/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/iCubErzelli01/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb6-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb6-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_leg_strain   </param>
+                    <param name="framename">            l_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_leg_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubErzelli01/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/iCubErzelli01/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb7-j4_5-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb7-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_lower_leg_strain   </param>
+                    <param name="framename">            l_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_l_lower_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubErzelli01/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/iCubErzelli01/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-eb3-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_arm-eb3-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_arm_strain   </param>
+                    <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_arm_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubErzelli01/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/iCubErzelli01/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb8-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb8-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_leg_strain   </param>
+                    <param name="framename">            r_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubErzelli01/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/iCubErzelli01/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb9-j4_5-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb9-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_lower_leg_strain   </param>
+                    <param name="framename">            r_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_lower_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubErzelli02/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/iCubErzelli02/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-eb1-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_arm-eb1-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_arm_strain   </param>
+                    <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
                 <param name="enabledSensors">           id_l_upper_arm_strain   </param>
-                <param name="temperature-acquisitionRate"> 1000                 </param>                
+                <param name="temperature-acquisitionRate"> 1000                 </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubErzelli02/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/iCubErzelli02/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb6-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb6-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_leg_strain   </param>
+                    <param name="framename">            l_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_leg_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubErzelli02/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/iCubErzelli02/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb7-j4_5-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb7-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_lower_leg_strain   </param>
+                    <param name="framename">            l_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_l_lower_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubErzelli02/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/iCubErzelli02/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-eb3-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_arm-eb3-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_arm_strain   </param>
+                    <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_arm_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubErzelli02/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/iCubErzelli02/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb8-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb8-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_leg_strain   </param>
+                    <param name="framename">            r_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubErzelli02/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/iCubErzelli02/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb9-j4_5-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb9-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_lower_leg_strain   </param>
+                    <param name="framename">            r_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_lower_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubGenova02/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/iCubGenova02/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-eb1-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_arm-eb1-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_arm_strain   </param>
+                    <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_arm_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubGenova02/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/iCubGenova02/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb6-j0_3-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb6-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2                 </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                   </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_leg_strain   </param>
+                    <param name="framename">            l_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_leg_strain   </param>  
-                <param name="temperature-acquisitionRate"> 1000 </param>//1 seconds               
+                <param name="enabledSensors">           id_l_upper_leg_strain   </param>
+                <param name="temperature-acquisitionRate"> 1000 </param>//1 seconds
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubGenova02/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/iCubGenova02/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb7-j4_5-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb7-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2                 </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                   </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_lower_leg_strain   </param>
+                    <param name="framename">            l_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_lower_leg_strain   </param>              
-                <param name="temperature-acquisitionRate"> 1000 </param>//1 seconds   
+                <param name="enabledSensors">           id_l_lower_leg_strain   </param>
+                <param name="temperature-acquisitionRate"> 1000 </param>//1 seconds
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubGenova02/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/iCubGenova02/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-eb3-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_arm-eb3-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_arm_strain   </param>
+                    <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_arm_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubGenova02/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/iCubGenova02/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb8-j0_3-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb8-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2                 </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                   </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_leg_strain   </param>
+                    <param name="framename">            r_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_leg_strain   </param>    
-                <param name="temperature-acquisitionRate"> 1000 </param>//1 seconds            
+                <param name="enabledSensors">           id_r_upper_leg_strain   </param>
+                <param name="temperature-acquisitionRate"> 1000 </param>//1 seconds
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubGenova02/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/iCubGenova02/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb9-j4_5-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb9-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2                 </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                   </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_lower_leg_strain   </param>
+                    <param name="framename">            r_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                  </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_lower_leg_strain   </param>
                 <param name="temperature-acquisitionRate"> 1000 </param>//1 seconds
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubGenova04/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/iCubGenova04/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-eb1-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_arm-eb1-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_arm_strain   </param>
+                    <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_arm_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubGenova04/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/iCubGenova04/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb6-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb6-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2                 </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                   </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_leg_strain   </param>
+                    <param name="framename">            l_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_leg_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubGenova04/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/iCubGenova04/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb7-j4_5-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb7-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2                 </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                   </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_lower_leg_strain   </param>
+                    <param name="framename">            l_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_l_lower_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubGenova04/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/iCubGenova04/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-eb3-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_arm-eb3-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_arm_strain   </param>
+                    <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_arm_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubGenova04/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/iCubGenova04/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb8-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb8-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2                </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                   </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_leg_strain   </param>
+                    <param name="framename">            r_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubGenova04/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/iCubGenova04/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb9-j4_5-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb9-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2                 </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                   </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_lower_leg_strain   </param>
+                    <param name="framename">            r_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_lower_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubGenova07/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/iCubGenova07/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-eb1-j0_3-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_arm-eb1-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            4                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_arm_strain   </param>
+                    <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_arm_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubGenova07/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/iCubGenova07/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb6-j0_3-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb6-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            4                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_leg_strain   </param>
+                    <param name="framename">            l_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_leg_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_leg_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubGenova07/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/iCubGenova07/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb7-j4_5-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb7-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            4                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_lower_leg_strain   </param>
+                    <param name="framename">            l_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_l_lower_leg_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubGenova07/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/iCubGenova07/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-eb3-j0_3-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_arm-eb3-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            4                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_arm_strain   </param>
+                    <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_arm_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubGenova07/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/iCubGenova07/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb8-j0_3-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb8-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            4                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_leg_strain   </param>
+                    <param name="framename">            r_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_leg_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubGenova07/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/iCubGenova07/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb9-j4_5-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb9-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            4                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_lower_leg_strain   </param>
+                    <param name="framename">            r_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_lower_leg_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubGenova08/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/iCubGenova08/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-eb1-j0_3-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_arm-eb1-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_arm_strain   </param>
+                    <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_arm_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubGenova08/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/iCubGenova08/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb6-j0_3-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb6-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_leg_strain   </param>
+                    <param name="framename">            l_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_leg_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_leg_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubGenova08/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/iCubGenova08/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb7-j4_5-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb7-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_lower_leg_strain   </param>
+                    <param name="framename">            l_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_l_lower_leg_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubGenova08/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/iCubGenova08/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-eb3-j0_3-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_arm-eb3-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_arm_strain   </param>
+                    <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_arm_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubGenova08/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/iCubGenova08/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb8-j0_3-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb8-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_leg_strain   </param>
+                    <param name="framename">            r_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_leg_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubGenova08/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/iCubGenova08/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb9-j4_5-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb9-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_lower_leg_strain   </param>
+                    <param name="framename">            r_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_lower_leg_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubGenova10/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/iCubGenova10/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-eb1-j0_3-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_arm-eb1-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_arm_strain   </param>
+                    <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_arm_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubGenova10/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/iCubGenova10/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb6-j0_3-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb6-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_leg_strain   </param>
+                    <param name="framename">            l_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_leg_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_leg_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubGenova10/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/iCubGenova10/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb7-j4_5-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb7-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_lower_leg_strain   </param>
+                    <param name="framename">            l_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_l_lower_leg_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubGenova10/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/iCubGenova10/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-eb3-j0_3-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_arm-eb3-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_arm_strain   </param>
+                    <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_arm_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubGenova10/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/iCubGenova10/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb8-j0_3-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb8-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_leg_strain   </param>
+                    <param name="framename">            r_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_leg_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubGenova10/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/iCubGenova10/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb9-j4_5-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb9-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_lower_leg_strain   </param>
+                    <param name="framename">            r_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_lower_leg_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubGenova11/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/iCubGenova11/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-eb1-j0_3-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_arm-eb1-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_arm_strain   </param>
+                    <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_arm_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubGenova11/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/iCubGenova11/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb6-j0_3-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb6-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_leg_strain   </param>
+                    <param name="framename">            l_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_leg_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_leg_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubGenova11/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/iCubGenova11/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb7-j4_5-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb7-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_lower_leg_strain   </param>
+                    <param name="framename">            l_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_l_lower_leg_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubGenova11/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/iCubGenova11/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-eb3-j0_3-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_arm-eb3-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_arm_strain   </param>
+                    <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_arm_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubGenova11/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/iCubGenova11/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb8-j0_3-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb8-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_leg_strain   </param>
+                    <param name="framename">            r_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_leg_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubGenova11/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/iCubGenova11/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb9-j4_5-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb9-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_lower_leg_strain   </param>
+                    <param name="framename">            r_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_lower_leg_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubHeidelberg01/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/iCubHeidelberg01/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb6-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb6-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            4                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_leg_strain   </param>
+                    <param name="framename">            l_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_leg_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubHeidelberg01/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/iCubHeidelberg01/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb7-j4_5-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb7-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            4                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_lower_leg_strain   </param>
+                    <param name="framename">            l_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:1                  </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_l_lower_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubHeidelberg01/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/iCubHeidelberg01/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb8-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb8-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            4                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_leg_strain   </param>
+                    <param name="framename">            r_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubHeidelberg01/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/iCubHeidelberg01/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb9-j4_5-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb9-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            4                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_lower_leg_strain   </param>
+                    <param name="framename">            r_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:1                  </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_lower_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubHongKong01/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/iCubHongKong01/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-eb1-j0_3-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_arm-eb1-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                   </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_arm_strain   </param>
+                    <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_arm_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubHongKong01/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/iCubHongKong01/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb6-j0_3-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb6-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                   </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_leg_strain   </param>
+                    <param name="framename">            l_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_leg_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_leg_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubHongKong01/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/iCubHongKong01/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb7-j4_5-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb7-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                   </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_lower_leg_strain   </param>
+                    <param name="framename">            l_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_l_lower_leg_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubHongKong01/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/iCubHongKong01/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-eb3-j0_3-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_arm-eb3-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                   </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_arm_strain   </param>
+                    <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_arm_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubHongKong01/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/iCubHongKong01/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb8-j0_3-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb8-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                   </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_leg_strain   </param>
+                    <param name="framename">            r_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_leg_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubHongKong01/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/iCubHongKong01/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb9-j4_5-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb9-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                   </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_lower_leg_strain   </param>
+                    <param name="framename">            r_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_lower_leg_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubLausanne02/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/iCubLausanne02/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-eb1-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_arm-eb1-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_arm_strain   </param>
+                    <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_arm_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubLausanne02/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/iCubLausanne02/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb6-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb6-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            4                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_leg_strain   </param>
+                    <param name="framename">            l_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_leg_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubLausanne02/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/iCubLausanne02/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb7-j4_5-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb7-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            4                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_lower_leg_strain   </param>
+                    <param name="framename">            l_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:1                  </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_l_lower_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubLausanne02/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/iCubLausanne02/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-eb3-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_arm-eb3-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_arm_strain   </param>
+                    <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_arm_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubLausanne02/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/iCubLausanne02/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb8-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb8-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            4                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_leg_strain   </param>
+                    <param name="framename">            r_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubLausanne02/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/iCubLausanne02/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb9-j4_5-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb9-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            4                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_lower_leg_strain   </param>
+                    <param name="framename">            r_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:1                  </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_lower_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubLisboa01/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/iCubLisboa01/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-eb1-j0_3-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_arm-eb1-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_arm_strain   </param>
+                    <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_arm_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubLisboa01/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/iCubLisboa01/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb6-j0_3-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb6-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_leg_strain   </param>
+                    <param name="framename">            l_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_leg_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_leg_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubLisboa01/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/iCubLisboa01/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb7-j4_5-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb7-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_lower_leg_strain   </param>
+                    <param name="framename">            l_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_l_lower_leg_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubLisboa01/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/iCubLisboa01/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-eb3-j0_3-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_arm-eb3-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_arm_strain   </param>
+                    <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_arm_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubLisboa01/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/iCubLisboa01/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb8-j0_3-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb8-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_leg_strain   </param>
+                    <param name="framename">            r_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_leg_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubLisboa01/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/iCubLisboa01/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb9-j4_5-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb9-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_lower_leg_strain   </param>
+                    <param name="framename">            r_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_lower_leg_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubMoscow01/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/iCubMoscow01/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-eb1-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_arm-eb1-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_arm_strain   </param>
+                    <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_arm_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubMoscow01/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/iCubMoscow01/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb6-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb6-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_leg_strain   </param>
+                    <param name="framename">            l_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_leg_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubMoscow01/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/iCubMoscow01/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb7-j4_5-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb7-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_lower_leg_strain   </param>
+                    <param name="framename">            l_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_l_lower_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubMoscow01/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/iCubMoscow01/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-eb3-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_arm-eb3-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_arm_strain   </param>
+                    <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_arm_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubMoscow01/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/iCubMoscow01/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb8-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb8-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_leg_strain   </param>
+                    <param name="framename">            r_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubMoscow01/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/iCubMoscow01/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb9-j4_5-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb9-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_lower_leg_strain   </param>
+                    <param name="framename">            r_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_lower_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubNancy01/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/iCubNancy01/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-eb1-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_arm-eb1-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_arm_strain   </param>
+                    <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_arm_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubNancy01/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/iCubNancy01/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -4,54 +4,55 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb6-j0_3-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb6-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_leg_strain   </param>
+                    <param name="framename">            l_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_leg_strain   </param>   
-                <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->             
+                <param name="enabledSensors">           id_l_upper_leg_strain   </param>
+                <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>   
-           
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubNancy01/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/iCubNancy01/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -4,55 +4,56 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb7-j4_5-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb7-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_lower_leg_strain   </param>
+                    <param name="framename">            l_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:1                  </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_lower_leg_strain   </param>    
-                <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->                         
+                <param name="enabledSensors">           id_l_lower_leg_strain   </param>
+                <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>   
-            
-           
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
+
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubNancy01/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/iCubNancy01/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-eb3-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_arm-eb3-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_arm_strain   </param>
+                    <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_arm_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubNancy01/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/iCubNancy01/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb8-j0_3-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb8-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_leg_strain   </param>
+                    <param name="framename">            r_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_leg_strain   </param>  
-                <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->                           
+                <param name="enabledSensors">           id_r_upper_leg_strain   </param>
+                <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>  
-       
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubNancy01/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/iCubNancy01/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -4,55 +4,56 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb9-j4_5-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb9-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_lower_leg_strain   </param>
+                    <param name="framename">            r_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:1                  </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_lower_leg_strain   </param>  
-                <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->                                           
+                <param name="enabledSensors">           id_r_lower_leg_strain   </param>
+                <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>     
-            
-         
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
+
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubNottingham01/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/iCubNottingham01/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-eb1-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_arm-eb1-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_arm_strain   </param>
+                    <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_arm_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubNottingham01/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/iCubNottingham01/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb6-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb6-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            4                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_leg_strain   </param>
+                    <param name="framename">            l_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_leg_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubNottingham01/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/iCubNottingham01/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb7-j4_5-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb7-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            4                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_lower_leg_strain   </param>
+                    <param name="framename">            l_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:1                  </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_l_lower_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubNottingham01/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/iCubNottingham01/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-eb3-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_arm-eb3-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_arm_strain   </param>
+                    <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_arm_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubNottingham01/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/iCubNottingham01/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb8-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb8-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            4                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_leg_strain   </param>
+                    <param name="framename">            r_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubNottingham01/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/iCubNottingham01/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb9-j4_5-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb9-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            4                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_lower_leg_strain   </param>
+                    <param name="framename">            r_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:1                  </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_lower_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubPrague01/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/iCubPrague01/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-eb1-j0_3-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_arm-eb1-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_arm_strain   </param>
+                    <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_arm_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubPrague01/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/iCubPrague01/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb6-j0_3-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb6-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_leg_strain   </param>
+                    <param name="framename">            l_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_leg_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_leg_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubPrague01/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/iCubPrague01/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb7-j4_5-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb7-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_lower_leg_strain   </param>
+                    <param name="framename">            l_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_l_lower_leg_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubPrague01/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/iCubPrague01/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-eb3-j0_3-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_arm-eb3-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_arm_strain   </param>
+                    <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_arm_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubPrague01/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/iCubPrague01/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb8-j0_3-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb8-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_leg_strain   </param>
+                    <param name="framename">            r_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_leg_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubPrague01/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/iCubPrague01/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb9-j4_5-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb9-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_lower_leg_strain   </param>
+                    <param name="framename">            r_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_lower_leg_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubShanghai01/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/iCubShanghai01/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-eb1-j0_3-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_arm-eb1-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_arm_strain   </param>
+                    <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_arm_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubShanghai01/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/iCubShanghai01/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb6-j0_3-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb6-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_leg_strain   </param>
+                    <param name="framename">            l_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_leg_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_leg_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubShanghai01/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/iCubShanghai01/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb7-j4_5-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb7-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_lower_leg_strain   </param>
+                    <param name="framename">            l_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_l_lower_leg_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubShanghai01/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/iCubShanghai01/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-eb3-j0_3-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_arm-eb3-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_arm_strain   </param>
+                    <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_arm_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubShanghai01/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/iCubShanghai01/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb8-j0_3-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb8-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_leg_strain   </param>
+                    <param name="framename">            r_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_leg_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubShanghai01/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/iCubShanghai01/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb9-j4_5-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb9-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_lower_leg_strain   </param>
+                    <param name="framename">            r_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_lower_leg_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubSheffield01/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/iCubSheffield01/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-eb1-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_arm-eb1-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_arm_strain   </param>
+                    <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_arm_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubSheffield01/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/iCubSheffield01/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-eb3-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_arm-eb3-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_arm_strain   </param>
+                    <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_arm_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubShenzhen01/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/iCubShenzhen01/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-eb1-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_arm-eb1-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_arm_strain   </param>
+                    <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_arm_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubShenzhen01/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/iCubShenzhen01/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb6-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb6-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_leg_strain   </param>
+                    <param name="framename">            l_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_leg_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubShenzhen01/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/iCubShenzhen01/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb7-j4_5-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb7-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_lower_leg_strain   </param>
+                    <param name="framename">            l_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_l_lower_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubShenzhen01/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/iCubShenzhen01/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-eb3-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_arm-eb3-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_arm_strain   </param>
+                    <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_arm_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubShenzhen01/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/iCubShenzhen01/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb8-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb8-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_leg_strain   </param>
+                    <param name="framename">            r_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubShenzhen01/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/iCubShenzhen01/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb9-j4_5-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb9-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_lower_leg_strain   </param>
+                    <param name="framename">            r_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_lower_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubSingapore01/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/iCubSingapore01/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-eb1-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_arm-eb1-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_arm_strain   </param>
+                    <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_arm_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubSingapore01/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/iCubSingapore01/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb6-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb6-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_leg_strain   </param>
+                    <param name="framename">            l_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_leg_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubSingapore01/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/iCubSingapore01/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb7-j4_5-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb7-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_lower_leg_strain   </param>
+                    <param name="framename">            l_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:1                  </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_l_lower_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubSingapore01/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/iCubSingapore01/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-eb3-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_arm-eb3-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_arm_strain   </param>
+                    <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_arm_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubSingapore01/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/iCubSingapore01/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb8-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb8-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_leg_strain   </param>
+                    <param name="framename">            r_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubSingapore01/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/iCubSingapore01/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb9-j4_5-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb9-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_lower_leg_strain   </param>
+                    <param name="framename">            r_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:1                  </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_lower_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubTwente01/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/iCubTwente01/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-eb1-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_arm-eb1-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_arm_strain   </param>
+                    <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_arm_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubTwente01/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/iCubTwente01/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb6-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb6-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_leg_strain   </param>
+                    <param name="framename">            l_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_leg_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubTwente01/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/iCubTwente01/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb7-j4_5-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb7-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_lower_leg_strain   </param>
+                    <param name="framename">            l_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:1                  </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_l_lower_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubTwente01/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/iCubTwente01/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-eb3-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_arm-eb3-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_arm_strain   </param>
+                    <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_arm_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubTwente01/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/iCubTwente01/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb8-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb8-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_leg_strain   </param>
+                    <param name="framename">            r_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubTwente01/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/iCubTwente01/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb9-j4_5-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb9-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_lower_leg_strain   </param>
+                    <param name="framename">            r_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:1                  </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_lower_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubValparaiso01/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/iCubValparaiso01/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-eb1-j0_3-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_arm-eb1-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_arm_strain   </param>
+                    <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_arm_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubValparaiso01/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/iCubValparaiso01/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb6-j0_3-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb6-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_leg_strain   </param>
+                    <param name="framename">            l_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_leg_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_leg_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubValparaiso01/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/iCubValparaiso01/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb7-j4_5-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb7-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_lower_leg_strain   </param>
+                    <param name="framename">            l_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_l_lower_leg_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubValparaiso01/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/iCubValparaiso01/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-eb3-j0_3-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_arm-eb3-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_arm_strain   </param>
+                    <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_arm_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubValparaiso01/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/iCubValparaiso01/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb8-j0_3-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb8-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_leg_strain   </param>
+                    <param name="framename">            r_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_leg_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubValparaiso01/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/iCubValparaiso01/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb9-j4_5-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb9-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_lower_leg_strain   </param>
+                    <param name="framename">            r_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_lower_leg_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubWaterloo01/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/iCubWaterloo01/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-eb1-j0_3-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_arm-eb1-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_arm_strain   </param>
+                    <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_arm_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubWaterloo01/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/iCubWaterloo01/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb6-j0_3-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb6-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_leg_strain   </param>
+                    <param name="framename">            l_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_leg_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_leg_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubWaterloo01/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/iCubWaterloo01/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb7-j4_5-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb7-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_lower_leg_strain   </param>
+                    <param name="framename">            l_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_l_lower_leg_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubWaterloo01/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/iCubWaterloo01/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-eb3-j0_3-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_arm-eb3-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_arm_strain   </param>
+                    <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_arm_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubWaterloo01/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/iCubWaterloo01/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb8-j0_3-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb8-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_leg_strain   </param>
+                    <param name="framename">            r_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_leg_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubWaterloo01/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/iCubWaterloo01/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb9-j4_5-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb9-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_lower_leg_strain   </param>
+                    <param name="framename">            r_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_lower_leg_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubZagreb01/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/iCubZagreb01/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-eb1-j0_3-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_arm-eb1-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_arm_strain   </param>
+                    <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_arm_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubZagreb01/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/iCubZagreb01/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb6-j0_3-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb6-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_leg_strain   </param>
+                    <param name="framename">            l_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_leg_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_leg_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubZagreb01/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/iCubZagreb01/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb7-j4_5-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb7-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_lower_leg_strain   </param>
+                    <param name="framename">            l_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_l_lower_leg_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubZagreb01/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/iCubZagreb01/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-eb3-j0_3-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_arm-eb3-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_arm_strain   </param>
+                    <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_arm_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubZagreb01/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/iCubZagreb01/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb8-j0_3-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb8-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_leg_strain   </param>
+                    <param name="framename">            r_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_leg_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iCubZagreb01/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/iCubZagreb01/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -4,53 +4,54 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb9-j4_5-strain" type="embObjFTsensor">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb9-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_lower_leg_strain   </param>
+                    <param name="framename">            r_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_lower_leg_strain   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iRonCub-Mk1/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/iRonCub-Mk1/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-eb1-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_arm-eb1-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_arm_strain   </param>
+                    <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_arm_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iRonCub-Mk1/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/iRonCub-Mk1/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb6-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb6-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2                 </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                   </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_upper_leg_strain   </param>
+                    <param name="framename">            l_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_upper_leg_strain   </param>                
+                <param name="enabledSensors">           id_l_upper_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iRonCub-Mk1/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/iRonCub-Mk1/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-eb7-j4_5-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/left_leg-eb7-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2                 </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                   </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_l_lower_leg_strain   </param>
+                    <param name="framename">            l_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_l_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_l_lower_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iRonCub-Mk1/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/iRonCub-Mk1/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-eb3-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_arm-eb3-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_strain            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            1                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            1                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            0                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            0                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_arm_strain   </param>
+                    <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_arm_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_arm_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iRonCub-Mk1/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/iRonCub-Mk1/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb8-j0_3-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb8-j0_3-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2                </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                   </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_upper_leg_strain   </param>
+                    <param name="framename">            r_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_upper_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_upper_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 

--- a/iRonCub-Mk1/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/iRonCub-Mk1/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -4,52 +4,53 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-eb9-j4_5-strain" type="embObjStrain">
-    
+
         <xi:include href="../../general.xml"/>
 
         <xi:include href="../../hardware/electronics/right_leg-eb9-j4_5-eln.xml" />
-    
+
         <group name="SERVICE">
-            
+
             <param name="type"> eomn_serv_AS_strain </param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 strain2                 </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            9                   </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
                     <param name="id">                   id_r_lower_leg_strain   </param>
+                    <param name="framename">            r_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
-                </group>                
-            
+                </group>
+
             </group>
 
-            <group name="SETTINGS">        
+            <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           id_r_lower_leg_strain   </param>                
+                <param name="enabledSensors">           id_r_lower_leg_strain   </param>
             </group>
-            
-            <group name="STRAIN_SETTINGS">        
-                <param name="useCalibration">           true                    </param>          
-            </group>            
-            
+
+            <group name="STRAIN_SETTINGS">
+                <param name="useCalibration">           true                    </param>
+            </group>
+
         </group>
-    
+
   </device>
-  
+
 
 
 


### PR DESCRIPTION
It is possible to specify the `framename` since https://github.com/robotology/icub-main/pull/822 but the XML files were never updated.

The names chosen are the same used in the urdfs (cc @traversaro).

I tested it on `iCubGenova11` visualizing the ft data in `rviz2`.