### PR TITLE
ergoCub: lower pitch and roll head PID gains to avoid overshoot

### DIFF
--- a/ergoCubSN000/hardware/motorControl/head-eb20-j0_1-mc.xml
+++ b/ergoCubSN000/hardware/motorControl/head-eb20-j0_1-mc.xml
@@ -47,9 +47,9 @@
         <param name="outputType">               pwm             </param>
         <param name="fbkControlUnits">          metric_units    </param>
         <param name="outputControlUnits">       machine_units   </param>
-        <param name="kp">                       -537        +571        </param>
-        <param name="kd">                       -17         +14         </param>
-        <param name="ki">                       -2822       +2923       </param>
+        <param name="kp">                       -512        +535        </param>
+        <param name="kd">                       -15         +14         </param>
+        <param name="ki">                       -1621       +1670       </param>
         <param name="maxOutput">                3360        3360        </param>
         <param name="maxInt">                   3360        3360        </param>
         <param name="stictionUp">               0           0           </param>


### PR DESCRIPTION
This PR changes the gains of the pitch and roll position PIDs of the ergoCub head. The gains were found by the automated robust procedure, with the following requirements:

```
sampling_time = 1e-3;         % sec
responsetime = 0.4; 			% sec
dcerror = 0.1;      				% perc
peakerror = 1.05;    			% fract relative
peak_disturbance = 0.1;      % abs deg
tSettle_disturbance = 0.2;   % sec
maxOvershoot = 5;  			% perc
```

which, compared to before, is a reduction in overshoot from 10% to 5% and a peak error from 1.1 to 1.05.

It results in the following plot:

![head](https://user-images.githubusercontent.com/38140169/215710014-6c05793e-4012-4f36-8b4c-a362462c0186.png)

And the related video: 

https://user-images.githubusercontent.com/38140169/215569439-92ca6b3e-0ead-4b54-9c16-29909db879de.mp4