### PR TITLE
ergocubSN000: rename and remap fingers joints

### DIFF
--- a/ergoCubSN000/hardware/mechanicals/left_arm-eb23-j7_10-mec.xml
+++ b/ergoCubSN000/hardware/mechanicals/left_arm-eb23-j7_10-mec.xml
@@ -4,12 +4,12 @@
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="ergoCubSN000" build="1">
     <group name="GENERAL">
         <param name="MotioncontrolVersion"> 6 </param>
-        <param name="Joints"> 4 </param> 
-        
+        <param name="Joints"> 4 </param>
+
         <!-- joint number in sub-part       0                       1                       2                           3                       -->
-        <!-- joint name                                                                                                                         -->         
+        <!-- joint name                                                                                                                         -->
         <param name="AxisMap">              0                       1                       2                           3                       </param>
-        <param name="AxisName">             "l_hand_thumb_proximal" "l_hand_index_proximal" "l_hand_medium_proximal"    "l_hand_pinky_proximal" </param>
+        <param name="AxisName">             "l_thumb_oc" "l_index_oc" "l_medium_oc"    "l_ring_pinky_oc" </param>
         <param name="AxisType">             "revolute"              "revolute"              "revolute"                  "revolute"              </param>
         <param name="Encoder">              182.044                 182.044                 182.044                     182.044                 </param>
         <param name="fullscalePWM">         3360                    3360                    3360                        3360                    </param>
@@ -18,7 +18,7 @@
         <param name="Gearbox_E2J">          1                       1                       1                           1                       </param>
         <param name="useMotorSpeedFbk">     0                       0                       0                           0                       </param>
         <param name="MotorType">            "DC"                    "DC"                    "DC"                        "DC"                    </param>
-                
+
         <param name="Verbose"> 0 </param>
     </group>
 
@@ -28,40 +28,40 @@
         <param name="rotorPosMin">          0               0               0               0          </param>
         <param name="rotorPosMax">          0               0               0               0          </param>
     </group>
-    
-    <group name="COUPLINGS"> 
 
-        <param name ="matrixJ2M"> 
+    <group name="COUPLINGS">
+
+        <param name ="matrixJ2M">
             1.000   0.000   0.000   0.000
             0.000   1.000   0.000   0.000
             0.000   0.000   1.000   0.000
-            0.000   0.000   0.000   1.000   
+            0.000   0.000   0.000   1.000
         </param>
-               
-        <param name ="matrixM2J"> 
+
+        <param name ="matrixM2J">
             1.000   0.000   0.000   0.000
             0.000   1.000   0.000   0.000
             0.000   0.000   1.000   0.000
-            0.000   0.000   0.000   1.000   
+            0.000   0.000   0.000   1.000
         </param>
-       
-        <param name ="matrixE2J">  
+
+        <param name ="matrixE2J">
             1.000   0.000   0.000   0.000   0.000   0.000
             0.000   1.000   0.000   0.000   0.000   0.000
             0.000   0.000   1.000   0.000   0.000   0.000
-            0.000   0.000   0.000   1.000   0.000   0.000 
+            0.000   0.000   0.000   1.000   0.000   0.000
         </param>
-                
-    </group>   
 
-    <group name="JOINTSET_CFG"> 
+    </group>
+
+    <group name="JOINTSET_CFG">
         <param name= "numberofsets"> 4 </param>
         <group name="JOINTSET_0">
             <param name="listofjoints">  0             </param>
             <param name="constraint">    none          </param>
             <param name="param1">        0             </param>
             <param name="param2">        0             </param>
-        </group> 
+        </group>
         <group name="JOINTSET_1">
             <param name="listofjoints">  1             </param>
             <param name="constraint">    none          </param>
@@ -79,7 +79,7 @@
             <param name="constraint">    none          </param>
             <param name="param1">        0             </param>
             <param name="param2">        0             </param>
-        </group>        
-    </group>                                       
-    
+        </group>
+    </group>
+
 </params>

--- a/ergoCubSN000/hardware/mechanicals/left_arm-eb25-j11_12-mec.xml
+++ b/ergoCubSN000/hardware/mechanicals/left_arm-eb25-j11_12-mec.xml
@@ -4,12 +4,12 @@
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="ergoCubSN000" build="1">
     <group name="GENERAL">
         <param name="MotioncontrolVersion"> 6 </param>
-        <param name="Joints"> 2 </param> 
-        
+        <param name="Joints"> 2 </param>
+
         <!-- joint number in sub-part       0                         1                        -->
-        <!-- joint name                                                                        -->         
+        <!-- joint name                                                                        -->
         <param name="AxisMap">              0                         1                        </param>
-        <param name="AxisName">             "l_hand_thumbmetacarpus"  "l_hand_indexadduction"  </param>
+        <param name="AxisName">             "l_thumb_add"  "l_index_add"  </param>
         <param name="AxisType">             "revolute"                "revolute"               </param>
         <param name="Encoder">              182.044                   182.044                  </param>
         <param name="fullscalePWM">         3360                      3360                     </param>
@@ -18,7 +18,7 @@
         <param name="Gearbox_E2J">          1                         1                        </param>
         <param name="useMotorSpeedFbk">     0                         0                        </param>
         <param name="MotorType">            "DC"                      "DC"                     </param>
-                
+
         <param name="Verbose"> 0 </param>
     </group>
 
@@ -28,46 +28,46 @@
         <param name="rotorPosMin">          0               0       </param>
         <param name="rotorPosMax">          0               0       </param>
     </group>
-    
-    <group name="COUPLINGS"> 
 
-        <param name ="matrixJ2M"> 
+    <group name="COUPLINGS">
+
+        <param name ="matrixJ2M">
             1.000   0.000   0.000   0.000
             0.000   1.000   0.000   0.000
             0.000   0.000   1.000   0.000
-            0.000   0.000   0.000   1.000   
+            0.000   0.000   0.000   1.000
         </param>
-               
-        <param name ="matrixM2J"> 
+
+        <param name ="matrixM2J">
             1.000   0.000   0.000   0.000
             0.000   1.000   0.000   0.000
             0.000   0.000   1.000   0.000
-            0.000   0.000   0.000   1.000   
+            0.000   0.000   0.000   1.000
         </param>
-       
-        <param name ="matrixE2J">  
+
+        <param name ="matrixE2J">
             1.000   0.000   0.000   0.000   0.000   0.000
             0.000   1.000   0.000   0.000   0.000   0.000
             0.000   0.000   1.000   0.000   0.000   0.000
-            0.000   0.000   0.000   1.000   0.000   0.000 
+            0.000   0.000   0.000   1.000   0.000   0.000
         </param>
-                
-    </group>   
 
-    <group name="JOINTSET_CFG"> 
+    </group>
+
+    <group name="JOINTSET_CFG">
         <param name= "numberofsets"> 2 </param>
         <group name="JOINTSET_0">
             <param name="listofjoints">  0             </param>
             <param name="constraint">    none          </param>
             <param name="param1">        0             </param>
             <param name="param2">        0             </param>
-        </group> 
+        </group>
         <group name="JOINTSET_1">
             <param name="listofjoints">  1             </param>
             <param name="constraint">    none          </param>
             <param name="param1">        0             </param>
             <param name="param2">        0             </param>
         </group>
-    </group>                                       
-    
+    </group>
+
 </params>

--- a/ergoCubSN000/hardware/mechanicals/right_arm-eb22-j7_10-mec.xml
+++ b/ergoCubSN000/hardware/mechanicals/right_arm-eb22-j7_10-mec.xml
@@ -4,12 +4,12 @@
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="ergoCubSN000" build="1">
     <group name="GENERAL">
         <param name="MotioncontrolVersion"> 6 </param>
-        <param name="Joints"> 4 </param> 
-        
+        <param name="Joints"> 4 </param>
+
         <!-- joint number in sub-part       0                       1                       2                           3                       -->
-        <!-- joint name                                                                                                                         -->         
+        <!-- joint name                                                                                                                         -->
         <param name="AxisMap">              0                       1                       2                           3                       </param>
-        <param name="AxisName">             "r_hand_thumb_proximal" "r_hand_index_proximal" "r_hand_medium_proximal"    "r_hand_pinky_proximal" </param>
+        <param name="AxisName">             "r_thumb_oc" "r_index_oc" "r_medium_oc"    "r_ring_pinky_oc" </param>
         <param name="AxisType">             "revolute"              "revolute"              "revolute"                  "revolute"              </param>
         <param name="Encoder">              182.044                 182.044                 182.044                     182.044                 </param>
         <param name="fullscalePWM">         3360                    3360                    3360                        3360                    </param>
@@ -18,7 +18,7 @@
         <param name="Gearbox_E2J">          1                       1                       1                           1                       </param>
         <param name="useMotorSpeedFbk">     0                       0                       0                           0                       </param>
         <param name="MotorType">            "DC"                    "DC"                    "DC"                        "DC"                    </param>
-                
+
         <param name="Verbose"> 0 </param>
     </group>
 
@@ -28,40 +28,40 @@
         <param name="rotorPosMin">          0               0               0               0          </param>
         <param name="rotorPosMax">          0               0               0               0          </param>
     </group>
-    
-    <group name="COUPLINGS"> 
 
-        <param name ="matrixJ2M"> 
+    <group name="COUPLINGS">
+
+        <param name ="matrixJ2M">
             1.000   0.000   0.000   0.000
             0.000   1.000   0.000   0.000
             0.000   0.000   1.000   0.000
-            0.000   0.000   0.000   1.000   
+            0.000   0.000   0.000   1.000
         </param>
-               
-        <param name ="matrixM2J"> 
+
+        <param name ="matrixM2J">
             1.000   0.000   0.000   0.000
             0.000   1.000   0.000   0.000
             0.000   0.000   1.000   0.000
-            0.000   0.000   0.000   1.000   
+            0.000   0.000   0.000   1.000
         </param>
-       
-        <param name ="matrixE2J">  
+
+        <param name ="matrixE2J">
             1.000   0.000   0.000   0.000   0.000   0.000
             0.000   1.000   0.000   0.000   0.000   0.000
             0.000   0.000   1.000   0.000   0.000   0.000
-            0.000   0.000   0.000   1.000   0.000   0.000 
+            0.000   0.000   0.000   1.000   0.000   0.000
         </param>
-                
-    </group>   
 
-    <group name="JOINTSET_CFG"> 
+    </group>
+
+    <group name="JOINTSET_CFG">
         <param name= "numberofsets"> 4 </param>
         <group name="JOINTSET_0">
             <param name="listofjoints">  0             </param>
             <param name="constraint">    none          </param>
             <param name="param1">        0             </param>
             <param name="param2">        0             </param>
-        </group> 
+        </group>
         <group name="JOINTSET_1">
             <param name="listofjoints">  1             </param>
             <param name="constraint">    none          </param>
@@ -79,7 +79,7 @@
             <param name="constraint">    none          </param>
             <param name="param1">        0             </param>
             <param name="param2">        0             </param>
-        </group>        
-    </group>                                       
-    
+        </group>
+    </group>
+
 </params>

--- a/ergoCubSN000/hardware/mechanicals/right_arm-eb24-j11_12-mec.xml
+++ b/ergoCubSN000/hardware/mechanicals/right_arm-eb24-j11_12-mec.xml
@@ -4,12 +4,12 @@
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="ergoCubSN000" build="1">
     <group name="GENERAL">
         <param name="MotioncontrolVersion"> 6 </param>
-        <param name="Joints"> 2 </param> 
-        
+        <param name="Joints"> 2 </param>
+
         <!-- joint number in sub-part       0                         1                        -->
-        <!-- joint name                                                                        -->         
+        <!-- joint name                                                                        -->
         <param name="AxisMap">              0                         1                        </param>
-        <param name="AxisName">             "r_hand_thumbmetacarpus"  "r_hand_indexadduction"  </param>
+        <param name="AxisName">             "r_thumb_add"  "r_index_add"  </param>
         <param name="AxisType">             "revolute"                "revolute"               </param>
         <param name="Encoder">              182.044                   182.044                  </param>
         <param name="fullscalePWM">         3360                      3360                     </param>
@@ -18,7 +18,7 @@
         <param name="Gearbox_E2J">          1                         1                        </param>
         <param name="useMotorSpeedFbk">     0                         0                        </param>
         <param name="MotorType">            "DC"                      "DC"                     </param>
-                
+
         <param name="Verbose"> 0 </param>
     </group>
 
@@ -28,46 +28,46 @@
         <param name="rotorPosMin">          0               0       </param>
         <param name="rotorPosMax">          0               0       </param>
     </group>
-    
-    <group name="COUPLINGS"> 
 
-        <param name ="matrixJ2M"> 
+    <group name="COUPLINGS">
+
+        <param name ="matrixJ2M">
             1.000   0.000   0.000   0.000
             0.000   1.000   0.000   0.000
             0.000   0.000   1.000   0.000
-            0.000   0.000   0.000   1.000   
+            0.000   0.000   0.000   1.000
         </param>
-               
-        <param name ="matrixM2J"> 
+
+        <param name ="matrixM2J">
             1.000   0.000   0.000   0.000
             0.000   1.000   0.000   0.000
             0.000   0.000   1.000   0.000
-            0.000   0.000   0.000   1.000   
+            0.000   0.000   0.000   1.000
         </param>
-       
-        <param name ="matrixE2J">  
+
+        <param name ="matrixE2J">
             1.000   0.000   0.000   0.000   0.000   0.000
             0.000   1.000   0.000   0.000   0.000   0.000
             0.000   0.000   1.000   0.000   0.000   0.000
-            0.000   0.000   0.000   1.000   0.000   0.000 
+            0.000   0.000   0.000   1.000   0.000   0.000
         </param>
-                
-    </group>   
 
-    <group name="JOINTSET_CFG"> 
+    </group>
+
+    <group name="JOINTSET_CFG">
         <param name= "numberofsets"> 2 </param>
         <group name="JOINTSET_0">
             <param name="listofjoints">  0             </param>
             <param name="constraint">    none          </param>
             <param name="param1">        0             </param>
             <param name="param2">        0             </param>
-        </group> 
+        </group>
         <group name="JOINTSET_1">
             <param name="listofjoints">  1             </param>
             <param name="constraint">    none          </param>
             <param name="param1">        0             </param>
             <param name="param2">        0             </param>
         </group>
-    </group>                                       
-    
+    </group>
+
 </params>

--- a/ergoCubSN000/wrappers/motorControl/left_arm-mc_remapper.xml
+++ b/ergoCubSN000/wrappers/motorControl/left_arm-mc_remapper.xml
@@ -6,8 +6,10 @@
         <elem name="left_arm_joints1">(  0  1 0 1 )  </elem>
         <elem name="left_arm_joints2">(  2  3 0 1 )  </elem>
         <elem name="left_arm_joints3">(  4  6 0 2 )  </elem>
-        <elem name="left_arm_joints4">(  7  10 0 3 ) </elem>
-        <elem name="left_arm_joints5">(  11 12 0 1 ) </elem>
+        <elem name="left_arm_joints5-1">(  7  7 0 0 ) </elem>
+        <elem name="left_arm_joints4-1">(  8  8 0 0 ) </elem>
+        <elem name="left_arm_joints5-2">(  9  9 1 1 ) </elem>
+        <elem name="left_arm_joints4-2">(  10 12 1 3 ) </elem>
     </paramlist>
     <param name="joints"> 13 </param>
     <action phase="startup" level="5" type="attach">
@@ -15,8 +17,10 @@
             <elem name="left_arm_joints1"> left_arm-eb2-j0_1-mc   </elem>
             <elem name="left_arm_joints2"> left_arm-eb4-j2_3-mc   </elem>
             <elem name="left_arm_joints3"> left_arm-eb31-j4_6-mc  </elem>
-            <elem name="left_arm_joints4"> left_arm-eb23-j7_10-mc </elem>
-            <elem name="left_arm_joints5"> left_arm-eb25-j11_12-mc </elem>
+            <elem name="left_arm_joints4-1"> left_arm-eb23-j7_10-mc </elem>
+            <elem name="left_arm_joints4-2"> left_arm-eb23-j7_10-mc </elem>
+            <elem name="left_arm_joints5-1"> left_arm-eb25-j11_12-mc </elem>
+            <elem name="left_arm_joints5-2"> left_arm-eb25-j11_12-mc </elem>
         </paramlist>
     </action>
     <action phase="shutdown" level="20" type="detach" />

--- a/ergoCubSN000/wrappers/motorControl/right_arm-mc_remapper.xml
+++ b/ergoCubSN000/wrappers/motorControl/right_arm-mc_remapper.xml
@@ -6,8 +6,10 @@
         <elem name="right_arm_joints1">(  0  1 0 1 )  </elem>
         <elem name="right_arm_joints2">(  2  3 0 1 )  </elem>
         <elem name="right_arm_joints3">(  4  6 0 2 )  </elem>
-        <elem name="right_arm_joints4">(  7  10 0 3 ) </elem>
-        <elem name="right_arm_joints5">(  11 12 0 1 ) </elem>
+        <elem name="right_arm_joints5-1">(  7  7 0 0 ) </elem>
+        <elem name="right_arm_joints4-1">(  8  8 0 0 ) </elem>
+        <elem name="right_arm_joints5-2">(  9  9 1 1 ) </elem>
+        <elem name="right_arm_joints4-2">(  10 12 1 3 ) </elem>
     </paramlist>
     <param name="joints"> 13 </param>
     <action phase="startup" level="5" type="attach">
@@ -15,8 +17,10 @@
             <elem name="right_arm_joints1"> right_arm-eb1-j0_1-mc    </elem>
             <elem name="right_arm_joints2"> right_arm-eb3-j2_3-mc    </elem>
             <elem name="right_arm_joints3"> right_arm-eb30-j4_6-mc   </elem>
-            <elem name="right_arm_joints4"> right_arm-eb22-j7_10-mc  </elem>
-            <elem name="right_arm_joints5"> right_arm-eb24-j11_12-mc </elem>
+            <elem name="right_arm_joints4-1"> right_arm-eb22-j7_10-mc  </elem>
+            <elem name="right_arm_joints4-2"> right_arm-eb22-j7_10-mc  </elem>
+            <elem name="right_arm_joints5-1"> right_arm-eb24-j11_12-mc </elem>
+            <elem name="right_arm_joints5-2"> right_arm-eb24-j11_12-mc </elem>
         </paramlist>
     </action>
     <action phase="shutdown" level="20" type="detach" />


### PR DESCRIPTION
After this change the names are renamed and remapped in this order:

```
l_thumb_add l_thumb_oc l_index_add l_index_oc l_middle_oc l_ring_pinky_oc
```

See https://github.com/icub-tech-iit/ergocub-software/issues/42