### PR TITLE
AMC_BLDC – Update application version for experimental setup `wrist-setup`

### DIFF
--- a/experimentalSetups/wristmk2_handmk3_amc_amcbldc/hardware/motorControl/wrist-eb2-j0_2-mc_service.xml
+++ b/experimentalSetups/wristmk2_handmk3_amc_amcbldc/hardware/motorControl/wrist-eb2-j0_2-mc_service.xml
@@ -22,7 +22,7 @@
                 <group name="FIRMWARE">
                     <param name="major">            1           </param>
                     <param name="minor">            0           </param>
-                    <param name="build">            7           </param>
+                    <param name="build">            8           </param>
                 </group>
             </group>
 


### PR DESCRIPTION
**What's new:**
- Update the application version of `amcbldc` accordingly to the last fw version available (`1.0.8`). 


**Notes:**
- This change affects only the `wrist-amc-amcbldc` setup.