### PR TITLE
R1SN003 ros2 control cer_all_joints parameter

### DIFF
--- a/R1SN003/wrappers/motorControl/cer_alljoints_ros2_wrapper.xml
+++ b/R1SN003/wrappers/motorControl/cer_alljoints_ros2_wrapper.xml
@@ -3,7 +3,7 @@
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cbw_ros2" type="controlBoard_nws_ros2">
     <param name="node_name"> ros2_cb_node </param>
-    <param extern-name="cbw_ros2_msgs_name" name="msgs_name"> "" </param>
+    <param extern-name="cbw_ros2_msgs_name" name="msgs_name"> ros2_cb_msgs </param>
     <param name="topic_name"> /joint_states </param>
     <action phase="startup" level="10" type="attach">
         <param name="device"> cer_all_joints_mc_remapper </param>

--- a/R1SN003/wrappers/motorControl/cer_alljoints_ros2_wrapper.xml
+++ b/R1SN003/wrappers/motorControl/cer_alljoints_ros2_wrapper.xml
@@ -3,6 +3,7 @@
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cbw_ros2" type="controlBoard_nws_ros2">
     <param name="node_name"> ros2_cb_node </param>
+    <param extern-name="cbw_ros2_msgs_name" name="msgs_name"> "" </param>
     <param name="topic_name"> /joint_states </param>
     <action phase="startup" level="10" type="attach">
         <param name="device"> cer_all_joints_mc_remapper </param>


### PR DESCRIPTION
Added to `cer_alljoints_ros2_wrapper.xml` the parameter needed to enable the additional ros2 services and topics needed to control the joints through ROS2  in `controlBoard_nws_ros2`