### PR TITLE
HandMK5: fix names accordingly to the new joint names

### DIFF
--- a/ergoCubSN000/hardware/POS/left_hand-pos2.xml
+++ b/ergoCubSN000/hardware/POS/left_hand-pos2.xml
@@ -4,35 +4,35 @@
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_hand-pos2" type="embObjPOS">
     <xi:include href="../../general.xml" />
     <xi:include href="../../hardware/electronics/left_arm-eb25-j11_12-eln.xml" />
-    
+
     <group name="SERVICE">
-        
+
     <param name="type"> eomn_serv_AS_pos	</param>
-    
+
         <group name="PROPERTIES">
 
             <group name="CANBOARDS">
                 <param name="type">                 eobrd_mtb4fap           </param>
 
                 <group name="PROTOCOL">
-                    <param name="major">            2                       </param>    
-                    <param name="minor">            0                       </param>     
-                </group>                    
+                    <param name="major">            2                       </param>
+                    <param name="minor">            0                       </param>
+                </group>
                 <group name="FIRMWARE">
-                    <param name="major">            1                       </param>    
-                    <param name="minor">            1                       </param> 
+                    <param name="major">            1                       </param>
+                    <param name="minor">            1                       </param>
                     <param name="build">            0                       </param>
                 </group>
             </group>
-            
+
             <group name="SENSORS">
 
                 <param name="location">             CAN1:2                        CAN1:2                    </param>
-               
+
                 <!-- common to all analog services -->
                 <param name="id">                   id_fapEE                      id_fapFF                  </param>
                 <param name="type">                 eoas_pos_angle                eoas_pos_angle            </param>
-                <param name="port">                 POS:hand_thumbmetacarpus      POS:hand_indexadduction   </param>
+                <param name="port">                 POS:hand_thumb_add      POS:hand_index_add   </param>
 
                 <param name="boardType">            mtb4fap                       mtb4fap                   </param>
                 <param name="connector">            CONN:J3_SDA2                  CONN:J3_SDA3              </param>
@@ -46,14 +46,14 @@
                 </group>
 
             </group>
-        
+
         </group>
 
         <group name="SETTINGS">
             <param name="acquisitionRate"> 50 </param>                    <!-- milliseconds -->
             <param name="enabledSensors"> id_fapEE id_fapFF</param>
         </group>
-                
+
     </group>
 
 </device>

--- a/ergoCubSN000/hardware/POS/left_hand-pos4.xml
+++ b/ergoCubSN000/hardware/POS/left_hand-pos4.xml
@@ -4,35 +4,35 @@
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_hand-pos4" type="embObjPOS">
     <xi:include href="../../general.xml" />
     <xi:include href="../../hardware/electronics/left_arm-eb23-j7_10-eln.xml" />
-    
+
     <group name="SERVICE">
-        
+
     <param name="type"> eomn_serv_AS_pos	</param>
-    
+
         <group name="PROPERTIES">
 
             <group name="CANBOARDS">
                 <param name="type">                 eobrd_mtb4fap           </param>
 
                 <group name="PROTOCOL">
-                    <param name="major">            2                       </param>    
-                    <param name="minor">            0                       </param>     
-                </group>                    
+                    <param name="major">            2                       </param>
+                    <param name="minor">            0                       </param>
+                </group>
                 <group name="FIRMWARE">
-                    <param name="major">            1                       </param>    
-                    <param name="minor">            1                       </param> 
+                    <param name="major">            1                       </param>
+                    <param name="minor">            1                       </param>
                     <param name="build">            0                       </param>
                 </group>
             </group>
-            
+
             <group name="SENSORS">
 
                 <param name="location">             CAN1:1         CAN1:1            CAN1:1           CAN1:1            </param>
-               
+
                 <!-- common to all analog services -->
                 <param name="id">                   id_fapAA        id_fapBB         id_fapCC         id_fapDD          </param>
                 <param name="type">                 eoas_pos_angle  eoas_pos_angle   eoas_pos_angle   eoas_pos_angle    </param>
-                <param name="port">                 POS:hand_thumb  POS:hand_index   POS:hand_medium  POS:hand_pinky    </param>
+                <param name="port">                 POS:hand_thumb_oc  POS:hand_index_oc   POS:hand_middle_oc  POS:hand_ring_pinky_oc    </param>
 
                 <param name="boardType">            mtb4fap         mtb4fap          mtb4fap          mtb4fap           </param>
                 <param name="connector">            CONN:J3_SDA3    CONN:J3_SDA0     CONN:J3_SDA1     CONN:J3_SDA2      </param>
@@ -46,14 +46,14 @@
                 </group>
 
             </group>
-        
+
         </group>
 
         <group name="SETTINGS">
             <param name="acquisitionRate"> 50 </param>                    <!-- milliseconds -->
             <param name="enabledSensors"> id_fapAA id_fapBB id_fapCC id_fapDD</param>
         </group>
-                
+
     </group>
 
 </device>

--- a/ergoCubSN000/hardware/POS/right_hand-pos2.xml
+++ b/ergoCubSN000/hardware/POS/right_hand-pos2.xml
@@ -4,35 +4,35 @@
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_hand-pos2" type="embObjPOS">
     <xi:include href="../../general.xml" />
     <xi:include href="../../hardware/electronics/right_arm-eb24-j11_12-eln.xml" />
-    
+
     <group name="SERVICE">
-        
+
     <param name="type"> eomn_serv_AS_pos	</param>
-    
+
         <group name="PROPERTIES">
 
             <group name="CANBOARDS">
                 <param name="type">                 eobrd_mtb4fap            </param>
 
                 <group name="PROTOCOL">
-                    <param name="major">            2                       </param>    
-                    <param name="minor">            0                       </param>     
-                </group>                    
+                    <param name="major">            2                       </param>
+                    <param name="minor">            0                       </param>
+                </group>
                 <group name="FIRMWARE">
-                    <param name="major">            1                       </param>    
-                    <param name="minor">            1                       </param> 
+                    <param name="major">            1                       </param>
+                    <param name="minor">            1                       </param>
                     <param name="build">            0                       </param>
                 </group>
             </group>
-            
+
             <group name="SENSORS">
 
                 <param name="location">             CAN1:2                        CAN1:2                    </param>
-               
+
                 <!-- common to all analog services -->
                 <param name="id">                   id_fapEE                      id_fapFF                  </param>
                 <param name="type">                 eoas_pos_angle                eoas_pos_angle            </param>
-                <param name="port">                 POS:hand_thumbmetacarpus      POS:hand_indexadduction   </param>
+                <param name="port">                 POS:hand_thumb_add      POS:hand_index_add   </param>
 
                 <param name="boardType">            mtb4fap                       mtb4fap                   </param>
                 <param name="connector">            CONN:J3_SDA2                  CONN:J3_SDA3              </param>
@@ -46,14 +46,14 @@
                 </group>
 
             </group>
-        
+
         </group>
 
         <group name="SETTINGS">
             <param name="acquisitionRate"> 50 </param>                    <!-- milliseconds -->
             <param name="enabledSensors"> id_fapEE id_fapFF</param>
         </group>
-                
+
     </group>
 
 </device>

--- a/ergoCubSN000/hardware/POS/right_hand-pos4.xml
+++ b/ergoCubSN000/hardware/POS/right_hand-pos4.xml
@@ -4,35 +4,35 @@
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_hand-pos4" type="embObjPOS">
     <xi:include href="../../general.xml" />
     <xi:include href="../../hardware/electronics/right_arm-eb22-j7_10-eln.xml" />
-    
+
     <group name="SERVICE">
-        
+
     <param name="type"> eomn_serv_AS_pos	</param>
-    
+
         <group name="PROPERTIES">
 
             <group name="CANBOARDS">
                 <param name="type">                 eobrd_mtb4fap            </param>
 
                 <group name="PROTOCOL">
-                    <param name="major">            2                       </param>    
-                    <param name="minor">            0                       </param>     
-                </group>                    
+                    <param name="major">            2                       </param>
+                    <param name="minor">            0                       </param>
+                </group>
                 <group name="FIRMWARE">
-                    <param name="major">            1                       </param>    
-                    <param name="minor">            1                       </param> 
+                    <param name="major">            1                       </param>
+                    <param name="minor">            1                       </param>
                     <param name="build">            0                       </param>
                 </group>
             </group>
-            
+
             <group name="SENSORS">
 
                 <param name="location">             CAN1:1         CAN1:1            CAN1:1           CAN1:1            </param>
-               
+
                 <!-- common to all analog services -->
                 <param name="id">                   id_fapAA        id_fapBB         id_fapCC         id_fapDD          </param>
                 <param name="type">                 eoas_pos_angle  eoas_pos_angle   eoas_pos_angle   eoas_pos_angle    </param>
-                <param name="port">                 POS:hand_thumb  POS:hand_index   POS:hand_medium  POS:hand_pinky    </param>
+                <param name="port">                 POS:hand_thumb_oc  POS:hand_index_oc   POS:hand_middle_oc  POS:hand_ring_pinky_oc    </param>
 
                 <param name="boardType">            mtb4fap         mtb4fap          mtb4fap          mtb4fap           </param>
                 <param name="connector">            CONN:J3_SDA3    CONN:J3_SDA0     CONN:J3_SDA1     CONN:J3_SDA2      </param>
@@ -46,14 +46,14 @@
                 </group>
 
             </group>
-        
+
         </group>
 
         <group name="SETTINGS">
             <param name="acquisitionRate"> 50 </param>                    <!-- milliseconds -->
             <param name="enabledSensors"> id_fapAA id_fapBB id_fapCC id_fapDD</param>
         </group>
-                
+
     </group>
 
 </device>

--- a/ergoCubSN000/hardware/motorControl/left_arm-eb23-j7_10-mc_service.xml
+++ b/ergoCubSN000/hardware/motorControl/left_arm-eb23-j7_10-mc_service.xml
@@ -34,7 +34,7 @@
                     <!-- common to all analog services -->
                     <param name="id">                   id_fapAA        id_fapBB         id_fapCC                 id_fapDD              </param>
                     <param name="type">                 eoas_pos_angle  eoas_pos_angle   eoas_pos_angle           eoas_pos_angle        </param>
-                    <param name="port">                 POS:hand_thumb  POS:hand_index   POS:hand_medium          POS:hand_pinky        </param>
+                    <param name="port">                 POS:hand_thumb_oc  POS:hand_index_oc   POS:hand_middle_oc          POS:hand_ring_pinky_oc        </param>
 
                     <param name="boardType">            mtb4fap         mtb4fap          mtb4fap                  mtb4fap               </param>
                     <param name="connector">            CONN:J3_SDA3    CONN:J3_SDA0     CONN:J3_SDA1             CONN:J3_SDA2          </param>
@@ -64,7 +64,7 @@
 
                 <group name="ENCODER1">
                     <param name="type">             pos                 pos                       pos                       pos                       </param>
-                    <param name="port">             POS:hand_thumb      POS:hand_index            POS:hand_medium           POS:hand_pinky            </param>
+                    <param name="port">             POS:hand_thumb_oc      POS:hand_index_oc            POS:hand_middle_oc           POS:hand_ring_pinky_oc            </param>
                     <param name="position">         atjoint             atjoint                   atjoint                   atjoint                   </param>
                     <param name="resolution">       65535               65535                     65535                     65535                     </param>
                     <param name="tolerance">        5                   5                         5                         5                         </param>

--- a/ergoCubSN000/hardware/motorControl/left_arm-eb25-j11_12-mc.xml
+++ b/ergoCubSN000/hardware/motorControl/left_arm-eb25-j11_12-mc.xml
@@ -11,17 +11,17 @@
     <xi:include href="../motorControl/left_arm-eb25-j11_12-mc_service.xml" />
 
     <!-- joint number                           0                        1                           -->
-    <!-- joint name                             hand_thumbmetacarpus     hand_indexadduction         -->    
+    <!-- joint name                             hand_thumb_add     hand_index_add         -->
     <group name="LIMITS">
         <param name="jntPosMin">                0                        8            </param>
         <param name="jntPosMax">                85                       21           </param>
         <param name="jntVelMax">                1000                     1000         </param>
         <param name="motorOverloadCurrents">    2000                     2000         </param>
         <param name="motorNominalCurrents">     700                      700          </param>
-        <param name="motorPeakCurrents">        1500                     1500         </param>    
+        <param name="motorPeakCurrents">        1500                     1500         </param>
         <param name="motorPwmLimit">            3360                     3360         </param>
-    </group>       
-    
+    </group>
+
     <group name="TIMEOUTS">
         <param name="velocity">                 100                 100                 </param>
     </group>
@@ -30,7 +30,7 @@
         <param name="stiffness">                0.0                 0.0                 </param>
         <param name="damping">                  0.0                 0.0                 </param>
     </group>
-    
+
     <group name="CONTROLS">
         <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
         <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
@@ -42,7 +42,7 @@
 
 
     <!-- default position PID: begin -->
-    
+
     <group name="POS_PID_DEFAULT">
         <param name="controlLaw">               minjerk                 </param>
         <param name="outputType">               pwm                     </param>
@@ -61,14 +61,14 @@
     <!-- default position PID: end -->
 
 
-    <!-- other default PIDs: begin -->   
+    <!-- other default PIDs: begin -->
     <!-- other default PIDs: end -->
 
 
-    <!-- custom PIDs: begin -->    
+    <!-- custom PIDs: begin -->
     <!-- custom PIDs: end -->
-    
+
 </device>
 
 
-        
+

--- a/ergoCubSN000/hardware/motorControl/left_arm-eb25-j11_12-mc_service.xml
+++ b/ergoCubSN000/hardware/motorControl/left_arm-eb25-j11_12-mc_service.xml
@@ -34,7 +34,7 @@
                     <!-- common to all analog services -->
                     <param name="id">                   id_fapEE                      id_fapFF                  </param>
                     <param name="type">                 eoas_pos_angle                eoas_pos_angle            </param>
-                    <param name="port">                 POS:hand_thumbmetacarpus      POS:hand_indexadduction   </param>
+                    <param name="port">                 POS:hand_thumb_add      POS:hand_index_add   </param>
 
                     <param name="boardType">            mtb4fap                       mtb4fap                   </param>
                     <param name="connector">            CONN:J3_SDA2                  CONN:J3_SDA3              </param>
@@ -64,7 +64,7 @@
 
                 <group name="ENCODER1">
                     <param name="type">             pos                           pos                      </param>
-                    <param name="port">             POS:hand_thumbmetacarpus      POS:hand_indexadduction  </param>
+                    <param name="port">             POS:hand_thumb_add      POS:hand_index_add  </param>
                     <param name="position">         atjoint                       atjoint                  </param>
                     <param name="resolution">       65535                         65535                    </param>
                     <param name="tolerance">        5                             5                        </param>

--- a/ergoCubSN000/hardware/motorControl/right_arm-eb22-j7_10-mc_service.xml
+++ b/ergoCubSN000/hardware/motorControl/right_arm-eb22-j7_10-mc_service.xml
@@ -34,7 +34,7 @@
                     <!-- common to all analog services -->
                     <param name="id">                   id_fapAA        id_fapBB         id_fapCC                 id_fapDD              </param>
                     <param name="type">                 eoas_pos_angle  eoas_pos_angle   eoas_pos_angle           eoas_pos_angle        </param>
-                    <param name="port">                 POS:hand_thumb  POS:hand_index   POS:hand_medium          POS:hand_pinky        </param>
+                    <param name="port">                 POS:hand_thumb_oc  POS:hand_index_oc   POS:hand_middle_oc          POS:hand_ring_pinky_oc        </param>
 
                     <param name="boardType">            mtb4fap         mtb4fap          mtb4fap                  mtb4fap               </param>
                     <param name="connector">            CONN:J3_SDA3    CONN:J3_SDA0     CONN:J3_SDA1             CONN:J3_SDA2          </param>
@@ -64,14 +64,14 @@
 
                 <group name="ENCODER1">
                     <param name="type">             pos                 pos                       pos                       pos                       </param>
-                    <param name="port">             POS:hand_thumb      POS:hand_index            POS:hand_medium            POS:hand_pinky            </param>
+                    <param name="port">             POS:hand_thumb_oc      POS:hand_index_oc            POS:hand_middle_oc            POS:hand_ring_pinky_oc            </param>
                     <param name="position">         atjoint             atjoint                   atjoint                   atjoint                   </param>
                     <param name="resolution">       65535               65535                     65535                     65535                     </param>
                     <param name="tolerance">        5                   5                         5                         5                         </param>
                 </group>
 
                 <group name="ENCODER2">
-                    <param name="type">             none                none                      none                      none                      </param>
+                    <param name="type">             qenc                qenc                      qenc                      qenc                      </param>
                     <param name="port">             CONN:P5             CONN:P4                   CONN:P3                   CONN:P2                   </param>
                     <param name="position">         atmotor             atmotor                   atmotor                   atmotor                   </param>
                     <param name="resolution">       -1600               1600                      1600                      1600                      </param>

--- a/ergoCubSN000/hardware/motorControl/right_arm-eb24-j11_12-mc.xml
+++ b/ergoCubSN000/hardware/motorControl/right_arm-eb24-j11_12-mc.xml
@@ -11,17 +11,17 @@
     <xi:include href="../motorControl/right_arm-eb24-j11_12-mc_service.xml" />
 
     <!-- joint number                           0                        1                           -->
-    <!-- joint name                             hand_thumbmetacarpus     hand_indexadduction         -->    
+    <!-- joint name                             hand_thumb_add     hand_index_add         -->
     <group name="LIMITS">
         <param name="jntPosMin">                0                        7            </param>
         <param name="jntPosMax">                85                       18           </param>
         <param name="jntVelMax">                1000                     1000         </param>
         <param name="motorOverloadCurrents">    2000                     2000         </param>
         <param name="motorNominalCurrents">     700                      700          </param>
-        <param name="motorPeakCurrents">        1500                     1500         </param>    
+        <param name="motorPeakCurrents">        1500                     1500         </param>
         <param name="motorPwmLimit">            3360                     3360         </param>
-    </group>       
-    
+    </group>
+
     <group name="TIMEOUTS">
         <param name="velocity">                 100                 100                 </param>
     </group>
@@ -30,7 +30,7 @@
         <param name="stiffness">                0.0                 0.0                 </param>
         <param name="damping">                  0.0                 0.0                 </param>
     </group>
-    
+
     <group name="CONTROLS">
         <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
         <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
@@ -42,7 +42,7 @@
 
 
     <!-- default position PID: begin -->
-    
+
     <group name="POS_PID_DEFAULT">
         <param name="controlLaw">               minjerk                 </param>
         <param name="outputType">               pwm                     </param>
@@ -61,14 +61,14 @@
     <!-- default position PID: end -->
 
 
-    <!-- other default PIDs: begin -->   
+    <!-- other default PIDs: begin -->
     <!-- other default PIDs: end -->
 
 
-    <!-- custom PIDs: begin -->    
+    <!-- custom PIDs: begin -->
     <!-- custom PIDs: end -->
-    
+
 </device>
 
 
-        
+

--- a/ergoCubSN000/hardware/motorControl/right_arm-eb24-j11_12-mc_service.xml
+++ b/ergoCubSN000/hardware/motorControl/right_arm-eb24-j11_12-mc_service.xml
@@ -34,7 +34,7 @@
                     <!-- common to all analog services -->
                     <param name="id">                   id_fapEE                      id_fapFF                  </param>
                     <param name="type">                 eoas_pos_angle                eoas_pos_angle            </param>
-                    <param name="port">                 POS:hand_thumbmetacarpus      POS:hand_indexadduction   </param>
+                    <param name="port">                 POS:hand_thumb_add      POS:hand_index_add   </param>
 
                     <param name="boardType">            mtb4fap                       mtb4fap                   </param>
                     <param name="connector">            CONN:J3_SDA2                  CONN:J3_SDA3              </param>
@@ -64,7 +64,7 @@
 
                 <group name="ENCODER1">
                     <param name="type">             pos                           pos                      </param>
-                    <param name="port">             POS:hand_thumbmetacarpus      POS:hand_indexadduction  </param>
+                    <param name="port">             POS:hand_thumb_add      POS:hand_index_add  </param>
                     <param name="position">         atjoint                       atjoint                  </param>
                     <param name="resolution">       65535                         65535                    </param>
                     <param name="tolerance">        5                             5                        </param>

--- a/experimentalSetups/lego-setup-mc4plus-fap/hardware/POS/left_hand-pos.xml
+++ b/experimentalSetups/lego-setup-mc4plus-fap/hardware/POS/left_hand-pos.xml
@@ -1,72 +1,72 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
-  
+
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_hand-pos" type="embObjPOS">
 	    <xi:include href="../../general.xml" />
- 
+
 	    <xi:include href="../../hardware/electronics/hv3_left_hand-mcp9-eln.xml" />
-        
+
         <group name="SERVICE">
-            
+
 		<param name="type"> eomn_serv_AS_pos	</param>
-        
+
             <group name="PROPERTIES">
-  
+
                 <group name="CANBOARDS">
                     <param name="type">                 eobrd_pmc            </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param>     
-                    </group>                    
+                        <param name="major">            2                       </param>
+                        <param name="minor">            0                       </param>
+                    </group>
                     <group name="FIRMWARE">
-                        <param name="major">            10                       </param>    
-                        <param name="minor">            0                       </param> 
+                        <param name="major">            10                       </param>
+                        <param name="minor">            0                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
-                
+
                 <group name="SENSORS">
 
                     <param name="location">             CAN1:1         CAN1:1         CAN1:1         CAN1:1         </param>
 
-                    
+
                     <!-- common to all analog services -->
                     <param name="id">                   id_fapAA        id_fapBB        id_fapCC                 id_fapDD                 </param>
                     <param name="type">                 eoas_pos_angle  eoas_pos_angle  eoas_pos_angle           eoas_pos_angle           </param>
-                    <param name="port">                 POS:hand_thumb  POS:hand_index  POS:hand_thumbmetacarpus POS:hand_indexadduction  </param>
-     <!--                               
+                    <param name="port">                 POS:hand_thumb_oc  POS:hand_index_oc  POS:hand_thumb_add POS:hand_index_add  </param>
+     <!--
                     <param name="boardType">            mtb4fap         mtb4fap         mtb4fap         mtb4fap         </param>
                     <param name="connector">            CONN:J3_SDA0    CONN:J3_SDA1    CONN:J3_SDA2    CONN:J3_SDA3    </param>
-      -->         
+      -->
                     <param name="boardType">            pmc             pmc             pmc             pmc             </param>
                     <param name="connector">            CONN:J6         CONN:J7         CONN:J4         CONN:J5         </param>
-                
+
                     <group name="CALIBRATION">
-                    <!-- it is not mandatory. if not present, sensors have defaults: TYPE:decideg, ROT:zero, 0.0, false 
-                    -->   
+                    <!-- it is not mandatory. if not present, sensors have defaults: TYPE:decideg, ROT:zero, 0.0, false
+                    -->
                         <param name="type">             TYPE:decideg    TYPE:decideg     TYPE:decideg    TYPE:decideg    </param>
                         <param name="rotation">         ROT:zero        ROT:zero         ROT:zero        ROT:zero        </param>
                         <param name="offset">           0.0             0.0              0.0             0.0             </param>
                         <param name="invertDirection">  false           false            false           false           </param>
                     </group>
-                </group>               
-            
+                </group>
+
             </group>
 
-                <group name="SETTINGS">        
+                <group name="SETTINGS">
                     <param name="acquisitionRate"> 50 </param>
                     <param name="enabledSensors"> id_fapAA id_fapBB </param>
                 </group>
-                   
-            
+
+
         </group>
-    
+
   </device>
-  
-  
+
+
 
 
 

--- a/experimentalSetups/lego-setup-mc4plus-fap/hardware/motorControl/hv3_left_hand-mc-service.xml
+++ b/experimentalSetups/lego-setup-mc4plus-fap/hardware/motorControl/hv3_left_hand-mc-service.xml
@@ -4,47 +4,47 @@
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="new_forearm" build="1">
 
     <group name="SERVICE">
-        
-        <param name="type"> eomn_serv_MC_mc4plusfaps </param> 
-    
-        <group name="PROPERTIES">
-        
-            <group name="ETHBOARD">
-                <param name="type">                 mc4plus             </param> 
-            </group>          
 
-            <group name="CANBOARDS"> 
-                <param name="type">                 pmc                 </param> 
-                <group name="PROTOCOL">                    
-                    <param name="major">            2                   </param>    
-                    <param name="minor">            0                   </param>     
-                </group>                                   
-                <group name="FIRMWARE">                    
+        <param name="type"> eomn_serv_MC_mc4plusfaps </param>
+
+        <group name="PROPERTIES">
+
+            <group name="ETHBOARD">
+                <param name="type">                 mc4plus             </param>
+            </group>
+
+            <group name="CANBOARDS">
+                <param name="type">                 pmc                 </param>
+                <group name="PROTOCOL">
+                    <param name="major">            2                   </param>
+                    <param name="minor">            0                   </param>
+                </group>
+                <group name="FIRMWARE">
                     <param name="major">            10                  </param>
                     <param name="minor">            0                   </param>
                     <param name="build">            0                   </param>
                 </group>
             </group>
-            
-            <group name="POS"> 
+
+            <group name="POS">
                 <param name="location">             CAN1:1  </param>
 
                 <group name="SENSORS">
-                    
+
                     <!-- common to all analog services -->
                     <param name="id">                   id_fapAA        id_fapBB        id_fapCC                 id_fapDD                 </param>
                     <param name="type">                 eoas_pos_angle  eoas_pos_angle  eoas_pos_angle           eoas_pos_angle           </param>
-                    <param name="port">                 POS:hand_thumb  POS:hand_index  POS:hand_thumbmetacarpus POS:hand_indexadduction  </param>
-     <!--                               
+                    <param name="port">                 POS:hand_thumb_oc  POS:hand_index_oc  POS:hand_thumb_add POS:hand_index_add  </param>
+     <!--
                     <param name="boardType">            mtb4fap         mtb4fap         mtb4fap         mtb4fap         </param>
                     <param name="connector">            CONN:J3_SDA0    CONN:J3_SDA1    CONN:J3_SDA2    CONN:J3_SDA3    </param>
-      -->         
+      -->
                     <param name="boardType">            pmc             pmc             pmc             pmc             </param>
                     <param name="connector">            CONN:J6         CONN:J7         CONN:J4         CONN:J5         </param>
-                
+
                     <group name="CALIBRATION">
-                    <!-- it is not mandatory. if not present, sensors have defaults: TYPE:decideg, ROT:zero, 0.0, false 
-                    -->   
+                    <!-- it is not mandatory. if not present, sensors have defaults: TYPE:decideg, ROT:zero, 0.0, false
+                    -->
                         <param name="type">             TYPE:decideg    TYPE:decideg     TYPE:decideg    TYPE:decideg    </param>
                         <param name="rotation">         ROT:zero        ROT:zero         ROT:zero        ROT:zero        </param>
                         <param name="offset">           0.0             0.0              0.0             0.0             </param>
@@ -52,41 +52,41 @@
                     </group>
                 </group>
 
-                <group name="SETTINGS">        
+                <group name="SETTINGS">
                     <param name="acquisitionRate"> 50 </param>
                     <param name="enabledSensors"> id_fapAA id_fapBB </param>
                 </group>
             </group>
-            
+
 
             <group name="JOINTMAPPING">
 
-                <group name="ACTUATOR">                 
+                <group name="ACTUATOR">
                     <param name="type">             pwm                 pwm                       </param>
                     <param name="port">             CONN:P4             CONN:P5                   </param>
                 </group>
-                
+
                 <group name="ENCODER1">
                     <param name="type">             pos                 pos                       </param>
-                    <param name="port">             POS:hand_thumb      POS:hand_index            </param>
+                    <param name="port">             POS:hand_thumb_oc      POS:hand_index_oc            </param>
                     <param name="position">         atjoint             atjoint                   </param>
                     <param name="resolution">       65535               65535                     </param>
                     <param name="tolerance">        5                   5                         </param>
-                </group>        
-                
+                </group>
+
                 <group name="ENCODER2">
                     <param name="type">             none                none                      </param>
                     <param name="port">             CONN:P4             CONN:P5                   </param>
                     <param name="position">         atmotor             atmotor                   </param>
                     <param name="resolution">       -1600               1600                      </param>
                     <param name="tolerance">        0                   0                         </param>
-                </group>  
+                </group>
             </group>
-           
+
         </group>
-           
+
     </group>
-    
-  
+
+
 </params>
 

--- a/experimentalSetups/wristmk2_handmk3_ems_2foc/hardware/motorControl/hv3_left_hand-mc-service.xml
+++ b/experimentalSetups/wristmk2_handmk3_ems_2foc/hardware/motorControl/hv3_left_hand-mc-service.xml
@@ -4,61 +4,61 @@
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="new_forearm" build="1">
 
     <group name="SERVICE">
-        
-        <param name="type"> eomn_serv_MC_mc4plusfaps </param> 
-    
-        <group name="PROPERTIES">
-        
-            <group name="ETHBOARD">
-                <param name="type">                 mc4plus             </param> 
-            </group>          
 
-            <group name="CANBOARDS"> 
-                <param name="type">                 pmc                 </param> 
-                <group name="PROTOCOL">                    
-                    <param name="major">            0                   </param>    
-                    <param name="minor">            0                   </param>     
-                </group>                                   
-                <group name="FIRMWARE">                    
-                    <param name="major">            0                   </param>    
-                    <param name="minor">            0                   </param> 
+        <param name="type"> eomn_serv_MC_mc4plusfaps </param>
+
+        <group name="PROPERTIES">
+
+            <group name="ETHBOARD">
+                <param name="type">                 mc4plus             </param>
+            </group>
+
+            <group name="CANBOARDS">
+                <param name="type">                 pmc                 </param>
+                <group name="PROTOCOL">
+                    <param name="major">            0                   </param>
+                    <param name="minor">            0                   </param>
+                </group>
+                <group name="FIRMWARE">
+                    <param name="major">            0                   </param>
+                    <param name="minor">            0                   </param>
                     <param name="build">            0                   </param>
                 </group>
             </group>
-            
-            <group name="POS"> 
-                <param name="location">             CAN1:1              </param> 
-            </group>                      
-            
+
+            <group name="POS">
+                <param name="location">             CAN1:1              </param>
+            </group>
+
 
             <group name="JOINTMAPPING">
 
-                <group name="ACTUATOR">                 
+                <group name="ACTUATOR">
                     <param name="type">             pwm                 pwm                 pwm                 pwm                     </param>
                     <param name="port">             CONN:P2             CONN:P3             CONN:P4             CONN:P5                 </param>
                 </group>
-                
-                <group name="ENCODER1">  
-                    <param name="type">             pos                 pos                 pos                 pos                     </param>  
-                    <param name="port">             POS:hand_thumb      POS:hand_index      POS:hand_medium     POS:hand_pinky          </param>
-                    <param name="position">         atjoint             atjoint             atjoint             atjoint                 </param> 
+
+                <group name="ENCODER1">
+                    <param name="type">             pos                 pos                 pos                 pos                     </param>
+                    <param name="port">             POS:hand_thumb_oc      POS:hand_index_oc      POS:hand_middle_oc     POS:hand_ring_pinky_oc          </param>
+                    <param name="position">         atjoint             atjoint             atjoint             atjoint                 </param>
                     <param name="resolution">       65535               65535               65535               65535                   </param>
-                    <param name="tolerance">        5                   5                   5                   5                       </param>  
-                </group>        
-                
+                    <param name="tolerance">        5                   5                   5                   5                       </param>
+                </group>
+
                 <group name="ENCODER2">
                     <param name="type">             qenc                qenc                qenc                qenc                    </param>
                     <param name="port">             CONN:P2             CONN:P3             CONN:P4             CONN:P5                 </param>
                     <param name="position">         atmotor             atmotor             atmotor             atmotor                 </param>
                     <param name="resolution">       -1600               1600                -1600               -1600                    </param>
-                    <param name="tolerance">        0                   0                   0                   0                       </param>  
-                </group>  
-            </group>                        
-           
+                    <param name="tolerance">        0                   0                   0                   0                       </param>
+                </group>
+            </group>
+
         </group>
-           
+
     </group>
-    
-  
+
+
 </params>
 

--- a/experimentalSetups/wristmk2_handmk3_ems_2foc/hardware/motorControl/hv3_left_hand7-mc-service.xml
+++ b/experimentalSetups/wristmk2_handmk3_ems_2foc/hardware/motorControl/hv3_left_hand7-mc-service.xml
@@ -4,61 +4,61 @@
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="new_forearm" build="1">
 
     <group name="SERVICE">
-        
-        <param name="type"> eomn_serv_MC_mc4pluspmc </param> 
-    
-        <group name="PROPERTIES">
-        
-            <group name="ETHBOARD">
-                <param name="type">                 mc4plus             </param> 
-            </group>          
 
-            <group name="CANBOARDS"> 
-                <param name="type">                 pmc                 </param> 
-                <group name="PROTOCOL">                    
-                    <param name="major">            2                   </param>    
-                    <param name="minor">            0                   </param>     
-                </group>                                   
-                <group name="FIRMWARE">                    
-                    <param name="major">            1                   </param>    
-                    <param name="minor">            0                   </param> 
+        <param name="type"> eomn_serv_MC_mc4pluspmc </param>
+
+        <group name="PROPERTIES">
+
+            <group name="ETHBOARD">
+                <param name="type">                 mc4plus             </param>
+            </group>
+
+            <group name="CANBOARDS">
+                <param name="type">                 pmc                 </param>
+                <group name="PROTOCOL">
+                    <param name="major">            2                   </param>
+                    <param name="minor">            0                   </param>
+                </group>
+                <group name="FIRMWARE">
+                    <param name="major">            1                   </param>
+                    <param name="minor">            0                   </param>
                     <param name="build">            0                   </param>
                 </group>
             </group>
-            
-            <group name="POS"> 
-                <param name="location">             CAN1:1              </param> 
-            </group>                      
-            
+
+            <group name="POS">
+                <param name="location">             CAN1:1              </param>
+            </group>
+
 
             <group name="JOINTMAPPING">
 
-                <group name="ACTUATOR">                 
+                <group name="ACTUATOR">
                     <param name="type">             pwm                 pwm                 pwm                 pwm                     pmc                     pmc                 pmc                     </param>
                     <param name="port">             CONN:P2             CONN:P3             CONN:P4             CONN:P5                 CAN1:1                  CAN1:1              CAN1:1                  </param>
                 </group>
-                
-                <group name="ENCODER1">  
-                    <param name="type">             pos                 pos                 pos                 pos                     pos                     pos                 pos                     </param>  
-                    <param name="port">             POS:hand_thumb      POS:hand_index      POS:hand_medium     POS:hand_pinky          POS:hand_thumbmetacarpus    POS:hand_thumbrotation   POS:hand_indexadduction      </param>
-                    <param name="position">         atjoint             atjoint             atjoint             atjoint                 atjoint                 atjoint             atjoint                 </param> 
+
+                <group name="ENCODER1">
+                    <param name="type">             pos                 pos                 pos                 pos                     pos                     pos                 pos                     </param>
+                    <param name="port">             POS:hand_thumb_oc      POS:hand_index_oc      POS:hand_middle_oc     POS:hand_ring_pinky_oc          POS:hand_thumb_add    POS:hand_thumbrotation   POS:hand_index_add      </param>
+                    <param name="position">         atjoint             atjoint             atjoint             atjoint                 atjoint                 atjoint             atjoint                 </param>
                     <param name="resolution">       65535               65535               65535               65535                   65535                   65535               65535                   </param>
-                    <param name="tolerance">        5                   5                   5                   5                       5                       5                   5                       </param>  
-                </group>        
-                
+                    <param name="tolerance">        5                   5                   5                   5                       5                       5                   5                       </param>
+                </group>
+
                 <group name="ENCODER2">
                     <param name="type">             qenc                qenc                qenc                qenc                    none                    none                none                    </param>
                     <param name="port">             CONN:P2             CONN:P3             CONN:P4             CONN:P5                 CONN:none               CONN:none           CONN:none               </param>
                     <param name="position">         atmotor             atmotor             atmotor             atmotor                 none                    none                none                    </param>
                     <param name="resolution">       -1600               1600                -1600               -1600                   0                       0                   0                       </param>
-                    <param name="tolerance">        0                   0                   0                   0                       0                       0                   0                       </param>  
-                </group>  
-            </group>                        
-           
+                    <param name="tolerance">        0                   0                   0                   0                       0                       0                   0                       </param>
+                </group>
+            </group>
+
         </group>
-           
+
     </group>
-    
-  
+
+
 </params>
 

--- a/experimentalSetups/wristmk2_handmk3_ems_amcbldc/hardware/motorControl/hv3_left_hand-mc-service.xml
+++ b/experimentalSetups/wristmk2_handmk3_ems_amcbldc/hardware/motorControl/hv3_left_hand-mc-service.xml
@@ -4,61 +4,61 @@
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="new_forearm" build="1">
 
     <group name="SERVICE">
-        
-        <param name="type"> eomn_serv_MC_mc4plusfaps </param> 
-    
-        <group name="PROPERTIES">
-        
-            <group name="ETHBOARD">
-                <param name="type">                 mc4plus             </param> 
-            </group>          
 
-            <group name="CANBOARDS"> 
-                <param name="type">                 pmc                 </param> 
-                <group name="PROTOCOL">                    
-                    <param name="major">            0                   </param>    
-                    <param name="minor">            0                   </param>     
-                </group>                                   
-                <group name="FIRMWARE">                    
-                    <param name="major">            0                   </param>    
-                    <param name="minor">            0                   </param> 
+        <param name="type"> eomn_serv_MC_mc4plusfaps </param>
+
+        <group name="PROPERTIES">
+
+            <group name="ETHBOARD">
+                <param name="type">                 mc4plus             </param>
+            </group>
+
+            <group name="CANBOARDS">
+                <param name="type">                 pmc                 </param>
+                <group name="PROTOCOL">
+                    <param name="major">            0                   </param>
+                    <param name="minor">            0                   </param>
+                </group>
+                <group name="FIRMWARE">
+                    <param name="major">            0                   </param>
+                    <param name="minor">            0                   </param>
                     <param name="build">            0                   </param>
                 </group>
             </group>
-            
-            <group name="POS"> 
-                <param name="location">             CAN1:1              </param> 
-            </group>                      
-            
+
+            <group name="POS">
+                <param name="location">             CAN1:1              </param>
+            </group>
+
 
             <group name="JOINTMAPPING">
 
-                <group name="ACTUATOR">                 
+                <group name="ACTUATOR">
                     <param name="type">             pwm                 pwm                 pwm                 pwm                     </param>
                     <param name="port">             CONN:P2             CONN:P3             CONN:P4             CONN:P5                 </param>
                 </group>
-                
-                <group name="ENCODER1">  
-                    <param name="type">             pos                 pos                 pos                 pos                     </param>  
-                    <param name="port">             POS:hand_thumb      POS:hand_index      POS:hand_medium     POS:hand_pinky          </param>
-                    <param name="position">         atjoint             atjoint             atjoint             atjoint                 </param> 
+
+                <group name="ENCODER1">
+                    <param name="type">             pos                 pos                 pos                 pos                     </param>
+                    <param name="port">             POS:hand_thumb_oc      POS:hand_index_oc      POS:hand_middle_oc     POS:hand_ring_pinky_oc          </param>
+                    <param name="position">         atjoint             atjoint             atjoint             atjoint                 </param>
                     <param name="resolution">       65535               65535               65535               65535                   </param>
-                    <param name="tolerance">        5                   5                   5                   5                       </param>  
-                </group>        
-                
+                    <param name="tolerance">        5                   5                   5                   5                       </param>
+                </group>
+
                 <group name="ENCODER2">
                     <param name="type">             qenc                qenc                qenc                qenc                    </param>
                     <param name="port">             CONN:P2             CONN:P3             CONN:P4             CONN:P5                 </param>
                     <param name="position">         atmotor             atmotor             atmotor             atmotor                 </param>
                     <param name="resolution">       -1600               1600                -1600               -1600                    </param>
-                    <param name="tolerance">        0                   0                   0                   0                       </param>  
-                </group>  
-            </group>                        
-           
+                    <param name="tolerance">        0                   0                   0                   0                       </param>
+                </group>
+            </group>
+
         </group>
-           
+
     </group>
-    
-  
+
+
 </params>
 

--- a/experimentalSetups/wristmk2_handmk3_ems_amcbldc/hardware/motorControl/hv3_left_hand7-mc-service.xml
+++ b/experimentalSetups/wristmk2_handmk3_ems_amcbldc/hardware/motorControl/hv3_left_hand7-mc-service.xml
@@ -4,61 +4,61 @@
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="new_forearm" build="1">
 
     <group name="SERVICE">
-        
-        <param name="type"> eomn_serv_MC_mc4pluspmc </param> 
-    
-        <group name="PROPERTIES">
-        
-            <group name="ETHBOARD">
-                <param name="type">                 mc4plus             </param> 
-            </group>          
 
-            <group name="CANBOARDS"> 
-                <param name="type">                 pmc                 </param> 
-                <group name="PROTOCOL">                    
-                    <param name="major">            2                   </param>    
-                    <param name="minor">            0                   </param>     
-                </group>                                   
-                <group name="FIRMWARE">                    
-                    <param name="major">            1                   </param>    
-                    <param name="minor">            0                   </param> 
+        <param name="type"> eomn_serv_MC_mc4pluspmc </param>
+
+        <group name="PROPERTIES">
+
+            <group name="ETHBOARD">
+                <param name="type">                 mc4plus             </param>
+            </group>
+
+            <group name="CANBOARDS">
+                <param name="type">                 pmc                 </param>
+                <group name="PROTOCOL">
+                    <param name="major">            2                   </param>
+                    <param name="minor">            0                   </param>
+                </group>
+                <group name="FIRMWARE">
+                    <param name="major">            1                   </param>
+                    <param name="minor">            0                   </param>
                     <param name="build">            0                   </param>
                 </group>
             </group>
-            
-            <group name="POS"> 
-                <param name="location">             CAN1:1              </param> 
-            </group>                      
-            
+
+            <group name="POS">
+                <param name="location">             CAN1:1              </param>
+            </group>
+
 
             <group name="JOINTMAPPING">
 
-                <group name="ACTUATOR">                 
+                <group name="ACTUATOR">
                     <param name="type">             pwm                 pwm                 pwm                 pwm                     pmc                     pmc                 pmc                     </param>
                     <param name="port">             CONN:P2             CONN:P3             CONN:P4             CONN:P5                 CAN1:1                  CAN1:1              CAN1:1                  </param>
                 </group>
-                
-                <group name="ENCODER1">  
-                    <param name="type">             pos                 pos                 pos                 pos                     pos                     pos                 pos                     </param>  
-                    <param name="port">             POS:hand_thumb      POS:hand_index      POS:hand_medium     POS:hand_pinky          POS:hand_thumbmetacarpus    POS:hand_thumbrotation   POS:hand_indexadduction      </param>
-                    <param name="position">         atjoint             atjoint             atjoint             atjoint                 atjoint                 atjoint             atjoint                 </param> 
+
+                <group name="ENCODER1">
+                    <param name="type">             pos                 pos                 pos                 pos                     pos                     pos                 pos                     </param>
+                    <param name="port">             POS:hand_thumb_oc      POS:hand_index_oc      POS:hand_middle_oc     POS:hand_ring_pinky_oc          POS:hand_thumb_add    POS:hand_thumbrotation   POS:hand_index_add      </param>
+                    <param name="position">         atjoint             atjoint             atjoint             atjoint                 atjoint                 atjoint             atjoint                 </param>
                     <param name="resolution">       65535               65535               65535               65535                   65535                   65535               65535                   </param>
-                    <param name="tolerance">        5                   5                   5                   5                       5                       5                   5                       </param>  
-                </group>        
-                
+                    <param name="tolerance">        5                   5                   5                   5                       5                       5                   5                       </param>
+                </group>
+
                 <group name="ENCODER2">
                     <param name="type">             qenc                qenc                qenc                qenc                    none                    none                none                    </param>
                     <param name="port">             CONN:P2             CONN:P3             CONN:P4             CONN:P5                 CONN:none               CONN:none           CONN:none               </param>
                     <param name="position">         atmotor             atmotor             atmotor             atmotor                 none                    none                none                    </param>
                     <param name="resolution">       -1600               1600                -1600               -1600                   0                       0                   0                       </param>
-                    <param name="tolerance">        0                   0                   0                   0                       0                       0                   0                       </param>  
-                </group>  
-            </group>                        
-           
+                    <param name="tolerance">        0                   0                   0                   0                       0                       0                   0                       </param>
+                </group>
+            </group>
+
         </group>
-           
+
     </group>
-    
-  
+
+
 </params>
 


### PR DESCRIPTION
See robotology/robots-configuration#436

(unfortunately VS Code cleaned up the trailing space, I advice to review the changes ticking "[Hide whitespace](https://github.com/robotology/robots-configuration/pull/444/files?w=1)")

TO BE TESTED

It requires:
- https://github.com/robotology/icub-firmware/pull/346
- https://github.com/robotology/icub-firmware-shared/pull/78