### PR TITLE
iCub: Update neck_pitch and neck_roll position PIDs in head version > = 2.0

### DIFF
--- a/iCubEdinburgh01/hardware/motorControl/head-eb20-j0_1-mc.xml
+++ b/iCubEdinburgh01/hardware/motorControl/head-eb20-j0_1-mc.xml
@@ -50,9 +50,9 @@
            <param name="outputType">             pwm                       </param>    
             <param name="fbkControlUnits">  metric_units   </param>
             <param name="outputControlUnits">  machine_units      </param> 
-            <param name="kp">                 -300        +300        </param>       
-            <param name="kd">                 -10.0       +10.0       </param>     
-            <param name="ki">                 -100.0      +100        </param>          
+            <param name="kp">                 -645        +547        </param>       
+            <param name="kd">                 -19.0       +16.0       </param>     
+            <param name="ki">                 -2983.0      +2879        </param>          
             <param name="maxOutput">          3360        3360        </param>  
             <param name="maxInt">             3360        3360        </param> 
             <param name="stictionUp">         0           0           </param> 

--- a/iCubErzelli01/hardware/motorControl/head-eb20-j0_1-mc.xml
+++ b/iCubErzelli01/hardware/motorControl/head-eb20-j0_1-mc.xml
@@ -47,9 +47,9 @@
         <param name="outputType">               pwm             </param>
         <param name="fbkControlUnits">          metric_units    </param>
         <param name="outputControlUnits">       machine_units   </param>
-        <param name="kp">                       -300        +300        </param>
-        <param name="kd">                       -10         +10         </param>
-        <param name="ki">                       -100        +100        </param>
+        <param name="kp">                       -645        +547        </param>
+        <param name="kd">                       -19         +16         </param>
+        <param name="ki">                       -2983        +2879        </param>
         <param name="maxOutput">                3360        3360        </param>
         <param name="maxInt">                   3360        3360        </param>
         <param name="stictionUp">               0           0           </param>

--- a/iCubErzelli02/hardware/motorControl/head-eb20-j0_1-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/head-eb20-j0_1-mc.xml
@@ -47,9 +47,9 @@
         <param name="outputType">               pwm             </param>
         <param name="fbkControlUnits">          metric_units    </param>
         <param name="outputControlUnits">       machine_units   </param>
-        <param name="kp">                       -300        +300        </param>
-        <param name="kd">                       -10         +10         </param>
-        <param name="ki">                       -100        +100        </param>
+        <param name="kp">                       -645        +547        </param>
+        <param name="kd">                       -19         +16         </param>
+        <param name="ki">                       -2983        +2879        </param>
         <param name="maxOutput">                3360        3360        </param>
         <param name="maxInt">                   3360        3360        </param>
         <param name="stictionUp">               0           0           </param>

--- a/iCubGenova02/hardware/motorControl/head-eb20-j0_1-mc.xml
+++ b/iCubGenova02/hardware/motorControl/head-eb20-j0_1-mc.xml
@@ -47,9 +47,9 @@
         <param name="outputType">               pwm             </param>
         <param name="fbkControlUnits">          metric_units    </param>
         <param name="outputControlUnits">       machine_units   </param>
-        <param name="kp">                       -300        +300        </param>
-        <param name="kd">                       -10         +10         </param>
-        <param name="ki">                       -100        +100        </param>
+        <param name="kp">                       -645        +547        </param>
+        <param name="kd">                       -19         +16         </param>
+        <param name="ki">                       -2983        +2879        </param>
         <param name="maxOutput">                3360        3360        </param>
         <param name="maxInt">                   3360        3360        </param>
         <param name="stictionUp">               0           0           </param>

--- a/iCubGenova04/hardware/motorControl/head-eb20-j0_1-mc.xml
+++ b/iCubGenova04/hardware/motorControl/head-eb20-j0_1-mc.xml
@@ -47,9 +47,9 @@
         <param name="outputType">               pwm             </param>
         <param name="fbkControlUnits">          metric_units    </param>
         <param name="outputControlUnits">       machine_units   </param>
-        <param name="kp">                       -300        +300        </param>
-        <param name="kd">                       -10         +10         </param>
-        <param name="ki">                       -100        +100        </param>
+        <param name="kp">                       -645        +547        </param>
+        <param name="kd">                       -19         +16         </param>
+        <param name="ki">                       -2983        +2879        </param>
         <param name="maxOutput">                3360        3360        </param>
         <param name="maxInt">                   3360        3360        </param>
         <param name="stictionUp">               0           0           </param>

--- a/iCubGenova07/hardware/motorControl/head-eb20-j0_1-mc.xml
+++ b/iCubGenova07/hardware/motorControl/head-eb20-j0_1-mc.xml
@@ -47,9 +47,9 @@
         <param name="outputType">               pwm             </param>
         <param name="fbkControlUnits">          metric_units    </param>
         <param name="outputControlUnits">       machine_units   </param>
-        <param name="kp">                       -300        +300        </param>
-        <param name="kd">                       -10         +10         </param>
-        <param name="ki">                       -100        +100        </param>
+        <param name="kp">                       -645        +547        </param>
+        <param name="kd">                       -19         +16         </param>
+        <param name="ki">                       -2983        +2879        </param>
         <param name="maxOutput">                3360        3360        </param>
         <param name="maxInt">                   3360        3360        </param>
         <param name="stictionUp">               0           0           </param>

--- a/iCubGenova08/hardware/motorControl/head-eb20-j0_1-mc.xml
+++ b/iCubGenova08/hardware/motorControl/head-eb20-j0_1-mc.xml
@@ -47,9 +47,9 @@
         <param name="outputType">               pwm             </param>
         <param name="fbkControlUnits">          metric_units    </param>
         <param name="outputControlUnits">       machine_units   </param>
-        <param name="kp">                       -300        +300        </param>
-        <param name="kd">                       -10         +10         </param>
-        <param name="ki">                       -100        +100        </param>
+        <param name="kp">                       -645        +547        </param>
+        <param name="kd">                       -19         +16         </param>
+        <param name="ki">                       -2983        +2879        </param>
         <param name="maxOutput">                3360        3360        </param>
         <param name="maxInt">                   3360        3360        </param>
         <param name="stictionUp">               0           0           </param>

--- a/iCubGenova09/hardware/motorControl/head-eb20-j0_1-mc.xml
+++ b/iCubGenova09/hardware/motorControl/head-eb20-j0_1-mc.xml
@@ -47,9 +47,9 @@
         <param name="outputType">               pwm             </param>
         <param name="fbkControlUnits">          metric_units    </param>
         <param name="outputControlUnits">       machine_units   </param>
-        <param name="kp">                       -300        +300        </param>
-        <param name="kd">                       -10         +10         </param>
-        <param name="ki">                       -100        +100        </param>
+        <param name="kp">                       -645        +547        </param>
+        <param name="kd">                       -19         +16         </param>
+        <param name="ki">                       -2983        +2879        </param>
         <param name="maxOutput">                3360        3360        </param>
         <param name="maxInt">                   3360        3360        </param>
         <param name="stictionUp">               0           0           </param>

--- a/iCubGenova10/hardware/motorControl/head-eb20-j0_1-mc.xml
+++ b/iCubGenova10/hardware/motorControl/head-eb20-j0_1-mc.xml
@@ -47,9 +47,9 @@
         <param name="outputType">               pwm             </param>
         <param name="fbkControlUnits">          metric_units    </param>
         <param name="outputControlUnits">       machine_units   </param>
-        <param name="kp">                       -300        +300        </param>
-        <param name="kd">                       -10         +10         </param>
-        <param name="ki">                       -100        +100        </param>
+        <param name="kp">                       -645        +547        </param>
+        <param name="kd">                       -19         +16         </param>
+        <param name="ki">                       -2983        +2879        </param>
         <param name="maxOutput">                3360        3360        </param>
         <param name="maxInt">                   3360        3360        </param>
         <param name="stictionUp">               0           0           </param>

--- a/iCubGenova11/hardware/motorControl/head-eb20-j0_1-mc.xml
+++ b/iCubGenova11/hardware/motorControl/head-eb20-j0_1-mc.xml
@@ -47,9 +47,9 @@
         <param name="outputType">               pwm             </param>
         <param name="fbkControlUnits">          metric_units    </param>
         <param name="outputControlUnits">       machine_units   </param>
-        <param name="kp">                       -300        +300        </param>
-        <param name="kd">                       -10         +10         </param>
-        <param name="ki">                       -100        +100        </param>
+        <param name="kp">                       -645        +547        </param>
+        <param name="kd">                       -19         +16         </param>
+        <param name="ki">                       -2983        +2879        </param>
         <param name="maxOutput">                3360        3360        </param>
         <param name="maxInt">                   3360        3360        </param>
         <param name="stictionUp">               0           0           </param>

--- a/iCubHongKong01/hardware/motorControl/head-eb20-j0_1-mc.xml
+++ b/iCubHongKong01/hardware/motorControl/head-eb20-j0_1-mc.xml
@@ -47,9 +47,9 @@
         <param name="outputType">               pwm             </param>
         <param name="fbkControlUnits">          metric_units    </param>
         <param name="outputControlUnits">       machine_units   </param>
-        <param name="kp">                       -300        +300        </param>
-        <param name="kd">                       -10         +10         </param>
-        <param name="ki">                       -100        +100        </param>
+        <param name="kp">                       -645        +547        </param>
+        <param name="kd">                       -19         +16         </param>
+        <param name="ki">                       -2983        +2879        </param>
         <param name="maxOutput">                3360        3360        </param>
         <param name="maxInt">                   3360        3360        </param>
         <param name="stictionUp">               0           0           </param>

--- a/iCubLausanne02/hardware/motorControl/head-eb20-j0_1-mc.xml
+++ b/iCubLausanne02/hardware/motorControl/head-eb20-j0_1-mc.xml
@@ -50,9 +50,9 @@
            <param name="outputType">             pwm                       </param>    
             <param name="fbkControlUnits">  metric_units   </param>
             <param name="outputControlUnits">  machine_units      </param> 
-            <param name="kp">                 -300        +300        </param>       
-            <param name="kd">                 -10.0       +10.0       </param>     
-            <param name="ki">                 -100.0      +100        </param>          
+            <param name="kp">                 -645        +547        </param>
+            <param name="kd">                 -19         +16         </param>
+            <param name="ki">                 -2983        +2879        </param>
             <param name="maxOutput">          3360        3360        </param>  
             <param name="maxInt">             3360        3360        </param> 
             <param name="stictionUp">         0           0           </param> 

--- a/iCubLisboa01/hardware/motorControl/head-eb20-j0_1-mc.xml
+++ b/iCubLisboa01/hardware/motorControl/head-eb20-j0_1-mc.xml
@@ -47,9 +47,9 @@
         <param name="outputType">               pwm             </param>
         <param name="fbkControlUnits">          metric_units    </param>
         <param name="outputControlUnits">       machine_units   </param>
-        <param name="kp">                       -300        +300        </param>
-        <param name="kd">                       -10         +10         </param>
-        <param name="ki">                       -100        +100        </param>
+        <param name="kp">                       -645        +547        </param>
+        <param name="kd">                       -19         +16         </param>
+        <param name="ki">                       -2983        +2879        </param>
         <param name="maxOutput">                3360        3360        </param>
         <param name="maxInt">                   3360        3360        </param>
         <param name="stictionUp">               0           0           </param>

--- a/iCubMoscow01/hardware/motorControl/head-eb20-j0_1-mc.xml
+++ b/iCubMoscow01/hardware/motorControl/head-eb20-j0_1-mc.xml
@@ -47,9 +47,9 @@
         <param name="outputType">               pwm             </param>
         <param name="fbkControlUnits">          metric_units    </param>
         <param name="outputControlUnits">       machine_units   </param>
-        <param name="kp">                       -300        +300        </param>
-        <param name="kd">                       -10         +10         </param>
-        <param name="ki">                       -100        +100        </param>
+        <param name="kp">                       -645        +547        </param>
+        <param name="kd">                       -19         +16         </param>
+        <param name="ki">                       -2983        +2879        </param>
         <param name="maxOutput">                3360        3360        </param>
         <param name="maxInt">                   3360        3360        </param>
         <param name="stictionUp">               0           0           </param>

--- a/iCubPrague01/hardware/motorControl/head-eb20-j0_1-mc.xml
+++ b/iCubPrague01/hardware/motorControl/head-eb20-j0_1-mc.xml
@@ -47,9 +47,9 @@
         <param name="outputType">               pwm             </param>
         <param name="fbkControlUnits">          metric_units    </param>
         <param name="outputControlUnits">       machine_units   </param>
-        <param name="kp">                       -300        +300        </param>
-        <param name="kd">                       -10         +10         </param>
-        <param name="ki">                       -100        +100        </param>
+        <param name="kp">                       -645        +547        </param>
+        <param name="kd">                       -19         +16         </param>
+        <param name="ki">                       -2983        +2879        </param>
         <param name="maxOutput">                3360        3360        </param>
         <param name="maxInt">                   3360        3360        </param>
         <param name="stictionUp">               0           0           </param>

--- a/iCubShanghai01/hardware/motorControl/head-eb20-j0_1-mc.xml
+++ b/iCubShanghai01/hardware/motorControl/head-eb20-j0_1-mc.xml
@@ -47,9 +47,9 @@
         <param name="outputType">               pwm             </param>
         <param name="fbkControlUnits">          metric_units    </param>
         <param name="outputControlUnits">       machine_units   </param>
-        <param name="kp">                       -300        +300        </param>
-        <param name="kd">                       -10         +10         </param>
-        <param name="ki">                       -100        +100        </param>
+        <param name="kp">                       -645        +547        </param>
+        <param name="kd">                       -19         +16         </param>
+        <param name="ki">                       -2983        +2879        </param>
         <param name="maxOutput">                3360        3360        </param>
         <param name="maxInt">                   3360        3360        </param>
         <param name="stictionUp">               0           0           </param>

--- a/iCubShenzhen01/hardware/motorControl/head-eb20-j0_1-mc.xml
+++ b/iCubShenzhen01/hardware/motorControl/head-eb20-j0_1-mc.xml
@@ -47,9 +47,9 @@
         <param name="outputType">               pwm             </param>
         <param name="fbkControlUnits">          metric_units    </param>
         <param name="outputControlUnits">       machine_units   </param>
-        <param name="kp">                       -300        +300        </param>
-        <param name="kd">                       -10         +10         </param>
-        <param name="ki">                       -100        +100        </param>
+        <param name="kp">                       -645        +547        </param>
+        <param name="kd">                       -19         +16         </param>
+        <param name="ki">                       -2983        +2879        </param>
         <param name="maxOutput">                3360        3360        </param>
         <param name="maxInt">                   3360        3360        </param>
         <param name="stictionUp">               0           0           </param>

--- a/iCubSingapore01/hardware/motorControl/head-eb20-j0_1-mc.xml
+++ b/iCubSingapore01/hardware/motorControl/head-eb20-j0_1-mc.xml
@@ -47,9 +47,9 @@
         <param name="outputType">               pwm             </param>
         <param name="fbkControlUnits">          metric_units    </param>
         <param name="outputControlUnits">       machine_units   </param>
-        <param name="kp">                       -300        +300        </param>
-        <param name="kd">                       -10         +10         </param>
-        <param name="ki">                       -100        +100        </param>
+        <param name="kp">                       -645        +547        </param>
+        <param name="kd">                       -19         +16         </param>
+        <param name="ki">                       -2983        +2879        </param>
         <param name="maxOutput">                3360        3360        </param>
         <param name="maxInt">                   3360        3360        </param>
         <param name="stictionUp">               0           0           </param>

--- a/iCubValparaiso01/hardware/motorControl/head-eb20-j0_1-mc.xml
+++ b/iCubValparaiso01/hardware/motorControl/head-eb20-j0_1-mc.xml
@@ -47,9 +47,9 @@
         <param name="outputType">               pwm             </param>
         <param name="fbkControlUnits">          metric_units    </param>
         <param name="outputControlUnits">       machine_units   </param>
-        <param name="kp">                       -300        +300        </param>
-        <param name="kd">                       -10         +10         </param>
-        <param name="ki">                       -100        +100        </param>
+        <param name="kp">                       -645        +547        </param>
+        <param name="kd">                       -19         +16         </param>
+        <param name="ki">                       -2983        +2879        </param>
         <param name="maxOutput">                3360        3360        </param>
         <param name="maxInt">                   3360        3360        </param>
         <param name="stictionUp">               0           0           </param>

--- a/iCubWaterloo01/hardware/motorControl/head-eb20-j0_1-mc.xml
+++ b/iCubWaterloo01/hardware/motorControl/head-eb20-j0_1-mc.xml
@@ -47,9 +47,9 @@
         <param name="outputType">               pwm             </param>
         <param name="fbkControlUnits">          metric_units    </param>
         <param name="outputControlUnits">       machine_units   </param>
-        <param name="kp">                       -300        +300        </param>
-        <param name="kd">                       -10         +10         </param>
-        <param name="ki">                       -100        +100        </param>
+        <param name="kp">                       -645        +547        </param>
+        <param name="kd">                       -19         +16         </param>
+        <param name="ki">                       -2983        +2879        </param>
         <param name="maxOutput">                3360        3360        </param>
         <param name="maxInt">                   3360        3360        </param>
         <param name="stictionUp">               0           0           </param>

--- a/iCubZagreb01/hardware/motorControl/head-eb20-j0_1-mc.xml
+++ b/iCubZagreb01/hardware/motorControl/head-eb20-j0_1-mc.xml
@@ -47,9 +47,9 @@
         <param name="outputType">               pwm             </param>
         <param name="fbkControlUnits">          metric_units    </param>
         <param name="outputControlUnits">       machine_units   </param>
-        <param name="kp">                       -300        +300        </param>
-        <param name="kd">                       -10         +10         </param>
-        <param name="ki">                       -100        +100        </param>
+        <param name="kp">                       -645        +547        </param>
+        <param name="kd">                       -19         +16         </param>
+        <param name="ki">                       -2983        +2879        </param>
         <param name="maxOutput">                3360        3360        </param>
         <param name="maxInt">                   3360        3360        </param>
         <param name="stictionUp">               0           0           </param>


### PR DESCRIPTION
The updated PID values are obtained by an automatic and robust tuning process described and simulated [here](https://github.com/icub-tech-iit/study-icub-head/tree/sim). 
These values were then tested on iCubGenova02 and iCubGenova09.