### PR TITLE
Full configuration file for test bench arm setup calib type6 FAP

### DIFF
--- a/experimentalSetups/ecub-hand-mc4plusfap/calibrators/left_arm-calib.xml
+++ b/experimentalSetups/ecub-hand-mc4plusfap/calibrators/left_arm-calib.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-calibrator" type="parametricCalibratorEth">
+	<xi:include href="../general.xml" />
+
+	<group name="GENERAL">
+		<param name="joints">3</param>		<!-- the number of joints of the robot part -->
+		<param name="deviceName"> Left_Arm_Calibrator </param>
+	</group>
+
+	
+	<group name="HOME">
+		<param name="positionHome">          30.00      30.00    30.00      </param>
+		<param name="velocityHome">          40.00      40.00    40.00      </param>
+	</group>
+	
+	<!-- For calibration type 6 the calibration values define what follows:
+        calibration1: not used - keep at 0
+        calibration2: speed during calibration in icubdeg/s
+        calibration3: 1 or -1 depending if set as target vmax or vmin, respectively
+        calibration4: vmin
+        calibration5: vmax in icubdegree -> icubdeg = deg * (2^16 / 360)
+	 -->
+	<group name="CALIBRATION">
+	     <param name="calibrationType">      6          6        6          </param> 
+		<param name="calibration1">          0          0        0          </param>
+		<param name="calibration2">	         9102       9102     9102       </param>
+		<param name="calibration3">          1          1        1          </param>
+		<param name="calibration4">          0          0        0          </param>
+		<param name="calibration5">          11833      14564    14564      </param>
+		<param name="calibrationZero">       0          0        0          </param>
+		<param name="calibrationDelta">      0          0        0          </param>
+		<param name="startupPosition">       0.0        0.0      0.0        </param>
+		<param name="startupVelocity">       0.0        0.0      0.0        </param>
+		<param name="startupMaxPwm">         0          0        0          </param>
+		<param name="startupPosThreshold">   0          0        0          </param>
+	</group>
+
+	<!-- motor's encoder of joint 7 can't read -->
+	<param name="CALIB_ORDER">  (2) (1) (0)</param> 
+
+	<action phase="startup" level="10" type="calibrate">
+		<param name="target">left_arm-mc_remapper</param>
+	</action>
+
+	<action phase="interrupt1" level="1" type="park">
+		<param name="target">left_arm-mc_remapper</param>
+	</action>
+
+	<action phase="interrupt3" level="1" type="abort" />
+
+</device>
+
+
+

--- a/experimentalSetups/ecub-hand-mc4plusfap/firmwareupdater.ini
+++ b/experimentalSetups/ecub-hand-mc4plusfap/firmwareupdater.ini
@@ -1,0 +1,2 @@
+[DRIVERS]
+ETH "eth"

--- a/experimentalSetups/ecub-hand-mc4plusfap/general.xml
+++ b/experimentalSetups/ecub-hand-mc4plusfap/general.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="ergoCubSN000" build="1">
+  
+  <group name="GENERAL">
+      <param name="skipCalibration">    true   </param>
+      <param name="useRawEncoderData">  false  </param>
+      <param name="useLimitedPWM">      false  </param>
+      <param name="verbose">            false  </param>
+  </group>
+</params>

--- a/experimentalSetups/ecub-hand-mc4plusfap/hardware/POS/left_hand-pos4.xml
+++ b/experimentalSetups/ecub-hand-mc4plusfap/hardware/POS/left_hand-pos4.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_hand-pos4" type="embObjPOS">
+    <xi:include href="../../general.xml" />
+    <xi:include href="../../hardware/electronics/left_arm-eb23-j7_10-eln.xml" />
+    
+    <group name="SERVICE">
+        
+    <param name="type"> eomn_serv_AS_pos	</param>
+    
+        <group name="PROPERTIES">
+
+            <group name="CANBOARDS">
+                <param name="type">                 eobrd_mtb4fap           </param>
+
+                <group name="PROTOCOL">
+                    <param name="major">            2                       </param>
+                    <param name="minor">            0                       </param>
+                </group>                    
+                <group name="FIRMWARE">
+                    <param name="major">            1                       </param> 
+                    <param name="minor">            1                       </param> 
+                    <param name="build">            0                       </param>
+                </group>
+            </group>
+            
+            <group name="SENSORS">
+
+                <param name="location">             CAN1:2               CAN1:2              CAN1:2                </param>
+               
+                <!-- common to all analog services -->
+                <param name="id">                   id_fapAA             id_fapBB            id_fapCC              </param>
+                <param name="type">                 eoas_pos_angle       eoas_pos_angle      eoas_pos_angle        </param>
+                <param name="port">                 POS:hand_thumb_oc    POS:hand_index_oc   POS:hand_middle_oc    </param>  <!-- According to convention, the full order is: POS:hand_thumb_oc POS:hand_index_oc POS:hand_middle_oc POS:hand_ring_pinky_oc -->
+
+                <param name="boardType">            mtb4fap              mtb4fap             mtb4fap               </param>
+                <param name="connector">            CONN:J3_SDA3         CONN:J3_SDA1        CONN:J3_SDA2          </param>   <!-- J2 does not work because of sw bug even if it is compliant with the serigraphy, keep J3-->
+
+                <group name="CALIBRATION">
+                    <!-- it is not mandatory. if not present, sensors have defaults: TYPE:decideg, ROT:zero, 0.0, false -->
+                    <param name="type">             TYPE:decideg         TYPE:decideg        TYPE:decideg          </param>
+                    <param name="rotation">         ROT:zero             ROT:zero            ROT:plus180           </param>
+                    <param name="offset">           0                    -166.2              -124.7                </param>
+                    <param name="invertDirection">  false                false               false                 </param>
+                </group>
+
+            </group>
+        
+        </group>
+
+        <group name="SETTINGS">
+            <param name="acquisitionRate"> 50 </param>                    <!-- milliseconds -->
+            <param name="enabledSensors"> id_fapAA id_fapBB id_fapCC</param>
+        </group>
+                
+    </group>
+
+</device>

--- a/experimentalSetups/ecub-hand-mc4plusfap/hardware/electronics/left_arm-eb23-j7_10-eln.xml
+++ b/experimentalSetups/ecub-hand-mc4plusfap/hardware/electronics/left_arm-eb23-j7_10-eln.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="ergoCubSN000" build="1">
+
+    <xi:include href="./pc104.xml" />
+
+    <group name="ETH_BOARD">
+
+        <group name="ETH_BOARD_PROPERTIES">
+            <param name="IpAddress">                10.0.1.1                </param>
+            <param name="IpPort">                   12345                   </param>
+            <param name="Type">                     mc4plus                 </param>
+            <param name="maxSizeRXpacket">          768                     </param>
+            <param name="maxSizeROP">               384                     </param>
+        </group>
+
+        <group name="ETH_BOARD_SETTINGS">
+            <param name="Name">                     "left_arm-eb23-j7_10"   </param>
+            <group name="RUNNINGMODE">
+                <param name="period">                   1000                </param>
+                <param name="maxTimeOfRXactivity">      400                 </param>
+                <param name="maxTimeOfDOactivity">      300                 </param>
+                <param name="maxTimeOfTXactivity">      300                 </param>
+                <param name="TXrateOfRegularROPs">      5                   </param>
+            </group>
+        </group>
+
+        <group name="ETH_BOARD_ACTIONS">
+            <group name="MONITOR_ITS_PRESENCE">
+                <param name="enabled">                  true                </param>
+                <param name="timeout">                  0.020               </param>
+                <param name="periodOfMissingReport">    60.0                </param>
+            </group>
+        </group>
+
+    </group>
+
+</params>
+

--- a/experimentalSetups/ecub-hand-mc4plusfap/hardware/electronics/pc104.xml
+++ b/experimentalSetups/ecub-hand-mc4plusfap/hardware/electronics/pc104.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="ergoCubSN000" build="1">
+
+    <group name="PC104">
+        <param name="PC104IpAddress">           10.0.1.104      </param>
+        <param name="PC104IpPort">              12345           </param>
+        <param name="PC104TXrate">              1               </param> 
+        <param name="PC104RXrate">              5               </param>
+    </group>
+
+        <group name="DEBUG">
+        <param name="embBoardsConnected"> 1 </param>
+    </group>
+
+</params>
+

--- a/experimentalSetups/ecub-hand-mc4plusfap/hardware/mechanicals/left_arm-eb23-j7_10-mec.xml
+++ b/experimentalSetups/ecub-hand-mc4plusfap/hardware/mechanicals/left_arm-eb23-j7_10-mec.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="ergoCubSN000" build="1">
+    <group name="GENERAL">
+        <param name="MotioncontrolVersion"> 6 </param>
+        <param name="Joints"> 3 </param>
+
+        <!-- joint number in sub-part       0                       1                       2                           3                       -->
+        <!-- joint name                                                                                                                         -->
+        <param name="AxisMap">              0                       1                       2                           </param>
+        <param name="AxisName">             "l_thumb_oc"            "l_index_oc"            "l_middle_oc"               </param>
+        <param name="AxisType">             "revolute"              "revolute"              "revolute"                  </param>
+        <param name="Encoder">              182.044                 182.044                 182.044                     </param>
+        <param name="fullscalePWM">         3360                    3360                    3360                        </param>
+        <param name="ampsToSensor">         1000.0                  1000.0                  1000.0                      </param>
+        <param name="Gearbox_M2J">          16                      159                     159                         </param> <!-- real value: 159 - await PR to solve this problem -->
+        <param name="Gearbox_E2J">          1                       1                       1                           </param>
+        <param name="useMotorSpeedFbk">     0                       0                       0                           </param>
+        <param name="MotorType">            "DC"                    "DC"                    "DC"                        </param>
+        <!-- NOTE: Keep attention to these details: it should be noted that on this setup encoder on the thumb is not registering the index, encoder on the middle has issue with ticks reading-->
+        <param name="Verbose"> 0 </param>
+    </group>
+
+    <group name="LIMITS">
+        <param name="hardwareJntPosMax">    90                      90                       90                         </param>
+        <param name="hardwareJntPosMin">    0                       0                        0                          </param>
+        <param name="rotorPosMin">          0                       -28000                   -2000                      </param> 
+        <param name="rotorPosMax">          0                       3500                     28000                      </param> 
+    </group>
+
+    <group name="COUPLINGS">
+
+        <param name ="matrixJ2M">
+            1.000   0.000   0.000   0.000
+            0.000   1.000   0.000   0.000
+            0.000   0.000   1.000   0.000
+            0.000   0.000   0.000   1.000
+        </param>
+
+        <param name ="matrixM2J">
+            1.000   0.000   0.000   0.000
+            0.000   1.000   0.000   0.000
+            0.000   0.000   1.000   0.000
+            0.000   0.000   0.000   1.000
+        </param>
+
+        <param name ="matrixE2J">
+            1.000   0.000   0.000   0.000   0.000   0.000
+            0.000   1.000   0.000   0.000   0.000   0.000
+            0.000   0.000   1.000   0.000   0.000   0.000
+            0.000   0.000   0.000   1.000   0.000   0.000
+        </param>
+
+    </group>
+
+    <group name="JOINTSET_CFG">
+        <param name= "numberofsets"> 3 </param>
+        <group name="JOINTSET_0">
+            <param name="listofjoints">  0             </param>
+            <param name="constraint">    none          </param>
+            <param name="param1">        0             </param>
+            <param name="param2">        0             </param>
+        </group>
+        <group name="JOINTSET_1">
+            <param name="listofjoints">  1             </param>
+            <param name="constraint">    none          </param>
+            <param name="param1">        0             </param>
+            <param name="param2">        0             </param>
+        </group>
+        <group name="JOINTSET_2">
+            <param name="listofjoints">  2             </param>
+            <param name="constraint">    none          </param>
+            <param name="param1">        0             </param>
+            <param name="param2">        0             </param>
+        </group>
+    </group>
+
+</params>

--- a/experimentalSetups/ecub-hand-mc4plusfap/hardware/motorControl/left_arm-eb23-j7_10-mc.xml
+++ b/experimentalSetups/ecub-hand-mc4plusfap/hardware/motorControl/left_arm-eb23-j7_10-mc.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-eb23-j7_10-mc" type="embObjMotionControl">
+
+    <xi:include href="../../general.xml" />
+    <xi:include href="../electronics/left_arm-eb23-j7_10-eln.xml" />
+    <xi:include href="../mechanicals/left_arm-eb23-j7_10-mec.xml" />
+    <xi:include href="../motorControl/left_arm-eb23-j7_10-mc_service.xml" />
+
+    <!-- joint number                           0                   1                   2                   3                   -->
+    <!-- joint name                             hand_thumb_oc       hand_index_oc       hand_middle_oc      hand_ring_pinky_oc  -->
+    <group name="LIMITS">
+        <param name="jntPosMin">                4                   4                   4                    </param>
+        <param name="jntPosMax">                72                  85                  85                   </param>
+        <param name="jntVelMax">                1000                1000                1000                 </param>
+        <param name="motorOverloadCurrents">    2000                2000                2000                 </param>
+        <param name="motorNominalCurrents">     700                 700                 700                  </param>
+        <param name="motorPeakCurrents">        1500                1500                1500                 </param>    
+        <param name="motorPwmLimit">            3360                3360                3360                 </param>
+    </group>       
+    
+    <group name="TIMEOUTS">
+        <param name="velocity">                 100                 100                 100                  </param>
+    </group>
+
+    <group name="IMPEDANCE">
+        <param name="stiffness">                0.0                 0.0                 0.0                  </param>
+        <param name="damping">                  0.0                 0.0                 0.0                  </param>
+    </group>
+    
+    <group name="CONTROLS">
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT      </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT      </param>
+        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT      </param>
+        <param name="torqueControl">            none                none                none                 </param>
+        <param name="currentPid">               none                none                none                 </param>
+        <param name="speedPid">                 none                none                none                 </param>
+    </group>
+
+
+    <!-- default position PID: begin -->
+    
+    <group name="POS_PID_DEFAULT">
+        <param name="controlLaw">               minjerk                                                      </param>
+        <param name="outputType">               pwm                                                          </param>
+        <param name="fbkControlUnits">          metric_units                                                 </param>
+        <param name="outputControlUnits">       machine_units                                                </param>
+        <param name="kp">                       +30               +30                     -30                </param>
+        <param name="kd">                       0                 0                       0                  </param>
+        <param name="ki">                       +10               +10                     -10                </param>
+        <param name="maxOutput">                3360              3360                    3360               </param>
+        <param name="maxInt">                   1000              1000                    1000               </param>
+        <param name="stictionUp">               0                 0                       0                  </param>
+        <param name="stictionDown">             0                 0                       0                  </param>
+        <param name="kff">                      0                 0                       0                  </param>
+    </group>
+
+    <!-- default position PID: end -->
+
+
+    <!-- other default PIDs: begin -->   
+    <!-- other default PIDs: end -->
+
+
+    <!-- custom PIDs: begin -->    
+    <!-- custom PIDs: end -->
+    
+</device>
+
+
+        

--- a/experimentalSetups/ecub-hand-mc4plusfap/hardware/motorControl/left_arm-eb23-j7_10-mc_service.xml
+++ b/experimentalSetups/ecub-hand-mc4plusfap/hardware/motorControl/left_arm-eb23-j7_10-mc_service.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="ergoCubSN000" build="1">
+
+    <group name="SERVICE">
+
+        <param name="type"> eomn_serv_MC_mc4plusfaps </param>
+
+        <group name="PROPERTIES">
+
+            <group name="ETHBOARD">
+                <param name="type">                 mc4plus             </param>
+            </group>
+
+            <group name="CANBOARDS">
+                <param name="type">                 mtb4fap             </param>
+                <group name="PROTOCOL">
+                    <param name="major">            2                   </param>
+                    <param name="minor">            0                   </param>
+                </group>
+                <group name="FIRMWARE">
+                    <param name="major">            1                   </param>
+                    <param name="minor">            1                   </param>
+                    <param name="build">            0                   </param>
+                </group>
+            </group>
+
+            <group name="POS">
+                <param name="location">             CAN1:2      </param>
+
+                <group name="SENSORS">
+
+                    <!-- common to all analog services -->
+                    <param name="id">               id_fapAA              id_fapBB            id_fapCC                    </param>
+                    <param name="type">             eoas_pos_angle        eoas_pos_angle      eoas_pos_angle              </param>
+                    <param name="port">             POS:hand_thumb_oc     POS:hand_index_oc   POS:hand_middle_oc          </param> <!-- According to convention, the full order is: POS:hand_thumb_oc POS:hand_index_oc POS:hand_middle_oc POS:hand_ring_pinky_oc -->
+
+                    <param name="boardType">        mtb4fap               mtb4fap             mtb4fap                     </param>
+                    <param name="connector">        CONN:J3_SDA3          CONN:J3_SDA1        CONN:J3_SDA2                </param> <!-- J2 does not work because of sw bug even if it is compliant with the ser2graphy, keep J3-->
+
+                    <group name="CALIBRATION">
+                        <!-- it is not mandatory. if not present, sensors have defaults: TYPE:decideg, ROT:zero, 0.0, false -->
+                        <param name="type">             TYPE:decideg     TYPE:decideg         TYPE:decideg                </param>
+                        <param name="rotation">         ROT:zero         ROT:zero             ROT:plus180                 </param>
+                        <param name="offset">           0               -166.2                -124.7                      </param>
+                        <param name="invertDirection">  false            false                false                       </param> <!-- to let the joint encoder know how to move based on the input given on the UI (if false close if degree increase)-->
+                    </group>
+                </group>
+                
+                <group name="SETTINGS">
+                    <param name="acquisitionRate"> 50 </param>                    <!-- milliseconds -->
+                    <param name="enabledSensors"> id_fapAA id_fapBB id_fapCC </param>
+                </group>
+            </group>
+
+
+            <group name="JOINTMAPPING">
+
+                <group name="ACTUATOR">
+                    <param name="type">             pwm                       pwm                   pwm                   </param>
+                    <param name="port">             CONN:P3                   CONN:P2               CONN:P5               </param>
+                </group>
+
+                <group name="ENCODER1">
+                    <param name="type">             pos                       pos                   pos                   </param>
+                    <param name="port">             POS:hand_thumb_oc         POS:hand_index_oc     POS:hand_middle_oc    </param>  <!-- According to convention, the full order is: POS:hand_thumb_oc POS:hand_index_oc POS:hand_middle_oc POS:hand_ring_pinky_oc -->
+                    <param name="position">         atjoint                   atjoint               atjoint               </param>
+                    <param name="resolution">       65535                     65535                 65535                 </param>
+                    <param name="tolerance">        5                         5                     5                     </param>
+                </group>
+
+                <group name="ENCODER2">
+                    <param name="type">             qenc                     qenc                   qenc                  </param>
+                    <param name="port">             CONN:P3                  CONN:P2                CONN:P5               </param>
+                    <param name="position">         atmotor                  atmotor                atmotor               </param>
+                    <param name="resolution">       1600                     1600                   1600                  </param>
+                    <param name="tolerance">        0                        0                      0                     </param>
+                </group>
+            </group>
+
+        </group>
+
+    </group>
+
+
+</params>
+

--- a/experimentalSetups/ecub-hand-mc4plusfap/la.xml
+++ b/experimentalSetups/ecub-hand-mc4plusfap/la.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<robot name="ergoCubSN000" xmlns:xi="http://www.w3.org/2001/XInclude">
+
+    <params>
+    <xi:include href="hardware/electronics/pc104.xml" />
+    </params>
+
+    <devices>
+
+    <!-- POS4 -->
+    <xi:include href="wrappers/POS/left_hand-pos_wrapper4.xml" /> 
+    <xi:include href="hardware/POS/left_hand-pos4.xml" />
+    
+    <!-- motor controllers wrappers -->
+    <xi:include href="wrappers/motorControl/left_arm-mc_wrapper.xml" />
+    <xi:include href="wrappers/motorControl/left_arm-mc_remapper.xml" />
+
+    <!-- LEFT ARM -->
+    <xi:include href="hardware/motorControl/left_arm-eb23-j7_10-mc.xml" /> -->
+
+
+    <!--CALIBRATORS -->
+    <xi:include href="calibrators/left_arm-calib.xml" /> 
+
+  </devices>
+</robot>

--- a/experimentalSetups/ecub-hand-mc4plusfap/wrappers/POS/left_hand-pos_wrapper4.xml
+++ b/experimentalSetups/ecub-hand-mc4plusfap/wrappers/POS/left_hand-pos_wrapper4.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_hand_as_wrapper4" type="analogServer">
+    <param name="period">   10  				         </param>
+    <param name="name">     /ergocub/left_hand/POS4:o    </param>
+
+    <action phase="startup" level="5" type="attach">
+        <paramlist name="networks">
+            <!-- The param value must match the device name in the file describing the service -->
+            <elem name="posLeftHand4">  left_hand-pos4 </elem>
+        </paramlist>
+    </action>
+
+    <action phase="shutdown" level="5" type="detach" />
+</device>
+

--- a/experimentalSetups/ecub-hand-mc4plusfap/wrappers/motorControl/left_arm-mc_remapper.xml
+++ b/experimentalSetups/ecub-hand-mc4plusfap/wrappers/motorControl/left_arm-mc_remapper.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mc_remapper" type="controlboardremapper">
+    <param name="axesNames">(l_thumb_oc, l_index_oc, l_middle_oc)</param>    <!-- full order of finger, using the convention, is l_thumb_add,l_thumb_oc,l_index_add,l_index_oc,l_middle_oc,l_ring_pinky_oc -->
+    <param name="joints"> 3 </param>
+    <action phase="startup" level="5" type="attach">
+        <paramlist name="networks">
+            <elem name="left_arm_joints1"> left_arm-eb23-j7_10-mc   </elem>
+        </paramlist>
+    </action>
+    <action phase="shutdown" level="20" type="detach" />
+</device>

--- a/experimentalSetups/ecub-hand-mc4plusfap/wrappers/motorControl/left_arm-mc_wrapper.xml
+++ b/experimentalSetups/ecub-hand-mc4plusfap/wrappers/motorControl/left_arm-mc_wrapper.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mc_nws_yarp" type="controlBoard_nws_yarp">
+    <param name="period"> 0.01  </param>
+    <param name="name"> /ergocub/left_arm </param>
+    <action phase="startup" level="10" type="attach">
+        <param name="device"> left_arm-mc_remapper </param>
+    </action>
+    <action phase="shutdown" level="15" type="detach" />
+</device>

--- a/experimentalSetups/ecub-hand-mc4plusfap/yarpScopePendConfig.xml
+++ b/experimentalSetups/ecub-hand-mc4plusfap/yarpScopePendConfig.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<portscope rows="2" columns="2" carrier="mcast">
+    <plot gridx="0"
+          gridy="0"
+          hspan="1"
+	  vspan="1"
+          minval="0"
+	  maxval="90"
+          title="Joint position Plot (Deg)"
+          bgcolor="LightSlateGrey">
+      <graph remote="/ergocub/left_arm/stateExt:o/split0:o"
+            index="1"
+            color="Red"
+            title="Joint position l_index_oc"
+            type="lines"
+            size="3" />
+      <graph remote="/ergocub/left_arm/stateExt:o/split0:o"
+            index="2"
+            color="Blue"
+            title="Joint position l_middle_oc"
+            type="lines"
+            size="3" />
+    </plot>
+    <plot gridx="1"
+          gridy="0"
+          hspan="1"
+          vspan="1"
+          title="PWM Duty Cycle"
+          minval="-100"
+          maxval="100"
+          bgcolor="LightSlateGrey">
+      <graph remote="/ergocub/left_arm/stateExt:o/split14:o"
+            index="1"
+            color="Red"
+            title="Torque at l_index_oc"
+            type="lines"
+            size="3"	/>
+      <graph remote="/ergocub/left_arm/stateExt:o/split14:o"
+            index="2"
+            color="Blue"
+            title="Torque at l_middle_oc"
+            type="lines"
+            size="3"	/>
+    </plot>
+    <plot gridx="0"
+          gridy="1"
+          hspan="1"
+          vspan="1"
+          title="Current Plot"
+          minval="-3"
+          maxval="3"
+          bgcolor="LightSlateGrey">
+    <graph remote="/ergocub/left_arm/stateExt:o/split16:o"
+            index="1"
+            color="Red"
+            title="Current for l_index_oc"
+            type="lines"
+            size="3"/>
+      <graph remote="/ergocub/left_arm/stateExt:o/split16:o"
+            index="2"
+            color="Blue"
+            title="Current for l_middle_oc"
+            type="lines"
+            size="3"/>
+    </plot>
+    <plot gridx="1"
+          gridy="1"
+          hspan="1"
+          vspan="1"
+          title="Motor Position Plot"
+          minval="-20000"
+          maxval="1000"
+          bgcolor="LightSlateGrey">
+      <graph remote="/ergocub/left_arm/stateExt:o/split6:o"
+            index="1"
+            color="Red"
+            title="Rotor position for l_index_oc"
+            type="lines"
+            size="3"/>
+      <graph remote="/ergocub/left_arm/stateExt:o/split6:o"
+            index="2"
+            color="Blue"
+            title="Rotor position for l_middle_oc"
+            type="lines"
+            size="3"/>
+    </plot>
+</portscope>

--- a/experimentalSetups/ecub-hand-mc4plusfap/yarpmotorgui.ini
+++ b/experimentalSetups/ecub-hand-mc4plusfap/yarpmotorgui.ini
@@ -1,0 +1,7 @@
+//name of the robot
+robot ergocub
+//parts to be opened by the GUI
+parts (left_arm)
+
+ //DO NOT REMOVE THIS LINE
+

--- a/experimentalSetups/ecub-hand-mc4plusfap/yarprobotinterface.ini
+++ b/experimentalSetups/ecub-hand-mc4plusfap/yarprobotinterface.ini
@@ -1,0 +1,2 @@
+config ./la.xml
+


### PR DESCRIPTION
This commit contains the complete files for testing calib type 6 FAP on the left arm test bench setup
Please keep connections and ports as specified in the files thus to do not have issues with connection errors
since boards have some issues on specific ports.
Update configuration to be aligned with new naming convention for axesNames and POS service