### PR TITLE
Add iCubGenova11 yarp nws wrappers for Realsense camera 

### DIFF
--- a/iCubGenova11/camera/realsense.xml
+++ b/iCubGenova11/camera/realsense.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="realsense2dev" type="realsense2">
+	<group name="SETTINGS">
+		<param name="depthResolution"> (640 480)           </param>
+		<param name="rgbResolution">  (640 480) </param>
+		<param name="framerate">    30  </param>
+		<param name="enableEmitter">    true</param>
+		<param name="needAlignment">    true</param>
+		<param name="alignmentFrame">    RGB</param>
+    </group>
+	<group name="HW_DESCRIPTION">
+		<param name="clipPlanes"> (0.2 10.0)</param>
+	</group>
+	<!-- <group name="QUANT_PARAM"> -->
+	<!-- 	<param name="depth_quant">2</param> -->
+	<!-- </group> -->
+</device>

--- a/iCubGenova11/realsense.xml
+++ b/iCubGenova11/realsense.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<robot name="iCubGenova11RealSense" build="2" portprefix="/icub" xmlns:xi="http://www.w3.org/2001/XInclude">
+    <devices>
+        <xi:include href="./camera/realsense.xml" />
+        <xi:include href="./wrappers/camera/realsense-nws_yarp.xml" />
+    </devices>
+</robot>

--- a/iCubGenova11/wrappers/camera/realsense-nws_yarp.xml
+++ b/iCubGenova11/wrappers/camera/realsense-nws_yarp.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="RGBDWrapperyarp" type="rgbdSensor_nws_yarp">
+    <param name="period"> 0.033 </param>
+    <param name="name">    /depthCamera </param>
+    <action phase="startup" level="5" type="attach">
+        <paramlist name="networks">
+            <elem name="subdevicergbd"> realsense2dev </elem>
+        </paramlist>
+    </action>
+    <action phase="shutdown" level="5" type="detach" />
+</device>


### PR DESCRIPTION
As per the title.

The depth quantization is disabled for now as we need to test it with the algorithms we use in our demos first.

cc @randaz81 