### PR TITLE
[iCubGenova11] R_thumb_proximal PID change

### DIFF
--- a/iCubGenova11/hardware/motorControl/right_arm-eb28-j8_11-mc.xml
+++ b/iCubGenova11/hardware/motorControl/right_arm-eb28-j8_11-mc.xml
@@ -47,9 +47,9 @@
         <param name="outputType">           pwm                       </param>
         <param name="fbkControlUnits">      metric_units              </param> 
         <param name="outputControlUnits">   machine_units             </param>
-        <param name="kp">                   -150.0      500.0       -500.0      500.0       </param>
+        <param name="kp">                   -150.0      400.0       -500.0      500.0       </param>
         <param name="kd">                   0.0         0.0         0.0         0.0         </param>
-        <param name="ki">                   -15.0       50.0        -50.0       50.0        </param>
+        <param name="ki">                   -15.0       40.0        -50.0       50.0        </param>
         <param name="maxOutput">            3360        3360        3360        3360        </param>
         <param name="maxInt">               3360        3360        3360        3360        </param>
         <param name="stictionUp">           0           0           0           0           </param>


### PR DESCRIPTION
The right thumb broke three times. We noticed that the PID of the right thumb was different from that of the left thumb, so with this PR we align the PIDs of the two hands. ([issue](https://github.com/robotology/icub-tech-support/issues/1525))

cc @sgiraz @xEnVrE 