### PR TITLE
Ergocubsn00: use calib 6 for open close fingers joints

### DIFF
--- a/ergoCubSN000/calibrators/left_arm-calib.xml
+++ b/ergoCubSN000/calibrators/left_arm-calib.xml
@@ -15,12 +15,12 @@
 		<param name="velocityHome">           10         10         10         10         10       10      10    40.00      40.00   40.00   40.00   40.00   40.00  </param>
 	</group>
 	<group name="CALIBRATION">
-		<param name="calibrationType">        10          10          10         10          12      12      12     12      12      12      12      12      12     </param>
+		<param name="calibrationType">        10          10          10         10          12      12      12     12      6      12       6      6      6     </param>
 		<param name="calibration1">           4000       -3000       -3000       4000        10816   7369    21632  0       0       0       0       0       0      </param>
-		<param name="calibration2">	          0           0           0          0           0       0       0      0       0       0       0       0       0      </param>
-		<param name="calibration3">           0           0           0          0           0       0       0      0       0       0       0       0       0      </param>
+		<param name="calibration2">	      0           0           0          0           0       0       0      0       9102    0       9102    9102    9102      </param>
+		<param name="calibration3">           0           0           0          0           0       0       0      0       1       0       1       1       1      </param>
 		<param name="calibration4">           0           0           0          0           0       0       0      0       0       0       0       0       0      </param>
-		<param name="calibration5">           0           0           0          0           0       0       0      0       0       0       0       0       0      </param>
+		<param name="calibration5">           0           0           0          0           0       0       0      0       10923   0       14564   14564   14564      </param>
 		<param name="calibrationZero">        35         -15         -52         -5          0       0       0      0       0       0       0       0       0      </param>
 		<param name="calibrationDelta">       0           0           0          0           0       0       0      0       0       0       0       0       0      </param>
 		<param name="startupPosition">        34          50          0          10          0.0     0.0     0.0      0.0     0.0     0.0     0.0     0.0     0.0    </param>
@@ -30,7 +30,8 @@
 	</group>
 
 	<!-- motor's encoder of joint 7 can't read -->
-	<param name="CALIB_ORDER"> (4 5 6) (3) (2) (0) (1) (7 8 9 10) (11 12) </param> 
+
+	<param name="CALIB_ORDER"> (4 5 6) (3) (2) (0) (1) (8) (7 9 10) (11 12) </param> 
 
 	<action phase="startup" level="10" type="calibrate">
 		<param name="target">left_arm-mc_remapper</param>

--- a/ergoCubSN000/hardware/mechanicals/left_arm-eb23-j7_10-mec.xml
+++ b/ergoCubSN000/hardware/mechanicals/left_arm-eb23-j7_10-mec.xml
@@ -9,12 +9,12 @@
         <!-- joint number in sub-part       0                       1                       2                           3                       -->
         <!-- joint name                                                                                                                         -->
         <param name="AxisMap">              0                       1                       2                           3                       </param>
-        <param name="AxisName">             "l_thumb_oc" "l_index_oc" "l_middle_oc"    "l_ring_pinky_oc" </param>
+        <param name="AxisName">             "l_thumb_oc"           "l_index_oc"            "l_middle_oc"               "l_ring_pinky_oc" </param>
         <param name="AxisType">             "revolute"              "revolute"              "revolute"                  "revolute"              </param>
         <param name="Encoder">              182.044                 182.044                 182.044                     182.044                 </param>
         <param name="fullscalePWM">         3360                    3360                    3360                        3360                    </param>
         <param name="ampsToSensor">         1000.0                  1000.0                  1000.0                      1000.0                  </param>
-        <param name="Gearbox_M2J">          16                      16                      16                          16                      </param> <!-- real value: 159 - await PR to solve this problem -->
+        <param name="Gearbox_M2J">          159                      159                      159                          159                      </param> <!-- real value: 159 - await PR to solve this problem -->
         <param name="Gearbox_E2J">          1                       1                       1                           1                       </param>
         <param name="useMotorSpeedFbk">     0                       0                       0                           0                       </param>
         <param name="MotorType">            "DC"                    "DC"                    "DC"                        "DC"                    </param>
@@ -25,8 +25,8 @@
     <group name="LIMITS">
         <param name="hardwareJntPosMax">    90              90              90              90         </param>
         <param name="hardwareJntPosMin">    0               0               0               0          </param>
-        <param name="rotorPosMin">          0               0               0               0          </param>
-        <param name="rotorPosMax">          0               0               0               0          </param>
+        <param name="rotorPosMin">          0               -1000          -1000           -1000          </param>
+        <param name="rotorPosMax">          0               32000               37000           24000          </param>
     </group>
 
     <group name="COUPLINGS">


### PR DESCRIPTION
Alongside @MSECode, we updated the configuration of left-hand fingers in order to use the new version of calib 6. It checks the rotor limit for safety reasons.

With this calibration, we can use the real value of the `gearbox`: 159.

Already tested on the robot.