### PR TITLE
Enable imu on mtb4

### DIFF
--- a/ergoCubSN000/ergocub_all.xml
+++ b/ergoCubSN000/ergocub_all.xml
@@ -94,6 +94,14 @@
     <xi:include href="wrappers/inertials/head-inertials_wrapper.xml" />
     <xi:include href="hardware/inertials/head-inertial.xml" />
 
+    <!-- IMU - MTB4 BOARDS -->
+    <xi:include href="hardware/inertials/left_arm_eb4-j2_3-inertial.xml" />
+    <xi:include href="hardware/inertials/right_arm-eb3-j2_3-inertial.xml" />
+    <xi:include href="wrappers/inertials/left_arm-inertials_wrapper.xml" />
+    <xi:include href="wrappers/inertials/right_arm-inertials_wrapper.xml" />
+    <xi:include href="wrappers/inertials/left_arm-inertials_remapper.xml" />
+    <xi:include href="wrappers/inertials/right_arm-inertials_remapper.xml" />
+
     <!-- FT SENSORS - IMU -->
     <xi:include href="hardware/inertials/left_arm-eb2-j0_1-inertial.xml" />
     <xi:include href="hardware/inertials/right_arm-eb1-j0_1-inertial.xml" />

--- a/ergoCubSN000/hardware/inertials/left_arm_eb4-j2_3-inertial.xml
+++ b/ergoCubSN000/hardware/inertials/left_arm_eb4-j2_3-inertial.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+   
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm_eb4-j2_3-inertial" type="embObjInertials3">
+    
+        <xi:include href="../../general.xml" />     
+
+        <xi:include href="../../hardware/electronics/left_arm-eb4-j2_3-eln.xml" />
+        
+        <group name="SERVICE">
+        
+            <param name="type"> eomn_serv_AS_inertials </param>                
+        
+            <group name="PROPERTIES">
+            
+                <group name="CANBOARDS">
+                    <param name="type">                 eobrd_mtb4c           </param>
+
+                    <group name="PROTOCOL">
+                        <param name="major">            0                   </param>    
+                        <param name="minor">            0                   </param>     
+                    </group>                    
+                    <group name="FIRMWARE">
+                        <param name="major">            2                   </param>    
+                        <param name="minor">            0                   </param> 
+                        <param name="build">            0                   </param>
+                    </group>
+                </group>
+
+                <group name="SENSORS">
+                    <param name="id">             l_hand                  l_hand_gyro
+                    </param>
+
+                    <param name="type">     eoas_accel_mtb_int      eoas_gyros_mtb_ext        
+                    </param>
+
+                    <param name="location"> CAN1:14                 CAN1:14
+                    </param>            
+                </group>
+                                            
+            </group>
+            
+            <group name="SETTINGS"> 
+                <param name="acquisitionRate">      50      </param>
+                <param name="enabledSensors">       l_hand l_hand_gyro </param>                
+            </group>
+            
+        </group>        
+        
+    </device>

--- a/ergoCubSN000/hardware/inertials/right_arm-eb3-j2_3-inertial.xml
+++ b/ergoCubSN000/hardware/inertials/right_arm-eb3-j2_3-inertial.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+   
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-eb3-j2_3-inertial" type="embObjInertials3">
+    
+        <xi:include href="../../general.xml" />     
+
+        <xi:include href="../../hardware/electronics/right_arm-eb3-j2_3-eln.xml" />
+        
+        <group name="SERVICE">
+        
+            <param name="type"> eomn_serv_AS_inertials </param>                
+        
+            <group name="PROPERTIES">
+            
+                <group name="CANBOARDS">
+                    <param name="type">                 eobrd_mtb4c           </param>
+
+                    <group name="PROTOCOL">
+                        <param name="major">            0                   </param>    
+                        <param name="minor">            0                   </param>     
+                    </group>                    
+                    <group name="FIRMWARE">
+                        <param name="major">            2                   </param>    
+                        <param name="minor">            0                   </param> 
+                        <param name="build">            0                   </param>
+                    </group>
+                </group>
+
+                <group name="SENSORS">
+                    <param name="id">             r_hand                  r_hand_gyro
+                    </param>
+
+                    <param name="type">     eoas_accel_mtb_int      eoas_gyros_mtb_ext        
+                    </param>
+
+                    <param name="location"> CAN1:14                 CAN1:14
+                    </param>            
+                </group>
+                                            
+            </group>
+            
+            <group name="SETTINGS"> 
+                <param name="acquisitionRate">      50      </param>
+                <param name="enabledSensors">       r_hand r_hand_gyro </param>                
+            </group>
+            
+        </group>        
+        
+    </device>

--- a/ergoCubSN000/wrappers/inertials/left_arm-inertials_remapper.xml
+++ b/ergoCubSN000/wrappers/inertials/left_arm-inertials_remapper.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-inertials_remapper" type="multipleanalogsensorsremapper">
+        <param name="period">       10                  </param>
+        <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
+             defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
+        <param name="ThreeAxisLinearAccelerometersNames">
+          (l_hand  l_hand_gyro)
+        </param>
+        <action phase="startup" level="5" type="attach">
+            <paramlist name="networks">
+                <!-- The name of the element can be any string (we use SetOfInertials to better express its nature).
+                     Its value must match the device name in the corresponding body_part-jx_y-inertials.xml file
+                     or in body_part-ebX-inertials.xml -->
+                <elem name="left_arm_inertial1">  left_arm-eb4-j2_3-inertials </elem>
+            </paramlist>
+        </action>
+
+        <action phase="shutdown" level="5" type="detach" />
+    </device>

--- a/ergoCubSN000/wrappers/inertials/left_arm-inertials_wrapper.xml
+++ b/ergoCubSN000/wrappers/inertials/left_arm-inertials_wrapper.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-inertials_wrapper" type="analogServer">
+        <param name="period">       10                  </param>
+        <param name="name">     /ergocub/left_hand/inertialMTB                </param>
+
+        
+        <action phase="startup" level="5" type="attach">
+            <paramlist name="networks">
+                <!-- The name of the element can be any string (we use SetOfInertials to better express its nature).
+                     Its value must match the device name in the corresponding body_part-jx_y-inertials.xml file
+                     or in body_part-ebX-inertials.xml -->
+                <elem name="SetOfInertials">  left_arm-eb4-j2_3-inertial </elem>
+            </paramlist>
+        </action>
+
+        <action phase="shutdown" level="5" type="detach" />
+    </device>

--- a/ergoCubSN000/wrappers/inertials/right_arm-inertials_remapper.xml
+++ b/ergoCubSN000/wrappers/inertials/right_arm-inertials_remapper.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-inertials_remapper" type="multipleanalogsensorsremapper">
+        <param name="period">       10                  </param>
+        <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
+             defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
+        <param name="ThreeAxisLinearAccelerometersNames">
+          (r_hand  r_hand_gyro)
+        </param>
+        <action phase="startup" level="5" type="attach">
+            <paramlist name="networks">
+                <!-- The name of the element can be any string (we use SetOfInertials to better express its nature).
+                     Its value must match the device name in the corresponding body_part-jx_y-inertials.xml file
+                     or in body_part-ebX-inertials.xml -->
+                <elem name="right_arm_inertial1">  right_arm-eb3-j2_3-inertials </elem>
+            </paramlist>
+        </action>
+
+        <action phase="shutdown" level="5" type="detach" />
+    </device>

--- a/ergoCubSN000/wrappers/inertials/right_arm-inertials_wrapper.xml
+++ b/ergoCubSN000/wrappers/inertials/right_arm-inertials_wrapper.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-inertials_wrapper" type="analogServer">
+        <param name="period">       10                  </param>
+        <param name="name">     /ergocub/right_hand/inertialMTB                </param>
+
+        
+        <action phase="startup" level="5" type="attach">
+            <paramlist name="networks">
+                <!-- The name of the element can be any string (we use SetOfInertials to better express its nature).
+                     Its value must match the device name in the corresponding body_part-jx_y-inertials.xml file
+                     or in body_part-ebX-inertials.xml -->
+                <elem name="SetOfInertials">  right_arm-eb3-j2_3-inertial </elem>
+            </paramlist>
+        </action>
+
+        <action phase="shutdown" level="5" type="detach" />
+    </device>


### PR DESCRIPTION
As per the title and in https://github.com/icub-tech-iit/fix/issues/1339, the configuration files for enabling the IMU on the MTB4 boards are created.