### PR TITLE
ergoCubSN000: removed mtb4fap

### DIFF
--- a/ergoCubSN000/hardware/POS/left_hand-pos2.xml
+++ b/ergoCubSN000/hardware/POS/left_hand-pos2.xml
@@ -12,15 +12,15 @@
         <group name="PROPERTIES">
 
             <group name="CANBOARDS">
-                <param name="type">                 eobrd_mtb4fap           </param>
+                <param name="type">                 eobrd_mtb4c           </param>
 
                 <group name="PROTOCOL">
                     <param name="major">            2                       </param>
                     <param name="minor">            0                       </param>
                 </group>
                 <group name="FIRMWARE">
-                    <param name="major">            1                       </param>
-                    <param name="minor">            1                       </param>
+                    <param name="major">            2                       </param>
+                    <param name="minor">            0                       </param>
                     <param name="build">            0                       </param>
                 </group>
             </group>
@@ -32,9 +32,9 @@
                 <!-- common to all analog services -->
                 <param name="id">                   id_fapEE                      id_fapFF                  </param>
                 <param name="type">                 eoas_pos_angle                eoas_pos_angle            </param>
-                <param name="port">                 POS:hand_thumb_add      POS:hand_index_add   </param>
+                <param name="port">                 POS:hand_thumb_add            POS:hand_index_add        </param>
 
-                <param name="boardType">            mtb4fap                       mtb4fap                   </param>
+                <param name="boardType">            mtb4c                         mtb4c                     </param>
                 <param name="connector">            CONN:J3_SDA2                  CONN:J3_SDA3              </param>
 
                 <group name="CALIBRATION">

--- a/ergoCubSN000/hardware/POS/left_hand-pos4.xml
+++ b/ergoCubSN000/hardware/POS/left_hand-pos4.xml
@@ -12,7 +12,7 @@
         <group name="PROPERTIES">
 
             <group name="CANBOARDS">
-                <param name="type">                 eobrd_mtb4              </param>
+                <param name="type">                 eobrd_mtb4c             </param>
 
                 <group name="PROTOCOL">
                     <param name="major">            2                       </param>

--- a/ergoCubSN000/hardware/POS/left_hand-pos4.xml
+++ b/ergoCubSN000/hardware/POS/left_hand-pos4.xml
@@ -12,15 +12,15 @@
         <group name="PROPERTIES">
 
             <group name="CANBOARDS">
-                <param name="type">                 eobrd_mtb4fap           </param>
+                <param name="type">                 eobrd_mtb4              </param>
 
                 <group name="PROTOCOL">
                     <param name="major">            2                       </param>
                     <param name="minor">            0                       </param>
                 </group>
                 <group name="FIRMWARE">
-                    <param name="major">            1                       </param>
-                    <param name="minor">            1                       </param>
+                    <param name="major">            2                       </param>
+                    <param name="minor">            0                       </param>
                     <param name="build">            0                       </param>
                 </group>
             </group>
@@ -34,7 +34,7 @@
                 <param name="type">                 eoas_pos_angle  eoas_pos_angle   eoas_pos_angle   eoas_pos_angle    </param>
                 <param name="port">                 POS:hand_thumb_oc  POS:hand_index_oc   POS:hand_middle_oc  POS:hand_ring_pinky_oc    </param>
 
-                <param name="boardType">            mtb4fap         mtb4fap          mtb4fap          mtb4fap           </param>
+                <param name="boardType">            mtb4c           mtb4c            mtb4c            mtb4c             </param>
                 <param name="connector">            CONN:J3_SDA3    CONN:J3_SDA0     CONN:J3_SDA1     CONN:J3_SDA2      </param>
 
                 <group name="CALIBRATION">

--- a/ergoCubSN000/hardware/POS/right_hand-pos2.xml
+++ b/ergoCubSN000/hardware/POS/right_hand-pos2.xml
@@ -12,15 +12,15 @@
         <group name="PROPERTIES">
 
             <group name="CANBOARDS">
-                <param name="type">                 eobrd_mtb4fap            </param>
+                <param name="type">                 eobrd_mtb4c             </param>
 
                 <group name="PROTOCOL">
                     <param name="major">            2                       </param>
                     <param name="minor">            0                       </param>
                 </group>
                 <group name="FIRMWARE">
-                    <param name="major">            1                       </param>
-                    <param name="minor">            1                       </param>
+                    <param name="major">            2                       </param>
+                    <param name="minor">            0                       </param>
                     <param name="build">            0                       </param>
                 </group>
             </group>
@@ -32,9 +32,9 @@
                 <!-- common to all analog services -->
                 <param name="id">                   id_fapEE                      id_fapFF                  </param>
                 <param name="type">                 eoas_pos_angle                eoas_pos_angle            </param>
-                <param name="port">                 POS:hand_thumb_add      POS:hand_index_add   </param>
+                <param name="port">                 POS:hand_thumb_add            POS:hand_index_add        </param>
 
-                <param name="boardType">            mtb4fap                       mtb4fap                   </param>
+                <param name="boardType">            mtb4c                         mtb4c                     </param>
                 <param name="connector">            CONN:J3_SDA2                  CONN:J3_SDA3              </param>
 
                 <group name="CALIBRATION">

--- a/ergoCubSN000/hardware/POS/right_hand-pos4.xml
+++ b/ergoCubSN000/hardware/POS/right_hand-pos4.xml
@@ -12,15 +12,15 @@
         <group name="PROPERTIES">
 
             <group name="CANBOARDS">
-                <param name="type">                 eobrd_mtb4fap            </param>
+                <param name="type">                 eobrd_mtb4c             </param>
 
                 <group name="PROTOCOL">
                     <param name="major">            2                       </param>
                     <param name="minor">            0                       </param>
                 </group>
                 <group name="FIRMWARE">
-                    <param name="major">            1                       </param>
-                    <param name="minor">            1                       </param>
+                    <param name="major">            2                       </param>
+                    <param name="minor">            0                       </param>
                     <param name="build">            0                       </param>
                 </group>
             </group>
@@ -34,7 +34,7 @@
                 <param name="type">                 eoas_pos_angle  eoas_pos_angle   eoas_pos_angle   eoas_pos_angle    </param>
                 <param name="port">                 POS:hand_thumb_oc  POS:hand_index_oc   POS:hand_middle_oc  POS:hand_ring_pinky_oc    </param>
 
-                <param name="boardType">            mtb4fap         mtb4fap          mtb4fap          mtb4fap           </param>
+                <param name="boardType">            mtb4c           mtb4c            mtb4c            mtb4c            </param>
                 <param name="connector">            CONN:J3_SDA3    CONN:J3_SDA0     CONN:J3_SDA1     CONN:J3_SDA2      </param>
 
                 <group name="CALIBRATION">

--- a/ergoCubSN000/hardware/motorControl/left_arm-eb23-j7_10-mc_service.xml
+++ b/ergoCubSN000/hardware/motorControl/left_arm-eb23-j7_10-mc_service.xml
@@ -14,14 +14,14 @@
             </group>
 
             <group name="CANBOARDS">
-                <param name="type">                 mtb4fap             </param>
+                <param name="type">                 mtb4c               </param>
                 <group name="PROTOCOL">
                     <param name="major">            2                   </param>
                     <param name="minor">            0                   </param>
                 </group>
                 <group name="FIRMWARE">
-                    <param name="major">            1                   </param>
-                    <param name="minor">            1                   </param>
+                    <param name="major">            2                   </param>
+                    <param name="minor">            0                   </param>
                     <param name="build">            0                   </param>
                 </group>
             </group>
@@ -36,7 +36,7 @@
                     <param name="type">                 eoas_pos_angle  eoas_pos_angle   eoas_pos_angle           eoas_pos_angle        </param>
                     <param name="port">                 POS:hand_thumb_oc  POS:hand_index_oc   POS:hand_middle_oc          POS:hand_ring_pinky_oc        </param>
 
-                    <param name="boardType">            mtb4fap         mtb4fap          mtb4fap                  mtb4fap               </param>
+                    <param name="boardType">            mtb4c           mtb4c            mtb4c                    mtb4c                 </param>
                     <param name="connector">            CONN:J3_SDA3    CONN:J3_SDA0     CONN:J3_SDA1             CONN:J3_SDA2          </param>
 
                     <group name="CALIBRATION">
@@ -64,7 +64,7 @@
 
                 <group name="ENCODER1">
                     <param name="type">             pos                 pos                       pos                       pos                       </param>
-                    <param name="port">             POS:hand_thumb_oc      POS:hand_index_oc            POS:hand_middle_oc           POS:hand_ring_pinky_oc            </param>
+                    <param name="port">             POS:hand_thumb_oc   POS:hand_index_oc         POS:hand_middle_oc        POS:hand_ring_pinky_oc    </param>
                     <param name="position">         atjoint             atjoint                   atjoint                   atjoint                   </param>
                     <param name="resolution">       65535               65535                     65535                     65535                     </param>
                     <param name="tolerance">        5                   5                         5                         5                         </param>
@@ -74,7 +74,7 @@
                     <param name="type">             qenc                qenc                      qenc                      qenc                      </param>
                     <param name="port">             CONN:P5             CONN:P4                   CONN:P3                   CONN:P2                   </param>
                     <param name="position">         atmotor             atmotor                   atmotor                   atmotor                   </param>
-                    <param name="resolution">       1600               1600                      1600                      1600                      </param>
+                    <param name="resolution">       1600                1600                      1600                      1600                      </param>
                     <param name="tolerance">        0                   0                         0                         0                         </param>
                 </group>
             </group>

--- a/ergoCubSN000/hardware/motorControl/left_arm-eb25-j11_12-mc_service.xml
+++ b/ergoCubSN000/hardware/motorControl/left_arm-eb25-j11_12-mc_service.xml
@@ -14,14 +14,14 @@
             </group>
 
             <group name="CANBOARDS">
-                <param name="type">                 mtb4fap             </param>
+                <param name="type">                 mtb4c               </param>
                 <group name="PROTOCOL">
                     <param name="major">            2                   </param>
                     <param name="minor">            0                   </param>
                 </group>
                 <group name="FIRMWARE">
-                    <param name="major">            1                   </param>
-                    <param name="minor">            1                   </param>
+                    <param name="major">            2                   </param>
+                    <param name="minor">            0                   </param>
                     <param name="build">            0                   </param>
                 </group>
             </group>
@@ -32,12 +32,12 @@
                 <group name="SENSORS">
 
                     <!-- common to all analog services -->
-                    <param name="id">                   id_fapEE                      id_fapFF                  </param>
-                    <param name="type">                 eoas_pos_angle                eoas_pos_angle            </param>
-                    <param name="port">                 POS:hand_thumb_add      POS:hand_index_add   </param>
+                    <param name="id">                   id_fapEE                    id_fapFF                    </param>
+                    <param name="type">                 eoas_pos_angle              eoas_pos_angle              </param>
+                    <param name="port">                 POS:hand_thumb_add          POS:hand_index_add          </param>
 
-                    <param name="boardType">            mtb4fap                       mtb4fap                   </param>
-                    <param name="connector">            CONN:J3_SDA2                  CONN:J3_SDA3              </param>
+                    <param name="boardType">            mtb4c                       mtb4c                       </param>
+                    <param name="connector">            CONN:J3_SDA2                CONN:J3_SDA3                </param>
 
                     <group name="CALIBRATION">
                         <!-- it is not mandatory. if not present, sensors have defaults: TYPE:decideg, ROT:zero, 0.0, false -->
@@ -58,24 +58,24 @@
             <group name="JOINTMAPPING">
 
                 <group name="ACTUATOR">
-                    <param name="type">             pwm                           pwm                      </param>
-                    <param name="port">             CONN:P5                       CONN:P2                  </param>
+                    <param name="type">             pwm                           pwm                       </param>
+                    <param name="port">             CONN:P5                       CONN:P2                   </param>
                 </group>
 
                 <group name="ENCODER1">
-                    <param name="type">             pos                           pos                      </param>
-                    <param name="port">             POS:hand_thumb_add      POS:hand_index_add  </param>
-                    <param name="position">         atjoint                       atjoint                  </param>
-                    <param name="resolution">       65535                         65535                    </param>
-                    <param name="tolerance">        5                             5                        </param>
+                    <param name="type">             pos                           pos                       </param>
+                    <param name="port">             POS:hand_thumb_add            POS:hand_index_add        </param>
+                    <param name="position">         atjoint                       atjoint                   </param>
+                    <param name="resolution">       65535                         65535                     </param>
+                    <param name="tolerance">        5                             5                         </param>
                 </group>
 
                 <group name="ENCODER2">
-                    <param name="type">             none                none            </param>
-                    <param name="port">             CONN:P2             CONN:P5         </param>
-                    <param name="position">         atmotor             atmotor         </param>
-                    <param name="resolution">       -1600               1600            </param>
-                    <param name="tolerance">        0                   0               </param>
+                    <param name="type">             none                        none                        </param>
+                    <param name="port">             CONN:P2                     CONN:P5                     </param>
+                    <param name="position">         atmotor                     atmotor                     </param>
+                    <param name="resolution">       -1600                       1600                        </param>
+                    <param name="tolerance">        0                           0                           </param>
                 </group>
             </group>
 

--- a/ergoCubSN000/hardware/motorControl/right_arm-eb22-j7_10-mc_service.xml
+++ b/ergoCubSN000/hardware/motorControl/right_arm-eb22-j7_10-mc_service.xml
@@ -14,14 +14,14 @@
             </group>
 
             <group name="CANBOARDS">
-                <param name="type">                 mtb4fap             </param>
+                <param name="type">                 mtb4c               </param>
                 <group name="PROTOCOL">
                     <param name="major">            2                   </param>
                     <param name="minor">            0                   </param>
                 </group>
                 <group name="FIRMWARE">
-                    <param name="major">            1                   </param>
-                    <param name="minor">            1                   </param>
+                    <param name="major">            2                   </param>
+                    <param name="minor">            0                   </param>
                     <param name="build">            0                   </param>
                 </group>
             </group>
@@ -36,7 +36,7 @@
                     <param name="type">                 eoas_pos_angle  eoas_pos_angle   eoas_pos_angle           eoas_pos_angle        </param>
                     <param name="port">                 POS:hand_thumb_oc  POS:hand_index_oc   POS:hand_middle_oc          POS:hand_ring_pinky_oc        </param>
 
-                    <param name="boardType">            mtb4fap         mtb4fap          mtb4fap                  mtb4fap               </param>
+                    <param name="boardType">            mtb4c           mtb4c            mtb4c                    mtb4c                 </param>
                     <param name="connector">            CONN:J3_SDA3    CONN:J3_SDA0     CONN:J3_SDA1             CONN:J3_SDA2          </param>
 
                     <group name="CALIBRATION">

--- a/ergoCubSN000/hardware/motorControl/right_arm-eb24-j11_12-mc_service.xml
+++ b/ergoCubSN000/hardware/motorControl/right_arm-eb24-j11_12-mc_service.xml
@@ -14,14 +14,14 @@
             </group>
 
             <group name="CANBOARDS">
-                <param name="type">                 mtb4fap             </param>
+                <param name="type">                 mtb4c               </param>
                 <group name="PROTOCOL">
                     <param name="major">            2                   </param>
                     <param name="minor">            0                   </param>
                 </group>
                 <group name="FIRMWARE">
-                    <param name="major">            1                   </param>
-                    <param name="minor">            1                   </param>
+                    <param name="major">            2                   </param>
+                    <param name="minor">            0                   </param>
                     <param name="build">            0                   </param>
                 </group>
             </group>
@@ -34,9 +34,9 @@
                     <!-- common to all analog services -->
                     <param name="id">                   id_fapEE                      id_fapFF                  </param>
                     <param name="type">                 eoas_pos_angle                eoas_pos_angle            </param>
-                    <param name="port">                 POS:hand_thumb_add      POS:hand_index_add   </param>
+                    <param name="port">                 POS:hand_thumb_add            POS:hand_index_add        </param>
 
-                    <param name="boardType">            mtb4fap                       mtb4fap                   </param>
+                    <param name="boardType">            mtb4c                         mtb4c                     </param>
                     <param name="connector">            CONN:J3_SDA2                  CONN:J3_SDA3              </param>
 
                     <group name="CALIBRATION">
@@ -64,7 +64,7 @@
 
                 <group name="ENCODER1">
                     <param name="type">             pos                           pos                      </param>
-                    <param name="port">             POS:hand_thumb_add      POS:hand_index_add  </param>
+                    <param name="port">             POS:hand_thumb_add            POS:hand_index_add       </param>
                     <param name="position">         atjoint                       atjoint                  </param>
                     <param name="resolution">       65535                         65535                    </param>
                     <param name="tolerance">        5                             5                        </param>


### PR DESCRIPTION
This PR allows to use the `mtb4c` board in the hands of `ergoCub` rather than the `mtb4fap`, which is due to be removed from `robotology`.

The PR is bet merged after a run of `yarprobotinterface` and the reprogramming of the four `mtb4fap` boards in the two hands so that they become four `mtb4c` w/ the same CAN addresses. No other changes are required as long as the robot runs the latest `devel`.