### PR TITLE
[ergoCubSN000] Correct calibration sequence for the arms

### DIFF
--- a/ergoCubSN000/calibrators/left_arm-calib.xml
+++ b/ergoCubSN000/calibrators/left_arm-calib.xml
@@ -29,9 +29,8 @@
 		<param name="startupPosThreshold">    2           2           2          2           2       2       2        90      90      90      90      90      90      </param>
 	</group>
 
-	<!-- motor's encoder of joint 7 can't read -->
-
-	<param name="CALIB_ORDER"> (4 5 6) (3) (2) (0) (1) (8) (7 9 10) (11 12) </param> 
+<!--	<param name="CALIB_ORDER"> (4 5 6) (3) (2) (0) (1) (7 8) (9) (10 11 12) </param> --> 
+	<param name="CALIB_ORDER"> (4 5 6) (3) (2) (0) (1) (7 8) (10 11 12) </param> 
 
 	<action phase="startup" level="10" type="calibrate">
 		<param name="target">left_arm-mc_remapper</param>

--- a/ergoCubSN000/calibrators/right_arm-calib.xml
+++ b/ergoCubSN000/calibrators/right_arm-calib.xml
@@ -17,8 +17,8 @@
 	</group>
 	<group name="CALIBRATION">
 		<param name="calibrationType">         10                10             10          10         12            12             12              12      12      12      12      12      12     </param>
-		<param name="calibration1">           -4000              3000           3000       -4000       19023          28993          36030           0       0       0       0       0       0      </param>
-		<param name="calibration2">	           0                 0              0           0          0             0              0               0       0       0       0       0       0      </param>
+		<param name="calibration1">           -4000              3000           3000       -4000       19023         28993          36030           0       0       0       0       0       0      </param>
+		<param name="calibration2">	       0                 0              0           0          0             0              0               0       0       0       0       0       0      </param>
 		<param name="calibration3">            0                 0              0           0          0             0              0               0       0       0       0       0       0      </param>
 		<param name="calibration4">            0                 0              0           0          0             0              0               0       0       0       0       0       0      </param>
 		<param name="calibration5">            0                 0              0           0          0             0              0               0       0       0       0       0       0      </param>
@@ -30,8 +30,8 @@
 		<param name="startupPosThreshold">     2                 2              2           2          2             2              2               90      90      90      90      90      90     </param>
 	</group>
 
-<!--	<param name="CALIB_ORDER"> (4 5 6)  (2) (0) (1) (3) (7 8) (11 12) </param> --> 
-	<param name="CALIB_ORDER"> (3) (2) (0) (1) (7 8) (11 12) </param>
+<!--	<param name="CALIB_ORDER"> (4 5 6) (3) (2) (0) (1) (7 8) (9) (10 11 12) </param> --> 
+	<param name="CALIB_ORDER"> (4 5 6) (3) (2) (0) (1) (7 8) (10 11 12) </param>
 
 	<action phase="startup" level="10" type="calibrate">
 		<param name="target">right_arm-mc_remapper</param>


### PR DESCRIPTION
### **What changes?

This PR corrects the calibration order for both arms.

### **Notes**

- The official calibration order is commented and it should not be changed.
- Joint 9 (index adduction) is temporarily disabled for both arms because it is not functioning correctly.

cc @sgiraz @mfussi66 @GiulioRomualdi @lrapetti @xEnVrE 