### PR TITLE
[ergoCubSN000] Fix right arm calib sequence on branch devel

### DIFF
--- a/ergoCubSN000/calibrators/right_arm-calib.xml
+++ b/ergoCubSN000/calibrators/right_arm-calib.xml
@@ -33,8 +33,8 @@
 
 <!--	<param name="CALIB_ORDER"> (4 5 6) (3) (2) (0) (1) (7 8) (9) (10 11 12) </param> --> 
 	<param name="CALIB_ORDER"> (4 5 6) (3) (2) (0) (1) (7 8) (10 11 12) </param>
-	<param name="CALIB_ORDER"> (4 5 6)  (2) (0) (1) (3) (7 8) (9 10) (11 12) </param>
 
+	
 	<action phase="startup" level="10" type="calibrate">
 		<param name="target">right_arm-mc_remapper</param>
 	</action>


### PR DESCRIPTION
### What changes?
During last [merging](https://github.com/robotology/robots-configuration/commit/3d1bdb2ce6eb8592f5d0b442874d50d1345fac21) of branch master into devel, two calib orders were created in the left arm calibration file in the devel branch.

This PR fix this problem.

cc @sgiraz 