### PR TITLE
[ergoCubSN000] Torso: changing of current limits and more

### DIFF
--- a/ergoCubSN000/calibrators/head-calib.xml
+++ b/ergoCubSN000/calibrators/head-calib.xml
@@ -19,16 +19,16 @@
         <!-- joint logical number               0           1           2           3         -->
         <!-- joint name                         neck-pitch  neck-roll   neck-yaw    eyes-tilt -->
         <group name="CALIBRATION">
-            <param name="calibrationType">      12          12          12           12         </param>
-            <param name="calibration1">   	27519	    -17823      61615	    52575      </param>
-            <param name="calibration2">         0           0           0	    0          </param>
+            <param name="calibrationType">      12          12          12          12         </param>
+            <param name="calibration1">   	    27519	    -17823      61615	    52575      </param>
+            <param name="calibration2">         0           0           0	        0          </param>
             <param name="calibration3">         0           0           0           0          </param>
 
             <param name="calibration4">         0           0           0           0    </param>
             <param name="calibration5">         0           0           0           0    </param>
 
-            <param name="calibrationZero">      0.0         0.0        0.0         0.0   </param>
-            <param name="calibrationDelta">     0.0         0.0        0.0         0.0   </param>
+            <param name="calibrationZero">      0.0         0.0         0.0         0.0   </param>
+            <param name="calibrationDelta">     0.0         0.0         0.0         0.0   </param>
 
             <param name="startupPosition">      0.0         0.0         0.0         0.0  </param>
             <param name="startupVelocity">      10          10          20.0        20.0 </param>

--- a/ergoCubSN000/calibrators/torso-calib.xml
+++ b/ergoCubSN000/calibrators/torso-calib.xml
@@ -37,8 +37,8 @@
 <param name="startupPosThreshold">                  2                       2                      2                       </param>
 </group>
 
- <!-- check old calibrator for the correct sequence, then ask to Randazz -->
-		<param name="CALIB_ORDER">(0) (1) (2) </param>
+ <!-- Joint 1 has been removed from the calibration order for motor safety -->
+		<param name="CALIB_ORDER">(0) (2) </param>
 
 		<action phase="startup" level="10" type="calibrate">
 		    <param name="target">torso-mc_remapper</param>

--- a/ergoCubSN000/hardware/mechanicals/torso-eb5-j0_2-mec.xml
+++ b/ergoCubSN000/hardware/mechanicals/torso-eb5-j0_2-mec.xml
@@ -11,7 +11,7 @@
         <param name="Encoder">              182.044             182.044          182.044             </param>
         <param name="fullscalePWM">         32000               32000            32000               </param>
         <param name="ampsToSensor">         1000.0              1000.0           1000.0              </param>
-        <param name="Gearbox_M2J">          100.0              100.0            -100.0              </param>
+        <param name="Gearbox_M2J">          100.0               160.0            -100.0              </param>
         <param name="Gearbox_E2J">          1                   1                1                   </param>
         <param name="useMotorSpeedFbk">     1                   1                1                   </param> 
         <param name="MotorType">            "MOOG_C2900576"     "MOOG_C2900576"   "MOOG_C2900576"     </param>
@@ -27,13 +27,13 @@
                                                                     
     <group name="2FOC">                                             
 		<param name="Verbose">              0                   0                0                  </param>
-        <param name="AutoCalibration">      0                   0               0                  </param>
+        <param name="AutoCalibration">      0                   0                0                  </param>
         <param name="HasHallSensor">        0                   0                0                  </param>
         <param name="HasTempSensor">        0                   0                0                  </param>
         <param name="HasRotorEncoder">      1                   1                1                  </param>
         <param name="HasRotorEncoderIndex"> 1                   1                1                  </param>
         <param name="HasSpeedEncoder">      0                   0                0                  </param>
-        <param name="RotorIndexOffset">     66                  131               228                </param>
+        <param name="RotorIndexOffset">     66                  85               228                </param>
         <param name="MotorPoles">           8                   8                8                  </param>
    </group>
 

--- a/ergoCubSN000/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/ergoCubSN000/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -16,10 +16,10 @@
         <param name="jntPosMax">                23                  45                  43                  </param>
         <param name="jntPosMin">                -23                 -18                 -43                 </param>
         <param name="jntVelMax">                120                 120                 120                 </param>
-        <param name="motorNominalCurrents">     5000                15000               5000                </param>
-        <param name="motorPeakCurrents">        10000               20000               10000                </param>
-        <param name="motorOverloadCurrents">    15000               30000               15000               </param>
-        <param name="motorPwmLimit">            10000               16000               10000               </param>
+        <param name="motorNominalCurrents">     3770                3770                5000                </param>
+        <param name="motorPeakCurrents">        14000               14000               10000                </param>
+        <param name="motorOverloadCurrents">    18000               18000               15000               </param>
+        <param name="motorPwmLimit">            10000               10000               10000               </param>
     </group>
 
     <group name="TIMEOUTS">

--- a/ergoCubSN000/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/ergoCubSN000/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -19,7 +19,7 @@
         <param name="motorNominalCurrents">     3770                3770                5000                </param>
         <param name="motorPeakCurrents">        14000               14000               10000                </param>
         <param name="motorOverloadCurrents">    18000               18000               15000               </param>
-        <param name="motorPwmLimit">            10000               10000               10000               </param>
+        <param name="motorPwmLimit">            16000               16000               16000               </param>
     </group>
 
     <group name="TIMEOUTS">


### PR DESCRIPTION
### What changes?
This PR change the current limit of the torso roll and the torso pitch motors. This PR also changes the gearbox ratio between the pitch motor and the joint, due to a hardware intervention.  


### Note
These new current limits are safe because they were extracted from the motor datasheets, but the pitch is not able to stay in position 0 for more then 4/5 seconds when the robot is in home position. It falls in HW fault for i2t.

cc @maggia80 @sgiraz @Fabrizio69 