### PR TITLE
[ergoCubSN000] Add hip FT sensors

### DIFF
--- a/ergoCubSN000/ergocub_all.xml
+++ b/ergoCubSN000/ergocub_all.xml
@@ -75,8 +75,8 @@
     <xi:include href="hardware/FT/right_arm-eb1-j0_1-strain.xml" />
     <xi:include href="hardware/FT/left_leg-eb9-j4_5-strain.xml" />
     <xi:include href="hardware/FT/right_leg-eb7-j4_5-strain.xml" />
-    <!-- <xi:include href="hardware/FT/left_leg-eb8-j0_3-strain.xml" /> -->
-    <!-- <xi:include href="hardware/FT/right_leg-eb6-j0_3-strain.xml" /> -->
+    <xi:include href="hardware/FT/left_leg-eb8-j0_3-strain.xml" /> 
+    <xi:include href="hardware/FT/right_leg-eb6-j0_3-strain.xml" /> 
 
 
     <!-- FT SENSORS - MULTIPLE ANALOG SENSOR SERVERS -->
@@ -84,8 +84,8 @@
     <xi:include href="wrappers/FT/right_arm-FT_wrapper.xml" />
     <xi:include href="wrappers/FT/left_foot-FT_wrapper.xml" />
     <xi:include href="wrappers/FT/right_foot-FT_wrapper.xml" />
-    <!-- <xi:include href="wrappers/FT/left_leg-FT_wrapper_multipleSens.xml" /> -->
-    <!-- <xi:include href="wrappers/FT/right_leg-FT_wrapper_multipleSens.xml" /> -->
+    <xi:include href="wrappers/FT/left_leg-FT_wrapper_multipleSens.xml" /> 
+    <xi:include href="wrappers/FT/right_leg-FT_wrapper_multipleSens.xml" /> 
 
 
     <!-- INERTIAL SENSOR -->

--- a/ergoCubSN000/ergocub_all_ros2.xml
+++ b/ergoCubSN000/ergocub_all_ros2.xml
@@ -78,6 +78,12 @@
    <xi:include href="hardware/FT/left_arm-eb2-j0_1-strain.xml" />
    <xi:include href="hardware/FT/right_arm-eb1-j0_1-strain.xml" />
 
+   <xi:include href="wrappers/FT/left_leg-FT_wrapper_multipleSens.xml" /> 
+   <xi:include href="wrappers/FT/right_leg-FT_wrapper_multipleSens.xml" /> 
+
+   <xi:include href="hardware/FT/left_leg-eb8-j0_3-strain.xml" /> 
+   <xi:include href="hardware/FT/right_leg-eb6-j0_3-strain.xml" /> 
+
 
    <xi:include href="wrappers/FT/left_foot-FT_wrapper.xml" />
    <xi:include href="wrappers/FT/right_foot-FT_wrapper.xml" />

--- a/ergoCubSN000/ergocub_wbd.xml
+++ b/ergoCubSN000/ergocub_wbd.xml
@@ -75,16 +75,16 @@
     <xi:include href="hardware/FT/right_arm-eb1-j0_1-strain.xml" />
     <xi:include href="hardware/FT/left_leg-eb9-j4_5-strain.xml" />
     <xi:include href="hardware/FT/right_leg-eb7-j4_5-strain.xml" />
-    <!-- <xi:include href="hardware/FT/left_leg-eb8-j0_3-strain.xml" /> -->
-    <!-- <xi:include href="hardware/FT/right_leg-eb6-j0_3-strain.xml" /> -->
+    <xi:include href="hardware/FT/left_leg-eb8-j0_3-strain.xml" />
+    <xi:include href="hardware/FT/right_leg-eb6-j0_3-strain.xml" />
 
     <!-- FT SENSORS - MULTIPLE ANALOG SENSOR SERVERS -->
     <xi:include href="wrappers/FT/left_arm-FT_wrapper.xml" />
     <xi:include href="wrappers/FT/right_arm-FT_wrapper.xml" />
     <xi:include href="wrappers/FT/left_foot-FT_wrapper.xml" />
     <xi:include href="wrappers/FT/right_foot-FT_wrapper.xml" />
-    <!-- <xi:include href="wrappers/FT/left_leg-FT_wrapper_multipleSens.xml" /> -->
-    <!-- <xi:include href="wrappers/FT/right_leg-FT_wrapper_multipleSens.xml" /> -->
+    <xi:include href="wrappers/FT/left_leg-FT_wrapper_multipleSens.xml" />
+    <xi:include href="wrappers/FT/right_leg-FT_wrapper_multipleSens.xml" />
 
     <!-- INERTIAL SENSOR -->
     <xi:include href="wrappers/inertials/head-imuFilter_wrapper.xml" />

--- a/ergoCubSN000/ft.xml
+++ b/ergoCubSN000/ft.xml
@@ -18,7 +18,11 @@
    <xi:include href="hardware/FT/left_arm-eb2-j0_1-strain.xml" />
    <xi:include href="hardware/FT/right_arm-eb1-j0_1-strain.xml" /> 
 
+   <xi:include href="wrappers/FT/left_leg-FT_wrapper_multipleSens.xml" /> 
+   <xi:include href="wrappers/FT/right_leg-FT_wrapper_multipleSens.xml" /> 
 
+   <xi:include href="hardware/FT/left_leg-eb8-j0_3-strain.xml" /> 
+   <xi:include href="hardware/FT/right_leg-eb6-j0_3-strain.xml" /> 
 
    <xi:include href="wrappers/FT/left_foot-FT_wrapper.xml" />
    <xi:include href="wrappers/FT/right_foot-FT_wrapper.xml" /> 


### PR DESCRIPTION
 ### What changes?
This PR enables FT sensors in the hip of both legs. 


### Note:
The FT sensors in the hip were disabled because they were not present in the robot. 
After a hardware intervention, the FT sensors were mounted on the robot.

cc @sgiraz @Fabrizio69 