### PR TITLE
Fixed files

### DIFF
--- a/ergoCubSN000/calibrators/left_leg-calib.xml
+++ b/ergoCubSN000/calibrators/left_leg-calib.xml
@@ -7,7 +7,7 @@
     <param name="joints">  6  </param> <!-- the number of joints of the robot part -->
     <param name="deviceName"> Left_Leg_Calibrator </param>
   </group>
- 						      pitch  	     roll	yaw	     knee	 ankle-pith	ankle-roll >				      
+ 						      pitch  	     roll	yaw	     knee	 ankle-pith	ankle-roll	      
   <group name="HOME">
     <param name="positionHome">                       0.00           5.00       0.00          0.00        0.00      0.00    </param>
     <param name="velocityHome">                       10.00          10.00      10.00        10.00       10.00     10.00    </param>

--- a/iCubGenova11/wrappers/motorControl/right_arm-mc_remapper.xml
+++ b/iCubGenova11/wrappers/motorControl/right_arm-mc_remapper.xml
@@ -14,7 +14,7 @@
             <elem name="right_arm_joints1"> right_arm-eb3-j0_3-mc     </elem>
             <elem name="right_arm_joints2"> right_arm-eb27-j4_7-mc    </elem>
             <elem name="right_arm_joints3"> right_arm-eb28-j8_11-mc   </elem>
-            <elem name="right_arm_joints4"> right_arm-eb29-j12_15-mc  </elem>>                         
+            <elem name="right_arm_joints4"> right_arm-eb29-j12_15-mc  </elem>                  
         </paramlist>
     </action>
     <action phase="shutdown" level="20" type="detach" />

--- a/iCubPrague01/wrappers/motorControl/right_arm-mc_remapper.xml
+++ b/iCubPrague01/wrappers/motorControl/right_arm-mc_remapper.xml
@@ -14,7 +14,7 @@
             <elem name="right_arm_joints1"> right_arm-eb3-j0_3-mc     </elem>
             <elem name="right_arm_joints2"> right_arm-eb27-j4_7-mc    </elem>
             <elem name="right_arm_joints3"> right_arm-eb28-j8_11-mc   </elem>
-            <elem name="right_arm_joints4"> right_arm-eb29-j12_15-mc  </elem>>                         
+            <elem name="right_arm_joints4"> right_arm-eb29-j12_15-mc  </elem>
         </paramlist>
     </action>
     <action phase="shutdown" level="20" type="detach" />

--- a/iCubShanghai01/wrappers/motorControl/right_arm-mc_remapper.xml
+++ b/iCubShanghai01/wrappers/motorControl/right_arm-mc_remapper.xml
@@ -14,7 +14,7 @@
             <elem name="right_arm_joints1"> right_arm-eb3-j0_3-mc     </elem>
             <elem name="right_arm_joints2"> right_arm-eb27-j4_7-mc    </elem>
             <elem name="right_arm_joints3"> right_arm-eb28-j8_11-mc   </elem>
-            <elem name="right_arm_joints4"> right_arm-eb29-j12_15-mc  </elem>>                         
+            <elem name="right_arm_joints4"> right_arm-eb29-j12_15-mc  </elem>       
         </paramlist>
     </action>
     <action phase="shutdown" level="20" type="detach" />

--- a/iCubShenzhen01/calibrators/right_arm-calib.xml
+++ b/iCubShenzhen01/calibrators/right_arm-calib.xml
@@ -33,7 +33,7 @@
 </group>
 
 
-	<param name="CALIB_ORDER">(0 1 2 3) (4) (5 6 7) (8 9 11 13) (10 12 14 15)</param> -->
+	<param name="CALIB_ORDER">(0 1 2 3) (4) (5 6 7) (8 9 11 13) (10 12 14 15)</param>
 <!--	<param name="CALIB_ORDER">(0 1 2 3) (4) (5 6 7) (8 9 11 13) (10 12 14 15) </param> -->
 
 		<action phase="startup" level="10" type="calibrate">

--- a/iCubShenzhen01/wrappers/motorControl/right_arm-mc_remapper.xml
+++ b/iCubShenzhen01/wrappers/motorControl/right_arm-mc_remapper.xml
@@ -14,7 +14,7 @@
             <elem name="right_arm_joints1"> right_arm-eb3-j0_3-mc     </elem>
             <elem name="right_arm_joints2"> right_arm-eb27-j4_7-mc    </elem>
             <elem name="right_arm_joints3"> right_arm-eb28-j8_11-mc   </elem>
-            <elem name="right_arm_joints4"> right_arm-eb29-j12_15-mc  </elem>>                         
+            <elem name="right_arm_joints4"> right_arm-eb29-j12_15-mc  </elem>
         </paramlist>
     </action>
     <action phase="shutdown" level="20" type="detach" />

--- a/iCubSingapore01/calibrators/right_arm-calib.xml
+++ b/iCubSingapore01/calibrators/right_arm-calib.xml
@@ -11,10 +11,10 @@
         </group>
 
 <group name="HOME">
-    <!-- joint logical number           0         1        2       3     4     5      6     7     8     9    10    11    12     13     14    15 -->                         -->    
+    <!-- joint logical number           0         1        2       3     4     5      6     7     8     9    10    11    12     13     14    15 --> 
 <param name="positionHome">          -30        30        0      45     0     0      0    25    30     0     0     0     0      0      0     0 </param>
 <param name="velocityHome">           10        10       10      10     0    30     30    60    30    30    30    30    30     30     30    30 </param>
-</group>                                                                                                                                       
+</group>  
 
 <group name="CALIBRATION">
 <param name="calibrationType">         3         3        3       3      5      3      3     7     7     6     6     6     6      6      6     6    </param>

--- a/iCubSingapore01/wrappers/motorControl/right_arm-mc_remapper.xml
+++ b/iCubSingapore01/wrappers/motorControl/right_arm-mc_remapper.xml
@@ -14,7 +14,7 @@
             <elem name="right_arm_joints1"> right_arm-eb3-j0_3-mc     </elem>
             <elem name="right_arm_joints2"> right_arm-eb27-j4_7-mc    </elem>
             <elem name="right_arm_joints3"> right_arm-eb28-j8_11-mc   </elem>
-            <elem name="right_arm_joints4"> right_arm-eb29-j12_15-mc  </elem>>                         
+            <elem name="right_arm_joints4"> right_arm-eb29-j12_15-mc  </elem>                     
         </paramlist>
     </action>
     <action phase="shutdown" level="20" type="detach" />

--- a/iCubValparaiso01/wrappers/motorControl/right_arm-mc_remapper.xml
+++ b/iCubValparaiso01/wrappers/motorControl/right_arm-mc_remapper.xml
@@ -14,7 +14,7 @@
             <elem name="right_arm_joints1"> right_arm-eb3-j0_3-mc     </elem>
             <elem name="right_arm_joints2"> right_arm-eb27-j4_7-mc    </elem>
             <elem name="right_arm_joints3"> right_arm-eb28-j8_11-mc   </elem>
-            <elem name="right_arm_joints4"> right_arm-eb29-j12_15-mc  </elem>>                         
+            <elem name="right_arm_joints4"> right_arm-eb29-j12_15-mc  </elem>
         </paramlist>
     </action>
     <action phase="shutdown" level="20" type="detach" />

--- a/iCubWaterloo01/wrappers/motorControl/right_arm-mc_remapper.xml
+++ b/iCubWaterloo01/wrappers/motorControl/right_arm-mc_remapper.xml
@@ -14,7 +14,7 @@
             <elem name="right_arm_joints1"> right_arm-eb3-j0_3-mc     </elem>
             <elem name="right_arm_joints2"> right_arm-eb27-j4_7-mc    </elem>
             <elem name="right_arm_joints3"> right_arm-eb28-j8_11-mc   </elem>
-            <elem name="right_arm_joints4"> right_arm-eb29-j12_15-mc  </elem>>                         
+            <elem name="right_arm_joints4"> right_arm-eb29-j12_15-mc  </elem>
         </paramlist>
     </action>
     <action phase="shutdown" level="20" type="detach" />

--- a/iCubZagreb01/wrappers/motorControl/right_arm-mc_remapper.xml
+++ b/iCubZagreb01/wrappers/motorControl/right_arm-mc_remapper.xml
@@ -14,7 +14,7 @@
             <elem name="right_arm_joints1"> right_arm-eb3-j0_3-mc     </elem>
             <elem name="right_arm_joints2"> right_arm-eb27-j4_7-mc    </elem>
             <elem name="right_arm_joints3"> right_arm-eb28-j8_11-mc   </elem>
-            <elem name="right_arm_joints4"> right_arm-eb29-j12_15-mc  </elem>>                         
+            <elem name="right_arm_joints4"> right_arm-eb29-j12_15-mc  </elem>
         </paramlist>
     </action>
     <action phase="shutdown" level="20" type="detach" />


### PR DESCRIPTION
These mistakes were found using `check-xml`[^1], which is a further dry-run layer I've been working on in https://github.com/robotology/robots-configuration/tree/ci/check-xml.

More to come.

cc @Nicogene @martinaxgloria 

[^1]: Apparently, the current dry-run layer failed to spot them.