### PR TITLE
Enable `check-xml` in ci/dry-run

### DIFF
--- a/R1SN001/wrappers/motorControl/cer_torso_tripod-mc_wrapper.xml
+++ b/R1SN001/wrappers/motorControl/cer_torso_tripod-mc_wrapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
-<device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_torso_tripod _mc_wrapper" type="controlBoard_nws_yarp">
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_torso_tripod_mc_wrapper" type="controlBoard_nws_yarp">
     <param name="name">   /cer/torso_tripod </param>
     <action phase="startup" level="10" type="attach">
             <param name="device">  cer_torso_tripod_mc_remapper </param>

--- a/R1SN002/wrappers/motorControl/cer_torso_tripod-mc_wrapper.xml
+++ b/R1SN002/wrappers/motorControl/cer_torso_tripod-mc_wrapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
-<device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_torso_tripod _mc_wrapper" type="controlBoard_nws_yarp">
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_torso_tripod_mc_wrapper" type="controlBoard_nws_yarp">
     <param name="name">   /cer/torso_tripod </param>
     <action phase="startup" level="10" type="attach">
             <param name="device">  cer_torso_tripod_mc_remapper </param>

--- a/R1SN003/wrappers/motorControl/cer_torso_tripod-mc_wrapper.xml
+++ b/R1SN003/wrappers/motorControl/cer_torso_tripod-mc_wrapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
-<device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_torso_tripod _mc_wrapper" type="controlBoard_nws_yarp">
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_torso_tripod_mc_wrapper" type="controlBoard_nws_yarp">
     <param name="name">   /cer/torso_tripod </param>
     <action phase="startup" level="10" type="attach">
             <param name="device">  cer_torso_tripod_mc_remapper </param>

--- a/tests/dry-run/check-xml/schemas/calibrators.xsd
+++ b/tests/dry-run/check-xml/schemas/calibrators.xsd
@@ -181,8 +181,8 @@
                     </xs:complexType>
                 </xs:element>
 
-                <!-- ACTION CALIBRATE-->
-                <xs:element minOccurs="1" maxOccurs="1" name="action">
+                <!-- ACTIONS -->
+                <xs:element minOccurs="1" maxOccurs="unbounded" name="action">
                     <xs:complexType>
                         <xs:sequence minOccurs="0">
                             <xs:element name="param">
@@ -195,49 +195,9 @@
                                 </xs:complexType>
                             </xs:element>
                         </xs:sequence>
-                        <xs:attribute name="phase" type="xs:string" use="required" fixed="startup"/>
+                        <xs:attribute name="phase" type="phase-values" use="required"/>
                         <xs:attribute name="level" type="xs:unsignedByte" use="required" />
-                        <xs:attribute name="type" type="xs:string" use="required" fixed="calibrate"/>
-                    </xs:complexType>
-                </xs:element>
-
-                <!-- ACTION PARK-->
-                <xs:element minOccurs="1" maxOccurs="1" name="action">
-                    <xs:complexType>
-                        <xs:sequence minOccurs="0">
-                            <xs:element name="param">
-                                <xs:complexType>
-                                    <xs:simpleContent>
-                                        <xs:extension base="xs:string">
-                                            <xs:attribute name="name" type="xs:string" use="required" />
-                                        </xs:extension>
-                                    </xs:simpleContent>
-                                </xs:complexType>
-                            </xs:element>
-                        </xs:sequence>
-                        <xs:attribute name="phase" type="xs:string" use="required" fixed="interrupt1"/>
-                        <xs:attribute name="level" type="xs:unsignedByte" use="required" />
-                        <xs:attribute name="type" type="xs:string" use="required" fixed="park"/>
-                    </xs:complexType>
-                </xs:element>
-
-                <!-- ACTION ABORT-->
-                <xs:element minOccurs="1" maxOccurs="1" name="action">
-                    <xs:complexType>
-                        <xs:sequence minOccurs="0">
-                            <xs:element name="param">
-                                <xs:complexType>
-                                    <xs:simpleContent>
-                                        <xs:extension base="xs:string">
-                                            <xs:attribute name="name" type="xs:string" use="required" />
-                                        </xs:extension>
-                                    </xs:simpleContent>
-                                </xs:complexType>
-                            </xs:element>
-                        </xs:sequence>
-                        <xs:attribute name="phase" type="xs:string" use="required" fixed="interrupt3"/>
-                        <xs:attribute name="level" type="xs:unsignedByte" use="required" />
-                        <xs:attribute name="type" type="xs:string" use="required" fixed="abort"/>
+                        <xs:attribute name="type" type="type-values" use="required"/>
                     </xs:complexType>
                 </xs:element>
 
@@ -251,6 +211,23 @@
         <xs:restriction base="xs:string">
             <xs:enumeration value="HOME" />
             <xs:enumeration value="PARKING_SEQUENCE" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="phase-values">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="startup" />
+            <xs:enumeration value="interrupt1" />
+            <xs:enumeration value="interrupt2" />
+            <xs:enumeration value="interrupt3" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="type-values">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="calibrate" />
+            <xs:enumeration value="park" />
+            <xs:enumeration value="abort" />
         </xs:restriction>
     </xs:simpleType>
 </xs:schema>

--- a/tests/dry-run/check-xml/schemas/remapper.xsd
+++ b/tests/dry-run/check-xml/schemas/remapper.xsd
@@ -61,7 +61,7 @@
               </xs:element>
             </xs:sequence>
             <xs:attribute name="phase" type="phase-values" use="required" />
-            <xs:attribute name="level" type="xs:integer" use="required" />
+            <xs:attribute name="level" type="xs:unsignedByte" use="required" />
             <xs:attribute name="type" type="type-values" use="required" />
           </xs:complexType>
         </xs:element>

--- a/tests/dry-run/check-xml/schemas/wrapper.xsd
+++ b/tests/dry-run/check-xml/schemas/wrapper.xsd
@@ -9,6 +9,7 @@
             <xs:simpleContent>
               <xs:extension base="xs:string">
                 <xs:attribute name="name" type="name-values" use="required"/>
+                <xs:attribute name="extern-name" type="extern-name-values"/>
               </xs:extension>
             </xs:simpleContent>
           </xs:complexType>
@@ -27,7 +28,7 @@
               </xs:element>
             </xs:sequence>
             <xs:attribute name="phase" type="phase-values" use="required" />
-            <xs:attribute name="level" type="xs:integer" use="required" />
+            <xs:attribute name="level" type="xs:unsignedByte" use="required" />
             <xs:attribute name="type" type="type-values" use="required" />
           </xs:complexType>
         </xs:element>
@@ -57,6 +58,15 @@
     <xs:enumeration value="period" />
     <xs:enumeration value="nodeName" />
     <xs:enumeration value="topicName" />
+    <xs:enumeration value="node_name" />
+    <xs:enumeration value="topic_name" />
+    <xs:enumeration value="msgs_name" />
+  </xs:restriction>
+</xs:simpleType>
+
+<xs:simpleType name="extern-name-values">
+  <xs:restriction base="xs:string">
+    <xs:enumeration value="cbw_ros2_msgs_name" />
   </xs:restriction>
 </xs:simpleType>
 

--- a/tests/dry-run/dry-run_xml.sh
+++ b/tests/dry-run/dry-run_xml.sh
@@ -49,14 +49,23 @@ if [[ ! -f "${file_launch}" ]]; then
   exit 1
 fi
 
+# specify the log filename
+log_file=dry-run_log_$1_xml.txt
+
+# check xml schemas
+echo "Checking the XML syntax..."
+if ! check-xml --robot-dir ${dir_robot} > ${log_file} 2>&1; then
+  echo "Found errors!"
+  exit 1
+fi
+
 # perform dry-run
 echo "Starting yarpserver..."
 yarpserver --write --silent &
 yarp wait /root
 
 echo "Starting yarprobotinterface..."
-log_file=dry-run_log_$1_xml.txt
-YARP_ROBOT_NAME=$1 yarprobotinterface --dryrun > ${log_file} 2>&1 &
+YARP_ROBOT_NAME=$1 yarprobotinterface --dryrun >> ${log_file} 2>&1 &
 
 exit_code=0
 


### PR DESCRIPTION
This PR fixes some typos plus enables the use of `check-xml` during ci/dry-run.