### PR TITLE
ergoCubSN000: modify alljoints-mc_remapper and torso-mc_remapper to not expose torso_pitch

### DIFF
--- a/ergoCubSN000/wrappers/motorControl/alljoints-mc_remapper.xml
+++ b/ergoCubSN000/wrappers/motorControl/alljoints-mc_remapper.xml
@@ -2,15 +2,12 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-mc_remapper" type="controlboardremapper">
-    <paramlist name="networks">
-        <elem name="head_joints">       (  0   3   0  3 )</elem>
-        <elem name="left_arm_joints">   (  4  16   0  12 )</elem>
-        <elem name="right_arm_joints">  ( 18  30   0  12 )</elem>
-        <elem name="torso_joints">      ( 31  33   0  2 )</elem>
-        <elem name="left_leg_joints">   ( 34  39   0  5 )</elem>
-        <elem name="right_leg_joints">  ( 40  45   0  5 )</elem>
-    </paramlist>
-    <param name="joints"> 46 </param>
+    <!--
+    These are the regular parameters 
+    <param name="axesNames">(neck_pitch,neck_roll,neck_yaw,camera_tilt,l_shoulder_pitch,l_shoulder_roll,l_shoulder_yaw,l_elbow,l_wrist_yaw,l_wrist_roll,l_wrist_pitch,l_thumb_add,l_thumb_oc,l_index_add,l_index_oc,l_middle_oc,l_ring_pinky_oc,r_shoulder_pitch,r_shoulder_roll,r_shoulder_yaw,r_elbow,r_wrist_yaw,r_wrist_roll,r_wrist_pitch,r_thumb_add,r_thumb_oc,r_index_add,r_index_oc,r_middle_oc,r_ring_pinky_oc,torso_roll,torso_pitch,torso_yaw,l_hip_pitch,l_hip_roll,l_hip_yaw,l_knee,l_ankle_pitch,l_ankle_roll,r_hip_pitch,r_hip_roll,r_hip_yaw,r_knee,r_ankle_pitch,r_ankle_roll)</param>
+    -->
+    <!-- These are the parameters with torso_pitch removed -->
+    <param name="axesNames">(neck_pitch,neck_roll,neck_yaw,camera_tilt,l_shoulder_pitch,l_shoulder_roll,l_shoulder_yaw,l_elbow,l_wrist_yaw,l_wrist_roll,l_wrist_pitch,l_thumb_add,l_thumb_oc,l_index_add,l_index_oc,l_middle_oc,l_ring_pinky_oc,r_shoulder_pitch,r_shoulder_roll,r_shoulder_yaw,r_elbow,r_wrist_yaw,r_wrist_roll,r_wrist_pitch,r_thumb_add,r_thumb_oc,r_index_add,r_index_oc,r_middle_oc,r_ring_pinky_oc,torso_roll,torso_yaw,l_hip_pitch,l_hip_roll,l_hip_yaw,l_knee,l_ankle_pitch,l_ankle_roll,r_hip_pitch,r_hip_roll,r_hip_yaw,r_knee,r_ankle_pitch,r_ankle_roll)</param>
     <action phase="startup" level="6" type="attach">
         <paramlist name="networks">
             <elem name="head_joints">       head-mc_remapper </elem>

--- a/ergoCubSN000/wrappers/motorControl/torso-mc_remapper.xml
+++ b/ergoCubSN000/wrappers/motorControl/torso-mc_remapper.xml
@@ -2,10 +2,12 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="torso-mc_remapper" type="controlboardremapper">
-    <paramlist name="networks">
-        <elem name="torso_joints">(  0 2 0 2 )</elem>
-    </paramlist>
-    <param name="joints"> 3			</param>
+    <!--
+    These are the regular parameters 
+    <param name="axesNames">(torso_roll,torso_pitch,torso_yaw)</param>    
+    -->
+    <!-- This are the parametes with torso_pitch not exposed outside of the yarprobotinterface -->
+    <param name="axesNames">(torso_roll,torso_yaw)</param>    
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">
             <elem name="torso_joints">  torso-eb5-j0_2-mc </elem>


### PR DESCRIPTION
These PR modifies the configuration files in `ergoCubSN000` to not expose the `torso_pitch` joint on YARP and ROS2 wrappers, while keep it in the configuration to minimize the amount of configuration files modified. 

To reach this goal, I migrated the `alljoints-mc_remapper` and `torso-mc_remapper` from specifying the joint that they control indirectly via the `networks` group, to explicitly specify the axes that they control via the `axesNames` parameter (see https://yarp.it/latest/classControlBoardRemapper.html#details for more details). For future mantainance, I also added commented the `axesNames` parameter in the case in which `torso_pitch` is actually present. In theory we could think of migrating all the other remappers from `networks` to `axesNames` for consistency, but this is out of the scope of this PR.

This PR ensures compatibility with the modifications in the simulation model done in https://github.com/icub-tech-iit/ergocub-software/pull/103 .

**I did not test this modification on the robot.**