### PR TITLE
[ergoCubSN000] added missing joints param

### DIFF
--- a/ergoCubSN000/wrappers/motorControl/alljoints-mc_remapper.xml
+++ b/ergoCubSN000/wrappers/motorControl/alljoints-mc_remapper.xml
@@ -8,6 +8,7 @@
     -->
     <!-- These are the parameters with torso_pitch removed -->
     <param name="axesNames">(neck_pitch,neck_roll,neck_yaw,camera_tilt,l_shoulder_pitch,l_shoulder_roll,l_shoulder_yaw,l_elbow,l_wrist_yaw,l_wrist_roll,l_wrist_pitch,l_thumb_add,l_thumb_oc,l_index_add,l_index_oc,l_middle_oc,l_ring_pinky_oc,r_shoulder_pitch,r_shoulder_roll,r_shoulder_yaw,r_elbow,r_wrist_yaw,r_wrist_roll,r_wrist_pitch,r_thumb_add,r_thumb_oc,r_index_add,r_index_oc,r_middle_oc,r_ring_pinky_oc,torso_roll,torso_yaw,l_hip_pitch,l_hip_roll,l_hip_yaw,l_knee,l_ankle_pitch,l_ankle_roll,r_hip_pitch,r_hip_roll,r_hip_yaw,r_knee,r_ankle_pitch,r_ankle_roll)</param>
+    <param name="joints"> 44 </param>
     <action phase="startup" level="6" type="attach">
         <paramlist name="networks">
             <elem name="head_joints">       head-mc_remapper </elem>

--- a/ergoCubSN000/wrappers/motorControl/torso-mc_remapper.xml
+++ b/ergoCubSN000/wrappers/motorControl/torso-mc_remapper.xml
@@ -7,7 +7,8 @@
     <param name="axesNames">(torso_roll,torso_pitch,torso_yaw)</param>    
     -->
     <!-- This are the parametes with torso_pitch not exposed outside of the yarprobotinterface -->
-    <param name="axesNames">(torso_roll,torso_yaw)</param>    
+    <param name="axesNames">(torso_roll,torso_yaw)</param>
+    <param name="joints"> 2 </param>
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">
             <elem name="torso_joints">  torso-eb5-j0_2-mc </elem>


### PR DESCRIPTION
This PR fixes #502 adding missing `joints` param.

The CI didn't catch it as it was running based on `pull_request_target` event (to fetch an env var). Previously fixed it via https://github.com/robotology/robots-configuration/commit/f8194810933e643d9a61bdbeb177a262d0aeb77f.