### PR TITLE
iCubWaterloo01: updated required FW versions for strain2

### DIFF
--- a/iCubWaterloo01/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/iCubWaterloo01/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -24,8 +24,8 @@
                     </group>
                     <group name="FIRMWARE">
                         <param name="major">            2                       </param>
-                        <param name="minor">            0                       </param>
-                        <param name="build">            9                       </param>
+                        <param name="minor">            1                       </param>
+                        <param name="build">            0                       </param>
                     </group>
                 </group>
 

--- a/iCubWaterloo01/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/iCubWaterloo01/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -24,8 +24,8 @@
                     </group>
                     <group name="FIRMWARE">
                         <param name="major">            2                       </param>
-                        <param name="minor">            0                       </param>
-                        <param name="build">            9                       </param>
+                        <param name="minor">            1                       </param>
+                        <param name="build">            0                       </param>
                     </group>
                 </group>
 

--- a/iCubWaterloo01/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/iCubWaterloo01/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -24,8 +24,8 @@
                     </group>
                     <group name="FIRMWARE">
                         <param name="major">            2                       </param>
-                        <param name="minor">            0                       </param>
-                        <param name="build">            9                       </param>
+                        <param name="minor">            1                       </param>
+                        <param name="build">            0                       </param>
                     </group>
                 </group>
 

--- a/iCubWaterloo01/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/iCubWaterloo01/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -24,8 +24,8 @@
                     </group>
                     <group name="FIRMWARE">
                         <param name="major">            2                       </param>
-                        <param name="minor">            0                       </param>
-                        <param name="build">            9                       </param>
+                        <param name="minor">            1                       </param>
+                        <param name="build">            0                       </param>
                     </group>
                 </group>
 

--- a/iCubWaterloo01/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/iCubWaterloo01/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -24,8 +24,8 @@
                     </group>
                     <group name="FIRMWARE">
                         <param name="major">            2                       </param>
-                        <param name="minor">            0                       </param>
-                        <param name="build">            9                       </param>
+                        <param name="minor">            1                       </param>
+                        <param name="build">            0                       </param>
                     </group>
                 </group>
 

--- a/iCubWaterloo01/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/iCubWaterloo01/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -24,8 +24,8 @@
                     </group>
                     <group name="FIRMWARE">
                         <param name="major">            2                       </param>
-                        <param name="minor">            0                       </param>
-                        <param name="build">            9                       </param>
+                        <param name="minor">            1                       </param>
+                        <param name="build">            0                       </param>
                     </group>
                 </group>
 

--- a/iCubWaterloo01/network.iCubWaterloo01.xml
+++ b/iCubWaterloo01/network.iCubWaterloo01.xml
@@ -57,6 +57,12 @@
             <connected bus="ETH" prev="10.0.1.20" next="10.0.1.22" />
         </board>
 
+        <board type='rfe' name="rfe.head">
+            <ondevice>ETH</ondevice>
+            <ataddress ip="10.0.1.21" canbus="1" canadr="1"  />
+            <connected bus="CAN" />
+        </board>
+        
     </part>
 
 
@@ -103,12 +109,11 @@
             <connected bus="CAN" />
         </board>
 
-        <board type='strain' name="strain.left_arm">
+        <board type='strain2' name="strain2.left_arm">
             <ondevice>ETH</ondevice>
             <ataddress ip="10.0.1.1" canbus="2" canadr="13"  />
             <connected bus="CAN" />
         </board>
-
 
         <board type='mc4plus' name="left_arm-eb24-j4_7">
             <ondevice>ETH</ondevice>
@@ -211,7 +216,7 @@
             <connected bus="CAN" />
         </board>
 
-        <board type='strain' name="strain.right_arm">
+        <board type='strain2' name="strain2.right_arm">
             <ondevice>ETH</ondevice>
             <ataddress ip="10.0.1.3" canbus="2" canadr="13"  />
             <connected bus="CAN" />
@@ -237,7 +242,7 @@
 
         <board type='mais' name="mais.right_hand">
             <ondevice>ETH</ondevice>
-            <ataddress ip="10.0.1.26" canbus="1" canadr="14"  />
+            <ataddress ip="10.0.1.29" canbus="1" canadr="14"  />
             <connected bus="CAN" />
         </board>
 
@@ -395,13 +400,13 @@
             <connected bus="CAN" />
         </board>
 
-        <board type='strain' name="strain.left_leg">
+        <board type='strain2' name="strain2.left_leg">
             <ondevice>ETH</ondevice>
             <ataddress ip="10.0.1.6" canbus="2" canadr="13"  />
             <connected bus="CAN" />
         </board>
 
-        <board type='strain' name="strain.left_foot">
+        <board type='strain2' name="strain2.left_foot">
             <ondevice>ETH</ondevice>
             <ataddress ip="10.0.1.7" canbus="2" canadr="13"  />
             <connected bus="CAN" />
@@ -544,13 +549,13 @@
             <connected bus="CAN" />
         </board>
 
-        <board type='strain' name="strain.right_leg">
+        <board type='strain2' name="strain2.right_leg">
             <ondevice>ETH</ondevice>
             <ataddress ip="10.0.1.8" canbus="2" canadr="13"  />
             <connected bus="CAN" />
         </board>
 
-        <board type='strain' name="strain.right_foot">
+        <board type='strain2' name="strain2.right_foot">
             <ondevice>ETH</ondevice>
             <ataddress ip="10.0.1.9" canbus="2" canadr="13"  />
             <connected bus="CAN" />


### PR DESCRIPTION
This PR aligns the `iCubWaterloo01` robot to use the latest FW versions of the `strain2` boards used for FT sensing. It also adds the `rfe` board to the `network.iCubWaterloo01.xml` file to support automatic FW update as per instructions in [here](https://github.com/robotology/icub-firmware-build/blob/master/docs/FirmwareUpdater.readme.fulldetails.txt#L201-L228).