### PR TITLE
ergocub: increase head pitch and roll position PID gains

### DIFF
--- a/ergoCubSN000/hardware/motorControl/head-eb20-j0_1-mc.xml
+++ b/ergoCubSN000/hardware/motorControl/head-eb20-j0_1-mc.xml
@@ -47,9 +47,9 @@
         <param name="outputType">               pwm             </param>
         <param name="fbkControlUnits">          metric_units    </param>
         <param name="outputControlUnits">       machine_units   </param>
-        <param name="kp">                       -150        +150        </param>
-        <param name="kd">                       0           0         </param>
-        <param name="ki">                       -15         +15       </param>
+        <param name="kp">                       -180        +178        </param>
+        <param name="kd">                       -5.39       +4.64       </param>
+        <param name="ki">                       -507        +514        </param>
         <param name="maxOutput">                3360        3360        </param>
         <param name="maxInt">                   3360        3360        </param>
         <param name="stictionUp">               0           0           </param>


### PR DESCRIPTION
This PR proposes increased PID gains of the pitch and roll of the ergoCub head, for position control.

The gains were tested with the still robot during external shake-ups on the shoulders and the tilted hip pitch:
![pidconfronto](https://github.com/robotology/robots-configuration/assets/38140169/636350d3-0be1-4147-a3ed-a3a3856a81dc)

And during the bend over sequence during the box lifting test:
![piddevel](https://github.com/robotology/robots-configuration/assets/38140169/9e00649c-2610-4ad2-9c67-736492e41429)
![pidmagici](https://github.com/robotology/robots-configuration/assets/38140169/69017d29-6c06-4836-9f5a-cdb0ca37d830)
