### PR TITLE
Expose BMS on ergoCubSN000 via `battery_nws_yarp`

### DIFF
--- a/ergoCubSN000/battery_test.xml
+++ b/ergoCubSN000/battery_test.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<robot name="ergoCubSN000" build="1" portprefix="/ergocub" xmlns:xi="http://www.w3.org/2001/XInclude">
+
+  <devices>
+    <xi:include href="hardware/battery/battery.xml" />
+    <xi:include href="wrappers/battery/battery.xml" />
+  </devices>
+
+</robot>

--- a/ergoCubSN000/ergocub_all.xml
+++ b/ergoCubSN000/ergocub_all.xml
@@ -111,6 +111,10 @@
     <xi:include href="wrappers/inertials/right_arm-imu_wrapper.xml" />
     <xi:include href="wrappers/inertials/left_foot-imu_wrapper.xml" />
     <xi:include href="wrappers/inertials/right_foot-imu_wrapper.xml" />
+    
+    <!-- BATTERY-->
+    <xi:include href="hardware/battery/battery.xml" />
+    <xi:include href="wrappers/battery/battery.xml" />
 
     <!--  CALIBRATORS -->
     <xi:include href="calibrators/torso-calib.xml" />

--- a/ergoCubSN000/ergocub_all_ros2.xml
+++ b/ergoCubSN000/ergocub_all_ros2.xml
@@ -97,6 +97,11 @@
     <xi:include href="wrappers/inertials/head-inertials_wrapper.xml" />
     <xi:include href="hardware/inertials/head-inertial.xml" />
 
+    
+    <!-- BATTERY-->
+    <xi:include href="hardware/battery/battery.xml" />
+    <xi:include href="wrappers/battery/battery.xml" />
+
     <!--  CALIBRATORS -->
     <xi:include href="calibrators/torso-calib.xml" />
     <xi:include href="calibrators/left_leg-calib.xml" />

--- a/ergoCubSN000/ergocub_wbd.xml
+++ b/ergoCubSN000/ergocub_wbd.xml
@@ -103,6 +103,10 @@
     <xi:include href="wrappers/inertials/right_arm-imu_wrapper.xml" />
     <xi:include href="wrappers/inertials/left_foot-imu_wrapper.xml" />
     <xi:include href="wrappers/inertials/right_foot-imu_wrapper.xml" />
+    
+    <!-- BATTERY-->
+    <xi:include href="hardware/battery/battery.xml" />
+    <xi:include href="wrappers/battery/battery.xml" />
 
     <!--  CALIBRATORS -->
     <xi:include href="calibrators/torso-calib.xml" />

--- a/ergoCubSN000/hardware/battery/battery.xml
+++ b/ergoCubSN000/hardware/battery/battery.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE device PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="canbattery" type="embObjBattery">
+
+    <xi:include href="../../general.xml" />
+
+    <group name="SERVICE">
+
+        <param name="type"> eomn_serv_AS_battery </param>
+
+        <group name="PROPERTIES">
+
+            <group name="CANBOARDS">
+                <param name="type">                 bms             </param>
+
+                <group name="PROTOCOL">
+                    <param name="major">            0                   </param>
+                    <param name="minor">            0                   </param>
+                </group>
+                <group name="FIRMWARE">
+                    <param name="major">            1                   </param>
+                    <param name="minor">            2                   </param>
+                    <param name="build">            0                   </param>
+                </group>
+            </group>
+
+            <group name="SENSORS">
+                <param name="id">                   battery1        </param>
+                <param name="board">                bms             </param>
+                <param name="location">             CAN1:1          </param>
+            </group>
+
+        </group>
+
+
+        <group name="SETTINGS">
+            <param name="enabledSensors">            battery1        </param>
+            <param name="acquisitionRate">           1000            </param>   <!-- msec -->
+        </group>
+
+
+    </group>
+
+</device>
+

--- a/ergoCubSN000/hardware/battery/battery.xml
+++ b/ergoCubSN000/hardware/battery/battery.xml
@@ -4,6 +4,7 @@
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="canbattery" type="embObjBattery">
 
     <xi:include href="../../general.xml" />
+    <xi:include href="../electronics/left_arm-eb2-j0_1-eln.xml" />
 
     <group name="SERVICE">
 

--- a/ergoCubSN000/wrappers/battery/battery.xml
+++ b/ergoCubSN000/wrappers/battery/battery.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="battery_wrapper" type="battery_nws_yarp">
+    <param name="period">       1.0                 </param>
+    <param name="name">       /ergocub/battery      </param>
+
+    <action phase="startup" level="5" type="attach">
+        <paramlist name="networks">
+        <!-- The param value must match the device name in the corresponding body_part-ebX-jA_B-strain.xml file -->
+            <elem name="battery">  canbattery </elem>
+        </paramlist>
+    </action>
+
+    <action phase="shutdown" level="5" type="detach" />
+</device>
+


### PR DESCRIPTION
I put this PR in draft since I have to check the `protocol` and `firmware` versions and test those files on ergoCub.