### PR TITLE
ergoCubSN000: Fix torso calibrator

### DIFF
--- a/ergoCubSN000/calibrators/torso-calib.xml
+++ b/ergoCubSN000/calibrators/torso-calib.xml
@@ -42,11 +42,11 @@
 		<param name="CALIB_ORDER">(0) (2) </param>
 
 		<action phase="startup" level="10" type="calibrate">
-		    <param name="target">torso-mc_remapper</param>
+		    <param name="target">torso-eb5-j0_2-mc</param>
 		</action>
 
 		<action phase="interrupt1" level="1" type="park">
-		    <param name="target">torso-mc_remapper</param>
+		    <param name="target">torso-eb5-j0_2-mc</param>
 		</action>
 
 		<action phase="interrupt3" level="1" type="abort" />


### PR DESCRIPTION
The PR https://github.com/robotology/robots-configuration/pull/502 removed `torso_pitch` from the `torso-mc_remapper` remapper device. However, the calibrator still expects three joints, so the best solution is to attach the calibrator directly to the hardware device instead of the remapper.

This should fix the problem reported in https://github.com/robotology/robots-configuration/pull/513#issuecomment-1549185646 by @isorrentino .