### PR TITLE
ergoCubSN000: Add use of r_leg_ft_sensor and l_leg_ft_sensor and remove use of torso_pitch to align with ergocub-software model

### DIFF
--- a/ergoCubSN000/estimators/wholebodydynamics.xml
+++ b/ergoCubSN000/estimators/wholebodydynamics.xml
@@ -3,7 +3,7 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="wholebodydynamics" type="wholebodydynamics">
-        <param name="axesNames">(torso_pitch,torso_roll,torso_yaw,neck_pitch, neck_roll,neck_yaw,l_shoulder_pitch,l_shoulder_roll,l_shoulder_yaw,l_elbow,l_wrist_roll,l_wrist_pitch,l_wrist_yaw,r_shoulder_pitch,r_shoulder_roll,r_shoulder_yaw,r_elbow,r_wrist_roll,r_wrist_pitch,r_wrist_yaw,l_hip_pitch,l_hip_roll,l_hip_yaw,l_knee,l_ankle_pitch,l_ankle_roll,r_hip_pitch,r_hip_roll,r_hip_yaw,r_knee,r_ankle_pitch,r_ankle_roll)</param>
+        <param name="axesNames">(torso_roll,torso_yaw,neck_pitch, neck_roll,neck_yaw,l_shoulder_pitch,l_shoulder_roll,l_shoulder_yaw,l_elbow,l_wrist_roll,l_wrist_pitch,l_wrist_yaw,r_shoulder_pitch,r_shoulder_roll,r_shoulder_yaw,r_elbow,r_wrist_roll,r_wrist_pitch,r_wrist_yaw,l_hip_pitch,l_hip_roll,l_hip_yaw,l_knee,l_ankle_pitch,l_ankle_roll,r_hip_pitch,r_hip_roll,r_hip_yaw,r_knee,r_ankle_pitch,r_ankle_roll)</param>
         <param name="modelFile">model.urdf</param>
         <param name="fixedFrameGravity">(0,0,-9.81)</param>
 	<param name="defaultContactFrames">(l_hand_palm,r_hand_palm,root_link,l_foot_front,l_foot_rear,r_foot_front,r_foot_rear,l_upper_leg,r_upper_leg)</param>
@@ -27,14 +27,14 @@
 	</group>
 
         <group name="multipleAnalogSensorsNames">
-              <param name="SixAxisForceTorqueSensorsNames">(l_arm_ft_sensor, r_arm_ft_sensor,l_foot_front_ft_sensor, l_foot_rear_ft_sensor, r_foot_front_ft_sensor, r_foot_rear_ft_sensor)</param>
-        </group>`
+            <param name="SixAxisForceTorqueSensorsNames">(l_arm_ft_sensor, r_arm_ft_sensor, r_leg_ft_sensor, l_foot_front_ft_sensor, l_foot_rear_ft_sensor, r_leg_ft_sensor, r_foot_front_ft_sensor, r_foot_rear_ft_sensor)</param>
+        </group>
 
 
         <group name="GRAVITY_COMPENSATION">
             <param name="enableGravityCompensation">true</param>
             <param name="gravityCompensationBaseLink">root_link</param>
-            <param name="gravityCompensationAxesNames">(torso_roll,torso_pitch,torso_yaw,neck_pitch,neck_roll,neck_yaw,l_shoulder_pitch,l_shoulder_roll,l_shoulder_yaw,l_elbow,r_shoulder_pitch,r_shoulder_roll,r_shoulder_yaw,r_elbow,l_hip_pitch,l_hip_roll,l_hip_yaw,l_knee,l_ankle_pitch,l_ankle_roll,r_hip_pitch,r_hip_roll,r_hip_yaw,r_knee,r_ankle_pitch,r_ankle_roll)</param>
+            <param name="gravityCompensationAxesNames">(torso_roll,torso_yaw,neck_pitch,neck_roll,neck_yaw,l_shoulder_pitch,l_shoulder_roll,l_shoulder_yaw,l_elbow,r_shoulder_pitch,r_shoulder_roll,r_shoulder_yaw,r_elbow,l_hip_pitch,l_hip_roll,l_hip_yaw,l_knee,l_ankle_pitch,l_ankle_roll,r_hip_pitch,r_hip_roll,r_hip_yaw,r_knee,r_ankle_pitch,r_ankle_roll)</param>
         </group>
 
 
@@ -71,14 +71,10 @@
                 <!-- imu_waist -->
 <!--            <elem name="imu">xsensmt-inertial</elem> -->
                 <!-- ft -->
-                <!--
-                <elem name="l_leg_ft_sensor">left_leg-eb6-j0_3-strain</elem>
-                <elem name="r_leg_ft_sensor">right_leg-eb8-j0_3-strain</elem> -->
-
-  		<elem name="l_arm_ft_sensor">left_arm-eb2-j0_1-strain</elem>
-                <elem name="r_arm_ft_sensor">right_arm-eb1-j0_1-strain</elem>
-                <elem name="l_foot_ft_sensors">left_leg-eb9-j4_5-strain</elem>
-                <elem name="r_foot_ft_sensors">right_leg-eb7-j4_5-strain</elem>
+                <elem name="l_leg_ft_sensors">left_leg-FT_remapper</elem>
+                <elem name="r_leg_ft_sensors">right_leg-FT_remapper</elem>
+                <elem name="l_arm_ft_sensors">left_arm-eb2-j0_1-strain</elem>
+                <elem name="r_arm_ft_sensors">right_arm-eb1-j0_1-strain</elem>
             </paramlist>
         </action>
 


### PR DESCRIPTION
The `ergoCubSN000/estimators/wholebodydynamics.xml` file was not working with the latest version of ergocub-software for the following reason:
* it referred to torso_pitch, that is not part of the model since https://github.com/icub-tech-iit/ergocub-software/pull/103
* it did not used the `r_leg_ft_sensor` and `l_leg_ft_sensor` FT sensors, that were added to the URDF stored in ergocub-software in https://github.com/icub-tech-iit/ergocub-software/pull/95

On the real `ergoCubSN000`  everything was working fine as ergocub-software was pinned to https://github.com/icub-tech-iit/ergocub-software/commit/3b629f1d566bc89bb6d81adcda9f4694237ab63f with an additional local modification, but with this fix we can update ergocub-software on ergocub-torso to the latest commit. 