### PR TITLE
[ergoCubSN000] Update the required firmware version of the strain2

### DIFF
--- a/ergoCubSN000/hardware/FT/left_arm-eb2-j0_1-strain.xml
+++ b/ergoCubSN000/hardware/FT/left_arm-eb2-j0_1-strain.xml
@@ -25,8 +25,8 @@
                     </group>                    
                     <group name="FIRMWARE">
                         <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
-                        <param name="build">            9                       </param>
+                        <param name="minor">            1                       </param>
+                        <param name="build">            0                       </param>
                     </group>
                 </group>
                 

--- a/ergoCubSN000/hardware/FT/left_leg-eb8-j0_3-strain.xml
+++ b/ergoCubSN000/hardware/FT/left_leg-eb8-j0_3-strain.xml
@@ -24,8 +24,8 @@
                     </group>
                     <group name="FIRMWARE">
                         <param name="major">            2                       </param>
-                        <param name="minor">            0                       </param>
-                        <param name="build">            9                       </param>
+                        <param name="minor">            1                       </param>
+                        <param name="build">            0                       </param>
                     </group>
                 </group>
 

--- a/ergoCubSN000/hardware/FT/left_leg-eb9-j4_5-strain.xml
+++ b/ergoCubSN000/hardware/FT/left_leg-eb9-j4_5-strain.xml
@@ -24,8 +24,8 @@
                     </group>                    
                     <group name="FIRMWARE">
                         <param name="major">            2   		            </param>    
-                        <param name="minor">            0  		            </param> 
-                        <param name="build">            9  		       </param>
+                        <param name="minor">            1  		            </param>
+                        <param name="build">            0  		       </param>
                     </group>
                 </group>
                 

--- a/ergoCubSN000/hardware/FT/right_arm-eb1-j0_1-strain.xml
+++ b/ergoCubSN000/hardware/FT/right_arm-eb1-j0_1-strain.xml
@@ -25,8 +25,8 @@
                     </group>                    
                     <group name="FIRMWARE">
                         <param name="major">            2                       </param>    
-                        <param name="minor">            0                       </param> 
-                        <param name="build">            9                       </param>
+                        <param name="minor">            1                       </param>
+                        <param name="build">            0                       </param>
                     </group>
                 </group>
                 

--- a/ergoCubSN000/hardware/FT/right_leg-eb6-j0_3-strain.xml
+++ b/ergoCubSN000/hardware/FT/right_leg-eb6-j0_3-strain.xml
@@ -24,8 +24,8 @@
                     </group>
                     <group name="FIRMWARE">
                         <param name="major">            2                       </param>
-                        <param name="minor">            0                       </param>
-                        <param name="build">            9                       </param>
+                        <param name="minor">            1                       </param>
+                        <param name="build">            0                       </param>
                     </group>
                 </group>
 

--- a/ergoCubSN000/hardware/FT/right_leg-eb7-j4_5-strain.xml
+++ b/ergoCubSN000/hardware/FT/right_leg-eb7-j4_5-strain.xml
@@ -24,8 +24,8 @@
                     </group>                    
                     <group name="FIRMWARE">
                         <param name="major">            2   		            </param>    
-                        <param name="minor">            0  		            </param> 
-                        <param name="build">            9  		       </param>
+                        <param name="minor">            1  		            </param>
+                        <param name="build">            0  		       </param>
                     </group>
                 </group>
                 


### PR DESCRIPTION
Today we flashed the strain2 on ergocubSN000 from this tag: https://github.com/robotology/icub-firmware-build/releases/tag/v1.34.1 This was required to stabilize the yaw measurements provided in  https://github.com/robotology/icub-firmware-build/pull/77 (see https://github.com/robotology/icub-firmware/pull/361)

After flashing and applying this PR, we tested the walking controller. Everything is working as expected. 

---

cc @S-Dafarra @lrapetti 