### PR TITLE
ergoCub1.0 S/N000 – update left/right calib for startup and home position

### DIFF
--- a/ergoCubSN000/calibrators/left_arm-calib.xml
+++ b/ergoCubSN000/calibrators/left_arm-calib.xml
@@ -12,7 +12,7 @@
 
 	<group name="HOME">
 	<!--                                shoulder-pitch    shoulder-roll    shoulder-yaw    elbow    wrist-yaw    wrist-roll    wrist-pitch    thumb_add    thumb_oc    index_add    index_oc    middle_oc    ring_pinky_oc -->
-		<param name="positionHome">            5                 30              0           10         0            0             0             0.00         0.00        0.00         0.00        0.00           0.00    </param>
+		<param name="positionHome">            5                 30              0           10         0            0             0             0.00         4.00        0.00         4.00        4.00           4.00     </param>
 		<param name="velocityHome">            10                10              10          10         10           10            10            40.00        40.00       40.00        40.00       40.00          40.00    </param>
 	</group>
 	<group name="CALIBRATION">
@@ -24,7 +24,7 @@
 		<param name="calibration5">           0                  0               0           0          0            0             0             0            -273.0      0            -261.0      -259.0         -296.0   </param>
 		<param name="calibrationZero">        35                -15             -52          -5         0            0             0             0            0           0            0           0              0        </param>
 		<param name="calibrationDelta">       0                  0               0           0          0            0             0             0            0           0            0           0              0        </param>
-		<param name="startupPosition">        34                 50              -10         90         0.0          0.0           0.0           0.0          0.0         0.0          0.0         0.0            0.0      </param>
+		<param name="startupPosition">        34                 50              -10         90         0.0          0.0           0.0           0.0          4.0         0.0          4.0         4.0            4.0      </param>
 		<param name="startupVelocity">        10.0               10.0            10.0        10.0       10.0         10.0          10.0          100.0        100.0       0.0          100         100.0          100.0    </param>
 		<param name="startupMaxPwm">          8000               8000            8000        8000       16000        16000         16000         0            0           0            0           0              0        </param>
 		<param name="startupPosThreshold">    2                  2               2           2          2            2             2             90           5          90            5           5              5        </param>

--- a/ergoCubSN000/calibrators/right_arm-calib.xml
+++ b/ergoCubSN000/calibrators/right_arm-calib.xml
@@ -13,19 +13,19 @@
 	<group name="HOME">
 	<!-- For calib6 to set calibration5, i.e. target just multiply desidered pos in deg by 182,044444 (2^(16)/360) -->
     <!--                                shoulder-pitch    shoulder-roll    shoulder-yaw    elbow    wrist-yaw    wrist-roll    wrist-pitch    thumb_add    thumb_oc    index_add    index_oc    middle_oc    ring_pinky_oc -->
-		<param name="positionHome">            5                30              0           10         0             0              0            0.00        0.00        30.00        0.00        0.00        0.00       </param>
-		<param name="velocityHome">            10               10              10          10         10            10             10           40.00        40.00       40.00        40.00       40.00       40.00       </param>
+		<param name="positionHome">            5                30              0           10         0             0              0            0.0          4.0         30.0         4.0         4.0         4.0         </param>
+		<param name="velocityHome">            10               10              10          10         10            10             10           40.0         40.0        40.0         40.0        40.0        40.0        </param>
 	</group>
 	<group name="CALIBRATION">
 		<param name="calibrationType">         10                10             10          10         12            12             12           12           14          12           14          14          14          </param>
 		<param name="calibration1">           -4000              3000           3000       -4000       19023         28993          36030        0            150         0            150         150         150         </param>
-		<param name="calibration2">	       0                 0              0           0          0             0              0            0            9000        0            10923       13653       9000       </param>
+		<param name="calibration2">	           0                 0              0           0          0             0              0            0            9000        0            10923       13653       9000        </param>
 		<param name="calibration3">            0                 0              0           0          0             0              0            0            1           0            1           0           0           </param>
 		<param name="calibration4">            0                 0              0           0          0             0              0            0            180         0            0           0           0           </param>
 		<param name="calibration5">            0                 0              0           0          0             0              0            0            -184.0      0            -294.0      -247.0      -65.0       </param>
 		<param name="calibrationZero">         35               -15            -52         -5          0             0              0            0            0           0            0           0           0           </param>
 		<param name="calibrationDelta">        0                 0              0           0          0             0              0            0            0           0            0           0           0           </param>
-		<param name="startupPosition">         34                50             -10         90         0.0           0.0            0.0          0.0          0.0         0.0          0.0         0.0         0           </param>
+		<param name="startupPosition">         34                50             -10         90         0.0           0.0            0.0          0.0          4.0         0.0          4.0         4.0         4.0         </param>
 		<param name="startupVelocity">         10.0              10.0           10.0        10.0       10.0          10.0           10.0         30.0         30.0        30.0         30.0        30.0        30.0        </param>
 		<param name="startupMaxPwm">           8000              8000           8000        8000       16000         16000          16000        0            0           0            0           0           0           </param>
 		<param name="startupPosThreshold">     2                 2              2           2          2             2              2            90           5           90           5           5           5           </param>

--- a/ergoCubSN000/hardware/motorControl/right_arm-eb22-j7_10-mc.xml
+++ b/ergoCubSN000/hardware/motorControl/right_arm-eb22-j7_10-mc.xml
@@ -13,7 +13,7 @@
     <!-- joint number                           0                   1                   2                   3                   -->
     <!-- joint name                             thumb               index               medium              pinky               -->    
     <group name="LIMITS">
-        <param name="jntPosMin">                0                   0                   0                   0                  </param>
+        <param name="jntPosMin">                4                   4                   4                   4                  </param>
         <param name="jntPosMax">                70                  63                  85                  85                 </param>
         <param name="jntVelMax">                1000                1000                1000                1000               </param>
         <param name="motorOverloadCurrents">    2000                2000                2000                2000               </param>


### PR DESCRIPTION
**What's new:**
- update  `startupPosition` and `homePosition` in `calibrators\left_arm-calib.xml` with the min values set for `jntPosMin` in `hardware\motorControl\left_arm-eb23-j7_10-mc.xml`
- update  `startupPosition` and `homePosition` in `calibrators\right_arm-calib.xml` with the min values set for `jntPosMin` in `hardware\motorControl\right_arm-eb22-j7_10-mc.xml`



**Note:**
- ⚠️ @AntonioConsilvio states that the `jntPosMin` parameter was set to 0 for the right arm since its joints can physically reach the 0 position. However, this is not the case for the left arm. Consequently, I adjusted the `jntPosMin` to 4 for the left arm to maintain consistency, considering it was already set to 4 for the right arm.
- Probably the `jntPosMin` and `jntPosMax` values for both hands may be improved to be more accurate 


cc @valegagge @MSECode @Nicogene 