### PR TITLE
iCubGenova11 - Add xml configuration for the RealSense D405

### DIFF
--- a/iCubGenova11/camera/realsense_d405.xml
+++ b/iCubGenova11/camera/realsense_d405.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="realsense2dev" type="realsense2">
+	<group name="SETTINGS">
+		<param name="depthResolution"> (640 480) </param>
+		<param name="rgbResolution"> (640 480) </param>
+		<param name="framerate"> 30 </param>
+		<param name="alignmentFrame">None</param>
+    </group>
+	<group name="HW_DESCRIPTION">
+		<param name="clipPlanes"> (0.01 10.0)</param>
+	</group>
+</device>

--- a/iCubGenova11/realsense_d405.xml
+++ b/iCubGenova11/realsense_d405.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<robot name="iCubGenova11RealSense" build="2" portprefix="/icub" xmlns:xi="http://www.w3.org/2001/XInclude">
+    <devices>
+        <xi:include href="./camera/realsense_d405.xml" />
+        <xi:include href="./wrappers/camera/realsense-nws_yarp.xml" />
+    </devices>
+</robot>


### PR DESCRIPTION
Adding the configuration files for using the RealSense D405 on this robot. 

**Note:** This is not a duplicate of the `iCubGenova11/camera/realsense.xml` and `iCubGenova11/realsense.xml` pair as this camera requires quite a different configuration with respect to the standard RS D415/435/455 cameras.

cc @fedeceola 