### PR TITLE
iCubGenova09: Cleanup hardware electronics files to avoid warnings and errors related to a total cycle ems time of 1100

### DIFF
--- a/robots-icebox/iCubGenova09/hardware/electronics/left_leg-eb8-j3_5-eln.xml
+++ b/robots-icebox/iCubGenova09/hardware/electronics/left_leg-eb8-j3_5-eln.xml
@@ -18,10 +18,10 @@
         <group name="ETH_BOARD_SETTINGS">
             <param name="Name">                     "left_leg-eb8-j3_5"     </param> 
             <group name="RUNNINGMODE">
-                <param name="period">                   1100                </param>
+                <param name="period">                   1000                </param>
                 <param name="maxTimeOfRXactivity">      400                 </param>
                 <param name="maxTimeOfDOactivity">      300                 </param>   
-                <param name="maxTimeOfTXactivity">      400                 </param>                
+                <param name="maxTimeOfTXactivity">      300                 </param>                
                 <param name="TXrateOfRegularROPs">      2                   </param> 
             </group>              
         </group>                 

--- a/robots-icebox/iCubGenova09/hardware/electronics/right_leg-eb12-j3_5-eln.xml
+++ b/robots-icebox/iCubGenova09/hardware/electronics/right_leg-eb12-j3_5-eln.xml
@@ -18,7 +18,7 @@
         <group name="ETH_BOARD_SETTINGS">
             <param name="Name">                     "right_leg-eb12-j3_5"     </param> 
             <group name="RUNNINGMODE">
-                <param name="period">                   1100                </param>
+                <param name="period">                   1000                </param>
                 <param name="maxTimeOfRXactivity">      400                 </param>
                 <param name="maxTimeOfDOactivity">      300                 </param>   
                 <param name="maxTimeOfTXactivity">      300                 </param>                

--- a/robots-icebox/iCubGenova09/hardware/electronics/right_leg-eb12-j3_5-eln.xml
+++ b/robots-icebox/iCubGenova09/hardware/electronics/right_leg-eb12-j3_5-eln.xml
@@ -21,7 +21,7 @@
                 <param name="period">                   1100                </param>
                 <param name="maxTimeOfRXactivity">      400                 </param>
                 <param name="maxTimeOfDOactivity">      300                 </param>   
-                <param name="maxTimeOfTXactivity">      400                 </param>                
+                <param name="maxTimeOfTXactivity">      300                 </param>                
                 <param name="TXrateOfRegularROPs">      2                   </param> 
             </group>              
         </group>                 


### PR DESCRIPTION
While this robot is in icebox, I preferred to cleanup its configuration file as working on iRonCub-Mk3 we experience many "mysterious" warnings in the form:

~~~
	0,071454	WARNING			eth::parser::read() for BOARD 10.0.1.8 In ETH_BOARD_SETTINGS::RUNNINGMODE sum(maxTimeOfRXactivity, maxTimeOfDOactivity, maxTimeOfTXactivity) != period !!! Using default values
	0,081301	ERROR			1100
	0,091682	WARNING			in EthReceiver::config() the config socket has queue size =  2097152 ; you request ETHRECEIVER_BUFFER_SIZE= 
	0,091725	WARNING			eth::parser::read() for BOARD 10.0.1.8 In ETH_BOARD_SETTINGS::RUNNINGMODE sum(maxTimeOfRXactivity, maxTimeOfDOactivity, maxTimeOfTXactivity) != period !!! Using default values
	0,091764	ERROR			1100
	0,091797	WARNING			eth::parser::read() for BOARD 10.0.1.8 In ETH_BOARD_SETTINGS::RUNNINGMODE sum(maxTimeOfRXactivity, maxTimeOfDOactivity, maxTimeOfTXactivity) != period !!! Using default values
	0,101679	ERROR			1100
	0,122344	WARNING			eth::parser::read() for BOARD 10.0.1.8 In ETH_BOARD_SETTINGS::RUNNINGMODE sum(maxTimeOfRXactivity, maxTimeOfDOactivity, maxTimeOfTXactivity) != period !!! Using default values
	0,122389	ERROR			1100

~~~

In particular, if one looked only to the "ERROR" stream, the only printed message was a mysterious "1100", that many users thought it was ok to have. Instead, the configuration files were malformed, so it is better to clean them up.