### PR TITLE
ergoCubSN000: update amcbldc version to 2.0.3

### DIFF
--- a/ergoCubSN000/hardware/motorControl/left_arm-eb31-j4_6-mc_service.xml
+++ b/ergoCubSN000/hardware/motorControl/left_arm-eb31-j4_6-mc_service.xml
@@ -20,9 +20,9 @@
                     <param name="minor">            0           </param>
                 </group>
                 <group name="FIRMWARE">
-                    <param name="major">            1           </param>
-                    <param name="minor">            2           </param>
-                    <param name="build">            12           </param>
+                    <param name="major">            2           </param>
+                    <param name="minor">            0           </param>
+                    <param name="build">            3           </param>
                 </group>
             </group>
 

--- a/ergoCubSN000/hardware/motorControl/right_arm-eb30-j4_6-mc_service.xml
+++ b/ergoCubSN000/hardware/motorControl/right_arm-eb30-j4_6-mc_service.xml
@@ -20,9 +20,9 @@
                     <param name="minor">            0           </param>
                 </group>
                 <group name="FIRMWARE">
-                    <param name="major">            1           </param>
-                    <param name="minor">            2           </param>
-                    <param name="build">            12          </param>
+                    <param name="major">            2           </param>
+                    <param name="minor">            0           </param>
+                    <param name="build">            3           </param>
                 </group>
             </group>
 


### PR DESCRIPTION
This PR is a MAJOR version update for the amcbldc boards, that aligns it to the latest icub-firmware-build, see the PR: https://github.com/robotology/icub-firmware-build/pull/92

Since it is a major update, the firmware 1.x currently on the robot will conflict with the config file, and the boards will not run.

Therefore, applying this commit necessitates a firmware update of the amcbldc boards for both left and right forearms.

cc @sgiraz @AntonioConsilvio @S-Dafarra @xEnVrE @GiulioRomualdi @pattacini @Nicogene 