### PR TITLE
ergoCubSN000: tune up position PID of index and middle fingers

### DIFF
--- a/ergoCubSN000/hardware/motorControl/left_arm-eb23-j7_10-mc.xml
+++ b/ergoCubSN000/hardware/motorControl/left_arm-eb23-j7_10-mc.xml
@@ -48,7 +48,7 @@
         <param name="outputType">               pwm             </param>
         <param name="fbkControlUnits">          metric_units    </param>
         <param name="outputControlUnits">       machine_units   </param>
-        <param name="kp">                       -200       -246        -200        -200    </param>
+        <param name="kp">                       -200       -246        -246        -200    </param>
         <param name="kd">                       -10           0           0         -10     </param>
         <param name="ki">                       -10         -33         -33         -10     </param>
         <param name="maxOutput">                2700        2700        2700        2700    </param>

--- a/ergoCubSN000/hardware/motorControl/left_arm-eb23-j7_10-mc.xml
+++ b/ergoCubSN000/hardware/motorControl/left_arm-eb23-j7_10-mc.xml
@@ -48,9 +48,9 @@
         <param name="outputType">               pwm             </param>
         <param name="fbkControlUnits">          metric_units    </param>
         <param name="outputControlUnits">       machine_units   </param>
-        <param name="kp">                       -200        -200        -200        -200    </param>
-        <param name="kd">                       -10         -10         -10         -10     </param>
-        <param name="ki">                       -10         -10         -10         -10     </param>
+        <param name="kp">                       -200       -246        -200        -200    </param>
+        <param name="kd">                       -10           0           0         -10     </param>
+        <param name="ki">                       -10         -33         -33         -10     </param>
         <param name="maxOutput">                2700        2700        2700        2700    </param>
         <param name="maxInt">                   1000        1000        1000        1000    </param>
         <param name="stictionUp">               0           0           0           0       </param>

--- a/ergoCubSN000/hardware/motorControl/right_arm-eb22-j7_10-mc.xml
+++ b/ergoCubSN000/hardware/motorControl/right_arm-eb22-j7_10-mc.xml
@@ -48,9 +48,9 @@
         <param name="outputType">               pwm             </param>
         <param name="fbkControlUnits">          metric_units    </param>
         <param name="outputControlUnits">       machine_units   </param>
-        <param name="kp">                       -200        -200        -200        -200    </param>
-        <param name="kd">                       -10         -10         -10         -10     </param>
-        <param name="ki">                       -10         -10         -10         -10     </param>
+        <param name="kp">                       -200       -246        -246        -200     </param>
+        <param name="kd">                       -10           0           0         -10     </param>
+        <param name="ki">                       -10         -33         -33         -10     </param>
         <param name="maxOutput">                2700        2700        2700        2700    </param>
         <param name="maxInt">                   1000        1000        1000        1000    </param>
         <param name="stictionUp">               0           0           0           0       </param>


### PR DESCRIPTION
This PR updates the PID controllers of the index and middle fingers of the ergoCub hands. The methodology involved linear identification and robust tuning after the addition of parametric uncertainties, bringing improvements both in error tracking and PWM noise. The Derivative component is set to zero, as it stiffens the system too much. 