### PR TITLE
Update R1SN003 w/ new BAT device

### DIFF
--- a/R1SN003/CER.xml
+++ b/R1SN003/CER.xml
@@ -100,5 +100,10 @@
     <xi:include href="wrappers/motorControl/cer_alljoints_remapper.xml" enabled_by="enable_ros enable_ros2" disabled_by="disable_base disable_head disable_left_arm disable_left_hand disable_right_arm disable_right_hand disable_torso"/>
     <xi:include href="wrappers/motorControl/cer_alljoints_ros_wrapper.xml" enabled_by="enable_ros" disabled_by="disable_base disable_head disable_left_arm disable_left_hand disable_right_arm disable_right_hand disable_torso"/>
     <xi:include href="wrappers/motorControl/cer_alljoints_ros2_wrapper.xml" enabled_by="enable_ros2" disabled_by="disable_base disable_head disable_left_arm disable_left_hand disable_right_arm disable_right_hand disable_torso"/>
+    
+    <!-- BATTERY -->
+    <xi:include href="wrappers/battery/r1battery.xml" /> 
+    <xi:include href="hardware/battery/r1battery.xml" /> 
+
 </devices>
 </robot>

--- a/R1SN003/hardware/battery/r1battery.xml
+++ b/R1SN003/hardware/battery/r1battery.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE device PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="r1battery" type="embObjBattery">  
+
+	<xi:include href="../../general.xml" />
+    <xi:include href="../electronics/cer_base-ems1-eln.xml" />
+
+    <group name="SERVICE">
+
+        <param name="type"> eomn_serv_AS_battery </param>
+
+        <group name="PROPERTIES">
+
+            <group name="CANBOARDS">
+                <param name="type">                 bms             </param>
+
+                <group name="PROTOCOL">
+                    <param name="major">            0                   </param>
+                    <param name="minor">            0                   </param>
+                </group>
+                <group name="FIRMWARE">
+                    <param name="major">            1                   </param>
+                    <param name="minor">            2                   </param>
+                    <param name="build">            1                   </param>
+                </group>
+            </group>
+
+            <group name="SENSORS">
+                <param name="id">                   battery1        </param>
+                <param name="board">                bms             </param>
+                <param name="location">             CAN1:1          </param>
+            </group>
+
+        </group>
+
+
+        <group name="SETTINGS">
+            <param name="enabledSensors">            battery1        </param>
+            <param name="acquisitionRate">           1000            </param>   <!-- msec -->
+        </group>
+
+
+    </group>         
+
+</device>    
+          

--- a/R1SN003/wrappers/battery/r1battery.xml
+++ b/R1SN003/wrappers/battery/r1battery.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="r1_battery-nws_yarp" type="battery_nws_yarp">
+
+      <param name="period">           1.0        </param>
+      <param name="name">        /cer/battery </param>
+      <param name="enable_log">        0         </param>
+      <param name="enable_shutdown">   0         </param>
+
+      <action phase="startup" level="5" type="attach">
+         <paramlist name="networks">
+            <elem name="r1battery">  r1battery </elem>
+         </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+  </device>


### PR DESCRIPTION
Update R1SN003 w/ the BAT board.
This board is connected through a CAN bus to the EMS board on the base of the robot.
Features:
- Introduced 2 new devices and added in `CER.xml`
- First device is `r1battery` of type `embObjBattery` under `hardware/battery/r1battery.xml`
- Second device is `r1_battery-nws_yarp` of type `battery_nws_yarp` under `wrappers/battery/r1battery.xml`

