### PR TITLE
ergoCub 1.0 S/N:000 – align config files with distro 2023.05.02

### DIFF
--- a/ergoCubSN000/calibrators/left_arm-calib.xml
+++ b/ergoCubSN000/calibrators/left_arm-calib.xml
@@ -17,11 +17,11 @@
 	</group>
 	<group name="CALIBRATION">
 		<param name="calibrationType">        10                 10              10          10         12           12            12            12           14          12           14          14             14       </param>
-		<param name="calibration1">           4000               -3000           -3000       4000       17565        8161          21461         0            150         0            150         150            150      </param>
-		<param name="calibration2">	      0                  0               0           0          0            0             0             0            2000        0            2000        2000           2000     </param>
+		<param name="calibration1">           4000               -3000           -3000       4000       17565        8161          21461         0            300         0            300         300            300      </param>
+		<param name="calibration2">	      0                  0               0           0          0            0             0             0            0        0                0            0               0     </param>
 		<param name="calibration3">           0                  0               0           0          0            0             0             0            1           0            0           0              1        </param>
-		<param name="calibration4">           0                  0               0           0          0            0             0             0            180         0            0           0              0        </param>
-		<param name="calibration5">           0                  0               0           0          0            0             0             0            -273.0      0            -261.0      -259.0         -296.0   </param>
+		<param name="calibration4">           0                  0               0           0          0            0             0             0            32768         0            0           0              0        </param>
+		<param name="calibration5">           0                  0               0           0          0            0             0             0            18477      0            -47514      -47150         53885  </param>
 		<param name="calibrationZero">        35                -15             -52          -5         0            0             0             0            0           0            0           0              0        </param>
 		<param name="calibrationDelta">       0                  0               0           0          0            0             0             0            0           0            0           0              0        </param>
 		<param name="startupPosition">        34                 50              -10         90         0.0          0.0           0.0           0.0          4.0         0.0          4.0         4.0            4.0      </param>

--- a/ergoCubSN000/calibrators/right_arm-calib.xml
+++ b/ergoCubSN000/calibrators/right_arm-calib.xml
@@ -18,11 +18,11 @@
 	</group>
 	<group name="CALIBRATION">
 		<param name="calibrationType">         10                10             10          10         12            12             12           12           14          12           14          14          14          </param>
-		<param name="calibration1">           -4000              3000           3000       -4000       19023         28993          36030        0            150         0            150         150         150         </param>
-		<param name="calibration2">	       0                 0              0           0          0             0              0            0            2000        0            2000       2000        2000        </param>
+		<param name="calibration1">           -4000              3000           3000       -4000       19023         28993          36030        0            300         0            300         300         300         </param>
+		<param name="calibration2">	       0                 0              0           0          0             0              0            0                0        0                0            0             0        </param>
 		<param name="calibration3">            0                 0              0           0          0             0              0            0            1           0            1           0           0           </param>
-		<param name="calibration4">            0                 0              0           0          0             0              0            0            180         0            0           0           0           </param>
-		<param name="calibration5">            0                 0              0           0          0             0              0            0            -184.0      0            -294.0      -247.0      -65.0       </param>
+		<param name="calibration4">            0                 0              0           0          0             0              0            0            32768         0            0           0           0           </param>
+		<param name="calibration5">            0                 0              0           0          0             0              0            0            66755      0            53521      -44965      -11833       </param>
 		<param name="calibrationZero">         35               -15            -52         -5          0             0              0            0            0           0            0           0           0           </param>
 		<param name="calibrationDelta">        0                 0              0           0          0             0              0            0            0           0            0           0           0           </param>
 		<param name="startupPosition">         34                50             -10         90         0.0           0.0            0.0          0.0          4.0         0.0          4.0         4.0         4.0         </param>

--- a/ergoCubSN000/hardware/FT/right_arm-eb1-j0_1-strain.xml
+++ b/ergoCubSN000/hardware/FT/right_arm-eb1-j0_1-strain.xml
@@ -25,7 +25,7 @@
                     </group>                    
                     <group name="FIRMWARE">
                         <param name="major">            2                       </param>    
-                        <param name="minor">            1                       </param>
+                        <param name="minor">            2                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>

--- a/ergoCubSN000/hardware/FT/right_arm-eb1-j0_1-strain.xml
+++ b/ergoCubSN000/hardware/FT/right_arm-eb1-j0_1-strain.xml
@@ -25,7 +25,7 @@
                     </group>                    
                     <group name="FIRMWARE">
                         <param name="major">            2                       </param>    
-                        <param name="minor">            2                       </param>
+                        <param name="minor">            1                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>

--- a/ergoCubSN000/hardware/POS/left_hand-pos2.xml
+++ b/ergoCubSN000/hardware/POS/left_hand-pos2.xml
@@ -20,7 +20,7 @@
                 </group>
                 <group name="FIRMWARE">
                     <param name="major">            2                       </param>
-                    <param name="minor">            0                       </param>
+                    <param name="minor">            1                       </param>
                     <param name="build">            0                       </param>
                 </group>
             </group>

--- a/ergoCubSN000/hardware/POS/left_hand-pos4.xml
+++ b/ergoCubSN000/hardware/POS/left_hand-pos4.xml
@@ -20,7 +20,7 @@
                 </group>
                 <group name="FIRMWARE">
                     <param name="major">            2                       </param>
-                    <param name="minor">            0                       </param>
+                    <param name="minor">            1                       </param>
                     <param name="build">            0                       </param>
                 </group>
             </group>

--- a/ergoCubSN000/hardware/inertials/head-inertial.xml
+++ b/ergoCubSN000/hardware/inertials/head-inertial.xml
@@ -24,8 +24,8 @@
                     </group>
                     <group name="FIRMWARE">
                         <param name="major">            1                   </param>
-                        <param name="minor">            2                   </param>
-                        <param name="build">            3                   </param>
+                        <param name="minor">            3                   </param>
+                        <param name="build">            0                   </param>
                     </group>
                 </group>
 

--- a/ergoCubSN000/hardware/inertials/left_arm-eb4-j2_3-inertial.xml
+++ b/ergoCubSN000/hardware/inertials/left_arm-eb4-j2_3-inertial.xml
@@ -23,8 +23,8 @@
                     </group>                    
                     <group name="FIRMWARE">
                         <param name="major">            1                   </param>    
-                        <param name="minor">            4                   </param> 
-                        <param name="build">            7                   </param>
+                        <param name="minor">            21                   </param> 
+                        <param name="build">            0                   </param>
                     </group>
                 </group>
 

--- a/ergoCubSN000/hardware/inertials/right_arm-eb1-j0_1-inertial.xml
+++ b/ergoCubSN000/hardware/inertials/right_arm-eb1-j0_1-inertial.xml
@@ -17,13 +17,13 @@
                     <param name="type">             eobrd_strain2           </param>
 
                     <group name="PROTOCOL">
-                        <param name="major">            0                   </param>
+                        <param name="major">            2                   </param>
                         <param name="minor">            0                   </param>
                     </group>
 
                     <group name="FIRMWARE">
-                        <param name="major">            0                   </param>
-                        <param name="minor">            0                   </param>
+                        <param name="major">            2                   </param>
+                        <param name="minor">            1                   </param>
                         <param name="build">            0                   </param>
                     </group>
                 </group>

--- a/ergoCubSN000/hardware/inertials/right_arm-eb3-j2_3-inertial.xml
+++ b/ergoCubSN000/hardware/inertials/right_arm-eb3-j2_3-inertial.xml
@@ -24,8 +24,8 @@
                     </group>                    
                     <group name="FIRMWARE">
                         <param name="major">            1                   </param>    
-                        <param name="minor">            4                   </param> 
-                        <param name="build">            7                   </param>
+                        <param name="minor">            21                   </param> 
+                        <param name="build">            0                   </param>
                     </group>
                 </group>
 

--- a/ergoCubSN000/hardware/motorControl/left_arm-eb23-j7_10-mc_service.xml
+++ b/ergoCubSN000/hardware/motorControl/left_arm-eb23-j7_10-mc_service.xml
@@ -21,7 +21,7 @@
                 </group>
                 <group name="FIRMWARE">
                     <param name="major">            2                   </param>
-                    <param name="minor">            0                   </param>
+                    <param name="minor">            1                   </param>
                     <param name="build">            0                   </param>
                 </group>
             </group>

--- a/ergoCubSN000/hardware/motorControl/left_arm-eb25-j11_12-mc_service.xml
+++ b/ergoCubSN000/hardware/motorControl/left_arm-eb25-j11_12-mc_service.xml
@@ -21,7 +21,7 @@
                 </group>
                 <group name="FIRMWARE">
                     <param name="major">            2                   </param>
-                    <param name="minor">            0                   </param>
+                    <param name="minor">            1                   </param>
                     <param name="build">            0                   </param>
                 </group>
             </group>

--- a/ergoCubSN000/hardware/motorControl/left_arm-eb31-j4_6-mc_service.xml
+++ b/ergoCubSN000/hardware/motorControl/left_arm-eb31-j4_6-mc_service.xml
@@ -20,9 +20,9 @@
                     <param name="minor">            0           </param>
                 </group>
                 <group name="FIRMWARE">
-                    <param name="major">            2           </param>
+                    <param name="major">            0           </param>
                     <param name="minor">            0           </param>
-                    <param name="build">            3           </param>
+                    <param name="build">            0           </param>
                 </group>
             </group>
 

--- a/ergoCubSN000/hardware/motorControl/left_arm-eb31-j4_6-mc_service.xml
+++ b/ergoCubSN000/hardware/motorControl/left_arm-eb31-j4_6-mc_service.xml
@@ -20,9 +20,9 @@
                     <param name="minor">            0           </param>
                 </group>
                 <group name="FIRMWARE">
-                    <param name="major">            0           </param>
+                    <param name="major">            2           </param>
                     <param name="minor">            0           </param>
-                    <param name="build">            0           </param>
+                    <param name="build">            4           </param>
                 </group>
             </group>
 

--- a/ergoCubSN000/hardware/motorControl/right_arm-eb22-j7_10-mc.xml
+++ b/ergoCubSN000/hardware/motorControl/right_arm-eb22-j7_10-mc.xml
@@ -14,7 +14,7 @@
     <!-- joint name                             thumb               index               medium              pinky               -->    
     <group name="LIMITS">
         <param name="jntPosMin">                4                   4                   4                   4                  </param>
-        <param name="jntPosMax">                70                  63                  85                  85                 </param>
+        <param name="jntPosMax">                70                  85                  85                  85                 </param>
         <param name="jntVelMax">                1000                1000                1000                1000               </param>
         <param name="motorOverloadCurrents">    2000                2000                2000                2000               </param>
         <param name="motorNominalCurrents">     1100                1100                1100                1100                </param>

--- a/ergoCubSN000/hardware/motorControl/right_arm-eb30-j4_6-mc_service.xml
+++ b/ergoCubSN000/hardware/motorControl/right_arm-eb30-j4_6-mc_service.xml
@@ -20,9 +20,9 @@
                     <param name="minor">            0           </param>
                 </group>
                 <group name="FIRMWARE">
-                    <param name="major">            2           </param>
+                    <param name="major">            0           </param>
                     <param name="minor">            0           </param>
-                    <param name="build">            3           </param>
+                    <param name="build">            0           </param>
                 </group>
             </group>
 

--- a/ergoCubSN000/hardware/motorControl/right_arm-eb30-j4_6-mc_service.xml
+++ b/ergoCubSN000/hardware/motorControl/right_arm-eb30-j4_6-mc_service.xml
@@ -20,9 +20,9 @@
                     <param name="minor">            0           </param>
                 </group>
                 <group name="FIRMWARE">
-                    <param name="major">            0           </param>
+                    <param name="major">            2           </param>
                     <param name="minor">            0           </param>
-                    <param name="build">            0           </param>
+                    <param name="build">            4           </param>
                 </group>
             </group>
 


### PR DESCRIPTION
**What's new:**
- The configuration files of ergoCub 1.0 S/N000. In particular, the configuration files are now aligned with the FW versions contained in [icub-firmware-build@v1.35.1][1].
- the calibration values for the hands of ergoCub 1.0 S/N000 are now as expected


**Notes:**
- ⚠️ Without these changes the last distro of [robotology-superbuild@v2023.05.02)2] does not work using the latest FW contained in [icub-firmware-build@v1.35.1][1].
- Actually the robots-configuration repository inside the robotology superbuild on the ergocub-torso is set on a local `master` branch containing these changes


cc @pattacini @AntonioConsilvio @MSECode @Nicogene @martinaxgloria @mfussi66 @isorrentino @Miche19 @GiulioRomualdi @S-Dafarra 

[1]: https://github.com/robotology/icub-firmware-build/releases/tag/v1.35.1
[2]: https://github.com/robotology/robotology-superbuild/releases/tag/v2023.05.2