### PR TITLE
ergoCub sn000 update hip pitch max

### DIFF
--- a/ergoCubSN000/hardware/motorControl/left_leg-eb8-j0_3-mc.xml
+++ b/ergoCubSN000/hardware/motorControl/left_leg-eb8-j0_3-mc.xml
@@ -12,7 +12,7 @@
     <!-- joint number                           0                   1           2         3 -->
     <!-- joint name -->
     <group name="LIMITS">
-        <param name="jntPosMax">                 106                 108       78        5      </param>
+        <param name="jntPosMax">                 102                 108       78        5      </param>
         <param name="jntPosMin">                -42                 -15      -78        -103    </param>
         <param name="jntVelMax">                240                 240       240       240    </param>
         <param name="motorNominalCurrents">     15000               15000     5000      10000  </param>

--- a/ergoCubSN000/hardware/motorControl/right_leg-eb6-j0_3-mc.xml
+++ b/ergoCubSN000/hardware/motorControl/right_leg-eb6-j0_3-mc.xml
@@ -12,7 +12,7 @@
     <!-- joint number                           0                   1           0         3 -->
     <!-- joint name -->
     <group name="LIMITS">
-        <param name="jntPosMax">                 106                 108       78        5      </param>
+        <param name="jntPosMax">                 102                 108       78        5      </param>
         <param name="jntPosMin">                -42                 -15      -78        -103    </param>
         <param name="jntVelMax">                240                 240       240      240    </param>
         <param name="motorNominalCurrents">     15000               15000     5000     10000  </param>


### PR DESCRIPTION
From an internal study aimed to check the possible collision of the covers, it turned out that it's precautional to reduce the soft limits of the hip pitch.

cc @Nicogene @lrapetti 