### PR TITLE
R1SN001: No PSC boards xml config file

### DIFF
--- a/R1SN001/CER_noPSC.xml
+++ b/R1SN001/CER_noPSC.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<robot name="R1SN001" build="1" portprefix="cer" xmlns:xi="http://www.w3.org/2001/XInclude">
+<devices>
+
+    <!-- ODOMETRY -->
+    <xi:include href="hardware/odometry/odometry.xml" disabled_by="disable_odometry" />
+    <xi:include href="wrappers/odometry/odometry_nws_yarp.xml" disabled_by="disable_odometry" />
+    <xi:include href="wrappers/odometry/odometry_nws_ros.xml" enabled_by="enable_ros" disabled_by="disable_odometry" />
+    <xi:include href="wrappers/odometry/odometry_nws_ros2.xml" enabled_by="enable_ros2" disabled_by="disable_odometry" />
+
+    <!-- LASER -->
+    <xi:include href="hardware/rpLidar/laserA3_hw_back.xml" disabled_by="disable_lidar" />
+    <xi:include href="wrappers/rpLidar/laser_back_nws_yarp.xml" disabled_by="disable_lidar" />
+    <xi:include href="hardware/rpLidar/laserA3_hw_front.xml" disabled_by="disable_lidar" />
+    <xi:include href="wrappers/rpLidar/laser_front_nws_yarp.xml" disabled_by="disable_lidar" />
+    <xi:include href="hardware/rpLidar/laserA3_hw_double.xml" disabled_by="disable_lidar" />
+    <xi:include href="wrappers/rpLidar/laser_double_nws_yarp.xml" disabled_by="disable_lidar" />
+    <xi:include href="wrappers/rpLidar/laser_double_nws_ros.xml" enabled_by="enable_ros" disabled_by="disable_lidar" />
+    <xi:include href="wrappers/rpLidar/laser_double_nws_ros2.xml" enabled_by="enable_ros2" disabled_by="disable_lidar" />
+
+    <!-- BASE -->
+    <xi:include href="hardware/motorControl/cer_base-ems1-mc.xml" disabled_by="disable_base" />
+    <xi:include href="wrappers/motorControl/cer_base-mc_remapper.xml" disabled_by="disable_base" />
+    <xi:include href="wrappers/motorControl/cer_base-mc_wrapper.xml" disabled_by="disable_base" />
+
+    <!-- TORSO -->
+    <xi:include href="hardware/motorControl/cer_torso-ems3-mc.xml" disabled_by="disable_torso" />
+    <xi:include href="wrappers/motorControl/cer_torso_tripod-mc_remapper.xml" disabled_by="disable_torso" />
+    <xi:include href="wrappers/motorControl/cer_torso_tripod-mc_wrapper.xml" disabled_by="disable_torso" />
+    <xi:include href="hardware/motorControl/cer_torso_equivalent-mc.xml" disabled_by="disable_torso" />
+    <xi:include href="wrappers/motorControl/cer_torso-mc_remapper.xml" disabled_by="disable_torso" />
+    <xi:include href="wrappers/motorControl/cer_torso-mc_wrapper.xml" disabled_by="disable_torso" />
+
+    <!-- LEFT ARM -->
+    <xi:include href="hardware/motorControl/cer_left_shoulder-ems5-mc.xml" disabled_by="disable_left_arm" />
+    <xi:include href="hardware/motorControl/cer_left_upper_arm-ems12-mc.xml" disabled_by="disable_left_arm"/>
+    <xi:include href="hardware/motorControl/cer_left_lower_arm-mcp8-mc.xml" disabled_by="disable_left_arm"/>
+    <xi:include href="hardware/motorControl/cer_left_wrist_equivalent-mc.xml" disabled_by="disable_left_arm"/>
+    <xi:include href="wrappers/motorControl/cer_left_wrist_tripod-mc_remapper.xml" disabled_by="disable_left_arm"/>
+    <xi:include href="wrappers/motorControl/cer_left_arm_no_hand-mc_remapper.xml" disabled_by="disable_left_arm"/>
+    <xi:include href="wrappers/motorControl/cer_left_wrist_tripod-mc_wrapper.xml" disabled_by="disable_left_arm"/>
+    <xi:include href="wrappers/motorControl/cer_left_arm_no_hand-mc_wrapper.xml" disabled_by="disable_left_arm"/>
+
+    <!-- LEFT HAND -->
+    <xi:include href="hardware/motorControl/cer_left_hand-mcp9-mc.xml" disabled_by="disable_left_hand"/>
+    <xi:include href="wrappers/motorControl/cer_left_hand-mc_remapper.xml" disabled_by="disable_left_hand"/>
+    <xi:include href="wrappers/motorControl/cer_left_hand-mc_wrapper.xml" disabled_by="disable_left_hand"/>
+
+    <!-- RIGHT ARM -->
+    <xi:include href="hardware/motorControl/cer_right_shoulder-ems4-mc.xml" disabled_by="disable_right_arm"/>
+    <xi:include href="hardware/motorControl/cer_right_upper_arm-ems11-mc.xml" disabled_by="disable_right_arm"/>
+    <xi:include href="hardware/motorControl/cer_right_lower_arm-mcp6-mc.xml" disabled_by="disable_right_arm"/>
+    <xi:include href="hardware/motorControl/cer_right_wrist_equivalent-mc.xml" disabled_by="disable_right_arm"/>
+    <xi:include href="wrappers/motorControl/cer_right_wrist_tripod-mc_remapper.xml" disabled_by="disable_right_arm"/>
+    <xi:include href="wrappers/motorControl/cer_right_arm_no_hand-mc_remapper.xml" disabled_by="disable_right_arm"/>
+    <xi:include href="wrappers/motorControl/cer_right_wrist_tripod-mc_wrapper.xml" disabled_by="disable_right_arm"/>
+    <xi:include href="wrappers/motorControl/cer_right_arm_no_hand-mc_wrapper.xml" disabled_by="disable_right_arm"/>
+
+    <!-- RIGHT HAND -->
+    <xi:include href="hardware/motorControl/cer_right_hand-mcp7-mc.xml" disabled_by="disable_right_hand"/>
+    <xi:include href="wrappers/motorControl/cer_right_hand-mc_remapper.xml" disabled_by="disable_right_hand" />
+    <xi:include href="wrappers/motorControl/cer_right_hand-mc_wrapper.xml" disabled_by="disable_right_hand"/>
+
+    <!-- HEAD -->
+    <xi:include href="hardware/motorControl/cer_head-mcp10-mc.xml" disabled_by="disable_head"/>
+    <xi:include href="wrappers/motorControl/cer_head-mc_remapper.xml" disabled_by="disable_head"/>
+    <xi:include href="wrappers/motorControl/cer_head-mc_wrapper.xml" disabled_by="disable_head"/>
+
+    <!--  CALIBRATORS -->
+    <xi:include href="calibrators/cer_torso-calib.xml" disabled_by="disable_torso"/>
+    <xi:include href="calibrators/cer_left_arm_no_hand-calib.xml" disabled_by="disable_left_arm"/>
+    <xi:include href="calibrators/cer_right_arm_no_hand-calib.xml" disabled_by="disable_right_arm"/>
+    <xi:include href="calibrators/cer_head-calib.xml" disabled_by="disable_head"/>
+    <xi:include href="calibrators/cer_base-calib.xml" disabled_by="disable_base"/>
+    <xi:include href="calibrators/cer_left_hand-calib.xml" disabled_by="disable_left_hand"/>
+    <xi:include href="calibrators/cer_right_hand-calib.xml" disabled_by="disable_right_hand"/>
+
+    <!-- SKIN-->
+<!--<xi:include href="hardware/skin/left_hand-mc9-skin.xml" />
+    <xi:include href="wrappers/skin/left_hand-skin_wrapper.xml" />
+    <xi:include href="hardware/skin/right_hand-mc7-skin.xml" />
+    <xi:include href="wrappers/skin/right_hand-skin_wrapper.xml" />
+-->
+
+    <!-- PSC -->
+    <!--
+    <xi:include href="wrappers/PSC/cer_right_arm-PSC_wrapper.xml" />
+    <xi:include href="hardware/PSC/right_hand-psc.xml" />
+    <xi:include href="wrappers/PSC/cer_left_arm-PSC_wrapper.xml" />
+    <xi:include href="hardware/PSC/left_hand-psc.xml" />
+    -->
+
+    <!--  FT -->
+    <xi:include href="hardware/FT/cer_left_shoulder-ems5-strain.xml" />
+    <xi:include href="hardware/FT/cer_right_shoulder-ems4-strain.xml" />
+    <xi:include href="wrappers/FT/cer_left_arm-FT_wrapper.xml" />
+    <xi:include href="wrappers/FT/cer_right_arm-FT_wrapper.xml" />
+
+    <!--  ROS -->
+    <xi:include href="wrappers/motorControl/cer_alljoints_remapper.xml" enabled_by="enable_ros enable_ros2" disabled_by="disable_base disable_head disable_left_arm disable_left_hand disable_right_arm disable_right_hand disable_torso"/>
+    <xi:include href="wrappers/motorControl/cer_alljoints_ros_wrapper.xml" enabled_by="enable_ros" disabled_by="disable_base disable_head disable_left_arm disable_left_hand disable_right_arm disable_right_hand disable_torso"/>
+    <xi:include href="wrappers/motorControl/cer_alljoints_ros2_wrapper.xml" enabled_by="enable_ros2" disabled_by="disable_base disable_head disable_left_arm disable_left_hand disable_right_arm disable_right_hand disable_torso"/>
+</devices>
+</robot>

--- a/R1SN001/CMakeLists.txt
+++ b/R1SN001/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(appname R1SN001)
 
-set(scripts CER.xml yarprobotinterface.ini general.xml yarpmotorgui.ini firmwareupdater.ini)
+set(scripts CER.xml CER_noPSC.xml yarprobotinterface.ini general.xml yarpmotorgui.ini firmwareupdater.ini)
 
 yarp_install(FILES ${scripts} DESTINATION ${ICUBCONTRIB_ROBOTS_INSTALL_DIR}/${appname})
 yarp_install(DIRECTORY calibrators DESTINATION ${ICUBCONTRIB_ROBOTS_INSTALL_DIR}/${appname})

--- a/R1SN001/yarprobotinterface.ini
+++ b/R1SN001/yarprobotinterface.ini
@@ -1,3 +1,3 @@
-config ./CER.xml
+config ./CER_noPSC.xml
 enable_tags (enable_ros2)
-disable_tags () 
+disable_tags ()


### PR DESCRIPTION
Added a new yarprobotinterface xml configuration file for R1SN001 with the PSC boards commented out since they do not seem to work properly.

This new file replaces the original one in the `yarprobotinterface.ini` file