### PR TITLE
ergoCubSN000: update left right thumb oc position pids

### DIFF
--- a/ergoCubSN000/hardware/motorControl/left_arm-eb23-j7_10-mc.xml
+++ b/ergoCubSN000/hardware/motorControl/left_arm-eb23-j7_10-mc.xml
@@ -48,9 +48,9 @@
         <param name="outputType">               pwm             </param>
         <param name="fbkControlUnits">          metric_units    </param>
         <param name="outputControlUnits">       machine_units   </param>
-        <param name="kp">                       -200       -246        -246        -200    </param>
-        <param name="kd">                       -10           0           0         -10     </param>
-        <param name="ki">                       -10         -33         -33         -10     </param>
+        <param name="kp">                       -246        -246        -246        -200    </param>
+        <param name="kd">                       0           0           0           -10     </param>
+        <param name="ki">                       -33         -33         -33         -10     </param>
         <param name="maxOutput">                2700        2700        2700        2700    </param>
         <param name="maxInt">                   1000        1000        1000        1000    </param>
         <param name="stictionUp">               0           0           0           0       </param>

--- a/ergoCubSN000/hardware/motorControl/right_arm-eb22-j7_10-mc.xml
+++ b/ergoCubSN000/hardware/motorControl/right_arm-eb22-j7_10-mc.xml
@@ -48,9 +48,9 @@
         <param name="outputType">               pwm             </param>
         <param name="fbkControlUnits">          metric_units    </param>
         <param name="outputControlUnits">       machine_units   </param>
-        <param name="kp">                       -200       -246        -246        -200     </param>
-        <param name="kd">                       -10           0           0         -10     </param>
-        <param name="ki">                       -10         -33         -33         -10     </param>
+        <param name="kp">                       -246       -246        -246        -200     </param>
+        <param name="kd">                       0           0           0           -10     </param>
+        <param name="ki">                       -33         -33         -33         -10     </param>
         <param name="maxOutput">                2700        2700        2700        2700    </param>
         <param name="maxInt">                   1000        1000        1000        1000    </param>
         <param name="stictionUp">               0           0           0           0       </param>


### PR DESCRIPTION
As per title, this PR updates the position PIDs of left and right thumb open-close action. 
The values are found by linear system identification and tuned after adding uncertainties, brining significant tracking improvements, across all  joint speeds.

![thumb](https://github.com/robotology/robots-configuration/assets/38140169/cc2a89f2-3a55-4ae6-90fe-ec7ca3f7ba5a)

cc @pattacini @xEnVrE 