### PR TITLE
Update left arm calibration file for working with calibration type 14

### DIFF
--- a/ergoCubSN000/calibrators/left_arm-calib.xml
+++ b/ergoCubSN000/calibrators/left_arm-calib.xml
@@ -12,16 +12,16 @@
 
 	<group name="HOME">
 	<!--                                shoulder-pitch    shoulder-roll    shoulder-yaw    elbow    wrist-yaw    wrist-roll    wrist-pitch    thumb_add    thumb_oc    index_add    index_oc    middle_oc    ring_pinky_oc -->
-		<param name="positionHome">            5                 30              0           10         0            0             0             0.00         4.00        0.00         4.00        4.00           4.00     </param>
+		<param name="positionHome">            5                 30              0           10         0            0             0             30.00        0.00        0.00         0.00        0.00           0.00    </param>
 		<param name="velocityHome">            10                10              10          10         10           10            10            40.00        40.00       40.00        40.00       40.00          40.00    </param>
 	</group>
 	<group name="CALIBRATION">
 		<param name="calibrationType">        10                 10              10          10         12           12            12            12           14          12           14          14             14       </param>
 		<param name="calibration1">           4000               -3000           -3000       4000       17565        8161          21461         0            300         0            300         300            300      </param>
-		<param name="calibration2">	      0                  0               0           0          0            0             0             0            0        0                0            0               0     </param>
+		<param name="calibration2">	          0                  0               0           0          0            0             0             0            0           0            0           0              0        </param>
 		<param name="calibration3">           0                  0               0           0          0            0             0             0            1           0            0           0              1        </param>
-		<param name="calibration4">           0                  0               0           0          0            0             0             0            32768         0            0           0              0        </param>
-		<param name="calibration5">           0                  0               0           0          0            0             0             0            18477      0            -47514      -47150         53885  </param>
+		<param name="calibration4">           0                  0               0           0          0            0             0             0            32768       0            0           0              0        </param>
+		<param name="calibration5">           0                  0               0           0          0            0             0             0            18277       0            47003       47513          54558    </param>
 		<param name="calibrationZero">        35                -15             -52          -5         0            0             0             0            0           0            0           0              0        </param>
 		<param name="calibrationDelta">       0                  0               0           0          0            0             0             0            0           0            0           0              0        </param>
 		<param name="startupPosition">        34                 50              -10         90         0.0          0.0           0.0           0.0          4.0         0.0          4.0         4.0            4.0      </param>

--- a/ergoCubSN000/calibrators/right_arm-calib.xml
+++ b/ergoCubSN000/calibrators/right_arm-calib.xml
@@ -13,16 +13,16 @@
 	<group name="HOME">
 	<!-- For calib6 to set calibration5, i.e. target just multiply desidered pos in deg by 182,044444 (2^(16)/360) -->
     <!--                                shoulder-pitch    shoulder-roll    shoulder-yaw    elbow    wrist-yaw    wrist-roll    wrist-pitch    thumb_add    thumb_oc    index_add    index_oc    middle_oc    ring_pinky_oc -->
-		<param name="positionHome">            5                30              0           10         0             0              0            0.0          4.0         30.0         4.0         4.0         4.0         </param>
-		<param name="velocityHome">            10               10              10          10         10            10             10           40.0         40.0        40.0         40.0        40.0        40.0        </param>
+		<param name="positionHome">            5                30              0           10         0             0              0            30.00        0.00        30.00        0.00        0.00        0.00       </param>
+		<param name="velocityHome">            10               10              10          10         10            10             10           40.00        40.00       40.00        40.00       40.00       40.00       </param>
 	</group>
 	<group name="CALIBRATION">
 		<param name="calibrationType">         10                10             10          10         12            12             12           12           14          12           14          14          14          </param>
 		<param name="calibration1">           -4000              3000           3000       -4000       19023         28993          36030        0            300         0            300         300         300         </param>
-		<param name="calibration2">	       0                 0              0           0          0             0              0            0                0        0                0            0             0        </param>
+		<param name="calibration2">	           0                 0              0           0          0             0              0            0            0           0            0           0           0           </param>
 		<param name="calibration3">            0                 0              0           0          0             0              0            0            1           0            1           0           0           </param>
-		<param name="calibration4">            0                 0              0           0          0             0              0            0            32768         0            0           0           0           </param>
-		<param name="calibration5">            0                 0              0           0          0             0              0            0            66755      0            53521      -44965      -11833       </param>
+		<param name="calibration4">            0                 0              0           0          0             0              0            0            32768       0            0           0           0           </param>
+		<param name="calibration5">            0                 0              0           0          0             0              0            0            2366        0            53484       45147       12415        </param>
 		<param name="calibrationZero">         35               -15            -52         -5          0             0              0            0            0           0            0           0           0           </param>
 		<param name="calibrationDelta">        0                 0              0           0          0             0              0            0            0           0            0           0           0           </param>
 		<param name="startupPosition">         34                50             -10         90         0.0           0.0            0.0          0.0          4.0         0.0          4.0         4.0         4.0         </param>

--- a/ergoCubSN000/general.xml
+++ b/ergoCubSN000/general.xml
@@ -5,7 +5,7 @@
   
   <group name="GENERAL">
       <param name="skipCalibration">    false  </param>
-      <param name="useRawEncoderData">  false  </param>
+      <param name="useRawEncoderData">  false   </param>
       <param name="useLimitedPWM">      false  </param>
       <param name="verbose">            false  </param>
   </group>

--- a/ergoCubSN000/hardware/POS/left_hand-pos4.xml
+++ b/ergoCubSN000/hardware/POS/left_hand-pos4.xml
@@ -44,7 +44,6 @@
                     <param name="offset">           -273            -261             -259             -296              </param>
                     <param name="invertDirection">  true            false            false            true              </param>
                 </group>
-
             </group>
 
         </group>

--- a/ergoCubSN000/hardware/motorControl/left_arm-eb23-j7_10-mc_service.xml
+++ b/ergoCubSN000/hardware/motorControl/left_arm-eb23-j7_10-mc_service.xml
@@ -43,7 +43,7 @@
                         <!-- it is not mandatory. if not present, sensors have defaults: TYPE:decideg, ROT:zero, 0.0, false -->
                         <param name="type">             TYPE:decideg    TYPE:decideg     TYPE:decideg    TYPE:decideg                   </param>
                         <param name="rotation">         ROT:plus180     ROT:zero         ROT:zero        ROT:zero                       </param>
-                        <param name="offset">           -190.0          -305.0           -230.0          -55.0                          </param>
+                        <param name="offset">           -273            -305.0           -230.0          -55.0                          </param>
                         <param name="invertDirection">  true            true             false           false                          </param>
                     </group>
                 </group>


### PR DESCRIPTION
This PR brings the following changes:
- update the configuration values of the calibrator for the open-close finger joints, which works with the new procedure of the calibration `type 14` described in the [documentation](https://icub-tech-iit.github.io/documentation/)
- fix  the mechanical limits for the rotor 