### PR TITLE
ergocubsn000: update position pid of ring-pinkie open-close

### DIFF
--- a/ergoCubSN000/hardware/motorControl/left_arm-eb23-j7_10-mc.xml
+++ b/ergoCubSN000/hardware/motorControl/left_arm-eb23-j7_10-mc.xml
@@ -48,9 +48,9 @@
         <param name="outputType">               pwm             </param>
         <param name="fbkControlUnits">          metric_units    </param>
         <param name="outputControlUnits">       machine_units   </param>
-        <param name="kp">                       -246        -246        -246        -200    </param>
-        <param name="kd">                       0           0           0           -10     </param>
-        <param name="ki">                       -33         -33         -33         -10     </param>
+        <param name="kp">                       -246        -246        -246        -381    </param>
+        <param name="kd">                       0           0           0           0       </param>
+        <param name="ki">                       -33         -33         -33         -21     </param>
         <param name="maxOutput">                2700        2700        2700        2700    </param>
         <param name="maxInt">                   1000        1000        1000        1000    </param>
         <param name="stictionUp">               0           0           0           0       </param>

--- a/ergoCubSN000/hardware/motorControl/right_arm-eb22-j7_10-mc.xml
+++ b/ergoCubSN000/hardware/motorControl/right_arm-eb22-j7_10-mc.xml
@@ -48,9 +48,9 @@
         <param name="outputType">               pwm             </param>
         <param name="fbkControlUnits">          metric_units    </param>
         <param name="outputControlUnits">       machine_units   </param>
-        <param name="kp">                       -246       -246        -246        -200     </param>
-        <param name="kd">                       0           0           0           -10     </param>
-        <param name="ki">                       -33         -33         -33         -10     </param>
+        <param name="kp">                       -246       -246        -246         -381    </param>
+        <param name="kd">                       0           0           0           0       </param>
+        <param name="ki">                       -33         -33         -33         -21     </param>
         <param name="maxOutput">                2700        2700        2700        2700    </param>
         <param name="maxInt">                   1000        1000        1000        1000    </param>
         <param name="stictionUp">               0           0           0           0       </param>


### PR DESCRIPTION
As per title, this PR increases the PID controllers for the position of the ring-pinkie couple in ergocub, bringing significant improvements. See the plots below that show the tracking error.

![trajectory_ring_pinkie](https://github.com/robotology/robots-configuration/assets/38140169/49bad115-1df4-4997-a4c7-50bac33eb7c8)
