### PR TITLE
fixed calibrator for CAN device

### DIFF
--- a/iCubGenova06/calibrators/head-calib.xml
+++ b/iCubGenova06/calibrators/head-calib.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
 
-	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="head_calibrator" type="parametricCalibratorEth">
+	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="head_calibrator" type="parametricCalibrator">
                 <xi:include href="../general.xml" />
 
 		<group name="GENERAL">

--- a/iCubNancy01/calibrators/head-calib.xml
+++ b/iCubNancy01/calibrators/head-calib.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 
-	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="head-calibrator" type="parametricCalibratorEth">
+	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="head-calibrator" type="parametricCalibrator">
                 <xi:include href="../general.xml"/>
 
 		<group name="GENERAL">


### PR DESCRIPTION
This PR fixes the calibrator for CAN devices on these robots : 

- iCubGenova06
- iCubNancy01

