### PR TITLE
[iCubGenova11] Add yarprobotinterface configuration for ROS2 without legs

### DIFF
--- a/iCubGenova11/icub_all_no_legs_ros2.xml
+++ b/iCubGenova11/icub_all_no_legs_ros2.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<robot name="iCubGenova11" portprefix="icub" build="1" xmlns:xi="http://www.w3.org/2001/XInclude">
+    <params>
+    <xi:include href="hardware/electronics/pc104.xml" />
+    </params>
+
+    <devices>
+
+    <!-- motor controllers wrappers -->
+    <xi:include href="wrappers/motorControl/left_arm-mc_wrapper.xml" />
+    <xi:include href="wrappers/motorControl/right_arm-mc_wrapper.xml" />
+    <xi:include href="wrappers/motorControl/head-mc_wrapper.xml" />
+    <xi:include href="wrappers/motorControl/face-mc_wrapper.xml" />
+    <xi:include href="wrappers/motorControl/torso-mc_wrapper.xml" />
+
+    <xi:include href="wrappers/motorControl/left_arm-mc_remapper.xml" />
+    <xi:include href="wrappers/motorControl/right_arm-mc_remapper.xml" />
+    <xi:include href="wrappers/motorControl/head-mc_remapper.xml" />
+    <xi:include href="wrappers/motorControl/face-mc_remapper.xml" />
+    <xi:include href="wrappers/motorControl/torso-mc_remapper.xml" />
+
+    <!-- CARTESIANS -->
+    <xi:include href="cartesian/left_arm-cartesian.xml" />
+    <xi:include href="cartesian/right_arm-cartesian.xml" />
+
+    <!-- HEAD -->
+    <xi:include href="./hardware/motorControl/head-eb20-j0_1-mc.xml" />
+    <xi:include href="./hardware/motorControl/head-eb21-j2_5-mc.xml" />
+
+    <!-- FACE -->
+    <xi:include href="./hardware/motorControl/face-eb22-j0-mc.xml" />
+
+    <!-- TORSO -->
+    <xi:include href="hardware/motorControl/torso-eb5-j0_2-mc.xml" />
+
+    <!-- LEFT ARM -->
+    <xi:include href="hardware/motorControl/left_arm-eb1-j0_3-mc.xml" />
+    <xi:include href="hardware/motorControl/left_arm-eb24-j4_7-mc.xml" />
+    <xi:include href="hardware/motorControl/left_arm-eb25-j8_11-mc.xml" />
+    <xi:include href="hardware/motorControl/left_arm-eb26-j12_15-mc.xml" />
+
+    <!-- RIGHT ARM -->
+    <xi:include href="hardware/motorControl/right_arm-eb3-j0_3-mc.xml" />
+    <xi:include href="hardware/motorControl/right_arm-eb27-j4_7-mc.xml" />
+    <xi:include href="hardware/motorControl/right_arm-eb28-j8_11-mc.xml" />
+    <xi:include href="hardware/motorControl/right_arm-eb29-j12_15-mc.xml" />
+
+
+    <!-- INERTIAL SENSOR -->
+    <xi:include href="wrappers/inertials/head-imuFilter_wrapper.xml" />
+    <xi:include href="wrappers/inertials/head-imuFilter.xml" />
+    <xi:include href="wrappers/inertials/head-inertials_wrapper.xml" />
+    <xi:include href="hardware/inertials/head-inertial.xml" />
+
+    <xi:include href="wrappers/inertials/waist-inertials_remapper.xml" />
+    <xi:include href="wrappers/inertials/waist-inertials_wrapper.xml" />
+    <xi:include href="wrappers/inertials/waist-inertials_wrapper-deprecated.xml" />
+    <xi:include href="hardware/inertials/waist-inertial.xml" />
+    <xi:include href="hardware/inertials/waist-eb5-inertials.xml" />
+
+
+    <!-- ANALOG SENSOR MAIS -->
+    <xi:include href="wrappers/MAIS/left_arm-mais_wrapper.xml" />
+    <xi:include href="wrappers/MAIS/right_arm-mais_wrapper.xml" />
+    <xi:include href="hardware/MAIS/left_arm-eb26-j12_15-mais.xml" />
+    <xi:include href="hardware/MAIS/right_arm-eb29-j12_15-mais.xml" />
+
+    <!--  SKINS  -->
+    <xi:include href="wrappers/skin/left_arm-skin_wrapper.xml" />
+    <xi:include href="hardware/skin/left_arm-eb24-j4_7-skin.xml" />
+    <xi:include href="wrappers/skin/right_arm-skin_wrapper.xml" />
+    <xi:include href="hardware/skin/right_arm-eb27-j4_7-skin.xml" />
+    <xi:include href="wrappers/skin/torso-skin_wrapper.xml" />
+    <xi:include href="hardware/skin/torso-eb22-skin.xml" />
+
+    <!-- ANALOG SENSOR FT -->
+
+    <xi:include href="wrappers/FT/left_arm-FT_wrapper.xml" />
+    <xi:include href="wrappers/FT/right_arm-FT_wrapper.xml" />
+    <xi:include href="hardware/FT/left_arm-eb1-j0_3-strain.xml" />
+    <xi:include href="hardware/FT/right_arm-eb3-j0_3-strain.xml" />
+
+    <!-- VIRTUAL ANALOG SENSORS (WRAPPER ONLY)-->
+    <xi:include href="wrappers/VFT/left_arm-VFT_wrapper.xml" />
+    <xi:include href="wrappers/VFT/right_arm-VFT_wrapper.xml" />
+    <xi:include href="wrappers/VFT/torso-VFT_wrapper.xml" />
+
+    <!--  CALIBRATORS -->
+    <xi:include href="calibrators/left_arm-calib.xml" />
+    <xi:include href="calibrators/right_arm-calib.xml" />
+    <xi:include href="calibrators/torso-calib.xml" />
+    <xi:include href="calibrators/head-calib.xml" />
+    <xi:include href="calibrators/face-calib.xml" />
+
+    <!-- ROS 2 entries -->
+    <xi:include href="wrappers/motorControl/alljoints_no_legs-mc_remapper.xml" />
+    <xi:include href="wrappers/motorControl/alljoints_no_legs-mc_nws_ros2.xml" />
+    <xi:include href="wrappers/FT/left_arm-FT_nws_ros2.xml" />
+    <xi:include href="wrappers/FT/right_arm-FT_nws_ros2.xml" />
+
+    </devices>
+</robot>
+

--- a/iCubGenova11/wrappers/motorControl/alljoints_no_legs-mc_nws_ros2.xml
+++ b/iCubGenova11/wrappers/motorControl/alljoints_no_legs-mc_nws_ros2.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints_no_legs-mc_nws_ros2" type="controlBoard_nws_ros2">
+    <param name="node_name"> icub_cb_node </param>
+    <param name="topic_name"> /joint_states </param>
+    <action phase="startup" level="15" type="attach">
+        <param name="device"> alljoints_no_legs-mc_remapper </param>
+    </action>
+    <action phase="shutdown" level="20" type="detach" />
+</device>

--- a/iCubGenova11/wrappers/motorControl/alljoints_no_legs-mc_remapper.xml
+++ b/iCubGenova11/wrappers/motorControl/alljoints_no_legs-mc_remapper.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints_no_legs-mc_remapper" type="controlboardremapper">
+    <paramlist name="networks">
+        <elem name="head_joints">       (  0   5   0  5 )</elem>
+        <elem name="face_joints">       (  6   6   0  0 )</elem>
+        <elem name="left_arm_joints">   (  7  22   0  15 )</elem>
+        <elem name="right_arm_joints">  ( 23  38   0  15 )</elem>
+        <elem name="torso_joints">      ( 39  41   0  2 )</elem>
+    </paramlist>
+    <param name="joints"> 42 </param>
+    <action phase="startup" level="6" type="attach">
+        <paramlist name="networks">
+            <elem name="head_joints">       head-mc_remapper </elem>
+            <elem name="face_joints">       face-mc_remapper </elem>
+            <elem name="left_arm_joints">   left_arm-mc_remapper</elem>
+            <elem name="right_arm_joints">  right_arm-mc_remapper </elem>
+            <elem name="torso_joints">      torso-mc_remapper </elem>
+        </paramlist>
+    </action>
+    <action phase="shutdown" level="19" type="detach" />
+</device>


### PR DESCRIPTION
As per the title.

This robot is usually employed without legs - they are not even powered. This PR allows running the joint publishing facilities with ROS 2 in the current configuration without legs.

cc @fbrand-new