### PR TITLE
[ergoCubSN000] New left ankle roll motor calibration

### DIFF
--- a/ergoCubSN000/hardware/mechanicals/left_leg-eb9-j4_5-mec.xml
+++ b/ergoCubSN000/hardware/mechanicals/left_leg-eb9-j4_5-mec.xml
@@ -34,7 +34,7 @@
         <param name="HasRotorEncoder">           1             1   </param>
         <param name="HasRotorEncoderIndex">      1             1   </param>
         <param name="HasSpeedEncoder">           0             0   </param>
-        <param name="RotorIndexOffset">          152           209 </param>
+        <param name="RotorIndexOffset">          152           33  </param>
         <param name="MotorPoles">                12            8   </param>
     </group>
 


### PR DESCRIPTION
## What changes:

This PR updates the rotor-stator calibration of the left ankle roll motor, after maintenance service. 

Check the issue for additional information:

- https://github.com/robotology/icub-tech-support/issues/1619
