### PR TITLE
Fix waist_imu conf files

### DIFF
--- a/ergoCubSN000/ergocub_all.xml
+++ b/ergoCubSN000/ergocub_all.xml
@@ -94,6 +94,7 @@
     <xi:include href="wrappers/inertials/head-imuFilter.xml" />
     <xi:include href="wrappers/inertials/head-inertials_wrapper.xml" />
     <xi:include href="hardware/inertials/head-inertial.xml" />
+    <xi:include href="hardware/inertials/waist-inertial.xml" />
     <xi:include href="wrappers/inertials/waist-inertials_wrapper.xml" />
 
     <!-- IMU - MTB4 BOARDS -->

--- a/ergoCubSN000/ergocub_all_ros2.xml
+++ b/ergoCubSN000/ergocub_all_ros2.xml
@@ -96,6 +96,7 @@
     <xi:include href="wrappers/inertials/head-imuFilter.xml" />
     <xi:include href="wrappers/inertials/head-inertials_wrapper.xml" />
     <xi:include href="hardware/inertials/head-inertial.xml" />
+    <xi:include href="hardware/inertials/waist-inertial.xml" />
     <xi:include href="wrappers/inertials/waist-inertials_wrapper.xml" />
 
     

--- a/ergoCubSN000/ergocub_wbd.xml
+++ b/ergoCubSN000/ergocub_wbd.xml
@@ -93,6 +93,7 @@
     <xi:include href="wrappers/inertials/head-imuFilter.xml" />
     <xi:include href="wrappers/inertials/head-inertials_wrapper.xml" />
     <xi:include href="hardware/inertials/head-inertial.xml" />
+    <xi:include href="hardware/inertials/waist-inertial.xml" />
     <xi:include href="wrappers/inertials/waist-inertials_wrapper.xml" />
 
     <!-- FT SENSORS - IMU -->

--- a/ergoCubSN000/hardware/inertials/waist-inertial.xml
+++ b/ergoCubSN000/hardware/inertials/waist-inertial.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+  <device type="xsensmt" name="waist-inertial">
+    <param name="serial">  /dev/ttyS0   </param>
+    <param name="xsensmt_period">0.01</param>
+    <param name="xsensmt_euler_period">0.005</param>
+    <param name="xsensmt_gyro_period">0.005</param>
+    <param name="xsensmt_acc_period">0.005</param>
+    <param name="xsensmt_mag_period">0.01</param>
+  </device>

--- a/ergoCubSN000/wrappers/inertials/waist-inertials_wrapper.xml
+++ b/ergoCubSN000/wrappers/inertials/waist-inertials_wrapper.xml
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
- <device xmlns:xi="http://www.w3.org/2001/XInclude" name="waist-inertial" type="multipleanalogsensorsserver">
-      <param name="period">       10                  </param>
+ <device xmlns:xi="http://www.w3.org/2001/XInclude" name="waist-inertials_wrapper" type="multipleanalogsensorsserver">
+      <param name="period">       5                  </param>
       <param name="name">  /ergocub/waist/inertials  </param>
-      <param name="subdevice">  xsensmt  </param>
-      <param name="serial">  /dev/ttyS0   </param>
 
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">


### PR DESCRIPTION
This PR fixes https://github.com/icub-tech-iit/ergocub-software/issues/163. 
Now, it could be possible to properly read from `yarp read ... /ergocub/waist/inertials/measures:o`

![MicrosoftTeams-image](https://github.com/robotology/robots-configuration/assets/114698424/6b7eaebc-702c-48c3-ab92-5bff17417a05)
