### PR TITLE
Harmonize ergocub FT sensor names with the one used in ergocub URDF

### DIFF
--- a/ergoCubSN000/estimators/wholebodydynamics.xml
+++ b/ergoCubSN000/estimators/wholebodydynamics.xml
@@ -27,7 +27,7 @@
 	</group>
 
         <group name="multipleAnalogSensorsNames">
-            <param name="SixAxisForceTorqueSensorsNames">(l_arm_ft_sensor, r_arm_ft_sensor, l_leg_ft_sensor, l_foot_front_ft_sensor, l_foot_rear_ft_sensor, r_leg_ft_sensor, r_foot_front_ft_sensor, r_foot_rear_ft_sensor)</param>
+            <param name="SixAxisForceTorqueSensorsNames">(l_arm_ft, r_arm_ft, l_leg_ft, l_foot_front_ft, l_foot_rear_ft, r_leg_ft, r_foot_front_ft, r_foot_rear_ft)</param>
         </group>
 
 

--- a/ergoCubSN000/hardware/FT/left_arm-eb2-j0_1-strain.xml
+++ b/ergoCubSN000/hardware/FT/left_arm-eb2-j0_1-strain.xml
@@ -31,7 +31,7 @@
                 </group>
                 
                 <group name="SENSORS">
-                    <param name="id">                   l_arm_ft_sensor   </param>
+                    <param name="id">                   l_arm_ft   </param>
                     <param name="board">                 strain2             </param>
                     <param name="location">             CAN2:13                 </param>
                 </group>                
@@ -39,7 +39,7 @@
             </group>
 
             <group name="SETTINGS">        
-                <param name="enabledSensors">       l_arm_ft_sensor               </param>
+                <param name="enabledSensors">       l_arm_ft               </param>
                 <param name="ftPeriod">             2         		                    </param>
                 <param name="temperaturePeriod">    1000      		                   </param>
                 <param name="useCalibration">       true      		              </param>           

--- a/ergoCubSN000/hardware/FT/left_leg-eb8-j0_3-strain.xml
+++ b/ergoCubSN000/hardware/FT/left_leg-eb8-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_leg_ft_sensor   </param>
+                    <param name="id">                   l_leg_ft   </param>
                     <param name="board">                 strain2             </param>
                     <param name="location">             CAN2:13                 </param>
                 </group>
@@ -38,7 +38,7 @@
             </group>
 
             <group name="SETTINGS">
-                <param name="enabledSensors">       l_leg_ft_sensor               </param>
+                <param name="enabledSensors">       l_leg_ft              </param>
                 <param name="ftPeriod">             2         		                    </param>
                 <param name="temperaturePeriod">    1000      		                   </param>
                 <param name="useCalibration">       true      		              </param>

--- a/ergoCubSN000/hardware/FT/left_leg-eb9-j4_5-strain.xml
+++ b/ergoCubSN000/hardware/FT/left_leg-eb9-j4_5-strain.xml
@@ -30,7 +30,7 @@
                 </group>
                 
                 <group name="SENSORS">
-                    <param name="id">                   l_foot_rear_ft_sensor	l_foot_front_ft_sensor   </param>
+                    <param name="id">                   l_foot_rear_ft	l_foot_front_ft   </param>
                     <param name="board">                 strain2		strain2             </param>
                     <param name="location">             CAN2:13		CAN2:14                 </param>
                 </group>                
@@ -38,7 +38,7 @@
             </group>
 
             <group name="SETTINGS">        
-                <param name="enabledSensors">       l_foot_rear_ft_sensor          l_foot_front_ft_sensor      </param>
+                <param name="enabledSensors">       l_foot_rear_ft          l_foot_front_ft      </param>
                 <param name="ftPeriod">             2         		 10                     </param>
                 <param name="temperaturePeriod">    1000      		 1000                    </param>
                 <param name="useCalibration">       true      		 true                 </param>           

--- a/ergoCubSN000/hardware/FT/right_arm-eb1-j0_1-strain.xml
+++ b/ergoCubSN000/hardware/FT/right_arm-eb1-j0_1-strain.xml
@@ -31,7 +31,7 @@
                 </group>
                 
                 <group name="SENSORS">
-                    <param name="id">                   r_arm_ft_sensor   </param>
+                    <param name="id">                   r_arm_ft   </param>
                     <param name="board">                 strain2             </param>
                     <param name="location">             CAN2:13                 </param>
                 </group>                
@@ -39,7 +39,7 @@
             </group>
 
             <group name="SETTINGS">        
-                <param name="enabledSensors">       r_arm_ft_sensor               </param>
+                <param name="enabledSensors">       r_arm_ft               </param>
                 <param name="ftPeriod">             2         		                    </param>
                 <param name="temperaturePeriod">    1000      		                   </param>
                 <param name="useCalibration">       true      		              </param>           

--- a/ergoCubSN000/hardware/FT/right_leg-eb6-j0_3-strain.xml
+++ b/ergoCubSN000/hardware/FT/right_leg-eb6-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_leg_ft_sensor   </param>
+                    <param name="id">                   r_leg_ft   </param>
                     <param name="board">                 strain2             </param>
                     <param name="location">             CAN2:13                 </param>
                 </group>
@@ -38,7 +38,7 @@
             </group>
 
             <group name="SETTINGS">
-                <param name="enabledSensors">       r_leg_ft_sensor           </param>
+                <param name="enabledSensors">       r_leg_ft           </param>
                 <param name="ftPeriod">             2         		                    </param>
                 <param name="temperaturePeriod">    1000      		                   </param>
                 <param name="useCalibration">       true      		              </param>

--- a/ergoCubSN000/hardware/FT/right_leg-eb7-j4_5-strain.xml
+++ b/ergoCubSN000/hardware/FT/right_leg-eb7-j4_5-strain.xml
@@ -30,7 +30,7 @@
                 </group>
                 
                 <group name="SENSORS">
-                    <param name="id">                   r_foot_rear_ft_sensor	r_foot_front_ft_sensor   </param>
+                    <param name="id">                   r_foot_rear_ft	r_foot_front_ft   </param>
                     <param name="board">                 strain2		strain2             </param>
                     <param name="location">             CAN2:13		CAN2:14                 </param>
                 </group>                
@@ -38,7 +38,7 @@
             </group>
 
             <group name="SETTINGS">        
-                <param name="enabledSensors">       r_foot_rear_ft_sensor          r_foot_front_ft_sensor       </param>
+                <param name="enabledSensors">       r_foot_rear_ft          r_foot_front_ft       </param>
                 <param name="ftPeriod">             2         		 10                     </param>
                 <param name="temperaturePeriod">    1000      		 1000                    </param>
                 <param name="useCalibration">       true      		 true                 </param>           

--- a/ergoCubSN000/wrappers/FT/left_leg-FT_remapper.xml
+++ b/ergoCubSN000/wrappers/FT/left_leg-FT_remapper.xml
@@ -6,10 +6,10 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (l_leg_ft_sensor l_foot_rear_ft_sensor l_foot_front_ft_sensor)
+          (l_leg_ft l_foot_rear_ft l_foot_front_ft)
         </param>
         <param name="TemperatureSensorsNames">
-          (l_leg_ft_sensor l_foot_rear_ft_sensor l_foot_front_ft_sensor)
+          (l_leg_ft l_foot_rear_ft l_foot_front_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/ergoCubSN000/wrappers/FT/right_leg-FT_remapper.xml
+++ b/ergoCubSN000/wrappers/FT/right_leg-FT_remapper.xml
@@ -6,10 +6,10 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (r_leg_ft_sensor r_foot_rear_ft_sensor r_foot_front_ft_sensor)
+          (r_leg_ft r_foot_rear_ft r_foot_front_ft)
         </param>
         <param name="TemperatureSensorsNames">
-          (r_leg_ft_sensor r_foot_rear_ft_sensor r_foot_front_ft_sensor)
+          (r_leg_ft r_foot_rear_ft r_foot_front_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/ergoCubSN001/estimators/wholebodydynamics.xml
+++ b/ergoCubSN001/estimators/wholebodydynamics.xml
@@ -27,7 +27,7 @@
 	</group>
 
         <group name="multipleAnalogSensorsNames">
-            <param name="SixAxisForceTorqueSensorsNames">(l_arm_ft_sensor, r_arm_ft_sensor, r_leg_ft_sensor, l_foot_front_ft_sensor, l_foot_rear_ft_sensor, r_leg_ft_sensor, r_foot_front_ft_sensor, r_foot_rear_ft_sensor)</param>
+            <param name="SixAxisForceTorqueSensorsNames">(l_arm_ft, r_arm_ft, l_leg_ft, l_foot_front_ft, l_foot_rear_ft, r_leg_ft, r_foot_front_ft, r_foot_rear_ft)</param>
         </group>
 
 

--- a/ergoCubSN001/hardware/FT/left_arm-eb2-j0_1-strain.xml
+++ b/ergoCubSN001/hardware/FT/left_arm-eb2-j0_1-strain.xml
@@ -31,7 +31,7 @@
                 </group>
                 
                 <group name="SENSORS">
-                    <param name="id">                   l_arm_ft_sensor   </param>
+                    <param name="id">                   l_arm_ft   </param>
                     <param name="board">                 strain2             </param>
                     <param name="location">             CAN2:13                 </param>
                 </group>                
@@ -39,7 +39,7 @@
             </group>
 
             <group name="SETTINGS">        
-                <param name="enabledSensors">       l_arm_ft_sensor               </param>
+                <param name="enabledSensors">       l_arm_ft               </param>
                 <param name="ftPeriod">             2         		                    </param>
                 <param name="temperaturePeriod">    1000      		                   </param>
                 <param name="useCalibration">       true      		              </param>           

--- a/ergoCubSN001/hardware/FT/left_leg-eb8-j0_3-strain.xml
+++ b/ergoCubSN001/hardware/FT/left_leg-eb8-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_leg_ft_sensor   </param>
+                    <param name="id">                   l_leg_ft   </param>
                     <param name="board">                 strain2             </param>
                     <param name="location">             CAN2:13                 </param>
                 </group>
@@ -38,7 +38,7 @@
             </group>
 
             <group name="SETTINGS">
-                <param name="enabledSensors">       l_leg_ft_sensor               </param>
+                <param name="enabledSensors">       l_leg_ft               </param>
                 <param name="ftPeriod">             2         		                    </param>
                 <param name="temperaturePeriod">    1000      		                   </param>
                 <param name="useCalibration">       true      		              </param>

--- a/ergoCubSN001/hardware/FT/left_leg-eb9-j4_5-strain.xml
+++ b/ergoCubSN001/hardware/FT/left_leg-eb9-j4_5-strain.xml
@@ -30,7 +30,7 @@
                 </group>
                 
                 <group name="SENSORS">
-                    <param name="id">                   l_foot_rear_ft_sensor	l_foot_front_ft_sensor   </param>
+                    <param name="id">                   l_foot_rear_ft	l_foot_front_ft  </param>
                     <param name="board">                 strain2		strain2             </param>
                     <param name="location">             CAN2:13		CAN2:14                 </param>
                 </group>                
@@ -38,7 +38,7 @@
             </group>
 
             <group name="SETTINGS">        
-                <param name="enabledSensors">       l_foot_rear_ft_sensor          l_foot_front_ft_sensor      </param>
+                <param name="enabledSensors">       l_foot_rear_ft          l_foot_front_ft      </param>
                 <param name="ftPeriod">             2         		 10                     </param>
                 <param name="temperaturePeriod">    1000      		 1000                    </param>
                 <param name="useCalibration">       true      		 true                 </param>           

--- a/ergoCubSN001/hardware/FT/right_arm-eb1-j0_1-strain.xml
+++ b/ergoCubSN001/hardware/FT/right_arm-eb1-j0_1-strain.xml
@@ -31,7 +31,7 @@
                 </group>
                 
                 <group name="SENSORS">
-                    <param name="id">                   r_arm_ft_sensor   </param>
+                    <param name="id">                   r_arm_ft  </param>
                     <param name="board">                 strain2             </param>
                     <param name="location">             CAN2:13                 </param>
                 </group>                
@@ -39,7 +39,7 @@
             </group>
 
             <group name="SETTINGS">        
-                <param name="enabledSensors">       r_arm_ft_sensor               </param>
+                <param name="enabledSensors">       r_arm_ft               </param>
                 <param name="ftPeriod">             2         		                    </param>
                 <param name="temperaturePeriod">    1000      		                   </param>
                 <param name="useCalibration">       true      		              </param>           

--- a/ergoCubSN001/hardware/FT/right_leg-eb6-j0_3-strain.xml
+++ b/ergoCubSN001/hardware/FT/right_leg-eb6-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_leg_ft_sensor   </param>
+                    <param name="id">                   r_leg_ft   </param>
                     <param name="board">                 strain2             </param>
                     <param name="location">             CAN2:13                 </param>
                 </group>
@@ -38,7 +38,7 @@
             </group>
 
             <group name="SETTINGS">
-                <param name="enabledSensors">       r_leg_ft_sensor           </param>
+                <param name="enabledSensors">       r_leg_ft           </param>
                 <param name="ftPeriod">             2         		                    </param>
                 <param name="temperaturePeriod">    1000      		                   </param>
                 <param name="useCalibration">       true      		              </param>

--- a/ergoCubSN001/hardware/FT/right_leg-eb7-j4_5-strain.xml
+++ b/ergoCubSN001/hardware/FT/right_leg-eb7-j4_5-strain.xml
@@ -30,7 +30,7 @@
                 </group>
                 
                 <group name="SENSORS">
-                    <param name="id">                   r_foot_rear_ft_sensor	r_foot_front_ft_sensor   </param>
+                    <param name="id">                   r_foot_rear_ft	r_foot_front_ft  </param>
                     <param name="board">                 strain2		strain2             </param>
                     <param name="location">             CAN2:13		CAN2:14                 </param>
                 </group>                
@@ -38,7 +38,7 @@
             </group>
 
             <group name="SETTINGS">        
-                <param name="enabledSensors">       r_foot_rear_ft_sensor          r_foot_front_ft_sensor       </param>
+                <param name="enabledSensors">       r_foot_rear_ft          r_foot_front_ft       </param>
                 <param name="ftPeriod">             2         		 10                     </param>
                 <param name="temperaturePeriod">    1000      		 1000                    </param>
                 <param name="useCalibration">       true      		 true                 </param>           

--- a/ergoCubSN001/wrappers/FT/left_leg-FT_remapper.xml
+++ b/ergoCubSN001/wrappers/FT/left_leg-FT_remapper.xml
@@ -6,10 +6,10 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (l_leg_ft_sensor l_foot_rear_ft_sensor l_foot_front_ft_sensor)
+          (l_leg_ft l_foot_rear_ft l_foot_front_ft)
         </param>
         <param name="TemperatureSensorsNames">
-          (l_leg_ft_sensor l_foot_rear_ft_sensor l_foot_front_ft_sensor)
+          (l_leg_ft l_foot_rear_ft l_foot_front_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/ergoCubSN001/wrappers/FT/right_leg-FT_remapper.xml
+++ b/ergoCubSN001/wrappers/FT/right_leg-FT_remapper.xml
@@ -6,10 +6,10 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (r_leg_ft_sensor r_foot_rear_ft_sensor r_foot_front_ft_sensor)
+          (r_leg_ft r_foot_rear_ft r_foot_front_ft)
         </param>
         <param name="TemperatureSensorsNames">
-          (r_leg_ft_sensor r_foot_rear_ft_sensor r_foot_front_ft_sensor)
+          (r_leg_ft r_foot_rear_ft r_foot_front_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">


### PR DESCRIPTION
The PR https://github.com/icub-tech-iit/ergocub-software/pull/158 (that was released in ergocub-software v0.3.4) change the FT sensor names:

* ergocub-software <= 0.3.3 names : l_arm_ft_sensor, r_arm_ft_sensor, l_leg_ft_sensor, l_foot_front_ft_sensor, l_foot_rear_ft_sensor, r_leg_ft_sensor, r_foot_front_ft_sensor, r_foot_rear_ft_sensor 
* ergocub-software >= 0.3.4 names : l_arm_ft, r_arm_ft, l_leg_ft, l_foot_front_ft, l_foot_rear_ft, r_leg_ft, r_foot_front_ft, r_foot_rear_ft

However, the wbd configuration files for the real robot were not updated accordingly. This PR should fix this.

Fix https://github.com/icub-tech-iit/ergocub-software/issues/165 .
Related to https://github.com/robotology/icub-models-generator/issues/242 . 
Implements Option 1 (O1) as described in https://github.com/robotology/icub-models-generator/pull/240#issuecomment-1604172317 .
