### PR TITLE
Fix compatibility with FT sensors names in URDF in icub-models >= 2

### DIFF
--- a/experimentalSetups/iCubGenova02-VelCtrl/estimators/wholebodydynamics.xml
+++ b/experimentalSetups/iCubGenova02-VelCtrl/estimators/wholebodydynamics.xml
@@ -63,12 +63,12 @@
                 <!-- imu -->
                 <elem name="imu">head-inertial</elem>
                 <!-- ft -->
-                <elem name="l_arm_ft_sensor">left_arm-eb1-j0_3-strain</elem>
-                <elem name="r_arm_ft_sensor">right_arm-eb3-j0_3-strain</elem>
-                <elem name="l_leg_ft_sensor">left_leg-eb6-j0_3-strain</elem>
-                <elem name="r_leg_ft_sensor">right_leg-eb8-j0_3-strain</elem>
-                <elem name="l_foot_ft_sensor">left_leg-eb7-j4_5-strain</elem>
-                <elem name="r_foot_ft_sensor">right_leg-eb9-j4_5-strain</elem>
+                <elem name="l_arm_ft">left_arm-eb1-j0_3-strain</elem>
+                <elem name="r_arm_ft">right_arm-eb3-j0_3-strain</elem>
+                <elem name="l_leg_ft">left_leg-eb6-j0_3-strain</elem>
+                <elem name="r_leg_ft">right_leg-eb8-j0_3-strain</elem>
+                <elem name="l_foot_ft">left_leg-eb7-j4_5-strain</elem>
+                <elem name="r_foot_ft">right_leg-eb9-j4_5-strain</elem>
             </paramlist>
         </action>
 

--- a/experimentalSetups/single_ftsensor_can/hardware/FT/left_arm_strain.xml
+++ b/experimentalSetups/single_ftsensor_can/hardware/FT/left_arm_strain.xml
@@ -3,7 +3,7 @@
 
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="left_arm_strain">
-    <param name="sensorName"> l_arm_ft_sensor </param>
+    <param name="sensorName"> l_arm_ft </param>
     <param name="frameName"> l_arm_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "ecan" </param>

--- a/experimentalSetups/single_joint_BLL_FT/hardware/FT/left_leg_strain.xml
+++ b/experimentalSetups/single_joint_BLL_FT/hardware/FT/left_leg_strain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="left_leg_strain">
-    <param name="sensorName"> l_leg_ft_sensor </param>
+    <param name="sensorName"> l_leg_ft </param>
     <param name="frameName"> l_leg_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "ecan" </param>

--- a/iCubDijon01/hardware/FT/left_arm_strain.xml
+++ b/iCubDijon01/hardware/FT/left_arm_strain.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="left_arm_strain">
-    <param name="sensorName"> l_arm_ft_sensor </param>
+    <param name="sensorName"> l_arm_ft </param>
     <param name="frameName"> l_arm_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/iCubDijon01/hardware/FT/left_leg_strain.xml
+++ b/iCubDijon01/hardware/FT/left_leg_strain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="left_leg_strain">
-    <param name="sensorName"> l_leg_ft_sensor </param>
+    <param name="sensorName"> l_leg_ft </param>
     <param name="frameName"> l_leg_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/iCubDijon01/hardware/FT/right_arm_strain.xml
+++ b/iCubDijon01/hardware/FT/right_arm_strain.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="right_arm_strain">
-    <param name="sensorName"> r_arm_ft_sensor </param>
+    <param name="sensorName"> r_arm_ft </param>
     <param name="frameName"> r_arm_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/iCubDijon01/hardware/FT/right_foot_strain.xml
+++ b/iCubDijon01/hardware/FT/right_foot_strain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="right_foot_strain">
-    <param name="sensorName"> r_foot_ft_sensor </param>
+    <param name="sensorName"> r_foot_ft </param>
     <param name="frameName"> r_foot_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/iCubDijon01/hardware/FT/right_leg_strain.xml
+++ b/iCubDijon01/hardware/FT/right_leg_strain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="right_leg_strain">
-    <param name="sensorName"> r_leg_ft_sensor </param>
+    <param name="sensorName"> r_leg_ft </param>
     <param name="frameName"> r_leg_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/iCubDijon01/wrappers/FT/left_leg-FT_remapper.xml
+++ b/iCubDijon01/wrappers/FT/left_leg-FT_remapper.xml
@@ -6,7 +6,7 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (l_leg_ft_sensor l_foot_ft_sensor)
+          (l_leg_ft l_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubDijon01/wrappers/FT/right_leg-FT_remapper.xml
+++ b/iCubDijon01/wrappers/FT/right_leg-FT_remapper.xml
@@ -6,7 +6,7 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (r_leg_ft_sensor r_foot_ft_sensor)
+          (r_leg_ft r_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubEdinburgh01/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/iCubEdinburgh01/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_arm_ft_sensor   </param>
+                    <param name="id">                   l_arm_ft   </param>
                     <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_arm_ft_sensor   </param>
+                <param name="enabledSensors">           l_arm_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/iCubEdinburgh01/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/iCubEdinburgh01/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_leg_ft_sensor   </param>
+                    <param name="id">                   l_leg_ft   </param>
                     <param name="framename">            l_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_leg_ft_sensor   </param>
+                <param name="enabledSensors">           l_leg_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/iCubEdinburgh01/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/iCubEdinburgh01/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_foot_ft_sensor   </param>
+                    <param name="id">                   l_foot_ft   </param>
                     <param name="framename">            l_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:1                  </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_foot_ft_sensor   </param>
+                <param name="enabledSensors">           l_foot_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/iCubEdinburgh01/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/iCubEdinburgh01/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_arm_ft_sensor   </param>
+                    <param name="id">                   r_arm_ft   </param>
                     <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_arm_ft_sensor   </param>
+                <param name="enabledSensors">           r_arm_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/iCubEdinburgh01/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/iCubEdinburgh01/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_leg_ft_sensor   </param>
+                    <param name="id">                   r_leg_ft   </param>
                     <param name="framename">            r_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_leg_ft_sensor   </param>
+                <param name="enabledSensors">           r_leg_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/iCubEdinburgh01/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/iCubEdinburgh01/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_foot_ft_sensor   </param>
+                    <param name="id">                   r_foot_ft   </param>
                     <param name="framename">            r_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:1                  </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_foot_ft_sensor   </param>
+                <param name="enabledSensors">           r_foot_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/iCubEdinburgh01/wrappers/FT/left_leg-FT_remapper.xml
+++ b/iCubEdinburgh01/wrappers/FT/left_leg-FT_remapper.xml
@@ -6,7 +6,7 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (l_leg_ft_sensor l_foot_ft_sensor)
+          (l_leg_ft l_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubEdinburgh01/wrappers/FT/right_leg-FT_remapper.xml
+++ b/iCubEdinburgh01/wrappers/FT/right_leg-FT_remapper.xml
@@ -6,7 +6,7 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (r_leg_ft_sensor r_foot_ft_sensor)
+          (r_leg_ft r_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubErzelli01/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/iCubErzelli01/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_arm_ft_sensor   </param>
+                    <param name="id">                   l_arm_ft   </param>
                     <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_arm_ft_sensor   </param>
+                <param name="enabledSensors">           l_arm_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/iCubErzelli01/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/iCubErzelli01/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_leg_ft_sensor   </param>
+                    <param name="id">                   l_leg_ft   </param>
                     <param name="framename">            l_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_leg_ft_sensor   </param>
+                <param name="enabledSensors">           l_leg_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/iCubErzelli01/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/iCubErzelli01/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_foot_ft_sensor   </param>
+                    <param name="id">                   l_foot_ft   </param>
                     <param name="framename">            l_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_foot_ft_sensor   </param>
+                <param name="enabledSensors">           l_foot_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/iCubErzelli01/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/iCubErzelli01/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_arm_ft_sensor   </param>
+                    <param name="id">                   r_arm_ft   </param>
                     <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_arm_ft_sensor   </param>
+                <param name="enabledSensors">           r_arm_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/iCubErzelli01/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/iCubErzelli01/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_leg_ft_sensor   </param>
+                    <param name="id">                   r_leg_ft   </param>
                     <param name="framename">            r_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_leg_ft_sensor   </param>
+                <param name="enabledSensors">           r_leg_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/iCubErzelli01/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/iCubErzelli01/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_foot_ft_sensor   </param>
+                    <param name="id">                   r_foot_ft   </param>
                     <param name="framename">            r_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_foot_ft_sensor   </param>
+                <param name="enabledSensors">           r_foot_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/iCubErzelli01/wrappers/FT/left_leg-FT_remapper.xml
+++ b/iCubErzelli01/wrappers/FT/left_leg-FT_remapper.xml
@@ -6,7 +6,7 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (l_leg_ft_sensor l_foot_ft_sensor)
+          (l_leg_ft l_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubErzelli01/wrappers/FT/right_leg-FT_remapper.xml
+++ b/iCubErzelli01/wrappers/FT/right_leg-FT_remapper.xml
@@ -6,7 +6,7 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (r_leg_ft_sensor r_foot_ft_sensor)
+          (r_leg_ft r_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubErzelli02/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/iCubErzelli02/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_arm_ft_sensor   </param>
+                    <param name="id">                   l_arm_ft   </param>
                     <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_arm_ft_sensor   </param>
+                <param name="enabledSensors">           l_arm_ft   </param>
                 <param name="temperature-acquisitionRate"> 1000                 </param>
             </group>
 

--- a/iCubErzelli02/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/iCubErzelli02/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_leg_ft_sensor   </param>
+                    <param name="id">                   l_leg_ft   </param>
                     <param name="framename">            l_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_leg_ft_sensor   </param>
+                <param name="enabledSensors">           l_leg_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/iCubErzelli02/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/iCubErzelli02/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_foot_ft_sensor   </param>
+                    <param name="id">                   l_foot_ft   </param>
                     <param name="framename">            l_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_foot_ft_sensor   </param>
+                <param name="enabledSensors">           l_foot_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/iCubErzelli02/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/iCubErzelli02/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_arm_ft_sensor   </param>
+                    <param name="id">                   r_arm_ft   </param>
                     <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_arm_ft_sensor   </param>
+                <param name="enabledSensors">           r_arm_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/iCubErzelli02/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/iCubErzelli02/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_leg_ft_sensor   </param>
+                    <param name="id">                   r_leg_ft   </param>
                     <param name="framename">            r_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_leg_ft_sensor   </param>
+                <param name="enabledSensors">           r_leg_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/iCubErzelli02/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/iCubErzelli02/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_foot_ft_sensor   </param>
+                    <param name="id">                   r_foot_ft   </param>
                     <param name="framename">            r_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_foot_ft_sensor   </param>
+                <param name="enabledSensors">           r_foot_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/iCubErzelli02/wrappers/FT/left_leg-FT_remapper.xml
+++ b/iCubErzelli02/wrappers/FT/left_leg-FT_remapper.xml
@@ -6,7 +6,7 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (l_leg_ft_sensor l_foot_ft_sensor)
+          (l_leg_ft l_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubErzelli02/wrappers/FT/right_leg-FT_remapper.xml
+++ b/iCubErzelli02/wrappers/FT/right_leg-FT_remapper.xml
@@ -6,7 +6,7 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (r_leg_ft_sensor r_foot_ft_sensor)
+          (r_leg_ft r_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubGenova02/estimators/wholebodydynamics.xml
+++ b/iCubGenova02/estimators/wholebodydynamics.xml
@@ -66,12 +66,12 @@
                 <!-- imu -->
                 <elem name="imu">head-inertial</elem>
                 <!-- ft -->
-                <elem name="l_arm_ft_sensor">left_arm-eb1-j0_3-strain</elem>
-                <elem name="r_arm_ft_sensor">right_arm-eb3-j0_3-strain</elem>
-                <elem name="l_leg_ft_sensor">left_leg-eb6-j0_3-strain</elem>
-                <elem name="r_leg_ft_sensor">right_leg-eb8-j0_3-strain</elem>
-                <elem name="l_foot_ft_sensor">left_leg-eb7-j4_5-strain</elem>
-                <elem name="r_foot_ft_sensor">right_leg-eb9-j4_5-strain</elem>
+                <elem name="l_arm_ft">left_arm-eb1-j0_3-strain</elem>
+                <elem name="r_arm_ft">right_arm-eb3-j0_3-strain</elem>
+                <elem name="l_leg_ft">left_leg-eb6-j0_3-strain</elem>
+                <elem name="r_leg_ft">right_leg-eb8-j0_3-strain</elem>
+                <elem name="l_foot_ft">left_leg-eb7-j4_5-strain</elem>
+                <elem name="r_foot_ft">right_leg-eb9-j4_5-strain</elem>
             </paramlist>
         </action>
 

--- a/iCubGenova02/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/iCubGenova02/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_arm_ft_sensor   </param>
+                    <param name="id">                   l_arm_ft   </param>
                     <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_arm_ft_sensor   </param>
+                <param name="enabledSensors">           l_arm_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/iCubGenova02/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/iCubGenova02/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_leg_ft_sensor   </param>
+                    <param name="id">                   l_leg_ft   </param>
                     <param name="framename">            l_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_leg_ft_sensor   </param>
+                <param name="enabledSensors">           l_leg_ft   </param>
                 <param name="temperature-acquisitionRate"> 1000 </param>//1 seconds
             </group>
 

--- a/iCubGenova02/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/iCubGenova02/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_foot_ft_sensor   </param>
+                    <param name="id">                   l_foot_ft   </param>
                     <param name="framename">            l_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_foot_ft_sensor   </param>
+                <param name="enabledSensors">           l_foot_ft   </param>
                 <param name="temperature-acquisitionRate"> 1000 </param>//1 seconds
             </group>
 

--- a/iCubGenova02/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/iCubGenova02/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_arm_ft_sensor   </param>
+                    <param name="id">                   r_arm_ft   </param>
                     <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_arm_ft_sensor   </param>
+                <param name="enabledSensors">           r_arm_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/iCubGenova02/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/iCubGenova02/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_leg_ft_sensor   </param>
+                    <param name="id">                   r_leg_ft   </param>
                     <param name="framename">            r_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_leg_ft_sensor   </param>
+                <param name="enabledSensors">           r_leg_ft   </param>
                 <param name="temperature-acquisitionRate"> 1000 </param>//1 seconds
             </group>
 

--- a/iCubGenova02/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/iCubGenova02/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_foot_ft_sensor   </param>
+                    <param name="id">                   r_foot_ft   </param>
                     <param name="framename">            r_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                  </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_foot_ft_sensor   </param>
+                <param name="enabledSensors">           r_foot_ft   </param>
                 <param name="temperature-acquisitionRate"> 1000 </param>//1 seconds
             </group>
 

--- a/iCubGenova02/wrappers/FT/left_leg-FT_remapper.xml
+++ b/iCubGenova02/wrappers/FT/left_leg-FT_remapper.xml
@@ -6,10 +6,10 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (l_leg_ft_sensor l_foot_ft_sensor)
+          (l_leg_ft l_foot_ft)
         </param>
         <param name="TemperatureSensorsNames">
-          (l_leg_ft_sensor l_foot_ft_sensor)
+          (l_leg_ft l_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubGenova02/wrappers/FT/right_leg-FT_remapper.xml
+++ b/iCubGenova02/wrappers/FT/right_leg-FT_remapper.xml
@@ -6,10 +6,10 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (r_leg_ft_sensor r_foot_ft_sensor)
+          (r_leg_ft r_foot_ft)
         </param>
         <param name="TemperatureSensorsNames">
-          (r_leg_ft_sensor r_foot_ft_sensor)
+          (r_leg_ft r_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubGenova03/hardware/FT/left_arm_strain.xml
+++ b/iCubGenova03/hardware/FT/left_arm_strain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="left_arm_strain">
-    <param name="sensorName"> l_arm_ft_sensor </param>
+    <param name="sensorName"> l_arm_ft </param>
     <param name="frameName"> l_arm_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/iCubGenova03/hardware/FT/left_leg_strain.xml
+++ b/iCubGenova03/hardware/FT/left_leg_strain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="left_leg_strain">
-    <param name="sensorName"> l_leg_ft_sensor </param>
+    <param name="sensorName"> l_leg_ft </param>
     <param name="frameName"> l_leg_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/iCubGenova03/hardware/FT/right_arm_strain.xml
+++ b/iCubGenova03/hardware/FT/right_arm_strain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="right_arm_strain">
-    <param name="sensorName"> r_arm_ft_sensor </param>
+    <param name="sensorName"> r_arm_ft </param>
     <param name="frameName"> r_arm_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/iCubGenova03/hardware/FT/right_foot_strain.xml
+++ b/iCubGenova03/hardware/FT/right_foot_strain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="right_foot_strain">
-    <param name="sensorName"> r_foot_ft_sensor </param>
+    <param name="sensorName"> r_foot_ft </param>
     <param name="frameName"> r_foot_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/iCubGenova03/hardware/FT/right_leg_strain.xml
+++ b/iCubGenova03/hardware/FT/right_leg_strain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="right_leg_strain">
-    <param name="sensorName"> r_leg_ft_sensor </param>
+    <param name="sensorName"> r_leg_ft </param>
     <param name="frameName"> r_leg_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/iCubGenova03/wrappers/FT/left_leg-FT_remapper.xml
+++ b/iCubGenova03/wrappers/FT/left_leg-FT_remapper.xml
@@ -6,7 +6,7 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (l_leg_ft_sensor l_foot_ft_sensor)
+          (l_leg_ft l_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubGenova03/wrappers/FT/right_leg-FT_remapper.xml
+++ b/iCubGenova03/wrappers/FT/right_leg-FT_remapper.xml
@@ -6,7 +6,7 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (r_leg_ft_sensor r_foot_ft_sensor)
+          (r_leg_ft r_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubGenova07/estimators/wholebodydynamics.xml
+++ b/iCubGenova07/estimators/wholebodydynamics.xml
@@ -45,7 +45,7 @@
         </group>
        
         <group name="FT_SECONDARY_CALIBRATION">
-             <param name="l_leg_ft_sensor"> 
+             <param name="l_leg_ft"> 
                    (5.969361e-01,2.428213e-02,-5.463457e-02,4.254463e-01,1.123516e+00,-1.303151e-01 
                     ,-2.818578e-02,6.863783e-01,2.028274e-02,6.585433e-01,1.573658e-01,1.544577e+00 
                     ,-3.915223e-02,3.971615e-02,9.679746e-01,-3.150958e-03,3.718397e-01,-8.653098e-02 
@@ -53,7 +53,7 @@
                     ,5.671831e-03,6.968371e-03,4.892937e-03,5.396529e-02,9.499420e-01,-1.575216e-01 
                     ,3.469447e-18,0,-7.993503e-20,0,0,1.000000e+00)</param>     
 
-             <param name="r_leg_ft_sensor">
+             <param name="r_leg_ft">
                    (7.619710e-01,-9.833019e-02,-5.603709e-02,-7.503703e-01,4.654638e-01,-2.100801e+00 
                    ,2.708629e-02,8.108288e-01,-3.377881e-03,8.122805e-01,4.181660e-02,8.531041e-01 
                    ,-7.067404e-02,-3.179978e-02,9.888732e-01,-4.080758e-02,5.046211e-01,-5.754858e-01 
@@ -90,12 +90,12 @@
                 <!-- imu -->
                 <elem name="imu">head-inertial</elem>
                 <!-- ft -->
-                <elem name="l_arm_ft_sensor">left_arm-eb1-j0_3-strain</elem>
-                <elem name="r_arm_ft_sensor">right_arm-eb3-j0_3-strain</elem>
-                <elem name="l_leg_ft_sensor">left_leg-eb6-j0_3-strain</elem>
-                <elem name="r_leg_ft_sensor">right_leg-eb8-j0_3-strain</elem>
-                <elem name="l_foot_ft_sensor">left_leg-eb7-j4_5-strain</elem>
-                <elem name="r_foot_ft_sensor">right_leg-eb9-j4_5-strain</elem>
+                <elem name="l_arm_ft">left_arm-eb1-j0_3-strain</elem>
+                <elem name="r_arm_ft">right_arm-eb3-j0_3-strain</elem>
+                <elem name="l_leg_ft">left_leg-eb6-j0_3-strain</elem>
+                <elem name="r_leg_ft">right_leg-eb8-j0_3-strain</elem>
+                <elem name="l_foot_ft">left_leg-eb7-j4_5-strain</elem>
+                <elem name="r_foot_ft">right_leg-eb9-j4_5-strain</elem>
             </paramlist>
         </action>
 

--- a/iCubGenova07/estimators/wholebodydynamics_standup.xml
+++ b/iCubGenova07/estimators/wholebodydynamics_standup.xml
@@ -46,7 +46,7 @@
         
        <group name="FT_SECONDARY_CALIBRATION">
 
-           <param name="r_leg_ft_sensor"> (1.165043e-01,-4.824760e-02,-2.838516e-03,-4.063452e-01,3.829723e+00,-4.049686e+00
+           <param name="r_leg_ft"> (1.165043e-01,-4.824760e-02,-2.838516e-03,-4.063452e-01,3.829723e+00,-4.049686e+00
            ,-1.646781e-02,1.028508e-01,1.218741e-03,-3.860480e+00,6.586313e-02,1.079024e-01
            ,-1.223875e-01,-1.720457e-01,9.950911e-01,-1.332774e+00,4.882303e-01,1.109860e+00
            ,-2.690149e-03,-1.097413e-02,1.942506e-03,9.459466e-01,2.006043e-02,4.074997e-02
@@ -80,12 +80,12 @@
                 <!-- imu -->
                 <elem name="imu">head-inertial</elem>
                 <!-- ft -->
-                <elem name="l_arm_ft_sensor">left_arm-eb1-j0_3-strain</elem>
-                <elem name="r_arm_ft_sensor">right_arm-eb3-j0_3-strain</elem>
-                <elem name="l_leg_ft_sensor">left_leg-eb6-j0_3-strain</elem>
-                <elem name="r_leg_ft_sensor">right_leg-eb8-j0_3-strain</elem>
-                <elem name="l_foot_ft_sensor">left_leg-eb7-j4_5-strain</elem>
-                <elem name="r_foot_ft_sensor">right_leg-eb9-j4_5-strain</elem>
+                <elem name="l_arm_ft">left_arm-eb1-j0_3-strain</elem>
+                <elem name="r_arm_ft">right_arm-eb3-j0_3-strain</elem>
+                <elem name="l_leg_ft">left_leg-eb6-j0_3-strain</elem>
+                <elem name="r_leg_ft">right_leg-eb8-j0_3-strain</elem>
+                <elem name="l_foot_ft">left_leg-eb7-j4_5-strain</elem>
+                <elem name="r_foot_ft">right_leg-eb9-j4_5-strain</elem>
             </paramlist>
         </action>
 

--- a/iCubGenova07/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/iCubGenova07/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_arm_ft_sensor   </param>
+                    <param name="id">                   l_arm_ft   </param>
                     <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_arm_ft_sensor   </param>
+                <param name="enabledSensors">           l_arm_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubGenova07/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/iCubGenova07/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_leg_ft_sensor   </param>
+                    <param name="id">                   l_leg_ft   </param>
                     <param name="framename">            l_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_leg_ft_sensor   </param>
+                <param name="enabledSensors">           l_leg_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubGenova07/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/iCubGenova07/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_foot_ft_sensor   </param>
+                    <param name="id">                   l_foot_ft   </param>
                     <param name="framename">            l_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_foot_ft_sensor   </param>
+                <param name="enabledSensors">           l_foot_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubGenova07/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/iCubGenova07/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_arm_ft_sensor   </param>
+                    <param name="id">                   r_arm_ft   </param>
                     <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_arm_ft_sensor   </param>
+                <param name="enabledSensors">           r_arm_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubGenova07/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/iCubGenova07/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_leg_ft_sensor   </param>
+                    <param name="id">                   r_leg_ft   </param>
                     <param name="framename">            r_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_leg_ft_sensor   </param>
+                <param name="enabledSensors">           r_leg_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubGenova07/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/iCubGenova07/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_foot_ft_sensor   </param>
+                    <param name="id">                   r_foot_ft   </param>
                     <param name="framename">            r_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_foot_ft_sensor   </param>
+                <param name="enabledSensors">           r_foot_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubGenova07/wrappers/FT/left_leg-FT_remapper.xml
+++ b/iCubGenova07/wrappers/FT/left_leg-FT_remapper.xml
@@ -6,10 +6,10 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (l_leg_ft_sensor l_foot_ft_sensor)
+          (l_leg_ft l_foot_ft)
         </param>
         <param name="TemperatureSensorsNames">
-          (l_leg_ft_sensor l_foot_ft_sensor)
+          (l_leg_ft l_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubGenova07/wrappers/FT/right_leg-FT_remapper.xml
+++ b/iCubGenova07/wrappers/FT/right_leg-FT_remapper.xml
@@ -6,10 +6,10 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (r_leg_ft_sensor r_foot_ft_sensor)
+          (r_leg_ft r_foot_ft)
         </param>
         <param name="TemperatureSensorsNames">
-          (r_leg_ft_sensor r_foot_ft_sensor)
+          (r_leg_ft r_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubGenova08/estimators/wholebodydynamics.xml
+++ b/iCubGenova08/estimators/wholebodydynamics.xml
@@ -41,7 +41,7 @@
         </group>
        
         <group name="FT_SECONDARY_CALIBRATION">
-             <param name="l_leg_ft_sensor"> 
+             <param name="l_leg_ft"> 
                    (5.969361e-01,2.428213e-02,-5.463457e-02,4.254463e-01,1.123516e+00,-1.303151e-01 
                     ,-2.818578e-02,6.863783e-01,2.028274e-02,6.585433e-01,1.573658e-01,1.544577e+00 
                     ,-3.915223e-02,3.971615e-02,9.679746e-01,-3.150958e-03,3.718397e-01,-8.653098e-02 
@@ -49,7 +49,7 @@
                     ,5.671831e-03,6.968371e-03,4.892937e-03,5.396529e-02,9.499420e-01,-1.575216e-01 
                     ,3.469447e-18,0,-7.993503e-20,0,0,1.000000e+00)</param>     
 
-             <param name="r_leg_ft_sensor">
+             <param name="r_leg_ft">
                    (7.619710e-01,-9.833019e-02,-5.603709e-02,-7.503703e-01,4.654638e-01,-2.100801e+00 
                    ,2.708629e-02,8.108288e-01,-3.377881e-03,8.122805e-01,4.181660e-02,8.531041e-01 
                    ,-7.067404e-02,-3.179978e-02,9.888732e-01,-4.080758e-02,5.046211e-01,-5.754858e-01 
@@ -86,12 +86,12 @@
                 <!-- imu -->
                 <elem name="imu">inertial</elem>
                 <!-- ft -->
-                <elem name="l_arm_ft_sensor">left_arm-eb1-j0_3-strain</elem>
-                <elem name="r_arm_ft_sensor">right_arm-eb3-j0_3-strain</elem>
-                <elem name="l_leg_ft_sensor">left_leg-eb6-j0_3-strain</elem>
-                <elem name="r_leg_ft_sensor">right_leg-eb8-j0_3-strain</elem>
-                <elem name="l_foot_ft_sensor">left_leg-eb7-j4_5-strain</elem>
-                <elem name="r_foot_ft_sensor">right_leg-eb9-j4_5-strain</elem>
+                <elem name="l_arm_ft">left_arm-eb1-j0_3-strain</elem>
+                <elem name="r_arm_ft">right_arm-eb3-j0_3-strain</elem>
+                <elem name="l_leg_ft">left_leg-eb6-j0_3-strain</elem>
+                <elem name="r_leg_ft">right_leg-eb8-j0_3-strain</elem>
+                <elem name="l_foot_ft">left_leg-eb7-j4_5-strain</elem>
+                <elem name="r_foot_ft">right_leg-eb9-j4_5-strain</elem>
             </paramlist>
         </action>
 

--- a/iCubGenova08/estimators/wholebodydynamics_standup.xml
+++ b/iCubGenova08/estimators/wholebodydynamics_standup.xml
@@ -40,7 +40,7 @@
         
        <group name="FT_SECONDARY_CALIBRATION">
 
-           <param name="r_leg_ft_sensor"> (1.165043e-01,-4.824760e-02,-2.838516e-03,-4.063452e-01,3.829723e+00,-4.049686e+00
+           <param name="r_leg_ft"> (1.165043e-01,-4.824760e-02,-2.838516e-03,-4.063452e-01,3.829723e+00,-4.049686e+00
            ,-1.646781e-02,1.028508e-01,1.218741e-03,-3.860480e+00,6.586313e-02,1.079024e-01
            ,-1.223875e-01,-1.720457e-01,9.950911e-01,-1.332774e+00,4.882303e-01,1.109860e+00
            ,-2.690149e-03,-1.097413e-02,1.942506e-03,9.459466e-01,2.006043e-02,4.074997e-02
@@ -74,12 +74,12 @@
                 <!-- imu -->
                 <elem name="imu">inertial</elem>
                 <!-- ft -->
-                <elem name="l_arm_ft_sensor">left_arm-eb1-j0_3-strain</elem>
-                <elem name="r_arm_ft_sensor">right_arm-eb3-j0_3-strain</elem>
-                <elem name="l_leg_ft_sensor">left_leg-eb6-j0_3-strain</elem>
-                <elem name="r_leg_ft_sensor">right_leg-eb8-j0_3-strain</elem>
-                <elem name="l_foot_ft_sensor">left_leg-eb7-j4_5-strain</elem>
-                <elem name="r_foot_ft_sensor">right_leg-eb9-j4_5-strain</elem>
+                <elem name="l_arm_ft">left_arm-eb1-j0_3-strain</elem>
+                <elem name="r_arm_ft">right_arm-eb3-j0_3-strain</elem>
+                <elem name="l_leg_ft">left_leg-eb6-j0_3-strain</elem>
+                <elem name="r_leg_ft">right_leg-eb8-j0_3-strain</elem>
+                <elem name="l_foot_ft">left_leg-eb7-j4_5-strain</elem>
+                <elem name="r_foot_ft">right_leg-eb9-j4_5-strain</elem>
             </paramlist>
         </action>
 

--- a/iCubGenova08/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/iCubGenova08/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_arm_ft_sensor   </param>
+                    <param name="id">                   l_arm_ft   </param>
                     <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_arm_ft_sensor   </param>
+                <param name="enabledSensors">           l_arm_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubGenova08/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/iCubGenova08/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_leg_ft_sensor   </param>
+                    <param name="id">                   l_leg_ft   </param>
                     <param name="framename">            l_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_leg_ft_sensor   </param>
+                <param name="enabledSensors">           l_leg_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubGenova08/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/iCubGenova08/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_foot_ft_sensor   </param>
+                    <param name="id">                   l_foot_ft   </param>
                     <param name="framename">            l_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_foot_ft_sensor   </param>
+                <param name="enabledSensors">           l_foot_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubGenova08/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/iCubGenova08/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_arm_ft_sensor   </param>
+                    <param name="id">                   r_arm_ft   </param>
                     <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_arm_ft_sensor   </param>
+                <param name="enabledSensors">           r_arm_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubGenova08/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/iCubGenova08/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_leg_ft_sensor   </param>
+                    <param name="id">                   r_leg_ft   </param>
                     <param name="framename">            r_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_leg_ft_sensor   </param>
+                <param name="enabledSensors">           r_leg_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubGenova08/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/iCubGenova08/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_foot_ft_sensor   </param>
+                    <param name="id">                   r_foot_ft   </param>
                     <param name="framename">            r_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_foot_ft_sensor   </param>
+                <param name="enabledSensors">           r_foot_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubGenova08/wrappers/FT/left_leg-FT_remapper.xml
+++ b/iCubGenova08/wrappers/FT/left_leg-FT_remapper.xml
@@ -6,10 +6,10 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (l_leg_ft_sensor l_foot_ft_sensor)
+          (l_leg_ft l_foot_ft)
         </param>
         <param name="TemperatureSensorsNames">
-          (l_leg_ft_sensor l_foot_ft_sensor)
+          (l_leg_ft l_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubGenova08/wrappers/FT/right_leg-FT_remapper.xml
+++ b/iCubGenova08/wrappers/FT/right_leg-FT_remapper.xml
@@ -6,10 +6,10 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (r_leg_ft_sensor r_foot_ft_sensor)
+          (r_leg_ft r_foot_ft)
         </param>
         <param name="TemperatureSensorsNames">
-          (r_leg_ft_sensor r_foot_ft_sensor)
+          (r_leg_ft r_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubGenova10/estimators/wholebodydynamics.xml
+++ b/iCubGenova10/estimators/wholebodydynamics.xml
@@ -41,7 +41,7 @@
         </group>
        
         <group name="FT_SECONDARY_CALIBRATION">
-             <param name="l_leg_ft_sensor"> 
+             <param name="l_leg_ft"> 
                    (5.969361e-01,2.428213e-02,-5.463457e-02,4.254463e-01,1.123516e+00,-1.303151e-01 
                     ,-2.818578e-02,6.863783e-01,2.028274e-02,6.585433e-01,1.573658e-01,1.544577e+00 
                     ,-3.915223e-02,3.971615e-02,9.679746e-01,-3.150958e-03,3.718397e-01,-8.653098e-02 
@@ -49,7 +49,7 @@
                     ,5.671831e-03,6.968371e-03,4.892937e-03,5.396529e-02,9.499420e-01,-1.575216e-01 
                     ,3.469447e-18,0,-7.993503e-20,0,0,1.000000e+00)</param>     
 
-             <param name="r_leg_ft_sensor">
+             <param name="r_leg_ft">
                    (7.619710e-01,-9.833019e-02,-5.603709e-02,-7.503703e-01,4.654638e-01,-2.100801e+00 
                    ,2.708629e-02,8.108288e-01,-3.377881e-03,8.122805e-01,4.181660e-02,8.531041e-01 
                    ,-7.067404e-02,-3.179978e-02,9.888732e-01,-4.080758e-02,5.046211e-01,-5.754858e-01 
@@ -86,12 +86,12 @@
                 <!-- imu -->
                 <elem name="imu">inertial</elem>
                 <!-- ft -->
-                <elem name="l_arm_ft_sensor">left_arm-eb1-j0_3-strain</elem>
-                <elem name="r_arm_ft_sensor">right_arm-eb3-j0_3-strain</elem>
-                <elem name="l_leg_ft_sensor">left_leg-eb6-j0_3-strain</elem>
-                <elem name="r_leg_ft_sensor">right_leg-eb8-j0_3-strain</elem>
-                <elem name="l_foot_ft_sensor">left_leg-eb7-j4_5-strain</elem>
-                <elem name="r_foot_ft_sensor">right_leg-eb9-j4_5-strain</elem>
+                <elem name="l_arm_ft">left_arm-eb1-j0_3-strain</elem>
+                <elem name="r_arm_ft">right_arm-eb3-j0_3-strain</elem>
+                <elem name="l_leg_ft">left_leg-eb6-j0_3-strain</elem>
+                <elem name="r_leg_ft">right_leg-eb8-j0_3-strain</elem>
+                <elem name="l_foot_ft">left_leg-eb7-j4_5-strain</elem>
+                <elem name="r_foot_ft">right_leg-eb9-j4_5-strain</elem>
             </paramlist>
         </action>
 

--- a/iCubGenova10/estimators/wholebodydynamics_standup.xml
+++ b/iCubGenova10/estimators/wholebodydynamics_standup.xml
@@ -40,7 +40,7 @@
         
        <group name="FT_SECONDARY_CALIBRATION">
 
-           <param name="r_leg_ft_sensor"> (1.165043e-01,-4.824760e-02,-2.838516e-03,-4.063452e-01,3.829723e+00,-4.049686e+00
+           <param name="r_leg_ft"> (1.165043e-01,-4.824760e-02,-2.838516e-03,-4.063452e-01,3.829723e+00,-4.049686e+00
            ,-1.646781e-02,1.028508e-01,1.218741e-03,-3.860480e+00,6.586313e-02,1.079024e-01
            ,-1.223875e-01,-1.720457e-01,9.950911e-01,-1.332774e+00,4.882303e-01,1.109860e+00
            ,-2.690149e-03,-1.097413e-02,1.942506e-03,9.459466e-01,2.006043e-02,4.074997e-02
@@ -74,12 +74,12 @@
                 <!-- imu -->
                 <elem name="imu">inertial</elem>
                 <!-- ft -->
-                <elem name="l_arm_ft_sensor">left_arm-eb1-j0_3-strain</elem>
-                <elem name="r_arm_ft_sensor">right_arm-eb3-j0_3-strain</elem>
-                <elem name="l_leg_ft_sensor">left_leg-eb6-j0_3-strain</elem>
-                <elem name="r_leg_ft_sensor">right_leg-eb8-j0_3-strain</elem>
-                <elem name="l_foot_ft_sensor">left_leg-eb7-j4_5-strain</elem>
-                <elem name="r_foot_ft_sensor">right_leg-eb9-j4_5-strain</elem>
+                <elem name="l_arm_ft">left_arm-eb1-j0_3-strain</elem>
+                <elem name="r_arm_ft">right_arm-eb3-j0_3-strain</elem>
+                <elem name="l_leg_ft">left_leg-eb6-j0_3-strain</elem>
+                <elem name="r_leg_ft">right_leg-eb8-j0_3-strain</elem>
+                <elem name="l_foot_ft">left_leg-eb7-j4_5-strain</elem>
+                <elem name="r_foot_ft">right_leg-eb9-j4_5-strain</elem>
             </paramlist>
         </action>
 

--- a/iCubGenova10/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/iCubGenova10/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_arm_ft_sensor   </param>
+                    <param name="id">                   l_arm_ft   </param>
                     <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_arm_ft_sensor   </param>
+                <param name="enabledSensors">           l_arm_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubGenova10/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/iCubGenova10/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_leg_ft_sensor   </param>
+                    <param name="id">                   l_leg_ft   </param>
                     <param name="framename">            l_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_leg_ft_sensor   </param>
+                <param name="enabledSensors">           l_leg_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubGenova10/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/iCubGenova10/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_foot_ft_sensor   </param>
+                    <param name="id">                   l_foot_ft   </param>
                     <param name="framename">            l_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_foot_ft_sensor   </param>
+                <param name="enabledSensors">           l_foot_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubGenova10/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/iCubGenova10/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_arm_ft_sensor   </param>
+                    <param name="id">                   r_arm_ft   </param>
                     <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_arm_ft_sensor   </param>
+                <param name="enabledSensors">           r_arm_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubGenova10/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/iCubGenova10/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_leg_ft_sensor   </param>
+                    <param name="id">                   r_leg_ft   </param>
                     <param name="framename">            r_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_leg_ft_sensor   </param>
+                <param name="enabledSensors">           r_leg_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubGenova10/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/iCubGenova10/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_foot_ft_sensor   </param>
+                    <param name="id">                   r_foot_ft   </param>
                     <param name="framename">            r_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_foot_ft_sensor   </param>
+                <param name="enabledSensors">           r_foot_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubGenova10/wrappers/FT/left_leg-FT_remapper.xml
+++ b/iCubGenova10/wrappers/FT/left_leg-FT_remapper.xml
@@ -6,10 +6,10 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (l_leg_ft_sensor l_foot_ft_sensor)
+          (l_leg_ft l_foot_ft)
         </param>
         <param name="TemperatureSensorsNames">
-          (l_leg_ft_sensor l_foot_ft_sensor)
+          (l_leg_ft l_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubGenova10/wrappers/FT/right_leg-FT_remapper.xml
+++ b/iCubGenova10/wrappers/FT/right_leg-FT_remapper.xml
@@ -6,10 +6,10 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (r_leg_ft_sensor r_foot_ft_sensor)
+          (r_leg_ft r_foot_ft)
         </param>
         <param name="TemperatureSensorsNames">
-          (r_leg_ft_sensor r_foot_ft_sensor)
+          (r_leg_ft r_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubGenova11/estimators/wholebodydynamics.xml
+++ b/iCubGenova11/estimators/wholebodydynamics.xml
@@ -41,7 +41,7 @@
         </group>
        
         <group name="FT_SECONDARY_CALIBRATION">
-             <param name="l_leg_ft_sensor"> 
+             <param name="l_leg_ft"> 
                    (5.969361e-01,2.428213e-02,-5.463457e-02,4.254463e-01,1.123516e+00,-1.303151e-01 
                     ,-2.818578e-02,6.863783e-01,2.028274e-02,6.585433e-01,1.573658e-01,1.544577e+00 
                     ,-3.915223e-02,3.971615e-02,9.679746e-01,-3.150958e-03,3.718397e-01,-8.653098e-02 
@@ -49,7 +49,7 @@
                     ,5.671831e-03,6.968371e-03,4.892937e-03,5.396529e-02,9.499420e-01,-1.575216e-01 
                     ,3.469447e-18,0,-7.993503e-20,0,0,1.000000e+00)</param>     
 
-             <param name="r_leg_ft_sensor">
+             <param name="r_leg_ft">
                    (7.619710e-01,-9.833019e-02,-5.603709e-02,-7.503703e-01,4.654638e-01,-2.100801e+00 
                    ,2.708629e-02,8.108288e-01,-3.377881e-03,8.122805e-01,4.181660e-02,8.531041e-01 
                    ,-7.067404e-02,-3.179978e-02,9.888732e-01,-4.080758e-02,5.046211e-01,-5.754858e-01 
@@ -86,12 +86,12 @@
                 <!-- imu -->
                 <elem name="imu">inertial</elem>
                 <!-- ft -->
-                <elem name="l_arm_ft_sensor">left_arm-eb1-j0_3-strain</elem>
-                <elem name="r_arm_ft_sensor">right_arm-eb3-j0_3-strain</elem>
-                <elem name="l_leg_ft_sensor">left_leg-eb6-j0_3-strain</elem>
-                <elem name="r_leg_ft_sensor">right_leg-eb8-j0_3-strain</elem>
-                <elem name="l_foot_ft_sensor">left_leg-eb7-j4_5-strain</elem>
-                <elem name="r_foot_ft_sensor">right_leg-eb9-j4_5-strain</elem>
+                <elem name="l_arm_ft">left_arm-eb1-j0_3-strain</elem>
+                <elem name="r_arm_ft">right_arm-eb3-j0_3-strain</elem>
+                <elem name="l_leg_ft">left_leg-eb6-j0_3-strain</elem>
+                <elem name="r_leg_ft">right_leg-eb8-j0_3-strain</elem>
+                <elem name="l_foot_ft">left_leg-eb7-j4_5-strain</elem>
+                <elem name="r_foot_ft">right_leg-eb9-j4_5-strain</elem>
             </paramlist>
         </action>
 

--- a/iCubGenova11/estimators/wholebodydynamics_standup.xml
+++ b/iCubGenova11/estimators/wholebodydynamics_standup.xml
@@ -40,7 +40,7 @@
         
        <group name="FT_SECONDARY_CALIBRATION">
 
-           <param name="r_leg_ft_sensor"> (1.165043e-01,-4.824760e-02,-2.838516e-03,-4.063452e-01,3.829723e+00,-4.049686e+00
+           <param name="r_leg_ft"> (1.165043e-01,-4.824760e-02,-2.838516e-03,-4.063452e-01,3.829723e+00,-4.049686e+00
            ,-1.646781e-02,1.028508e-01,1.218741e-03,-3.860480e+00,6.586313e-02,1.079024e-01
            ,-1.223875e-01,-1.720457e-01,9.950911e-01,-1.332774e+00,4.882303e-01,1.109860e+00
            ,-2.690149e-03,-1.097413e-02,1.942506e-03,9.459466e-01,2.006043e-02,4.074997e-02
@@ -74,12 +74,12 @@
                 <!-- imu -->
                 <elem name="imu">inertial</elem>
                 <!-- ft -->
-                <elem name="l_arm_ft_sensor">left_arm-eb1-j0_3-strain</elem>
-                <elem name="r_arm_ft_sensor">right_arm-eb3-j0_3-strain</elem>
-                <elem name="l_leg_ft_sensor">left_leg-eb6-j0_3-strain</elem>
-                <elem name="r_leg_ft_sensor">right_leg-eb8-j0_3-strain</elem>
-                <elem name="l_foot_ft_sensor">left_leg-eb7-j4_5-strain</elem>
-                <elem name="r_foot_ft_sensor">right_leg-eb9-j4_5-strain</elem>
+                <elem name="l_arm_ft">left_arm-eb1-j0_3-strain</elem>
+                <elem name="r_arm_ft">right_arm-eb3-j0_3-strain</elem>
+                <elem name="l_leg_ft">left_leg-eb6-j0_3-strain</elem>
+                <elem name="r_leg_ft">right_leg-eb8-j0_3-strain</elem>
+                <elem name="l_foot_ft">left_leg-eb7-j4_5-strain</elem>
+                <elem name="r_foot_ft">right_leg-eb9-j4_5-strain</elem>
             </paramlist>
         </action>
 

--- a/iCubGenova11/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/iCubGenova11/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_arm_ft_sensor   </param>
+                    <param name="id">                   l_arm_ft   </param>
                     <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_arm_ft_sensor   </param>
+                <param name="enabledSensors">           l_arm_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubGenova11/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/iCubGenova11/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_leg_ft_sensor   </param>
+                    <param name="id">                   l_leg_ft   </param>
                     <param name="framename">            l_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_leg_ft_sensor   </param>
+                <param name="enabledSensors">           l_leg_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubGenova11/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/iCubGenova11/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_foot_ft_sensor   </param>
+                    <param name="id">                   l_foot_ft   </param>
                     <param name="framename">            l_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_foot_ft_sensor   </param>
+                <param name="enabledSensors">           l_foot_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubGenova11/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/iCubGenova11/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_arm_ft_sensor   </param>
+                    <param name="id">                   r_arm_ft   </param>
                     <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_arm_ft_sensor   </param>
+                <param name="enabledSensors">           r_arm_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubGenova11/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/iCubGenova11/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_leg_ft_sensor   </param>
+                    <param name="id">                   r_leg_ft   </param>
                     <param name="framename">            r_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_leg_ft_sensor   </param>
+                <param name="enabledSensors">           r_leg_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubGenova11/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/iCubGenova11/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_foot_ft_sensor   </param>
+                    <param name="id">                   r_foot_ft   </param>
                     <param name="framename">            r_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_foot_ft_sensor   </param>
+                <param name="enabledSensors">           r_foot_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubGenova11/wrappers/FT/left_leg-FT_remapper.xml
+++ b/iCubGenova11/wrappers/FT/left_leg-FT_remapper.xml
@@ -6,10 +6,10 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (l_leg_ft_sensor l_foot_ft_sensor)
+          (l_leg_ft l_foot_ft)
         </param>
         <param name="TemperatureSensorsNames">
-          (l_leg_ft_sensor l_foot_ft_sensor)
+          (l_leg_ft l_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubGenova11/wrappers/FT/right_leg-FT_remapper.xml
+++ b/iCubGenova11/wrappers/FT/right_leg-FT_remapper.xml
@@ -6,10 +6,10 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (r_leg_ft_sensor r_foot_ft_sensor)
+          (r_leg_ft r_foot_ft)
         </param>
         <param name="TemperatureSensorsNames">
-          (r_leg_ft_sensor r_foot_ft_sensor)
+          (r_leg_ft r_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubGrenoble01/hardware/FT/left_arm_strain.xml
+++ b/iCubGrenoble01/hardware/FT/left_arm_strain.xml
@@ -3,7 +3,7 @@
 
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="left_arm_strain">
-    <param name="sensorName"> l_arm_ft_sensor </param>
+    <param name="sensorName"> l_arm_ft </param>
     <param name="frameName"> l_arm_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/iCubGrenoble01/hardware/FT/left_leg_strain.xml
+++ b/iCubGrenoble01/hardware/FT/left_leg_strain.xml
@@ -3,7 +3,7 @@
 
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="left_leg_strain">
-    <param name="sensorName"> l_leg_ft_sensor </param>
+    <param name="sensorName"> l_leg_ft </param>
     <param name="frameName"> l_leg_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/iCubGrenoble01/hardware/FT/right_arm_strain.xml
+++ b/iCubGrenoble01/hardware/FT/right_arm_strain.xml
@@ -3,7 +3,7 @@
 
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="right_arm_strain">
-    <param name="sensorName"> r_arm_ft_sensor </param>
+    <param name="sensorName"> r_arm_ft </param>
     <param name="frameName"> r_arm_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/iCubGrenoble01/hardware/FT/right_foot_strain.xml
+++ b/iCubGrenoble01/hardware/FT/right_foot_strain.xml
@@ -3,7 +3,7 @@
 
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="right_foot_strain">
-    <param name="sensorName"> r_foot_ft_sensor </param>
+    <param name="sensorName"> r_foot_ft </param>
     <param name="frameName"> r_foot_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/iCubGrenoble01/hardware/FT/right_leg_strain.xml
+++ b/iCubGrenoble01/hardware/FT/right_leg_strain.xml
@@ -3,7 +3,7 @@
 
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="right_leg_strain">
-    <param name="sensorName"> r_leg_ft_sensor </param>
+    <param name="sensorName"> r_leg_ft </param>
     <param name="frameName"> r_leg_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/iCubGrenoble01/wrappers/FT/left_leg-FT_remapper.xml
+++ b/iCubGrenoble01/wrappers/FT/left_leg-FT_remapper.xml
@@ -6,7 +6,7 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (l_leg_ft_sensor l_foot_ft_sensor)
+          (l_leg_ft l_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubGrenoble01/wrappers/FT/right_leg-FT_remapper.xml
+++ b/iCubGrenoble01/wrappers/FT/right_leg-FT_remapper.xml
@@ -6,7 +6,7 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (r_leg_ft_sensor r_foot_ft_sensor)
+          (r_leg_ft r_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubHertfordshire01/hardware/FT/left_arm_strain.xml
+++ b/iCubHertfordshire01/hardware/FT/left_arm_strain.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="left_arm_strain">
-    <param name="sensorName"> l_arm_ft_sensor </param>
+    <param name="sensorName"> l_arm_ft </param>
     <param name="frameName"> l_arm_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/iCubHertfordshire01/hardware/FT/left_leg_strain.xml
+++ b/iCubHertfordshire01/hardware/FT/left_leg_strain.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="left_leg_strain">
-    <param name="sensorName"> l_leg_ft_sensor </param>
+    <param name="sensorName"> l_leg_ft </param>
     <param name="frameName"> l_leg_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/iCubHertfordshire01/hardware/FT/right_arm_strain.xml
+++ b/iCubHertfordshire01/hardware/FT/right_arm_strain.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="right_arm_strain">
-    <param name="sensorName"> r_arm_ft_sensor </param>
+    <param name="sensorName"> r_arm_ft </param>
     <param name="frameName"> r_arm_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/iCubHertfordshire01/hardware/FT/right_foot_strain.xml
+++ b/iCubHertfordshire01/hardware/FT/right_foot_strain.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="right_foot_strain">
-    <param name="sensorName"> r_foot_ft_sensor </param>
+    <param name="sensorName"> r_foot_ft </param>
     <param name="frameName"> r_foot_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/iCubHertfordshire01/hardware/FT/right_leg_strain.xml
+++ b/iCubHertfordshire01/hardware/FT/right_leg_strain.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="right_leg_strain">
-    <param name="sensorName"> r_leg_ft_sensor </param>
+    <param name="sensorName"> r_leg_ft </param>
     <param name="frameName"> r_leg_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/iCubLisboa01/estimators/wholebodydynamics.xml
+++ b/iCubLisboa01/estimators/wholebodydynamics.xml
@@ -41,7 +41,7 @@
         </group>
        
         <group name="FT_SECONDARY_CALIBRATION">
-             <param name="l_leg_ft_sensor"> 
+             <param name="l_leg_ft"> 
                    (5.969361e-01,2.428213e-02,-5.463457e-02,4.254463e-01,1.123516e+00,-1.303151e-01 
                     ,-2.818578e-02,6.863783e-01,2.028274e-02,6.585433e-01,1.573658e-01,1.544577e+00 
                     ,-3.915223e-02,3.971615e-02,9.679746e-01,-3.150958e-03,3.718397e-01,-8.653098e-02 
@@ -49,7 +49,7 @@
                     ,5.671831e-03,6.968371e-03,4.892937e-03,5.396529e-02,9.499420e-01,-1.575216e-01 
                     ,3.469447e-18,0,-7.993503e-20,0,0,1.000000e+00)</param>     
 
-             <param name="r_leg_ft_sensor">
+             <param name="r_leg_ft">
                    (7.619710e-01,-9.833019e-02,-5.603709e-02,-7.503703e-01,4.654638e-01,-2.100801e+00 
                    ,2.708629e-02,8.108288e-01,-3.377881e-03,8.122805e-01,4.181660e-02,8.531041e-01 
                    ,-7.067404e-02,-3.179978e-02,9.888732e-01,-4.080758e-02,5.046211e-01,-5.754858e-01 
@@ -86,12 +86,12 @@
                 <!-- imu -->
                 <elem name="imu">inertial</elem>
                 <!-- ft -->
-                <elem name="l_arm_ft_sensor">left_arm-eb1-j0_3-strain</elem>
-                <elem name="r_arm_ft_sensor">right_arm-eb3-j0_3-strain</elem>
-                <elem name="l_leg_ft_sensor">left_leg-eb6-j0_3-strain</elem>
-                <elem name="r_leg_ft_sensor">right_leg-eb8-j0_3-strain</elem>
-                <elem name="l_foot_ft_sensor">left_leg-eb7-j4_5-strain</elem>
-                <elem name="r_foot_ft_sensor">right_leg-eb9-j4_5-strain</elem>
+                <elem name="l_arm_ft">left_arm-eb1-j0_3-strain</elem>
+                <elem name="r_arm_ft">right_arm-eb3-j0_3-strain</elem>
+                <elem name="l_leg_ft">left_leg-eb6-j0_3-strain</elem>
+                <elem name="r_leg_ft">right_leg-eb8-j0_3-strain</elem>
+                <elem name="l_foot_ft">left_leg-eb7-j4_5-strain</elem>
+                <elem name="r_foot_ft">right_leg-eb9-j4_5-strain</elem>
             </paramlist>
         </action>
 

--- a/iCubLisboa01/estimators/wholebodydynamics_standup.xml
+++ b/iCubLisboa01/estimators/wholebodydynamics_standup.xml
@@ -40,7 +40,7 @@
         
        <group name="FT_SECONDARY_CALIBRATION">
 
-           <param name="r_leg_ft_sensor"> (1.165043e-01,-4.824760e-02,-2.838516e-03,-4.063452e-01,3.829723e+00,-4.049686e+00
+           <param name="r_leg_ft"> (1.165043e-01,-4.824760e-02,-2.838516e-03,-4.063452e-01,3.829723e+00,-4.049686e+00
            ,-1.646781e-02,1.028508e-01,1.218741e-03,-3.860480e+00,6.586313e-02,1.079024e-01
            ,-1.223875e-01,-1.720457e-01,9.950911e-01,-1.332774e+00,4.882303e-01,1.109860e+00
            ,-2.690149e-03,-1.097413e-02,1.942506e-03,9.459466e-01,2.006043e-02,4.074997e-02
@@ -74,12 +74,12 @@
                 <!-- imu -->
                 <elem name="imu">inertial</elem>
                 <!-- ft -->
-                <elem name="l_arm_ft_sensor">left_arm-eb1-j0_3-strain</elem>
-                <elem name="r_arm_ft_sensor">right_arm-eb3-j0_3-strain</elem>
-                <elem name="l_leg_ft_sensor">left_leg-eb6-j0_3-strain</elem>
-                <elem name="r_leg_ft_sensor">right_leg-eb8-j0_3-strain</elem>
-                <elem name="l_foot_ft_sensor">left_leg-eb7-j4_5-strain</elem>
-                <elem name="r_foot_ft_sensor">right_leg-eb9-j4_5-strain</elem>
+                <elem name="l_arm_ft">left_arm-eb1-j0_3-strain</elem>
+                <elem name="r_arm_ft">right_arm-eb3-j0_3-strain</elem>
+                <elem name="l_leg_ft">left_leg-eb6-j0_3-strain</elem>
+                <elem name="r_leg_ft">right_leg-eb8-j0_3-strain</elem>
+                <elem name="l_foot_ft">left_leg-eb7-j4_5-strain</elem>
+                <elem name="r_foot_ft">right_leg-eb9-j4_5-strain</elem>
             </paramlist>
         </action>
 

--- a/iCubLisboa01/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/iCubLisboa01/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_arm_ft_sensor   </param>
+                    <param name="id">                   l_arm_ft   </param>
                     <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_arm_ft_sensor   </param>
+                <param name="enabledSensors">           l_arm_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubLisboa01/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/iCubLisboa01/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_leg_ft_sensor   </param>
+                    <param name="id">                   l_leg_ft   </param>
                     <param name="framename">            l_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_leg_ft_sensor   </param>
+                <param name="enabledSensors">           l_leg_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubLisboa01/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/iCubLisboa01/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_foot_ft_sensor   </param>
+                    <param name="id">                   l_foot_ft   </param>
                     <param name="framename">            l_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_foot_ft_sensor   </param>
+                <param name="enabledSensors">           l_foot_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubLisboa01/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/iCubLisboa01/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_arm_ft_sensor   </param>
+                    <param name="id">                   r_arm_ft   </param>
                     <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_arm_ft_sensor   </param>
+                <param name="enabledSensors">           r_arm_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubLisboa01/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/iCubLisboa01/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_leg_ft_sensor   </param>
+                    <param name="id">                   r_leg_ft   </param>
                     <param name="framename">            r_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_leg_ft_sensor   </param>
+                <param name="enabledSensors">           r_leg_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubLisboa01/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/iCubLisboa01/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_foot_ft_sensor   </param>
+                    <param name="id">                   r_foot_ft   </param>
                     <param name="framename">            r_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_foot_ft_sensor   </param>
+                <param name="enabledSensors">           r_foot_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubLisboa01/wrappers/FT/left_leg-FT_remapper.xml
+++ b/iCubLisboa01/wrappers/FT/left_leg-FT_remapper.xml
@@ -6,10 +6,10 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (l_leg_ft_sensor l_foot_ft_sensor)
+          (l_leg_ft l_foot_ft)
         </param>
         <param name="TemperatureSensorsNames">
-          (l_leg_ft_sensor l_foot_ft_sensor)
+          (l_leg_ft l_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubLisboa01/wrappers/FT/right_leg-FT_remapper.xml
+++ b/iCubLisboa01/wrappers/FT/right_leg-FT_remapper.xml
@@ -6,10 +6,10 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (r_leg_ft_sensor r_foot_ft_sensor)
+          (r_leg_ft r_foot_ft)
         </param>
         <param name="TemperatureSensorsNames">
-          (r_leg_ft_sensor r_foot_ft_sensor)
+          (r_leg_ft r_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubLondon01/hardware/FT/left_arm_strain.xml
+++ b/iCubLondon01/hardware/FT/left_arm_strain.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="left_arm_strain">
-    <param name="sensorName"> l_arm_ft_sensor </param>
+    <param name="sensorName"> l_arm_ft </param>
     <param name="frameName"> l_arm_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/iCubLondon01/hardware/FT/left_leg_strain.xml
+++ b/iCubLondon01/hardware/FT/left_leg_strain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="left_leg_strain">
-    <param name="sensorName"> l_leg_ft_sensor </param>
+    <param name="sensorName"> l_leg_ft </param>
     <param name="frameName"> l_leg_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/iCubLondon01/hardware/FT/right_arm_strain.xml
+++ b/iCubLondon01/hardware/FT/right_arm_strain.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="right_arm_strain">
-    <param name="sensorName"> r_arm_ft_sensor </param>
+    <param name="sensorName"> r_arm_ft </param>
     <param name="frameName"> r_arm_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/iCubLondon01/hardware/FT/right_foot_strain.xml
+++ b/iCubLondon01/hardware/FT/right_foot_strain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="right_foot_strain">
-    <param name="sensorName"> r_foot_ft_sensor </param>
+    <param name="sensorName"> r_foot_ft </param>
     <param name="frameName"> r_foot_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/iCubLondon01/hardware/FT/right_leg_strain.xml
+++ b/iCubLondon01/hardware/FT/right_leg_strain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="right_leg_strain">
-    <param name="sensorName"> r_leg_ft_sensor </param>
+    <param name="sensorName"> r_leg_ft </param>
     <param name="frameName"> r_leg_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/iCubLondon01/wrappers/FT/left_leg-FT_remapper.xml
+++ b/iCubLondon01/wrappers/FT/left_leg-FT_remapper.xml
@@ -6,7 +6,7 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (l_leg_ft_sensor l_foot_ft_sensor)
+          (l_leg_ft l_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubLondon01/wrappers/FT/right_leg-FT_remapper.xml
+++ b/iCubLondon01/wrappers/FT/right_leg-FT_remapper.xml
@@ -6,7 +6,7 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (r_leg_ft_sensor r_foot_ft_sensor)
+          (r_leg_ft r_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubNancy01/estimators/wholebodydynamics.xml
+++ b/iCubNancy01/estimators/wholebodydynamics.xml
@@ -61,12 +61,12 @@
                 <!-- imu -->
                 <elem name="imu">head-inertial</elem>
                 <!-- ft -->
-                <elem name="l_arm_ft_sensor">left_arm-eb1-j0_3-strain</elem>
-                <elem name="r_arm_ft_sensor">right_arm-eb3-j0_3-strain</elem>
-                <elem name="l_leg_ft_sensor">left_leg-eb6-j0_3-strain</elem>
-                <elem name="r_leg_ft_sensor">right_leg-eb8-j0_3-strain</elem>
-                <elem name="l_foot_ft_sensor">left_leg-eb7-j4_5-strain</elem>
-                <elem name="r_foot_ft_sensor">right_leg-eb9-j4_5-strain</elem>
+                <elem name="l_arm_ft">left_arm-eb1-j0_3-strain</elem>
+                <elem name="r_arm_ft">right_arm-eb3-j0_3-strain</elem>
+                <elem name="l_leg_ft">left_leg-eb6-j0_3-strain</elem>
+                <elem name="r_leg_ft">right_leg-eb8-j0_3-strain</elem>
+                <elem name="l_foot_ft">left_leg-eb7-j4_5-strain</elem>
+                <elem name="r_foot_ft">right_leg-eb9-j4_5-strain</elem>
             </paramlist>
         </action>
 

--- a/iCubNancy01/estimators/wholebodydynamics_BALANCING_IIT.xml
+++ b/iCubNancy01/estimators/wholebodydynamics_BALANCING_IIT.xml
@@ -61,12 +61,12 @@
                 <!-- imu -->
                 <elem name="imu">head-inertial</elem>
                 <!-- ft -->
-                <elem name="l_arm_ft_sensor">left_arm-eb1-j0_3-strain</elem>
-                <elem name="r_arm_ft_sensor">right_arm-eb3-j0_3-strain</elem>
-                <elem name="l_leg_ft_sensor">left_leg-eb6-j0_3-strain</elem>
-                <elem name="r_leg_ft_sensor">right_leg-eb8-j0_3-strain</elem>
-                <elem name="l_foot_ft_sensor">left_leg-eb7-j4_5-strain</elem>
-                <elem name="r_foot_ft_sensor">right_leg-eb9-j4_5-strain</elem>
+                <elem name="l_arm_ft">left_arm-eb1-j0_3-strain</elem>
+                <elem name="r_arm_ft">right_arm-eb3-j0_3-strain</elem>
+                <elem name="l_leg_ft">left_leg-eb6-j0_3-strain</elem>
+                <elem name="r_leg_ft">right_leg-eb8-j0_3-strain</elem>
+                <elem name="l_foot_ft">left_leg-eb7-j4_5-strain</elem>
+                <elem name="r_foot_ft">right_leg-eb9-j4_5-strain</elem>
             </paramlist>
         </action>
 

--- a/iCubNancy01/estimators/wholebodydynamics_BALANCING_NANCY.xml
+++ b/iCubNancy01/estimators/wholebodydynamics_BALANCING_NANCY.xml
@@ -63,12 +63,12 @@
                 <!-- imu -->
                 <elem name="imu">head-inertial</elem>
                 <!-- ft -->
-                <elem name="l_arm_ft_sensor">left_arm-eb1-j0_3-strain</elem>
-                <elem name="r_arm_ft_sensor">right_arm-eb3-j0_3-strain</elem>
-                <elem name="l_leg_ft_sensor">left_leg-eb6-j0_3-strain</elem>
-                <elem name="r_leg_ft_sensor">right_leg-eb8-j0_3-strain</elem>
-                <elem name="l_foot_ft_sensor">left_leg-eb7-j4_5-strain</elem>
-                <elem name="r_foot_ft_sensor">right_leg-eb9-j4_5-strain</elem>
+                <elem name="l_arm_ft">left_arm-eb1-j0_3-strain</elem>
+                <elem name="r_arm_ft">right_arm-eb3-j0_3-strain</elem>
+                <elem name="l_leg_ft">left_leg-eb6-j0_3-strain</elem>
+                <elem name="r_leg_ft">right_leg-eb8-j0_3-strain</elem>
+                <elem name="l_foot_ft">left_leg-eb7-j4_5-strain</elem>
+                <elem name="r_foot_ft">right_leg-eb9-j4_5-strain</elem>
             </paramlist>
         </action>
 

--- a/iCubNancy01/estimators/wholebodydynamics_STANDUP.xml
+++ b/iCubNancy01/estimators/wholebodydynamics_STANDUP.xml
@@ -67,12 +67,12 @@
                 <!-- imu -->
                 <elem name="imu">head-inertial</elem>
                 <!-- ft -->
-                <elem name="l_arm_ft_sensor">left_arm-eb1-j0_3-strain</elem>
-                <elem name="r_arm_ft_sensor">right_arm-eb3-j0_3-strain</elem>
-                <elem name="l_leg_ft_sensor">left_leg-eb6-j0_3-strain</elem>
-                <elem name="r_leg_ft_sensor">right_leg-eb8-j0_3-strain</elem>
-                <elem name="l_foot_ft_sensor">left_leg-eb7-j4_5-strain</elem>
-                <elem name="r_foot_ft_sensor">right_leg-eb9-j4_5-strain</elem>
+                <elem name="l_arm_ft">left_arm-eb1-j0_3-strain</elem>
+                <elem name="r_arm_ft">right_arm-eb3-j0_3-strain</elem>
+                <elem name="l_leg_ft">left_leg-eb6-j0_3-strain</elem>
+                <elem name="r_leg_ft">right_leg-eb8-j0_3-strain</elem>
+                <elem name="l_foot_ft">left_leg-eb7-j4_5-strain</elem>
+                <elem name="r_foot_ft">right_leg-eb9-j4_5-strain</elem>
             </paramlist>
         </action>
 

--- a/iCubNancy01/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/iCubNancy01/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_arm_ft_sensor   </param>
+                    <param name="id">                   l_arm_ft   </param>
                     <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_arm_ft_sensor   </param>
+                <param name="enabledSensors">           l_arm_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/iCubNancy01/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/iCubNancy01/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_leg_ft_sensor   </param>
+                    <param name="id">                   l_leg_ft   </param>
                     <param name="framename">            l_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_leg_ft_sensor   </param>
+                <param name="enabledSensors">           l_leg_ft   </param>
                 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubNancy01/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/iCubNancy01/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_foot_ft_sensor   </param>
+                    <param name="id">                   l_foot_ft   </param>
                     <param name="framename">            l_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:1                  </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_foot_ft_sensor   </param>
+                <param name="enabledSensors">           l_foot_ft   </param>
                 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubNancy01/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/iCubNancy01/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_arm_ft_sensor   </param>
+                    <param name="id">                   r_arm_ft   </param>
                     <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_arm_ft_sensor   </param>
+                <param name="enabledSensors">           r_arm_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/iCubNancy01/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/iCubNancy01/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_leg_ft_sensor   </param>
+                    <param name="id">                   r_leg_ft   </param>
                     <param name="framename">            r_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_leg_ft_sensor   </param>
+                <param name="enabledSensors">           r_leg_ft   </param>
                 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubNancy01/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/iCubNancy01/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_foot_ft_sensor   </param>
+                    <param name="id">                   r_foot_ft   </param>
                     <param name="framename">            r_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:1                  </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_foot_ft_sensor   </param>
+                <param name="enabledSensors">           r_foot_ft   </param>
                 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubNancy01/wrappers/FT/left_leg-FT_remapper.xml
+++ b/iCubNancy01/wrappers/FT/left_leg-FT_remapper.xml
@@ -6,10 +6,10 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (l_leg_ft_sensor l_foot_ft_sensor)
+          (l_leg_ft l_foot_ft)
         </param>
         <param name="TemperatureSensorsNames">
-          (l_leg_ft_sensor l_foot_ft_sensor)
+          (l_leg_ft l_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubNancy01/wrappers/FT/right_leg-FT_remapper.xml
+++ b/iCubNancy01/wrappers/FT/right_leg-FT_remapper.xml
@@ -6,10 +6,10 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (r_leg_ft_sensor r_foot_ft_sensor)
+          (r_leg_ft r_foot_ft)
         </param>
         <param name="TemperatureSensorsNames">
-          (r_leg_ft_sensor r_foot_ft_sensor)
+          (r_leg_ft r_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubPrague01/estimators/wholebodydynamics.xml
+++ b/iCubPrague01/estimators/wholebodydynamics.xml
@@ -41,7 +41,7 @@
         </group>
        
         <group name="FT_SECONDARY_CALIBRATION">
-             <param name="l_leg_ft_sensor"> 
+             <param name="l_leg_ft"> 
                    (5.969361e-01,2.428213e-02,-5.463457e-02,4.254463e-01,1.123516e+00,-1.303151e-01 
                     ,-2.818578e-02,6.863783e-01,2.028274e-02,6.585433e-01,1.573658e-01,1.544577e+00 
                     ,-3.915223e-02,3.971615e-02,9.679746e-01,-3.150958e-03,3.718397e-01,-8.653098e-02 
@@ -49,7 +49,7 @@
                     ,5.671831e-03,6.968371e-03,4.892937e-03,5.396529e-02,9.499420e-01,-1.575216e-01 
                     ,3.469447e-18,0,-7.993503e-20,0,0,1.000000e+00)</param>     
 
-             <param name="r_leg_ft_sensor">
+             <param name="r_leg_ft">
                    (7.619710e-01,-9.833019e-02,-5.603709e-02,-7.503703e-01,4.654638e-01,-2.100801e+00 
                    ,2.708629e-02,8.108288e-01,-3.377881e-03,8.122805e-01,4.181660e-02,8.531041e-01 
                    ,-7.067404e-02,-3.179978e-02,9.888732e-01,-4.080758e-02,5.046211e-01,-5.754858e-01 
@@ -86,12 +86,12 @@
                 <!-- imu -->
                 <elem name="imu">inertial</elem>
                 <!-- ft -->
-                <elem name="l_arm_ft_sensor">left_arm-eb1-j0_3-strain</elem>
-                <elem name="r_arm_ft_sensor">right_arm-eb3-j0_3-strain</elem>
-                <elem name="l_leg_ft_sensor">left_leg-eb6-j0_3-strain</elem>
-                <elem name="r_leg_ft_sensor">right_leg-eb8-j0_3-strain</elem>
-                <elem name="l_foot_ft_sensor">left_leg-eb7-j4_5-strain</elem>
-                <elem name="r_foot_ft_sensor">right_leg-eb9-j4_5-strain</elem>
+                <elem name="l_arm_ft">left_arm-eb1-j0_3-strain</elem>
+                <elem name="r_arm_ft">right_arm-eb3-j0_3-strain</elem>
+                <elem name="l_leg_ft">left_leg-eb6-j0_3-strain</elem>
+                <elem name="r_leg_ft">right_leg-eb8-j0_3-strain</elem>
+                <elem name="l_foot_ft">left_leg-eb7-j4_5-strain</elem>
+                <elem name="r_foot_ft">right_leg-eb9-j4_5-strain</elem>
             </paramlist>
         </action>
 

--- a/iCubPrague01/estimators/wholebodydynamics_standup.xml
+++ b/iCubPrague01/estimators/wholebodydynamics_standup.xml
@@ -40,7 +40,7 @@
         
        <group name="FT_SECONDARY_CALIBRATION">
 
-           <param name="r_leg_ft_sensor"> (1.165043e-01,-4.824760e-02,-2.838516e-03,-4.063452e-01,3.829723e+00,-4.049686e+00
+           <param name="r_leg_ft"> (1.165043e-01,-4.824760e-02,-2.838516e-03,-4.063452e-01,3.829723e+00,-4.049686e+00
            ,-1.646781e-02,1.028508e-01,1.218741e-03,-3.860480e+00,6.586313e-02,1.079024e-01
            ,-1.223875e-01,-1.720457e-01,9.950911e-01,-1.332774e+00,4.882303e-01,1.109860e+00
            ,-2.690149e-03,-1.097413e-02,1.942506e-03,9.459466e-01,2.006043e-02,4.074997e-02
@@ -74,12 +74,12 @@
                 <!-- imu -->
                 <elem name="imu">inertial</elem>
                 <!-- ft -->
-                <elem name="l_arm_ft_sensor">left_arm-eb1-j0_3-strain</elem>
-                <elem name="r_arm_ft_sensor">right_arm-eb3-j0_3-strain</elem>
-                <elem name="l_leg_ft_sensor">left_leg-eb6-j0_3-strain</elem>
-                <elem name="r_leg_ft_sensor">right_leg-eb8-j0_3-strain</elem>
-                <elem name="l_foot_ft_sensor">left_leg-eb7-j4_5-strain</elem>
-                <elem name="r_foot_ft_sensor">right_leg-eb9-j4_5-strain</elem>
+                <elem name="l_arm_ft">left_arm-eb1-j0_3-strain</elem>
+                <elem name="r_arm_ft">right_arm-eb3-j0_3-strain</elem>
+                <elem name="l_leg_ft">left_leg-eb6-j0_3-strain</elem>
+                <elem name="r_leg_ft">right_leg-eb8-j0_3-strain</elem>
+                <elem name="l_foot_ft">left_leg-eb7-j4_5-strain</elem>
+                <elem name="r_foot_ft">right_leg-eb9-j4_5-strain</elem>
             </paramlist>
         </action>
 

--- a/iCubPrague01/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/iCubPrague01/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_arm_ft_sensor   </param>
+                    <param name="id">                   l_arm_ft   </param>
                     <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_arm_ft_sensor   </param>
+                <param name="enabledSensors">           l_arm_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubPrague01/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/iCubPrague01/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_leg_ft_sensor   </param>
+                    <param name="id">                   l_leg_ft   </param>
                     <param name="framename">            l_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_leg_ft_sensor   </param>
+                <param name="enabledSensors">           l_leg_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubPrague01/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/iCubPrague01/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_foot_ft_sensor   </param>
+                    <param name="id">                   l_foot_ft   </param>
                     <param name="framename">            l_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_foot_ft_sensor   </param>
+                <param name="enabledSensors">           l_foot_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubPrague01/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/iCubPrague01/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_arm_ft_sensor   </param>
+                    <param name="id">                   r_arm_ft   </param>
                     <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_arm_ft_sensor   </param>
+                <param name="enabledSensors">           r_arm_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubPrague01/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/iCubPrague01/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_leg_ft_sensor   </param>
+                    <param name="id">                   r_leg_ft   </param>
                     <param name="framename">            r_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_leg_ft_sensor   </param>
+                <param name="enabledSensors">           r_leg_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubPrague01/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/iCubPrague01/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_foot_ft_sensor   </param>
+                    <param name="id">                   r_foot_ft   </param>
                     <param name="framename">            r_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_foot_ft_sensor   </param>
+                <param name="enabledSensors">           r_foot_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubPrague01/wrappers/FT/left_leg-FT_remapper.xml
+++ b/iCubPrague01/wrappers/FT/left_leg-FT_remapper.xml
@@ -6,10 +6,10 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (l_leg_ft_sensor l_foot_ft_sensor)
+          (l_leg_ft l_foot_ft)
         </param>
         <param name="TemperatureSensorsNames">
-          (l_leg_ft_sensor l_foot_ft_sensor)
+          (l_leg_ft l_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubPrague01/wrappers/FT/right_leg-FT_remapper.xml
+++ b/iCubPrague01/wrappers/FT/right_leg-FT_remapper.xml
@@ -6,10 +6,10 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (r_leg_ft_sensor r_foot_ft_sensor)
+          (r_leg_ft r_foot_ft)
         </param>
         <param name="TemperatureSensorsNames">
-          (r_leg_ft_sensor r_foot_ft_sensor)
+          (r_leg_ft r_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubShanghai01/estimators/wholebodydynamics.xml
+++ b/iCubShanghai01/estimators/wholebodydynamics.xml
@@ -41,7 +41,7 @@
         </group>
        
         <group name="FT_SECONDARY_CALIBRATION">
-             <param name="l_leg_ft_sensor"> 
+             <param name="l_leg_ft"> 
                    (5.969361e-01,2.428213e-02,-5.463457e-02,4.254463e-01,1.123516e+00,-1.303151e-01 
                     ,-2.818578e-02,6.863783e-01,2.028274e-02,6.585433e-01,1.573658e-01,1.544577e+00 
                     ,-3.915223e-02,3.971615e-02,9.679746e-01,-3.150958e-03,3.718397e-01,-8.653098e-02 
@@ -49,7 +49,7 @@
                     ,5.671831e-03,6.968371e-03,4.892937e-03,5.396529e-02,9.499420e-01,-1.575216e-01 
                     ,3.469447e-18,0,-7.993503e-20,0,0,1.000000e+00)</param>     
 
-             <param name="r_leg_ft_sensor">
+             <param name="r_leg_ft">
                    (7.619710e-01,-9.833019e-02,-5.603709e-02,-7.503703e-01,4.654638e-01,-2.100801e+00 
                    ,2.708629e-02,8.108288e-01,-3.377881e-03,8.122805e-01,4.181660e-02,8.531041e-01 
                    ,-7.067404e-02,-3.179978e-02,9.888732e-01,-4.080758e-02,5.046211e-01,-5.754858e-01 
@@ -86,12 +86,12 @@
                 <!-- imu -->
                 <elem name="imu">inertial</elem>
                 <!-- ft -->
-                <elem name="l_arm_ft_sensor">left_arm-eb1-j0_3-strain</elem>
-                <elem name="r_arm_ft_sensor">right_arm-eb3-j0_3-strain</elem>
-                <elem name="l_leg_ft_sensor">left_leg-eb6-j0_3-strain</elem>
-                <elem name="r_leg_ft_sensor">right_leg-eb8-j0_3-strain</elem>
-                <elem name="l_foot_ft_sensor">left_leg-eb7-j4_5-strain</elem>
-                <elem name="r_foot_ft_sensor">right_leg-eb9-j4_5-strain</elem>
+                <elem name="l_arm_ft">left_arm-eb1-j0_3-strain</elem>
+                <elem name="r_arm_ft">right_arm-eb3-j0_3-strain</elem>
+                <elem name="l_leg_ft">left_leg-eb6-j0_3-strain</elem>
+                <elem name="r_leg_ft">right_leg-eb8-j0_3-strain</elem>
+                <elem name="l_foot_ft">left_leg-eb7-j4_5-strain</elem>
+                <elem name="r_foot_ft">right_leg-eb9-j4_5-strain</elem>
             </paramlist>
         </action>
 

--- a/iCubShanghai01/estimators/wholebodydynamics_standup.xml
+++ b/iCubShanghai01/estimators/wholebodydynamics_standup.xml
@@ -40,7 +40,7 @@
         
        <group name="FT_SECONDARY_CALIBRATION">
 
-           <param name="r_leg_ft_sensor"> (1.165043e-01,-4.824760e-02,-2.838516e-03,-4.063452e-01,3.829723e+00,-4.049686e+00
+           <param name="r_leg_ft"> (1.165043e-01,-4.824760e-02,-2.838516e-03,-4.063452e-01,3.829723e+00,-4.049686e+00
            ,-1.646781e-02,1.028508e-01,1.218741e-03,-3.860480e+00,6.586313e-02,1.079024e-01
            ,-1.223875e-01,-1.720457e-01,9.950911e-01,-1.332774e+00,4.882303e-01,1.109860e+00
            ,-2.690149e-03,-1.097413e-02,1.942506e-03,9.459466e-01,2.006043e-02,4.074997e-02
@@ -74,12 +74,12 @@
                 <!-- imu -->
                 <elem name="imu">inertial</elem>
                 <!-- ft -->
-                <elem name="l_arm_ft_sensor">left_arm-eb1-j0_3-strain</elem>
-                <elem name="r_arm_ft_sensor">right_arm-eb3-j0_3-strain</elem>
-                <elem name="l_leg_ft_sensor">left_leg-eb6-j0_3-strain</elem>
-                <elem name="r_leg_ft_sensor">right_leg-eb8-j0_3-strain</elem>
-                <elem name="l_foot_ft_sensor">left_leg-eb7-j4_5-strain</elem>
-                <elem name="r_foot_ft_sensor">right_leg-eb9-j4_5-strain</elem>
+                <elem name="l_arm_ft">left_arm-eb1-j0_3-strain</elem>
+                <elem name="r_arm_ft">right_arm-eb3-j0_3-strain</elem>
+                <elem name="l_leg_ft">left_leg-eb6-j0_3-strain</elem>
+                <elem name="r_leg_ft">right_leg-eb8-j0_3-strain</elem>
+                <elem name="l_foot_ft">left_leg-eb7-j4_5-strain</elem>
+                <elem name="r_foot_ft">right_leg-eb9-j4_5-strain</elem>
             </paramlist>
         </action>
 

--- a/iCubShanghai01/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/iCubShanghai01/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_arm_ft_sensor   </param>
+                    <param name="id">                   l_arm_ft   </param>
                     <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_arm_ft_sensor   </param>
+                <param name="enabledSensors">           l_arm_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubShanghai01/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/iCubShanghai01/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_leg_ft_sensor   </param>
+                    <param name="id">                   l_leg_ft   </param>
                     <param name="framename">            l_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_leg_ft_sensor   </param>
+                <param name="enabledSensors">           l_leg_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubShanghai01/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/iCubShanghai01/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_foot_ft_sensor   </param>
+                    <param name="id">                   l_foot_ft   </param>
                     <param name="framename">            l_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_foot_ft_sensor   </param>
+                <param name="enabledSensors">           l_foot_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubShanghai01/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/iCubShanghai01/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_arm_ft_sensor   </param>
+                    <param name="id">                   r_arm_ft   </param>
                     <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_arm_ft_sensor   </param>
+                <param name="enabledSensors">           r_arm_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubShanghai01/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/iCubShanghai01/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_leg_ft_sensor   </param>
+                    <param name="id">                   r_leg_ft   </param>
                     <param name="framename">            r_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_leg_ft_sensor   </param>
+                <param name="enabledSensors">           r_leg_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubShanghai01/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/iCubShanghai01/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_foot_ft_sensor   </param>
+                    <param name="id">                   r_foot_ft   </param>
                     <param name="framename">            r_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_foot_ft_sensor   </param>
+                <param name="enabledSensors">           r_foot_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubShanghai01/wrappers/FT/left_leg-FT_remapper.xml
+++ b/iCubShanghai01/wrappers/FT/left_leg-FT_remapper.xml
@@ -6,10 +6,10 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (l_leg_ft_sensor l_foot_ft_sensor)
+          (l_leg_ft l_foot_ft)
         </param>
         <param name="TemperatureSensorsNames">
-          (l_leg_ft_sensor l_foot_ft_sensor)
+          (l_leg_ft l_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubShanghai01/wrappers/FT/right_leg-FT_remapper.xml
+++ b/iCubShanghai01/wrappers/FT/right_leg-FT_remapper.xml
@@ -6,10 +6,10 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (r_leg_ft_sensor r_foot_ft_sensor)
+          (r_leg_ft r_foot_ft)
         </param>
         <param name="TemperatureSensorsNames">
-          (r_leg_ft_sensor r_foot_ft_sensor)
+          (r_leg_ft r_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubShenzhen01/estimators/wholebodydynamics.xml
+++ b/iCubShenzhen01/estimators/wholebodydynamics.xml
@@ -45,7 +45,7 @@
         </group>
        
         <group name="FT_SECONDARY_CALIBRATION">
-             <param name="l_leg_ft_sensor"> 
+             <param name="l_leg_ft"> 
                    (5.969361e-01,2.428213e-02,-5.463457e-02,4.254463e-01,1.123516e+00,-1.303151e-01 
                     ,-2.818578e-02,6.863783e-01,2.028274e-02,6.585433e-01,1.573658e-01,1.544577e+00 
                     ,-3.915223e-02,3.971615e-02,9.679746e-01,-3.150958e-03,3.718397e-01,-8.653098e-02 
@@ -53,7 +53,7 @@
                     ,5.671831e-03,6.968371e-03,4.892937e-03,5.396529e-02,9.499420e-01,-1.575216e-01 
                     ,3.469447e-18,0,-7.993503e-20,0,0,1.000000e+00)</param>     
 
-             <param name="r_leg_ft_sensor">
+             <param name="r_leg_ft">
                    (7.619710e-01,-9.833019e-02,-5.603709e-02,-7.503703e-01,4.654638e-01,-2.100801e+00 
                    ,2.708629e-02,8.108288e-01,-3.377881e-03,8.122805e-01,4.181660e-02,8.531041e-01 
                    ,-7.067404e-02,-3.179978e-02,9.888732e-01,-4.080758e-02,5.046211e-01,-5.754858e-01 
@@ -90,12 +90,12 @@
                 <!-- imu -->
                 <elem name="imu">head-inertial</elem>
                 <!-- ft -->
-                <elem name="l_arm_ft_sensor">left_arm-eb1-j0_3-strain</elem>
-                <elem name="r_arm_ft_sensor">right_arm-eb3-j0_3-strain</elem>
-                <elem name="l_leg_ft_sensor">left_leg-eb6-j0_3-strain</elem>
-                <elem name="r_leg_ft_sensor">right_leg-eb8-j0_3-strain</elem>
-                <elem name="l_foot_ft_sensor">left_leg-eb7-j4_5-strain</elem>
-                <elem name="r_foot_ft_sensor">right_leg-eb9-j4_5-strain</elem>
+                <elem name="l_arm_ft">left_arm-eb1-j0_3-strain</elem>
+                <elem name="r_arm_ft">right_arm-eb3-j0_3-strain</elem>
+                <elem name="l_leg_ft">left_leg-eb6-j0_3-strain</elem>
+                <elem name="r_leg_ft">right_leg-eb8-j0_3-strain</elem>
+                <elem name="l_foot_ft">left_leg-eb7-j4_5-strain</elem>
+                <elem name="r_foot_ft">right_leg-eb9-j4_5-strain</elem>
             </paramlist>
         </action>
 

--- a/iCubShenzhen01/estimators/wholebodydynamics_standup.xml
+++ b/iCubShenzhen01/estimators/wholebodydynamics_standup.xml
@@ -46,7 +46,7 @@
         
        <group name="FT_SECONDARY_CALIBRATION">
 
-           <param name="r_leg_ft_sensor"> (1.165043e-01,-4.824760e-02,-2.838516e-03,-4.063452e-01,3.829723e+00,-4.049686e+00
+           <param name="r_leg_ft"> (1.165043e-01,-4.824760e-02,-2.838516e-03,-4.063452e-01,3.829723e+00,-4.049686e+00
            ,-1.646781e-02,1.028508e-01,1.218741e-03,-3.860480e+00,6.586313e-02,1.079024e-01
            ,-1.223875e-01,-1.720457e-01,9.950911e-01,-1.332774e+00,4.882303e-01,1.109860e+00
            ,-2.690149e-03,-1.097413e-02,1.942506e-03,9.459466e-01,2.006043e-02,4.074997e-02
@@ -80,12 +80,12 @@
                 <!-- imu -->
                 <elem name="imu">head-inertial</elem>
                 <!-- ft -->
-                <elem name="l_arm_ft_sensor">left_arm-eb1-j0_3-strain</elem>
-                <elem name="r_arm_ft_sensor">right_arm-eb3-j0_3-strain</elem>
-                <elem name="l_leg_ft_sensor">left_leg-eb6-j0_3-strain</elem>
-                <elem name="r_leg_ft_sensor">right_leg-eb8-j0_3-strain</elem>
-                <elem name="l_foot_ft_sensor">left_leg-eb7-j4_5-strain</elem>
-                <elem name="r_foot_ft_sensor">right_leg-eb9-j4_5-strain</elem>
+                <elem name="l_arm_ft">left_arm-eb1-j0_3-strain</elem>
+                <elem name="r_arm_ft">right_arm-eb3-j0_3-strain</elem>
+                <elem name="l_leg_ft">left_leg-eb6-j0_3-strain</elem>
+                <elem name="r_leg_ft">right_leg-eb8-j0_3-strain</elem>
+                <elem name="l_foot_ft">left_leg-eb7-j4_5-strain</elem>
+                <elem name="r_foot_ft">right_leg-eb9-j4_5-strain</elem>
             </paramlist>
         </action>
 

--- a/iCubShenzhen01/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/iCubShenzhen01/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_arm_ft_sensor   </param>
+                    <param name="id">                   l_arm_ft   </param>
                     <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_arm_ft_sensor   </param>
+                <param name="enabledSensors">           l_arm_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/iCubShenzhen01/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/iCubShenzhen01/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_leg_ft_sensor   </param>
+                    <param name="id">                   l_leg_ft   </param>
                     <param name="framename">            l_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_leg_ft_sensor   </param>
+                <param name="enabledSensors">           l_leg_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/iCubShenzhen01/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/iCubShenzhen01/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_foot_ft_sensor   </param>
+                    <param name="id">                   l_foot_ft   </param>
                     <param name="framename">            l_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_foot_ft_sensor   </param>
+                <param name="enabledSensors">           l_foot_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/iCubShenzhen01/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/iCubShenzhen01/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_arm_ft_sensor   </param>
+                    <param name="id">                   r_arm_ft   </param>
                     <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_arm_ft_sensor   </param>
+                <param name="enabledSensors">           r_arm_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/iCubShenzhen01/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/iCubShenzhen01/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_leg_ft_sensor   </param>
+                    <param name="id">                   r_leg_ft   </param>
                     <param name="framename">            r_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_leg_ft_sensor   </param>
+                <param name="enabledSensors">           r_leg_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/iCubShenzhen01/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/iCubShenzhen01/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_foot_ft_sensor   </param>
+                    <param name="id">                   r_foot_ft   </param>
                     <param name="framename">            r_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_foot_ft_sensor   </param>
+                <param name="enabledSensors">           r_foot_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/iCubShenzhen01/wrappers/FT/left_leg-FT_remapper.xml
+++ b/iCubShenzhen01/wrappers/FT/left_leg-FT_remapper.xml
@@ -6,7 +6,7 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (l_leg_ft_sensor l_foot_ft_sensor)
+          (l_leg_ft l_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubShenzhen01/wrappers/FT/right_leg-FT_remapper.xml
+++ b/iCubShenzhen01/wrappers/FT/right_leg-FT_remapper.xml
@@ -6,7 +6,7 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (r_leg_ft_sensor r_foot_ft_sensor)
+          (r_leg_ft r_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubSingapore01/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/iCubSingapore01/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_arm_ft_sensor   </param>
+                    <param name="id">                   l_arm_ft   </param>
                     <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_arm_ft_sensor   </param>
+                <param name="enabledSensors">           l_arm_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/iCubSingapore01/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/iCubSingapore01/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_leg_ft_sensor   </param>
+                    <param name="id">                   l_leg_ft   </param>
                     <param name="framename">            l_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_leg_ft_sensor   </param>
+                <param name="enabledSensors">           l_leg_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/iCubSingapore01/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/iCubSingapore01/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_foot_ft_sensor   </param>
+                    <param name="id">                   l_foot_ft   </param>
                     <param name="framename">            l_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:1                  </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_foot_ft_sensor   </param>
+                <param name="enabledSensors">           l_foot_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/iCubSingapore01/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/iCubSingapore01/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_arm_ft_sensor   </param>
+                    <param name="id">                   r_arm_ft   </param>
                     <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_arm_ft_sensor   </param>
+                <param name="enabledSensors">           r_arm_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/iCubSingapore01/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/iCubSingapore01/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_leg_ft_sensor   </param>
+                    <param name="id">                   r_leg_ft   </param>
                     <param name="framename">            r_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_leg_ft_sensor   </param>
+                <param name="enabledSensors">           r_leg_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/iCubSingapore01/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/iCubSingapore01/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_foot_ft_sensor   </param>
+                    <param name="id">                   r_foot_ft   </param>
                     <param name="framename">            r_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:1                  </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_foot_ft_sensor   </param>
+                <param name="enabledSensors">           r_foot_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/iCubSingapore01/wrappers/FT/left_leg-FT_remapper.xml
+++ b/iCubSingapore01/wrappers/FT/left_leg-FT_remapper.xml
@@ -6,7 +6,7 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (l_leg_ft_sensor l_foot_ft_sensor)
+          (l_leg_ft l_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubSingapore01/wrappers/FT/right_leg-FT_remapper.xml
+++ b/iCubSingapore01/wrappers/FT/right_leg-FT_remapper.xml
@@ -6,7 +6,7 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (r_leg_ft_sensor r_foot_ft_sensor)
+          (r_leg_ft r_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubTokyo01/hardware/FT/left_arm_strain.xml
+++ b/iCubTokyo01/hardware/FT/left_arm_strain.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="left_arm_strain">
-    <param name="sensorName"> l_arm_ft_sensor </param>
+    <param name="sensorName"> l_arm_ft </param>
     <param name="frameName"> l_arm_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/iCubTokyo01/hardware/FT/left_leg_strain.xml
+++ b/iCubTokyo01/hardware/FT/left_leg_strain.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="left_leg_strain">
-    <param name="sensorName"> l_leg_ft_sensor </param>
+    <param name="sensorName"> l_leg_ft </param>
     <param name="frameName"> l_leg_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/iCubTokyo01/hardware/FT/right_arm_strain.xml
+++ b/iCubTokyo01/hardware/FT/right_arm_strain.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="right_arm_strain">
-    <param name="sensorName"> r_arm_ft_sensor </param>
+    <param name="sensorName"> r_arm_ft </param>
     <param name="frameName"> r_arm_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/iCubTokyo01/hardware/FT/right_foot_strain.xml
+++ b/iCubTokyo01/hardware/FT/right_foot_strain.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="right_foot_strain">
-    <param name="sensorName"> r_foot_ft_sensor </param>
+    <param name="sensorName"> r_foot_ft </param>
     <param name="frameName"> r_foot_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/iCubTokyo01/hardware/FT/right_leg_strain.xml
+++ b/iCubTokyo01/hardware/FT/right_leg_strain.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="right_leg_strain">
-    <param name="sensorName"> r_leg_ft_sensor </param>
+    <param name="sensorName"> r_leg_ft </param>
     <param name="frameName"> r_leg_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/iCubTokyo01/wrappers/FT/left_leg-FT_remapper.xml
+++ b/iCubTokyo01/wrappers/FT/left_leg-FT_remapper.xml
@@ -6,7 +6,7 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (l_leg_ft_sensor l_foot_ft_sensor)
+          (l_leg_ft l_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubTokyo01/wrappers/FT/right_leg-FT_remapper.xml
+++ b/iCubTokyo01/wrappers/FT/right_leg-FT_remapper.xml
@@ -6,7 +6,7 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (r_leg_ft_sensor r_foot_ft_sensor)
+          (r_leg_ft r_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubValparaiso01/estimators/wholebodydynamics.xml
+++ b/iCubValparaiso01/estimators/wholebodydynamics.xml
@@ -41,7 +41,7 @@
         </group>
        
         <group name="FT_SECONDARY_CALIBRATION">
-             <param name="l_leg_ft_sensor"> 
+             <param name="l_leg_ft"> 
                    (5.969361e-01,2.428213e-02,-5.463457e-02,4.254463e-01,1.123516e+00,-1.303151e-01 
                     ,-2.818578e-02,6.863783e-01,2.028274e-02,6.585433e-01,1.573658e-01,1.544577e+00 
                     ,-3.915223e-02,3.971615e-02,9.679746e-01,-3.150958e-03,3.718397e-01,-8.653098e-02 
@@ -49,7 +49,7 @@
                     ,5.671831e-03,6.968371e-03,4.892937e-03,5.396529e-02,9.499420e-01,-1.575216e-01 
                     ,3.469447e-18,0,-7.993503e-20,0,0,1.000000e+00)</param>     
 
-             <param name="r_leg_ft_sensor">
+             <param name="r_leg_ft">
                    (7.619710e-01,-9.833019e-02,-5.603709e-02,-7.503703e-01,4.654638e-01,-2.100801e+00 
                    ,2.708629e-02,8.108288e-01,-3.377881e-03,8.122805e-01,4.181660e-02,8.531041e-01 
                    ,-7.067404e-02,-3.179978e-02,9.888732e-01,-4.080758e-02,5.046211e-01,-5.754858e-01 
@@ -86,12 +86,12 @@
                 <!-- imu -->
                 <elem name="imu">inertial</elem>
                 <!-- ft -->
-                <elem name="l_arm_ft_sensor">left_arm-eb1-j0_3-strain</elem>
-                <elem name="r_arm_ft_sensor">right_arm-eb3-j0_3-strain</elem>
-                <elem name="l_leg_ft_sensor">left_leg-eb6-j0_3-strain</elem>
-                <elem name="r_leg_ft_sensor">right_leg-eb8-j0_3-strain</elem>
-                <elem name="l_foot_ft_sensor">left_leg-eb7-j4_5-strain</elem>
-                <elem name="r_foot_ft_sensor">right_leg-eb9-j4_5-strain</elem>
+                <elem name="l_arm_ft">left_arm-eb1-j0_3-strain</elem>
+                <elem name="r_arm_ft">right_arm-eb3-j0_3-strain</elem>
+                <elem name="l_leg_ft">left_leg-eb6-j0_3-strain</elem>
+                <elem name="r_leg_ft">right_leg-eb8-j0_3-strain</elem>
+                <elem name="l_foot_ft">left_leg-eb7-j4_5-strain</elem>
+                <elem name="r_foot_ft">right_leg-eb9-j4_5-strain</elem>
             </paramlist>
         </action>
 

--- a/iCubValparaiso01/estimators/wholebodydynamics_standup.xml
+++ b/iCubValparaiso01/estimators/wholebodydynamics_standup.xml
@@ -40,7 +40,7 @@
         
        <group name="FT_SECONDARY_CALIBRATION">
 
-           <param name="r_leg_ft_sensor"> (1.165043e-01,-4.824760e-02,-2.838516e-03,-4.063452e-01,3.829723e+00,-4.049686e+00
+           <param name="r_leg_ft"> (1.165043e-01,-4.824760e-02,-2.838516e-03,-4.063452e-01,3.829723e+00,-4.049686e+00
            ,-1.646781e-02,1.028508e-01,1.218741e-03,-3.860480e+00,6.586313e-02,1.079024e-01
            ,-1.223875e-01,-1.720457e-01,9.950911e-01,-1.332774e+00,4.882303e-01,1.109860e+00
            ,-2.690149e-03,-1.097413e-02,1.942506e-03,9.459466e-01,2.006043e-02,4.074997e-02
@@ -74,12 +74,12 @@
                 <!-- imu -->
                 <elem name="imu">inertial</elem>
                 <!-- ft -->
-                <elem name="l_arm_ft_sensor">left_arm-eb1-j0_3-strain</elem>
-                <elem name="r_arm_ft_sensor">right_arm-eb3-j0_3-strain</elem>
-                <elem name="l_leg_ft_sensor">left_leg-eb6-j0_3-strain</elem>
-                <elem name="r_leg_ft_sensor">right_leg-eb8-j0_3-strain</elem>
-                <elem name="l_foot_ft_sensor">left_leg-eb7-j4_5-strain</elem>
-                <elem name="r_foot_ft_sensor">right_leg-eb9-j4_5-strain</elem>
+                <elem name="l_arm_ft">left_arm-eb1-j0_3-strain</elem>
+                <elem name="r_arm_ft">right_arm-eb3-j0_3-strain</elem>
+                <elem name="l_leg_ft">left_leg-eb6-j0_3-strain</elem>
+                <elem name="r_leg_ft">right_leg-eb8-j0_3-strain</elem>
+                <elem name="l_foot_ft">left_leg-eb7-j4_5-strain</elem>
+                <elem name="r_foot_ft">right_leg-eb9-j4_5-strain</elem>
             </paramlist>
         </action>
 

--- a/iCubValparaiso01/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/iCubValparaiso01/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_arm_ft_sensor   </param>
+                    <param name="id">                   l_arm_ft   </param>
                     <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_arm_ft_sensor   </param>
+                <param name="enabledSensors">           l_arm_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubValparaiso01/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/iCubValparaiso01/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_leg_ft_sensor   </param>
+                    <param name="id">                   l_leg_ft   </param>
                     <param name="framename">            l_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_leg_ft_sensor   </param>
+                <param name="enabledSensors">           l_leg_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubValparaiso01/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/iCubValparaiso01/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_foot_ft_sensor   </param>
+                    <param name="id">                   l_foot_ft   </param>
                     <param name="framename">            l_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_foot_ft_sensor   </param>
+                <param name="enabledSensors">           l_foot_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubValparaiso01/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/iCubValparaiso01/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_arm_ft_sensor   </param>
+                    <param name="id">                   r_arm_ft   </param>
                     <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_arm_ft_sensor   </param>
+                <param name="enabledSensors">           r_arm_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubValparaiso01/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/iCubValparaiso01/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_leg_ft_sensor   </param>
+                    <param name="id">                   r_leg_ft   </param>
                     <param name="framename">            r_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_leg_ft_sensor   </param>
+                <param name="enabledSensors">           r_leg_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubValparaiso01/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/iCubValparaiso01/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_foot_ft_sensor   </param>
+                    <param name="id">                   r_foot_ft   </param>
                     <param name="framename">            r_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_foot_ft_sensor   </param>
+                <param name="enabledSensors">           r_foot_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubValparaiso01/wrappers/FT/left_leg-FT_remapper.xml
+++ b/iCubValparaiso01/wrappers/FT/left_leg-FT_remapper.xml
@@ -6,10 +6,10 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (l_leg_ft_sensor l_foot_ft_sensor)
+          (l_leg_ft l_foot_ft)
         </param>
         <param name="TemperatureSensorsNames">
-          (l_leg_ft_sensor l_foot_ft_sensor)
+          (l_leg_ft l_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubValparaiso01/wrappers/FT/right_leg-FT_remapper.xml
+++ b/iCubValparaiso01/wrappers/FT/right_leg-FT_remapper.xml
@@ -6,10 +6,10 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (r_leg_ft_sensor r_foot_ft_sensor)
+          (r_leg_ft r_foot_ft)
         </param>
         <param name="TemperatureSensorsNames">
-          (r_leg_ft_sensor r_foot_ft_sensor)
+          (r_leg_ft r_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubWaterloo01/estimators/wholebodydynamics.xml
+++ b/iCubWaterloo01/estimators/wholebodydynamics.xml
@@ -41,7 +41,7 @@
         </group>
        
         <group name="FT_SECONDARY_CALIBRATION">
-             <param name="l_leg_ft_sensor"> 
+             <param name="l_leg_ft"> 
                    (5.969361e-01,2.428213e-02,-5.463457e-02,4.254463e-01,1.123516e+00,-1.303151e-01 
                     ,-2.818578e-02,6.863783e-01,2.028274e-02,6.585433e-01,1.573658e-01,1.544577e+00 
                     ,-3.915223e-02,3.971615e-02,9.679746e-01,-3.150958e-03,3.718397e-01,-8.653098e-02 
@@ -49,7 +49,7 @@
                     ,5.671831e-03,6.968371e-03,4.892937e-03,5.396529e-02,9.499420e-01,-1.575216e-01 
                     ,3.469447e-18,0,-7.993503e-20,0,0,1.000000e+00)</param>     
 
-             <param name="r_leg_ft_sensor">
+             <param name="r_leg_ft">
                    (7.619710e-01,-9.833019e-02,-5.603709e-02,-7.503703e-01,4.654638e-01,-2.100801e+00 
                    ,2.708629e-02,8.108288e-01,-3.377881e-03,8.122805e-01,4.181660e-02,8.531041e-01 
                    ,-7.067404e-02,-3.179978e-02,9.888732e-01,-4.080758e-02,5.046211e-01,-5.754858e-01 
@@ -86,12 +86,12 @@
                 <!-- imu -->
                 <elem name="imu">inertial</elem>
                 <!-- ft -->
-                <elem name="l_arm_ft_sensor">left_arm-eb1-j0_3-strain</elem>
-                <elem name="r_arm_ft_sensor">right_arm-eb3-j0_3-strain</elem>
-                <elem name="l_leg_ft_sensor">left_leg-eb6-j0_3-strain</elem>
-                <elem name="r_leg_ft_sensor">right_leg-eb8-j0_3-strain</elem>
-                <elem name="l_foot_ft_sensor">left_leg-eb7-j4_5-strain</elem>
-                <elem name="r_foot_ft_sensor">right_leg-eb9-j4_5-strain</elem>
+                <elem name="l_arm_ft">left_arm-eb1-j0_3-strain</elem>
+                <elem name="r_arm_ft">right_arm-eb3-j0_3-strain</elem>
+                <elem name="l_leg_ft">left_leg-eb6-j0_3-strain</elem>
+                <elem name="r_leg_ft">right_leg-eb8-j0_3-strain</elem>
+                <elem name="l_foot_ft">left_leg-eb7-j4_5-strain</elem>
+                <elem name="r_foot_ft">right_leg-eb9-j4_5-strain</elem>
             </paramlist>
         </action>
 

--- a/iCubWaterloo01/estimators/wholebodydynamics_standup.xml
+++ b/iCubWaterloo01/estimators/wholebodydynamics_standup.xml
@@ -40,7 +40,7 @@
         
        <group name="FT_SECONDARY_CALIBRATION">
 
-           <param name="r_leg_ft_sensor"> (1.165043e-01,-4.824760e-02,-2.838516e-03,-4.063452e-01,3.829723e+00,-4.049686e+00
+           <param name="r_leg_ft"> (1.165043e-01,-4.824760e-02,-2.838516e-03,-4.063452e-01,3.829723e+00,-4.049686e+00
            ,-1.646781e-02,1.028508e-01,1.218741e-03,-3.860480e+00,6.586313e-02,1.079024e-01
            ,-1.223875e-01,-1.720457e-01,9.950911e-01,-1.332774e+00,4.882303e-01,1.109860e+00
            ,-2.690149e-03,-1.097413e-02,1.942506e-03,9.459466e-01,2.006043e-02,4.074997e-02
@@ -74,12 +74,12 @@
                 <!-- imu -->
                 <elem name="imu">inertial</elem>
                 <!-- ft -->
-                <elem name="l_arm_ft_sensor">left_arm-eb1-j0_3-strain</elem>
-                <elem name="r_arm_ft_sensor">right_arm-eb3-j0_3-strain</elem>
-                <elem name="l_leg_ft_sensor">left_leg-eb6-j0_3-strain</elem>
-                <elem name="r_leg_ft_sensor">right_leg-eb8-j0_3-strain</elem>
-                <elem name="l_foot_ft_sensor">left_leg-eb7-j4_5-strain</elem>
-                <elem name="r_foot_ft_sensor">right_leg-eb9-j4_5-strain</elem>
+                <elem name="l_arm_ft">left_arm-eb1-j0_3-strain</elem>
+                <elem name="r_arm_ft">right_arm-eb3-j0_3-strain</elem>
+                <elem name="l_leg_ft">left_leg-eb6-j0_3-strain</elem>
+                <elem name="r_leg_ft">right_leg-eb8-j0_3-strain</elem>
+                <elem name="l_foot_ft">left_leg-eb7-j4_5-strain</elem>
+                <elem name="r_foot_ft">right_leg-eb9-j4_5-strain</elem>
             </paramlist>
         </action>
 

--- a/iCubWaterloo01/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/iCubWaterloo01/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_arm_ft_sensor   </param>
+                    <param name="id">                   l_arm_ft   </param>
                     <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_arm_ft_sensor   </param>
+                <param name="enabledSensors">           l_arm_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubWaterloo01/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/iCubWaterloo01/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_leg_ft_sensor   </param>
+                    <param name="id">                   l_leg_ft   </param>
                     <param name="framename">            l_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_leg_ft_sensor   </param>
+                <param name="enabledSensors">           l_leg_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubWaterloo01/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/iCubWaterloo01/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_foot_ft_sensor   </param>
+                    <param name="id">                   l_foot_ft   </param>
                     <param name="framename">            l_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_foot_ft_sensor   </param>
+                <param name="enabledSensors">           l_foot_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubWaterloo01/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/iCubWaterloo01/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_arm_ft_sensor   </param>
+                    <param name="id">                   r_arm_ft   </param>
                     <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_arm_ft_sensor   </param>
+                <param name="enabledSensors">           r_arm_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubWaterloo01/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/iCubWaterloo01/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_leg_ft_sensor   </param>
+                    <param name="id">                   r_leg_ft   </param>
                     <param name="framename">            r_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_leg_ft_sensor   </param>
+                <param name="enabledSensors">           r_leg_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubWaterloo01/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/iCubWaterloo01/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_foot_ft_sensor   </param>
+                    <param name="id">                   r_foot_ft   </param>
                     <param name="framename">            r_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_foot_ft_sensor   </param>
+                <param name="enabledSensors">           r_foot_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubWaterloo01/wrappers/FT/left_leg-FT_remapper.xml
+++ b/iCubWaterloo01/wrappers/FT/left_leg-FT_remapper.xml
@@ -6,10 +6,10 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (l_leg_ft_sensor l_foot_ft_sensor)
+          (l_leg_ft l_foot_ft)
         </param>
         <param name="TemperatureSensorsNames">
-          (l_leg_ft_sensor l_foot_ft_sensor)
+          (l_leg_ft l_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubWaterloo01/wrappers/FT/right_leg-FT_remapper.xml
+++ b/iCubWaterloo01/wrappers/FT/right_leg-FT_remapper.xml
@@ -6,10 +6,10 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (r_leg_ft_sensor r_foot_ft_sensor)
+          (r_leg_ft r_foot_ft)
         </param>
         <param name="TemperatureSensorsNames">
-          (r_leg_ft_sensor r_foot_ft_sensor)
+          (r_leg_ft r_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubZagreb01/estimators/wholebodydynamics.xml
+++ b/iCubZagreb01/estimators/wholebodydynamics.xml
@@ -41,7 +41,7 @@
         </group>
        
         <group name="FT_SECONDARY_CALIBRATION">
-             <param name="l_leg_ft_sensor"> 
+             <param name="l_leg_ft"> 
                    (5.969361e-01,2.428213e-02,-5.463457e-02,4.254463e-01,1.123516e+00,-1.303151e-01 
                     ,-2.818578e-02,6.863783e-01,2.028274e-02,6.585433e-01,1.573658e-01,1.544577e+00 
                     ,-3.915223e-02,3.971615e-02,9.679746e-01,-3.150958e-03,3.718397e-01,-8.653098e-02 
@@ -49,7 +49,7 @@
                     ,5.671831e-03,6.968371e-03,4.892937e-03,5.396529e-02,9.499420e-01,-1.575216e-01 
                     ,3.469447e-18,0,-7.993503e-20,0,0,1.000000e+00)</param>     
 
-             <param name="r_leg_ft_sensor">
+             <param name="r_leg_ft">
                    (7.619710e-01,-9.833019e-02,-5.603709e-02,-7.503703e-01,4.654638e-01,-2.100801e+00 
                    ,2.708629e-02,8.108288e-01,-3.377881e-03,8.122805e-01,4.181660e-02,8.531041e-01 
                    ,-7.067404e-02,-3.179978e-02,9.888732e-01,-4.080758e-02,5.046211e-01,-5.754858e-01 
@@ -86,12 +86,12 @@
                 <!-- imu -->
                 <elem name="imu">inertial</elem>
                 <!-- ft -->
-                <elem name="l_arm_ft_sensor">left_arm-eb1-j0_3-strain</elem>
-                <elem name="r_arm_ft_sensor">right_arm-eb3-j0_3-strain</elem>
-                <elem name="l_leg_ft_sensor">left_leg-eb6-j0_3-strain</elem>
-                <elem name="r_leg_ft_sensor">right_leg-eb8-j0_3-strain</elem>
-                <elem name="l_foot_ft_sensor">left_leg-eb7-j4_5-strain</elem>
-                <elem name="r_foot_ft_sensor">right_leg-eb9-j4_5-strain</elem>
+                <elem name="l_arm_ft">left_arm-eb1-j0_3-strain</elem>
+                <elem name="r_arm_ft">right_arm-eb3-j0_3-strain</elem>
+                <elem name="l_leg_ft">left_leg-eb6-j0_3-strain</elem>
+                <elem name="r_leg_ft">right_leg-eb8-j0_3-strain</elem>
+                <elem name="l_foot_ft">left_leg-eb7-j4_5-strain</elem>
+                <elem name="r_foot_ft">right_leg-eb9-j4_5-strain</elem>
             </paramlist>
         </action>
 

--- a/iCubZagreb01/estimators/wholebodydynamics_standup.xml
+++ b/iCubZagreb01/estimators/wholebodydynamics_standup.xml
@@ -40,7 +40,7 @@
         
        <group name="FT_SECONDARY_CALIBRATION">
 
-           <param name="r_leg_ft_sensor"> (1.165043e-01,-4.824760e-02,-2.838516e-03,-4.063452e-01,3.829723e+00,-4.049686e+00
+           <param name="r_leg_ft"> (1.165043e-01,-4.824760e-02,-2.838516e-03,-4.063452e-01,3.829723e+00,-4.049686e+00
            ,-1.646781e-02,1.028508e-01,1.218741e-03,-3.860480e+00,6.586313e-02,1.079024e-01
            ,-1.223875e-01,-1.720457e-01,9.950911e-01,-1.332774e+00,4.882303e-01,1.109860e+00
            ,-2.690149e-03,-1.097413e-02,1.942506e-03,9.459466e-01,2.006043e-02,4.074997e-02
@@ -74,12 +74,12 @@
                 <!-- imu -->
                 <elem name="imu">inertial</elem>
                 <!-- ft -->
-                <elem name="l_arm_ft_sensor">left_arm-eb1-j0_3-strain</elem>
-                <elem name="r_arm_ft_sensor">right_arm-eb3-j0_3-strain</elem>
-                <elem name="l_leg_ft_sensor">left_leg-eb6-j0_3-strain</elem>
-                <elem name="r_leg_ft_sensor">right_leg-eb8-j0_3-strain</elem>
-                <elem name="l_foot_ft_sensor">left_leg-eb7-j4_5-strain</elem>
-                <elem name="r_foot_ft_sensor">right_leg-eb9-j4_5-strain</elem>
+                <elem name="l_arm_ft">left_arm-eb1-j0_3-strain</elem>
+                <elem name="r_arm_ft">right_arm-eb3-j0_3-strain</elem>
+                <elem name="l_leg_ft">left_leg-eb6-j0_3-strain</elem>
+                <elem name="r_leg_ft">right_leg-eb8-j0_3-strain</elem>
+                <elem name="l_foot_ft">left_leg-eb7-j4_5-strain</elem>
+                <elem name="r_foot_ft">right_leg-eb9-j4_5-strain</elem>
             </paramlist>
         </action>
 

--- a/iCubZagreb01/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/iCubZagreb01/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_arm_ft_sensor   </param>
+                    <param name="id">                   l_arm_ft   </param>
                     <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_arm_ft_sensor   </param>
+                <param name="enabledSensors">           l_arm_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubZagreb01/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/iCubZagreb01/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_leg_ft_sensor   </param>
+                    <param name="id">                   l_leg_ft   </param>
                     <param name="framename">            l_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_leg_ft_sensor   </param>
+                <param name="enabledSensors">           l_leg_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubZagreb01/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/iCubZagreb01/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_foot_ft_sensor   </param>
+                    <param name="id">                   l_foot_ft   </param>
                     <param name="framename">            l_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_foot_ft_sensor   </param>
+                <param name="enabledSensors">           l_foot_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubZagreb01/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/iCubZagreb01/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_arm_ft_sensor   </param>
+                    <param name="id">                   r_arm_ft   </param>
                     <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_arm_ft_sensor   </param>
+                <param name="enabledSensors">           r_arm_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubZagreb01/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/iCubZagreb01/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_leg_ft_sensor   </param>
+                    <param name="id">                   r_leg_ft   </param>
                     <param name="framename">            r_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_leg_ft_sensor   </param>
+                <param name="enabledSensors">           r_leg_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubZagreb01/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/iCubZagreb01/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_foot_ft_sensor   </param>
+                    <param name="id">                   r_foot_ft   </param>
                     <param name="framename">            r_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_foot_ft_sensor   </param>
+                <param name="enabledSensors">           r_foot_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/iCubZagreb01/wrappers/FT/left_leg-FT_remapper.xml
+++ b/iCubZagreb01/wrappers/FT/left_leg-FT_remapper.xml
@@ -6,10 +6,10 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (l_leg_ft_sensor l_foot_ft_sensor)
+          (l_leg_ft l_foot_ft)
         </param>
         <param name="TemperatureSensorsNames">
-          (l_leg_ft_sensor l_foot_ft_sensor)
+          (l_leg_ft l_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubZagreb01/wrappers/FT/right_leg-FT_remapper.xml
+++ b/iCubZagreb01/wrappers/FT/right_leg-FT_remapper.xml
@@ -6,10 +6,10 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (r_leg_ft_sensor r_foot_ft_sensor)
+          (r_leg_ft r_foot_ft)
         </param>
         <param name="TemperatureSensorsNames">
-          (r_leg_ft_sensor r_foot_ft_sensor)
+          (r_leg_ft r_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/robots-icebox/iCubAberystwyth01/hardware/FT/left_arm_strain.xml
+++ b/robots-icebox/iCubAberystwyth01/hardware/FT/left_arm_strain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="left_arm_strain">
-    <param name="sensorName"> l_arm_ft_sensor </param>
+    <param name="sensorName"> l_arm_ft </param>
     <param name="frameName"> l_arm_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubAberystwyth01/hardware/FT/left_leg_strain.xml
+++ b/robots-icebox/iCubAberystwyth01/hardware/FT/left_leg_strain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="left_leg_strain">
-    <param name="sensorName"> l_leg_ft_sensor </param>
+    <param name="sensorName"> l_leg_ft </param>
     <param name="frameName"> l_leg_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubAberystwyth01/hardware/FT/right_arm_strain.xml
+++ b/robots-icebox/iCubAberystwyth01/hardware/FT/right_arm_strain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="right_arm_strain">
-    <param name="sensorName"> r_arm_ft_sensor </param>
+    <param name="sensorName"> r_arm_ft </param>
     <param name="frameName"> r_arm_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubAberystwyth01/hardware/FT/right_foot_strain.xml
+++ b/robots-icebox/iCubAberystwyth01/hardware/FT/right_foot_strain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="right_foot_strain">
-    <param name="sensorName"> r_foot_ft_sensor </param>
+    <param name="sensorName"> r_foot_ft </param>
     <param name="frameName"> r_foot_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubAberystwyth01/hardware/FT/right_leg_strain.xml
+++ b/robots-icebox/iCubAberystwyth01/hardware/FT/right_leg_strain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="right_leg_strain">
-    <param name="sensorName"> r_leg_ft_sensor </param>
+    <param name="sensorName"> r_leg_ft </param>
     <param name="frameName"> r_leg_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubAberystwyth01/wrappers/FT/left_leg-FT_remapper.xml
+++ b/robots-icebox/iCubAberystwyth01/wrappers/FT/left_leg-FT_remapper.xml
@@ -6,7 +6,7 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (l_leg_ft_sensor l_foot_ft_sensor)
+          (l_leg_ft l_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/robots-icebox/iCubAberystwyth01/wrappers/FT/right_leg-FT_remapper.xml
+++ b/robots-icebox/iCubAberystwyth01/wrappers/FT/right_leg-FT_remapper.xml
@@ -6,7 +6,7 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (r_leg_ft_sensor r_foot_ft_sensor)
+          (r_leg_ft r_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/robots-icebox/iCubAnkara01/hardware/FT/left_arm_strain.xml
+++ b/robots-icebox/iCubAnkara01/hardware/FT/left_arm_strain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="left_arm_strain">
-    <param name="sensorName"> l_arm_ft_sensor </param>
+    <param name="sensorName"> l_arm_ft </param>
     <param name="frameName"> l_arm_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubAnkara01/hardware/FT/left_leg_strain.xml
+++ b/robots-icebox/iCubAnkara01/hardware/FT/left_leg_strain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="left_leg_strain">
-    <param name="sensorName"> l_leg_ft_sensor </param>
+    <param name="sensorName"> l_leg_ft </param>
     <param name="frameName"> l_leg_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubAnkara01/hardware/FT/right_arm_strain.xml
+++ b/robots-icebox/iCubAnkara01/hardware/FT/right_arm_strain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="right_arm_strain">
-    <param name="sensorName"> r_arm_ft_sensor </param>
+    <param name="sensorName"> r_arm_ft </param>
     <param name="frameName"> r_arm_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubAnkara01/hardware/FT/right_foot_strain.xml
+++ b/robots-icebox/iCubAnkara01/hardware/FT/right_foot_strain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="right_foot_strain">
-    <param name="sensorName"> r_foot_ft_sensor </param>
+    <param name="sensorName"> r_foot_ft </param>
     <param name="frameName"> r_foot_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubAnkara01/hardware/FT/right_leg_strain.xml
+++ b/robots-icebox/iCubAnkara01/hardware/FT/right_leg_strain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="right_leg_strain">
-    <param name="sensorName"> r_leg_ft_sensor </param>
+    <param name="sensorName"> r_leg_ft </param>
     <param name="frameName"> r_leg_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubAnkara01/wrappers/FT/left_leg-FT_remapper.xml
+++ b/robots-icebox/iCubAnkara01/wrappers/FT/left_leg-FT_remapper.xml
@@ -6,7 +6,7 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (l_leg_ft_sensor l_foot_ft_sensor)
+          (l_leg_ft l_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/robots-icebox/iCubAnkara01/wrappers/FT/right_leg-FT_remapper.xml
+++ b/robots-icebox/iCubAnkara01/wrappers/FT/right_leg-FT_remapper.xml
@@ -6,7 +6,7 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (r_leg_ft_sensor r_foot_ft_sensor)
+          (r_leg_ft r_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/robots-icebox/iCubBarcelona01/hardware/FT/left_arm_strain.xml
+++ b/robots-icebox/iCubBarcelona01/hardware/FT/left_arm_strain.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="left_arm_strain">
-    <param name="sensorName"> l_arm_ft_sensor </param>
+    <param name="sensorName"> l_arm_ft </param>
     <param name="frameName"> l_arm_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubBarcelona01/hardware/FT/left_leg_strain.xml
+++ b/robots-icebox/iCubBarcelona01/hardware/FT/left_leg_strain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="left_leg_strain">
-    <param name="sensorName"> l_leg_ft_sensor </param>
+    <param name="sensorName"> l_leg_ft </param>
     <param name="frameName"> l_leg_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubBarcelona01/hardware/FT/right_arm_strain.xml
+++ b/robots-icebox/iCubBarcelona01/hardware/FT/right_arm_strain.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="right_arm_strain">
-    <param name="sensorName"> r_arm_ft_sensor </param>
+    <param name="sensorName"> r_arm_ft </param>
     <param name="frameName"> r_arm_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubBarcelona01/hardware/FT/right_foot_strain.xml
+++ b/robots-icebox/iCubBarcelona01/hardware/FT/right_foot_strain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="right_foot_strain">
-    <param name="sensorName"> r_foot_ft_sensor </param>
+    <param name="sensorName"> r_foot_ft </param>
     <param name="frameName"> r_foot_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubBarcelona01/hardware/FT/right_leg_strain.xml
+++ b/robots-icebox/iCubBarcelona01/hardware/FT/right_leg_strain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="right_leg_strain">
-    <param name="sensorName"> r_leg_ft_sensor </param>
+    <param name="sensorName"> r_leg_ft </param>
     <param name="frameName"> r_leg_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubBarcelona01/wrappers/FT/left_leg-FT_remapper.xml
+++ b/robots-icebox/iCubBarcelona01/wrappers/FT/left_leg-FT_remapper.xml
@@ -6,7 +6,7 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (l_leg_ft_sensor l_foot_ft_sensor)
+          (l_leg_ft l_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/robots-icebox/iCubBarcelona01/wrappers/FT/right_leg-FT_remapper.xml
+++ b/robots-icebox/iCubBarcelona01/wrappers/FT/right_leg-FT_remapper.xml
@@ -6,7 +6,7 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (r_leg_ft_sensor r_foot_ft_sensor)
+          (r_leg_ft r_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/robots-icebox/iCubChemnitz01/estimators/wholebodydynamics.xml
+++ b/robots-icebox/iCubChemnitz01/estimators/wholebodydynamics.xml
@@ -46,7 +46,7 @@
         </group>
 
         <group name="FT_SECONDARY_CALIBRATION">
-            <param name="l_leg_ft_sensor">
+            <param name="l_leg_ft">
                    (7.425024e-01,5.604686e-02,-4.408041e-02,3.727271e-01,6.718566e-01,2.605184e-01
                     ,2.376318e-02,4.601413e-01,9.920935e-03,-8.951425e-01,-1.167558e-01,1.971860e+00
                     ,-7.972684e-02,-2.326263e-01,9.977213e-01,-1.405751e+00,3.249553e-01,-1.666625e+00
@@ -55,7 +55,7 @@
                     ,1.979480e-03,1.733975e-04,-3.815689e-05,-1.993212e-02,-1.673455e-02,9.158948e-01)
 	    </param>
 
-            <param name="r_leg_ft_sensor">
+            <param name="r_leg_ft">
                     (9.308601e-01,7.328130e-03,-1.211788e-02,-1.123839e-01,-2.977943e-01,-1.954805e-02
                     ,-8.177519e-02,7.160387e-01,-4.158542e-02,1.077732e+00,4.997348e-01,2.431916e+00
                     ,-4.174433e-02,-1.784640e-01,9.661752e-01,-1.386611e+00,1.538259e-01,-5.603641e-01
@@ -95,12 +95,12 @@
                 <!-- imu_waist -->
 <!--            <elem name="imu">xsensmt-inertial</elem> -->
                 <!-- ft -->
-                <elem name="l_arm_ft_sensor">left_arm-eb1-j0_3-strain</elem>
-                <elem name="r_arm_ft_sensor">right_arm-eb3-j0_3-strain</elem>
-                <elem name="l_leg_ft_sensor">left_leg-eb6-j0_3-strain</elem>
-                <elem name="r_leg_ft_sensor">right_leg-eb8-j0_3-strain</elem>
-                <elem name="l_foot_ft_sensor">left_leg-eb7-j4_5-strain</elem>
-                <elem name="r_foot_ft_sensor">right_leg-eb9-j4_5-strain</elem>
+                <elem name="l_arm_ft">left_arm-eb1-j0_3-strain</elem>
+                <elem name="r_arm_ft">right_arm-eb3-j0_3-strain</elem>
+                <elem name="l_leg_ft">left_leg-eb6-j0_3-strain</elem>
+                <elem name="r_leg_ft">right_leg-eb8-j0_3-strain</elem>
+                <elem name="l_foot_ft">left_leg-eb7-j4_5-strain</elem>
+                <elem name="r_foot_ft">right_leg-eb9-j4_5-strain</elem>
             </paramlist>
         </action>
 

--- a/robots-icebox/iCubChemnitz01/estimators/wholebodydynamics_standup.xml
+++ b/robots-icebox/iCubChemnitz01/estimators/wholebodydynamics_standup.xml
@@ -46,7 +46,7 @@
         </group>
        
         <group name="FT_SECONDARY_CALIBRATION">
-             <param name="l_leg_ft_sensor"> 
+             <param name="l_leg_ft"> 
                    (5.969361e-01,2.428213e-02,-5.463457e-02,4.254463e-01,1.123516e+00,-1.303151e-01 
                     ,-2.818578e-02,6.863783e-01,2.028274e-02,6.585433e-01,1.573658e-01,1.544577e+00 
                     ,-3.915223e-02,3.971615e-02,9.679746e-01,-3.150958e-03,3.718397e-01,-8.653098e-02 
@@ -54,7 +54,7 @@
                     ,5.671831e-03,6.968371e-03,4.892937e-03,5.396529e-02,9.499420e-01,-1.575216e-01 
                     ,3.469447e-18,0,-7.993503e-20,0,0,1.000000e+00)</param>     
 
-             <param name="r_leg_ft_sensor">
+             <param name="r_leg_ft">
                    (7.619710e-01,-9.833019e-02,-5.603709e-02,-7.503703e-01,4.654638e-01,-2.100801e+00 
                    ,2.708629e-02,8.108288e-01,-3.377881e-03,8.122805e-01,4.181660e-02,8.531041e-01 
                    ,-7.067404e-02,-3.179978e-02,9.888732e-01,-4.080758e-02,5.046211e-01,-5.754858e-01 
@@ -91,12 +91,12 @@
                 <!-- imu -->
                 <elem name="imu">head-inertial</elem>
                 <!-- ft -->
-                <elem name="l_arm_ft_sensor">left_arm-eb1-j0_3-strain</elem>
-                <elem name="r_arm_ft_sensor">right_arm-eb3-j0_3-strain</elem>
-                <elem name="l_leg_ft_sensor">left_leg-eb6-j0_3-strain</elem>
-                <elem name="r_leg_ft_sensor">right_leg-eb8-j0_3-strain</elem>
-                <elem name="l_foot_ft_sensor">left_leg-eb7-j4_5-strain</elem>
-                <elem name="r_foot_ft_sensor">right_leg-eb9-j4_5-strain</elem>
+                <elem name="l_arm_ft">left_arm-eb1-j0_3-strain</elem>
+                <elem name="r_arm_ft">right_arm-eb3-j0_3-strain</elem>
+                <elem name="l_leg_ft">left_leg-eb6-j0_3-strain</elem>
+                <elem name="r_leg_ft">right_leg-eb8-j0_3-strain</elem>
+                <elem name="l_foot_ft">left_leg-eb7-j4_5-strain</elem>
+                <elem name="r_foot_ft">right_leg-eb9-j4_5-strain</elem>
             </paramlist>
         </action>
 

--- a/robots-icebox/iCubChemnitz01/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/robots-icebox/iCubChemnitz01/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_arm_ft_sensor   </param>
+                    <param name="id">                   r_arm_ft   </param>
                     <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_arm_ft_sensor   </param>
+                <param name="enabledSensors">           r_arm_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/robots-icebox/iCubDarmstadt01/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/robots-icebox/iCubDarmstadt01/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_arm_ft_sensor   </param>
+                    <param name="id">                   l_arm_ft   </param>
                     <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_arm_ft_sensor   </param>
+                <param name="enabledSensors">           l_arm_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/robots-icebox/iCubDarmstadt01/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/robots-icebox/iCubDarmstadt01/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_leg_ft_sensor   </param>
+                    <param name="id">                   l_leg_ft   </param>
                     <param name="framename">            l_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_leg_ft_sensor   </param>
+                <param name="enabledSensors">           l_leg_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/robots-icebox/iCubDarmstadt01/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/robots-icebox/iCubDarmstadt01/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_foot_ft_sensor   </param>
+                    <param name="id">                   l_foot_ft   </param>
                     <param name="framename">            l_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:1                  </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_foot_ft_sensor   </param>
+                <param name="enabledSensors">           l_foot_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/robots-icebox/iCubDarmstadt01/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/robots-icebox/iCubDarmstadt01/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_arm_ft_sensor   </param>
+                    <param name="id">                   r_arm_ft   </param>
                     <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_arm_ft_sensor   </param>
+                <param name="enabledSensors">           r_arm_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/robots-icebox/iCubDarmstadt01/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/robots-icebox/iCubDarmstadt01/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_leg_ft_sensor   </param>
+                    <param name="id">                   r_leg_ft   </param>
                     <param name="framename">            r_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_leg_ft_sensor   </param>
+                <param name="enabledSensors">           r_leg_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/robots-icebox/iCubDarmstadt01/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/robots-icebox/iCubDarmstadt01/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_foot_ft_sensor   </param>
+                    <param name="id">                   r_foot_ft   </param>
                     <param name="framename">            r_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:1                  </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_foot_ft_sensor   </param>
+                <param name="enabledSensors">           r_foot_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/robots-icebox/iCubDarmstadt01/wrappers/FT/left_leg-FT_remapper.xml
+++ b/robots-icebox/iCubDarmstadt01/wrappers/FT/left_leg-FT_remapper.xml
@@ -6,7 +6,7 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (l_leg_ft_sensor l_foot_ft_sensor)
+          (l_leg_ft l_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/robots-icebox/iCubDarmstadt01/wrappers/FT/right_leg-FT_remapper.xml
+++ b/robots-icebox/iCubDarmstadt01/wrappers/FT/right_leg-FT_remapper.xml
@@ -6,7 +6,7 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (r_leg_ft_sensor r_foot_ft_sensor)
+          (r_leg_ft r_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/robots-icebox/iCubGenova01/hardware/FT/left_arm_strain.xml
+++ b/robots-icebox/iCubGenova01/hardware/FT/left_arm_strain.xml
@@ -3,7 +3,7 @@
 
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="left_arm_strain">
-    <param name="sensorName"> l_arm_ft_sensor </param>
+    <param name="sensorName"> l_arm_ft </param>
     <param name="frameName"> l_arm_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubGenova01/hardware/FT/left_leg_strain.xml
+++ b/robots-icebox/iCubGenova01/hardware/FT/left_leg_strain.xml
@@ -3,7 +3,7 @@
 
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="left_leg_strain">
-    <param name="sensorName"> l_leg_ft_sensor </param>
+    <param name="sensorName"> l_leg_ft </param>
     <param name="frameName"> l_leg_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubGenova01/hardware/FT/right_arm_strain.xml
+++ b/robots-icebox/iCubGenova01/hardware/FT/right_arm_strain.xml
@@ -3,7 +3,7 @@
 
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="right_arm_strain">
-    <param name="sensorName"> r_arm_ft_sensor </param>
+    <param name="sensorName"> r_arm_ft </param>
     <param name="frameName"> r_arm_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubGenova01/hardware/FT/right_foot_strain.xml
+++ b/robots-icebox/iCubGenova01/hardware/FT/right_foot_strain.xml
@@ -3,7 +3,7 @@
 
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="right_foot_strain">
-    <param name="sensorName"> r_foot_ft_sensor </param>
+    <param name="sensorName"> r_foot_ft </param>
     <param name="frameName"> r_foot_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubGenova01/hardware/FT/right_leg_strain.xml
+++ b/robots-icebox/iCubGenova01/hardware/FT/right_leg_strain.xml
@@ -3,7 +3,7 @@
 
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="right_leg_strain">
-    <param name="sensorName"> r_leg_ft_sensor </param>
+    <param name="sensorName"> r_leg_ft </param>
     <param name="frameName"> r_leg_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubGenova01/wrappers/FT/left_leg-FT_remapper.xml
+++ b/robots-icebox/iCubGenova01/wrappers/FT/left_leg-FT_remapper.xml
@@ -6,7 +6,7 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (l_leg_ft_sensor l_foot_ft_sensor)
+          (l_leg_ft l_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/robots-icebox/iCubGenova01/wrappers/FT/right_leg-FT_remapper.xml
+++ b/robots-icebox/iCubGenova01/wrappers/FT/right_leg-FT_remapper.xml
@@ -6,7 +6,7 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (r_leg_ft_sensor r_foot_ft_sensor)
+          (r_leg_ft r_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/robots-icebox/iCubGenova04/estimators/wholebodydynamics.xml
+++ b/robots-icebox/iCubGenova04/estimators/wholebodydynamics.xml
@@ -47,7 +47,7 @@
         </group>
 
         <group name="FT_SECONDARY_CALIBRATION">
-            <param name="l_leg_ft_sensor">
+            <param name="l_leg_ft">
                    (7.425024e-01,5.604686e-02,-4.408041e-02,3.727271e-01,6.718566e-01,2.605184e-01
                     ,2.376318e-02,4.601413e-01,9.920935e-03,-8.951425e-01,-1.167558e-01,1.971860e+00
                     ,-7.972684e-02,-2.326263e-01,9.977213e-01,-1.405751e+00,3.249553e-01,-1.666625e+00
@@ -56,7 +56,7 @@
                     ,1.979480e-03,1.733975e-04,-3.815689e-05,-1.993212e-02,-1.673455e-02,9.158948e-01)
 	    </param>
 
-            <param name="r_leg_ft_sensor">
+            <param name="r_leg_ft">
                     (9.308601e-01,7.328130e-03,-1.211788e-02,-1.123839e-01,-2.977943e-01,-1.954805e-02
                     ,-8.177519e-02,7.160387e-01,-4.158542e-02,1.077732e+00,4.997348e-01,2.431916e+00
                     ,-4.174433e-02,-1.784640e-01,9.661752e-01,-1.386611e+00,1.538259e-01,-5.603641e-01
@@ -96,12 +96,12 @@
                 <!-- imu_waist -->
 <!--            <elem name="imu">xsensmt-inertial</elem> -->
                 <!-- ft -->
-                <elem name="l_arm_ft_sensor">left_arm-eb1-j0_3-strain</elem>
-                <elem name="r_arm_ft_sensor">right_arm-eb3-j0_3-strain</elem>
-                <elem name="l_leg_ft_sensor">left_leg-eb6-j0_3-strain</elem>
-                <elem name="r_leg_ft_sensor">right_leg-eb8-j0_3-strain</elem>
-                <elem name="l_foot_ft_sensor">left_leg-eb7-j4_5-strain</elem>
-                <elem name="r_foot_ft_sensor">right_leg-eb9-j4_5-strain</elem>
+                <elem name="l_arm_ft">left_arm-eb1-j0_3-strain</elem>
+                <elem name="r_arm_ft">right_arm-eb3-j0_3-strain</elem>
+                <elem name="l_leg_ft">left_leg-eb6-j0_3-strain</elem>
+                <elem name="r_leg_ft">right_leg-eb8-j0_3-strain</elem>
+                <elem name="l_foot_ft">left_leg-eb7-j4_5-strain</elem>
+                <elem name="r_foot_ft">right_leg-eb9-j4_5-strain</elem>
             </paramlist>
         </action>
 

--- a/robots-icebox/iCubGenova04/estimators/wholebodydynamics_iRonCub.xml
+++ b/robots-icebox/iCubGenova04/estimators/wholebodydynamics_iRonCub.xml
@@ -46,7 +46,7 @@
         </group>
 
         <!-- <group name="FT_SECONDARY_CALIBRATION">
-            <param name="l_leg_ft_sensor">
+            <param name="l_leg_ft">
                    (7.425024e-01,5.604686e-02,-4.408041e-02,3.727271e-01,6.718566e-01,2.605184e-01
                     ,2.376318e-02,4.601413e-01,9.920935e-03,-8.951425e-01,-1.167558e-01,1.971860e+00
                     ,-7.972684e-02,-2.326263e-01,9.977213e-01,-1.405751e+00,3.249553e-01,-1.666625e+00
@@ -55,7 +55,7 @@
                     ,1.979480e-03,1.733975e-04,-3.815689e-05,-1.993212e-02,-1.673455e-02,9.158948e-01)
 	    </param>
 
-            <param name="r_leg_ft_sensor">
+            <param name="r_leg_ft">
                     (9.308601e-01,7.328130e-03,-1.211788e-02,-1.123839e-01,-2.977943e-01,-1.954805e-02
                     ,-8.177519e-02,7.160387e-01,-4.158542e-02,1.077732e+00,4.997348e-01,2.431916e+00
                     ,-4.174433e-02,-1.784640e-01,9.661752e-01,-1.386611e+00,1.538259e-01,-5.603641e-01
@@ -95,12 +95,12 @@
                 <!-- imu_waist -->
 <!--            <elem name="imu">xsensmt-inertial</elem> -->
                 <!-- ft -->
-                <elem name="l_arm_ft_sensor">left_arm-eb1-j0_3-strain</elem>
-                <elem name="r_arm_ft_sensor">right_arm-eb3-j0_3-strain</elem>
-                <elem name="l_leg_ft_sensor">left_leg-eb6-j0_3-strain</elem>
-                <elem name="r_leg_ft_sensor">right_leg-eb8-j0_3-strain</elem>
-                <elem name="l_foot_ft_sensor">left_leg-eb7-j4_5-strain</elem>
-                <elem name="r_foot_ft_sensor">right_leg-eb9-j4_5-strain</elem>
+                <elem name="l_arm_ft">left_arm-eb1-j0_3-strain</elem>
+                <elem name="r_arm_ft">right_arm-eb3-j0_3-strain</elem>
+                <elem name="l_leg_ft">left_leg-eb6-j0_3-strain</elem>
+                <elem name="r_leg_ft">right_leg-eb8-j0_3-strain</elem>
+                <elem name="l_foot_ft">left_leg-eb7-j4_5-strain</elem>
+                <elem name="r_foot_ft">right_leg-eb9-j4_5-strain</elem>
             </paramlist>
         </action>
 

--- a/robots-icebox/iCubGenova04/estimators/wholebodydynamics_noFeet.xml
+++ b/robots-icebox/iCubGenova04/estimators/wholebodydynamics_noFeet.xml
@@ -43,7 +43,7 @@
         </group>
        
         <group name="FT_SECONDARY_CALIBRATION">
-             <param name="l_leg_ft_sensor"> 
+             <param name="l_leg_ft"> 
                    (5.969361e-01,2.428213e-02,-5.463457e-02,4.254463e-01,1.123516e+00,-1.303151e-01 
                     ,-2.818578e-02,6.863783e-01,2.028274e-02,6.585433e-01,1.573658e-01,1.544577e+00 
                     ,-3.915223e-02,3.971615e-02,9.679746e-01,-3.150958e-03,3.718397e-01,-8.653098e-02 
@@ -51,7 +51,7 @@
                     ,5.671831e-03,6.968371e-03,4.892937e-03,5.396529e-02,9.499420e-01,-1.575216e-01 
                     ,3.469447e-18,0,-7.993503e-20,0,0,1.000000e+00)</param>     
 
-             <param name="r_leg_ft_sensor">
+             <param name="r_leg_ft">
                    (7.619710e-01,-9.833019e-02,-5.603709e-02,-7.503703e-01,4.654638e-01,-2.100801e+00 
                    ,2.708629e-02,8.108288e-01,-3.377881e-03,8.122805e-01,4.181660e-02,8.531041e-01 
                    ,-7.067404e-02,-3.179978e-02,9.888732e-01,-4.080758e-02,5.046211e-01,-5.754858e-01 
@@ -88,12 +88,12 @@
                 <!-- imu -->
                 <elem name="imu">inertial</elem>
                 <!-- ft -->
-                <elem name="l_arm_ft_sensor">left_arm-eb1-j0_3-strain</elem>
-                <elem name="r_arm_ft_sensor">right_arm-eb3-j0_3-strain</elem>
-                <elem name="l_leg_ft_sensor">left_leg-eb6-j0_3-strain</elem>
-                <elem name="r_leg_ft_sensor">right_leg-eb8-j0_3-strain</elem>
-<!--                <elem name="l_foot_ft_sensor">left_leg-eb7-j4_5-strain</elem>-->
-  <!--              <elem name="r_foot_ft_sensor">right_leg-eb9-j4_5-strain</elem>-->
+                <elem name="l_arm_ft">left_arm-eb1-j0_3-strain</elem>
+                <elem name="r_arm_ft">right_arm-eb3-j0_3-strain</elem>
+                <elem name="l_leg_ft">left_leg-eb6-j0_3-strain</elem>
+                <elem name="r_leg_ft">right_leg-eb8-j0_3-strain</elem>
+<!--                <elem name="l_foot_ft">left_leg-eb7-j4_5-strain</elem>-->
+  <!--              <elem name="r_foot_ft">right_leg-eb9-j4_5-strain</elem>-->
             </paramlist>
         </action>
 

--- a/robots-icebox/iCubGenova04/estimators/wholebodydynamics_nohands.xml
+++ b/robots-icebox/iCubGenova04/estimators/wholebodydynamics_nohands.xml
@@ -46,7 +46,7 @@
         </group>
 
         <group name="FT_SECONDARY_CALIBRATION">
-            <param name="l_leg_ft_sensor">
+            <param name="l_leg_ft">
                    (7.425024e-01,5.604686e-02,-4.408041e-02,3.727271e-01,6.718566e-01,2.605184e-01
                     ,2.376318e-02,4.601413e-01,9.920935e-03,-8.951425e-01,-1.167558e-01,1.971860e+00
                     ,-7.972684e-02,-2.326263e-01,9.977213e-01,-1.405751e+00,3.249553e-01,-1.666625e+00
@@ -55,7 +55,7 @@
                     ,1.979480e-03,1.733975e-04,-3.815689e-05,-1.993212e-02,-1.673455e-02,9.158948e-01)
 	    </param>
 
-            <param name="r_leg_ft_sensor">
+            <param name="r_leg_ft">
                     (9.308601e-01,7.328130e-03,-1.211788e-02,-1.123839e-01,-2.977943e-01,-1.954805e-02
                     ,-8.177519e-02,7.160387e-01,-4.158542e-02,1.077732e+00,4.997348e-01,2.431916e+00
                     ,-4.174433e-02,-1.784640e-01,9.661752e-01,-1.386611e+00,1.538259e-01,-5.603641e-01
@@ -93,12 +93,12 @@
                 <!-- imu_waist -->
 <!--            <elem name="imu">xsensmt-inertial</elem> -->
                 <!-- ft -->
-                <elem name="l_arm_ft_sensor">left_arm-eb1-j0_3-strain</elem>
-                <elem name="r_arm_ft_sensor">right_arm-eb3-j0_3-strain</elem>
-                <elem name="l_leg_ft_sensor">left_leg-eb6-j0_3-strain</elem>
-                <elem name="r_leg_ft_sensor">right_leg-eb8-j0_3-strain</elem>
-                <elem name="l_foot_ft_sensor">left_leg-eb7-j4_5-strain</elem>
-                <elem name="r_foot_ft_sensor">right_leg-eb9-j4_5-strain</elem>
+                <elem name="l_arm_ft">left_arm-eb1-j0_3-strain</elem>
+                <elem name="r_arm_ft">right_arm-eb3-j0_3-strain</elem>
+                <elem name="l_leg_ft">left_leg-eb6-j0_3-strain</elem>
+                <elem name="r_leg_ft">right_leg-eb8-j0_3-strain</elem>
+                <elem name="l_foot_ft">left_leg-eb7-j4_5-strain</elem>
+                <elem name="r_foot_ft">right_leg-eb9-j4_5-strain</elem>
             </paramlist>
         </action>
 

--- a/robots-icebox/iCubGenova04/estimators/wholebodydynamics_standup.xml
+++ b/robots-icebox/iCubGenova04/estimators/wholebodydynamics_standup.xml
@@ -46,7 +46,7 @@
         </group>
        
         <group name="FT_SECONDARY_CALIBRATION">
-             <param name="l_leg_ft_sensor"> 
+             <param name="l_leg_ft"> 
                    (5.969361e-01,2.428213e-02,-5.463457e-02,4.254463e-01,1.123516e+00,-1.303151e-01 
                     ,-2.818578e-02,6.863783e-01,2.028274e-02,6.585433e-01,1.573658e-01,1.544577e+00 
                     ,-3.915223e-02,3.971615e-02,9.679746e-01,-3.150958e-03,3.718397e-01,-8.653098e-02 
@@ -54,7 +54,7 @@
                     ,5.671831e-03,6.968371e-03,4.892937e-03,5.396529e-02,9.499420e-01,-1.575216e-01 
                     ,3.469447e-18,0,-7.993503e-20,0,0,1.000000e+00)</param>     
 
-             <param name="r_leg_ft_sensor">
+             <param name="r_leg_ft">
                    (7.619710e-01,-9.833019e-02,-5.603709e-02,-7.503703e-01,4.654638e-01,-2.100801e+00 
                    ,2.708629e-02,8.108288e-01,-3.377881e-03,8.122805e-01,4.181660e-02,8.531041e-01 
                    ,-7.067404e-02,-3.179978e-02,9.888732e-01,-4.080758e-02,5.046211e-01,-5.754858e-01 
@@ -91,12 +91,12 @@
                 <!-- imu -->
                 <elem name="imu">head-inertial</elem>
                 <!-- ft -->
-                <elem name="l_arm_ft_sensor">left_arm-eb1-j0_3-strain</elem>
-                <elem name="r_arm_ft_sensor">right_arm-eb3-j0_3-strain</elem>
-                <elem name="l_leg_ft_sensor">left_leg-eb6-j0_3-strain</elem>
-                <elem name="r_leg_ft_sensor">right_leg-eb8-j0_3-strain</elem>
-                <elem name="l_foot_ft_sensor">left_leg-eb7-j4_5-strain</elem>
-                <elem name="r_foot_ft_sensor">right_leg-eb9-j4_5-strain</elem>
+                <elem name="l_arm_ft">left_arm-eb1-j0_3-strain</elem>
+                <elem name="r_arm_ft">right_arm-eb3-j0_3-strain</elem>
+                <elem name="l_leg_ft">left_leg-eb6-j0_3-strain</elem>
+                <elem name="r_leg_ft">right_leg-eb8-j0_3-strain</elem>
+                <elem name="l_foot_ft">left_leg-eb7-j4_5-strain</elem>
+                <elem name="r_foot_ft">right_leg-eb9-j4_5-strain</elem>
             </paramlist>
         </action>
 

--- a/robots-icebox/iCubGenova04/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/robots-icebox/iCubGenova04/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_arm_ft_sensor   </param>
+                    <param name="id">                   l_arm_ft   </param>
                     <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_arm_ft_sensor   </param>
+                <param name="enabledSensors">           l_arm_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/robots-icebox/iCubGenova04/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/robots-icebox/iCubGenova04/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_leg_ft_sensor   </param>
+                    <param name="id">                   l_leg_ft   </param>
                     <param name="framename">            l_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_leg_ft_sensor   </param>
+                <param name="enabledSensors">           l_leg_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/robots-icebox/iCubGenova04/hardware/FT/left_leg-eb6-j0_3-strain2.xml
+++ b/robots-icebox/iCubGenova04/hardware/FT/left_leg-eb6-j0_3-strain2.xml
@@ -30,7 +30,7 @@
                 </group>
                 
                 <group name="SENSORS">
-                    <param name="id">                   l_leg_ft_sensor   </param>
+                    <param name="id">                   l_leg_ft   </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
                 </group>                
@@ -39,7 +39,7 @@
 
             <group name="SETTINGS">        
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_leg_ft_sensor         </param>  
+                <param name="enabledSensors">           l_leg_ft         </param>  
                 <param name="temperature-acquisitionRate"> 1000                  </param>//1 seconds
             </group>
             

--- a/robots-icebox/iCubGenova04/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/robots-icebox/iCubGenova04/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_foot_ft_sensor   </param>
+                    <param name="id">                   l_foot_ft   </param>
                     <param name="framename">            l_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_foot_ft_sensor   </param>
+                <param name="enabledSensors">           l_foot_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/robots-icebox/iCubGenova04/hardware/FT/left_leg-eb7-j4_5-strain2.xml
+++ b/robots-icebox/iCubGenova04/hardware/FT/left_leg-eb7-j4_5-strain2.xml
@@ -30,7 +30,7 @@
                 </group>
                 
                 <group name="SENSORS">
-                    <param name="id">                   l_foot_ft_sensor   </param>
+                    <param name="id">                   l_foot_ft   </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
                 </group>                
@@ -39,7 +39,7 @@
 
             <group name="SETTINGS">        
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_foot_ft_sensor   </param>
+                <param name="enabledSensors">           l_foot_ft   </param>
                 <param name="temperature-acquisitionRate"> 1000                  </param>//1 seconds                
             </group>
             

--- a/robots-icebox/iCubGenova04/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/robots-icebox/iCubGenova04/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_arm_ft_sensor   </param>
+                    <param name="id">                   r_arm_ft   </param>
                     <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_arm_ft_sensor   </param>
+                <param name="enabledSensors">           r_arm_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/robots-icebox/iCubGenova04/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/robots-icebox/iCubGenova04/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_leg_ft_sensor   </param>
+                    <param name="id">                   r_leg_ft   </param>
                     <param name="framename">            r_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_leg_ft_sensor   </param>
+                <param name="enabledSensors">           r_leg_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/robots-icebox/iCubGenova04/hardware/FT/right_leg-eb8-j0_3-strain2.xml
+++ b/robots-icebox/iCubGenova04/hardware/FT/right_leg-eb8-j0_3-strain2.xml
@@ -30,7 +30,7 @@
                 </group>
                 
                 <group name="SENSORS">
-                    <param name="id">                   r_leg_ft_sensor   </param>
+                    <param name="id">                   r_leg_ft   </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
                 </group>                
@@ -39,7 +39,7 @@
 
             <group name="SETTINGS">        
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_leg_ft_sensor   </param>        
+                <param name="enabledSensors">           r_leg_ft   </param>        
                 <param name="temperature-acquisitionRate"> 1000                  </param>//1 seconds              
             </group>
             

--- a/robots-icebox/iCubGenova04/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/robots-icebox/iCubGenova04/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_foot_ft_sensor   </param>
+                    <param name="id">                   r_foot_ft   </param>
                     <param name="framename">            r_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_foot_ft_sensor   </param>
+                <param name="enabledSensors">           r_foot_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/robots-icebox/iCubGenova04/hardware/FT/right_leg-eb9-j4_5-strain2.xml
+++ b/robots-icebox/iCubGenova04/hardware/FT/right_leg-eb9-j4_5-strain2.xml
@@ -30,7 +30,7 @@
                 </group>
                 
                 <group name="SENSORS">
-                    <param name="id">                   r_foot_ft_sensor   </param>
+                    <param name="id">                   r_foot_ft   </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
                 </group>                
@@ -39,7 +39,7 @@
 
             <group name="SETTINGS">        
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_foot_ft_sensor   </param>                
+                <param name="enabledSensors">           r_foot_ft   </param>                
                 <param name="temperature-acquisitionRate"> 1000                  </param>//1 seconds
             </group>
             

--- a/robots-icebox/iCubGenova04/wrappers/FT/left_leg-FT_remapper.xml
+++ b/robots-icebox/iCubGenova04/wrappers/FT/left_leg-FT_remapper.xml
@@ -6,10 +6,10 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (l_leg_ft_sensor l_foot_ft_sensor)
+          (l_leg_ft l_foot_ft)
         </param>
         <param name="TemperatureSensorsNames">
-          (l_leg_ft_sensor l_foot_ft_sensor)
+          (l_leg_ft l_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/robots-icebox/iCubGenova04/wrappers/FT/right_leg-FT_remapper.xml
+++ b/robots-icebox/iCubGenova04/wrappers/FT/right_leg-FT_remapper.xml
@@ -6,10 +6,10 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (r_leg_ft_sensor r_foot_ft_sensor)
+          (r_leg_ft r_foot_ft)
         </param>
         <param name="TemperatureSensorsNames">
-          (r_leg_ft_sensor r_foot_ft_sensor)
+          (r_leg_ft r_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/robots-icebox/iCubGenova09/estimators/wholebodydynamics.xml
+++ b/robots-icebox/iCubGenova09/estimators/wholebodydynamics.xml
@@ -70,8 +70,8 @@
         </group>
 
         <group name="multipleAnalogSensorsNames">
-              <!--param name="TemperatureSensorsNames">(l_leg_ft_sensor,r_leg_ft_sensor,l_foot_ft_sensor,r_foot_ft_sensor)</param-->
-              <param name="SixAxisForceTorqueSensorsNames">(l_arm_ft_sensor, r_arm_ft_sensor, l_leg_ft_sensor, r_leg_ft_sensor,l_foot_front_ft_sensor, l_foot_rear_ft_sensor, r_foot_front_ft_sensor, r_foot_rear_ft_sensor)</param>
+              <!--param name="TemperatureSensorsNames">(l_leg_ft,r_leg_ft,l_foot_ft,r_foot_ft)</param-->
+              <param name="SixAxisForceTorqueSensorsNames">(l_arm_ft, r_arm_ft, l_leg_ft, r_leg_ft,l_foot_front_ft, l_foot_rear_ft, r_foot_front_ft, r_foot_rear_ft)</param>
         </group>`
 
 
@@ -83,7 +83,7 @@
         </group>
 
 	<group name="FT_SECONDARY_CALIBRATION">
-            <param name="l_arm_ft_sensor">
+            <param name="l_arm_ft">
                    (0.725416845954673,-0.193734889477843,-0.000750660116279,-0.493389204924643,0.208721401684598,0.232216866114498,
                     0.277911482834144,0.721669682720518,0.079744273870858,-0.551806684320880,0.340796536112566,-0.095726506086055,
                     0.058512691880839,-0.026259245359369,0.961054892438277,-0.001672588061163,-0.040144684119862,0.028904858845599,
@@ -92,7 +92,7 @@
                     0.000422242850389,-0.004114883067249,0.000064277247963,0.012455688813988,-0.013878080964184,0.987572790828476)
             </param>
 
-            <param name="r_arm_ft_sensor">
+            <param name="r_arm_ft">
                     (0.794940626500074,0.125334287778540,-0.062869746776510,-0.305980690332562,0.011226779742047,-0.367504489060532,
                     -0.166608779053738,0.478035535864582,-0.100426896898395,-1.880708606173178,-0.623814944550364,-0.291467179541353,
                     0.107573784081792,-0.023994376340728,0.945781778888619,-0.613317179977426,0.101165492337217,0.015351248214599,
@@ -103,11 +103,11 @@
         </group>
 
         <group name="FT_OFFSET">
-            <param name="l_arm_ft_sensor">
+            <param name="l_arm_ft">
                    (-55.710365859965009,-19.782075036167221,-7.821819529447135,1.524292098125204,2.055306999014841,-0.143741677610297)
             </param>
 
-            <param name="r_arm_ft_sensor">
+            <param name="r_arm_ft">
                     (-73.639860156269819,24.072660497240438,-28.817082293698117,-1.928682746629074,1.760186171442543,0.723043880391045)
             </param>
         </group>
@@ -147,12 +147,12 @@
                 <!-- imu_waist -->
 <!--            <elem name="imu">xsensmt-inertial</elem> -->
                 <!-- ft -->
-  		<elem name="l_arm_ft_sensor">left_arm-eb1-j0_1-strain</elem>
-                <elem name="r_arm_ft_sensor">right_arm-eb3-j0_1-strain</elem>
-                <elem name="l_foot_ft_sensors">left_leg-eb8-j3_5-strain</elem> <!-- left_rear, left_front -->
-		<elem name="l_leg_ft_sensor">left_leg-eb7-j0_2-strain</elem>    <!-- left_upper_leg -->
-                <elem name="r_foot_ft_sensors">right_leg-eb12-j3_5-strain</elem> <!-- right_rear, right_front -->
-		<elem name="r_leg_ft_sensor">right_leg-eb11-j0_2-strain</elem>    <!-- right_upper_leg -->
+  		<elem name="l_arm_ft">left_arm-eb1-j0_1-strain</elem>
+                <elem name="r_arm_ft">right_arm-eb3-j0_1-strain</elem>
+                <elem name="l_foot_fts">left_leg-eb8-j3_5-strain</elem> <!-- left_rear, left_front -->
+		<elem name="l_leg_ft">left_leg-eb7-j0_2-strain</elem>    <!-- left_upper_leg -->
+                <elem name="r_foot_fts">right_leg-eb12-j3_5-strain</elem> <!-- right_rear, right_front -->
+		<elem name="r_leg_ft">right_leg-eb11-j0_2-strain</elem>    <!-- right_upper_leg -->
 
             </paramlist>
         </action>

--- a/robots-icebox/iCubGenova09/hardware/FT/left_arm-eb1-j0_1-strain.xml
+++ b/robots-icebox/iCubGenova09/hardware/FT/left_arm-eb1-j0_1-strain.xml
@@ -30,7 +30,7 @@
                 </group>
                 
                 <group name="SENSORS">
-                    <param name="id">                   l_arm_ft_sensor   </param>
+                    <param name="id">                   l_arm_ft   </param>
                     <param name="board">                 strain2             </param>
                     <param name="location">             CAN2:13                 </param>
                 </group>                
@@ -38,7 +38,7 @@
             </group>
 
             <group name="SETTINGS">        
-                <param name="enabledSensors">       l_arm_ft_sensor               </param>
+                <param name="enabledSensors">       l_arm_ft               </param>
                 <param name="ftPeriod">             5         		                    </param>
                 <param name="temperaturePeriod">    1000      		                   </param>
                 <param name="useCalibration">       true      		              </param>           

--- a/robots-icebox/iCubGenova09/hardware/FT/left_leg-eb7-j0_2-strain.xml
+++ b/robots-icebox/iCubGenova09/hardware/FT/left_leg-eb7-j0_2-strain.xml
@@ -30,7 +30,7 @@
                 </group>
                 
                 <group name="SENSORS">
-                    <param name="id">                   l_leg_ft_sensor   </param>
+                    <param name="id">                   l_leg_ft   </param>
                     <param name="board">                 strain2             </param>
                     <param name="location">             CAN2:13                 </param>
                 </group>                
@@ -38,7 +38,7 @@
             </group>
 
             <group name="SETTINGS">        
-                <param name="enabledSensors">       l_leg_ft_sensor               </param>
+                <param name="enabledSensors">       l_leg_ft               </param>
                 <param name="ftPeriod">             2         		                    </param>
                 <param name="temperaturePeriod">    1000      		                   </param>
                 <param name="useCalibration">       true      		              </param>           

--- a/robots-icebox/iCubGenova09/hardware/FT/left_leg-eb8-j3_5-strain.xml
+++ b/robots-icebox/iCubGenova09/hardware/FT/left_leg-eb8-j3_5-strain.xml
@@ -30,7 +30,7 @@
                 </group>
                 
                 <group name="SENSORS">
-                    <param name="id">                   l_foot_rear_ft_sensor	l_foot_front_ft_sensor   </param>
+                    <param name="id">                   l_foot_rear_ft	l_foot_front_ft   </param>
                     <param name="board">                 strain2		strain2             </param>
                     <param name="location">             CAN2:13		CAN2:14                 </param>
                 </group>                
@@ -38,7 +38,7 @@
             </group>
 
             <group name="SETTINGS">        
-                <param name="enabledSensors">       l_foot_rear_ft_sensor          l_foot_front_ft_sensor      </param>
+                <param name="enabledSensors">       l_foot_rear_ft          l_foot_front_ft      </param>
                 <param name="ftPeriod">             2         		 2                     </param>
                 <param name="temperaturePeriod">    1000      		 1000                    </param>
                 <param name="useCalibration">       true      		 true                 </param>           

--- a/robots-icebox/iCubGenova09/hardware/FT/right_arm-eb3-j0_1-strain.xml
+++ b/robots-icebox/iCubGenova09/hardware/FT/right_arm-eb3-j0_1-strain.xml
@@ -30,7 +30,7 @@
                 </group>
                 
                 <group name="SENSORS">
-                    <param name="id">                   r_arm_ft_sensor   </param>
+                    <param name="id">                   r_arm_ft   </param>
                     <param name="board">                 strain2             </param>
                     <param name="location">             CAN2:13                 </param>
                 </group>                
@@ -38,7 +38,7 @@
             </group>
 
             <group name="SETTINGS">        
-                <param name="enabledSensors">       r_arm_ft_sensor               </param>
+                <param name="enabledSensors">       r_arm_ft               </param>
                 <param name="ftPeriod">             5         		                    </param>
                 <param name="temperaturePeriod">    1000      		                   </param>
                 <param name="useCalibration">       true      		              </param>           

--- a/robots-icebox/iCubGenova09/hardware/FT/right_leg-eb11-j0_2-strain.xml
+++ b/robots-icebox/iCubGenova09/hardware/FT/right_leg-eb11-j0_2-strain.xml
@@ -30,7 +30,7 @@
                 </group>
                 
                 <group name="SENSORS">
-                    <param name="id">                   r_leg_ft_sensor   </param>
+                    <param name="id">                   r_leg_ft   </param>
                     <param name="board">                 strain2             </param>
                     <param name="location">             CAN2:13                 </param>
                 </group>                
@@ -38,7 +38,7 @@
             </group>
 
             <group name="SETTINGS">        
-                <param name="enabledSensors">       r_leg_ft_sensor           </param>
+                <param name="enabledSensors">       r_leg_ft           </param>
                 <param name="ftPeriod">             2         		                    </param>
                 <param name="temperaturePeriod">    1000      		                   </param>
                 <param name="useCalibration">       true      		              </param>           

--- a/robots-icebox/iCubGenova09/hardware/FT/right_leg-eb12-j3_5-strain.xml
+++ b/robots-icebox/iCubGenova09/hardware/FT/right_leg-eb12-j3_5-strain.xml
@@ -30,7 +30,7 @@
                 </group>
                 
                 <group name="SENSORS">
-                    <param name="id">                   r_foot_rear_ft_sensor	r_foot_front_ft_sensor   </param>
+                    <param name="id">                   r_foot_rear_ft	r_foot_front_ft   </param>
                     <param name="board">                 strain2		strain2             </param>
                     <param name="location">             CAN2:13		CAN2:14                 </param>
                 </group>                
@@ -38,7 +38,7 @@
             </group>
 
             <group name="SETTINGS">        
-                <param name="enabledSensors">       r_foot_rear_ft_sensor          r_foot_front_ft_sensor       </param>
+                <param name="enabledSensors">       r_foot_rear_ft          r_foot_front_ft       </param>
                 <param name="ftPeriod">             2         		 2                     </param>
                 <param name="temperaturePeriod">    1000      		 1000                    </param>
                 <param name="useCalibration">       true      		 true                 </param>           

--- a/robots-icebox/iCubGenova09/wrappers/FT/left_leg-FT_remapper.xml
+++ b/robots-icebox/iCubGenova09/wrappers/FT/left_leg-FT_remapper.xml
@@ -6,10 +6,10 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (l_leg_ft_sensor l_foot_rear_ft_sensor l_foot_front_ft_sensor)
+          (l_leg_ft l_foot_rear_ft l_foot_front_ft)
         </param>
         <param name="TemperatureSensorsNames">
-          (l_leg_ft_sensor l_foot_rear_ft_sensor l_foot_front_ft_sensor)
+          (l_leg_ft l_foot_rear_ft l_foot_front_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/robots-icebox/iCubGenova09/wrappers/FT/right_leg-FT_remapper.xml
+++ b/robots-icebox/iCubGenova09/wrappers/FT/right_leg-FT_remapper.xml
@@ -6,10 +6,10 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (r_leg_ft_sensor r_foot_rear_ft_sensor r_foot_front_ft_sensor)
+          (r_leg_ft r_foot_rear_ft r_foot_front_ft)
         </param>
         <param name="TemperatureSensorsNames">
-          (r_leg_ft_sensor r_foot_rear_ft_sensor r_foot_front_ft_sensor)
+          (r_leg_ft r_foot_rear_ft r_foot_front_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/robots-icebox/iCubHeidelberg01/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/robots-icebox/iCubHeidelberg01/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_leg_ft_sensor   </param>
+                    <param name="id">                   l_leg_ft   </param>
                     <param name="framename">            l_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_leg_ft_sensor   </param>
+                <param name="enabledSensors">           l_leg_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/robots-icebox/iCubHeidelberg01/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/robots-icebox/iCubHeidelberg01/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_foot_ft_sensor   </param>
+                    <param name="id">                   l_foot_ft   </param>
                     <param name="framename">            l_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:1                  </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_foot_ft_sensor   </param>
+                <param name="enabledSensors">           l_foot_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/robots-icebox/iCubHeidelberg01/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/robots-icebox/iCubHeidelberg01/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_leg_ft_sensor   </param>
+                    <param name="id">                   r_leg_ft   </param>
                     <param name="framename">            r_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_leg_ft_sensor   </param>
+                <param name="enabledSensors">           r_leg_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/robots-icebox/iCubHeidelberg01/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/robots-icebox/iCubHeidelberg01/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_foot_ft_sensor   </param>
+                    <param name="id">                   r_foot_ft   </param>
                     <param name="framename">            r_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:1                  </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_foot_ft_sensor   </param>
+                <param name="enabledSensors">           r_foot_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/robots-icebox/iCubHeidelberg01/wrappers/FT/left_leg-FT_remapper.xml
+++ b/robots-icebox/iCubHeidelberg01/wrappers/FT/left_leg-FT_remapper.xml
@@ -6,7 +6,7 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (l_leg_ft_sensor l_foot_ft_sensor)
+          (l_leg_ft l_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/robots-icebox/iCubHeidelberg01/wrappers/FT/right_leg-FT_remapper.xml
+++ b/robots-icebox/iCubHeidelberg01/wrappers/FT/right_leg-FT_remapper.xml
@@ -6,7 +6,7 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (r_leg_ft_sensor r_foot_ft_sensor)
+          (r_leg_ft r_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/robots-icebox/iCubHongKong01/estimators/wholebodydynamics.xml
+++ b/robots-icebox/iCubHongKong01/estimators/wholebodydynamics.xml
@@ -41,7 +41,7 @@
         </group>
        
         <group name="FT_SECONDARY_CALIBRATION">
-             <param name="l_leg_ft_sensor"> 
+             <param name="l_leg_ft"> 
                    (5.969361e-01,2.428213e-02,-5.463457e-02,4.254463e-01,1.123516e+00,-1.303151e-01 
                     ,-2.818578e-02,6.863783e-01,2.028274e-02,6.585433e-01,1.573658e-01,1.544577e+00 
                     ,-3.915223e-02,3.971615e-02,9.679746e-01,-3.150958e-03,3.718397e-01,-8.653098e-02 
@@ -49,7 +49,7 @@
                     ,5.671831e-03,6.968371e-03,4.892937e-03,5.396529e-02,9.499420e-01,-1.575216e-01 
                     ,3.469447e-18,0,-7.993503e-20,0,0,1.000000e+00)</param>     
 
-             <param name="r_leg_ft_sensor">
+             <param name="r_leg_ft">
                    (7.619710e-01,-9.833019e-02,-5.603709e-02,-7.503703e-01,4.654638e-01,-2.100801e+00 
                    ,2.708629e-02,8.108288e-01,-3.377881e-03,8.122805e-01,4.181660e-02,8.531041e-01 
                    ,-7.067404e-02,-3.179978e-02,9.888732e-01,-4.080758e-02,5.046211e-01,-5.754858e-01 
@@ -86,12 +86,12 @@
                 <!-- imu -->
                 <elem name="imu">inertial</elem>
                 <!-- ft -->
-                <elem name="l_arm_ft_sensor">left_arm-eb1-j0_3-strain</elem>
-                <elem name="r_arm_ft_sensor">right_arm-eb3-j0_3-strain</elem>
-                <elem name="l_leg_ft_sensor">left_leg-eb6-j0_3-strain</elem>
-                <elem name="r_leg_ft_sensor">right_leg-eb8-j0_3-strain</elem>
-                <elem name="l_foot_ft_sensor">left_leg-eb7-j4_5-strain</elem>
-                <elem name="r_foot_ft_sensor">right_leg-eb9-j4_5-strain</elem>
+                <elem name="l_arm_ft">left_arm-eb1-j0_3-strain</elem>
+                <elem name="r_arm_ft">right_arm-eb3-j0_3-strain</elem>
+                <elem name="l_leg_ft">left_leg-eb6-j0_3-strain</elem>
+                <elem name="r_leg_ft">right_leg-eb8-j0_3-strain</elem>
+                <elem name="l_foot_ft">left_leg-eb7-j4_5-strain</elem>
+                <elem name="r_foot_ft">right_leg-eb9-j4_5-strain</elem>
             </paramlist>
         </action>
 

--- a/robots-icebox/iCubHongKong01/estimators/wholebodydynamics_standup.xml
+++ b/robots-icebox/iCubHongKong01/estimators/wholebodydynamics_standup.xml
@@ -40,7 +40,7 @@
         
        <group name="FT_SECONDARY_CALIBRATION">
 
-           <param name="r_leg_ft_sensor"> (1.165043e-01,-4.824760e-02,-2.838516e-03,-4.063452e-01,3.829723e+00,-4.049686e+00
+           <param name="r_leg_ft"> (1.165043e-01,-4.824760e-02,-2.838516e-03,-4.063452e-01,3.829723e+00,-4.049686e+00
            ,-1.646781e-02,1.028508e-01,1.218741e-03,-3.860480e+00,6.586313e-02,1.079024e-01
            ,-1.223875e-01,-1.720457e-01,9.950911e-01,-1.332774e+00,4.882303e-01,1.109860e+00
            ,-2.690149e-03,-1.097413e-02,1.942506e-03,9.459466e-01,2.006043e-02,4.074997e-02
@@ -74,12 +74,12 @@
                 <!-- imu -->
                 <elem name="imu">inertial</elem>
                 <!-- ft -->
-                <elem name="l_arm_ft_sensor">left_arm-eb1-j0_3-strain</elem>
-                <elem name="r_arm_ft_sensor">right_arm-eb3-j0_3-strain</elem>
-                <elem name="l_leg_ft_sensor">left_leg-eb6-j0_3-strain</elem>
-                <elem name="r_leg_ft_sensor">right_leg-eb8-j0_3-strain</elem>
-                <elem name="l_foot_ft_sensor">left_leg-eb7-j4_5-strain</elem>
-                <elem name="r_foot_ft_sensor">right_leg-eb9-j4_5-strain</elem>
+                <elem name="l_arm_ft">left_arm-eb1-j0_3-strain</elem>
+                <elem name="r_arm_ft">right_arm-eb3-j0_3-strain</elem>
+                <elem name="l_leg_ft">left_leg-eb6-j0_3-strain</elem>
+                <elem name="r_leg_ft">right_leg-eb8-j0_3-strain</elem>
+                <elem name="l_foot_ft">left_leg-eb7-j4_5-strain</elem>
+                <elem name="r_foot_ft">right_leg-eb9-j4_5-strain</elem>
             </paramlist>
         </action>
 

--- a/robots-icebox/iCubHongKong01/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/robots-icebox/iCubHongKong01/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_arm_ft_sensor   </param>
+                    <param name="id">                   l_arm_ft   </param>
                     <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_arm_ft_sensor   </param>
+                <param name="enabledSensors">           l_arm_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/robots-icebox/iCubHongKong01/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/robots-icebox/iCubHongKong01/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_leg_ft_sensor   </param>
+                    <param name="id">                   l_leg_ft   </param>
                     <param name="framename">            l_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_leg_ft_sensor   </param>
+                <param name="enabledSensors">           l_leg_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/robots-icebox/iCubHongKong01/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/robots-icebox/iCubHongKong01/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_foot_ft_sensor   </param>
+                    <param name="id">                   l_foot_ft   </param>
                     <param name="framename">            l_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_foot_ft_sensor   </param>
+                <param name="enabledSensors">           l_foot_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/robots-icebox/iCubHongKong01/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/robots-icebox/iCubHongKong01/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_arm_ft_sensor   </param>
+                    <param name="id">                   r_arm_ft   </param>
                     <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_arm_ft_sensor   </param>
+                <param name="enabledSensors">           r_arm_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/robots-icebox/iCubHongKong01/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/robots-icebox/iCubHongKong01/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_leg_ft_sensor   </param>
+                    <param name="id">                   r_leg_ft   </param>
                     <param name="framename">            r_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_leg_ft_sensor   </param>
+                <param name="enabledSensors">           r_leg_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/robots-icebox/iCubHongKong01/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/robots-icebox/iCubHongKong01/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_foot_ft_sensor   </param>
+                    <param name="id">                   r_foot_ft   </param>
                     <param name="framename">            r_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_foot_ft_sensor   </param>
+                <param name="enabledSensors">           r_foot_ft   </param>
 				 <param name="temperature-acquisitionRate"> 1000                  </param> <!-- 1 seconds -->
             </group>
 

--- a/robots-icebox/iCubHongKong01/wrappers/FT/left_leg-FT_remapper.xml
+++ b/robots-icebox/iCubHongKong01/wrappers/FT/left_leg-FT_remapper.xml
@@ -6,10 +6,10 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (l_leg_ft_sensor l_foot_ft_sensor)
+          (l_leg_ft l_foot_ft)
         </param>
         <param name="TemperatureSensorsNames">
-          (l_leg_ft_sensor l_foot_ft_sensor)
+          (l_leg_ft l_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/robots-icebox/iCubHongKong01/wrappers/FT/right_leg-FT_remapper.xml
+++ b/robots-icebox/iCubHongKong01/wrappers/FT/right_leg-FT_remapper.xml
@@ -6,10 +6,10 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (r_leg_ft_sensor r_foot_ft_sensor)
+          (r_leg_ft r_foot_ft)
         </param>
         <param name="TemperatureSensorsNames">
-          (r_leg_ft_sensor r_foot_ft_sensor)
+          (r_leg_ft r_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/robots-icebox/iCubLausanne01/hardware/FT/left_arm_strain.xml
+++ b/robots-icebox/iCubLausanne01/hardware/FT/left_arm_strain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="left_arm_strain">
-    <param name="sensorName"> l_arm_ft_sensor </param>
+    <param name="sensorName"> l_arm_ft </param>
     <param name="frameName"> l_arm_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubLausanne01/hardware/FT/left_leg_strain.xml
+++ b/robots-icebox/iCubLausanne01/hardware/FT/left_leg_strain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="left_leg_strain">
-    <param name="sensorName"> l_leg_ft_sensor </param>
+    <param name="sensorName"> l_leg_ft </param>
     <param name="frameName"> l_leg_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubLausanne01/hardware/FT/right_arm_strain.xml
+++ b/robots-icebox/iCubLausanne01/hardware/FT/right_arm_strain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="right_arm_strain">
-    <param name="sensorName"> r_arm_ft_sensor </param>
+    <param name="sensorName"> r_arm_ft </param>
     <param name="frameName"> r_arm_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubLausanne01/hardware/FT/right_foot_strain.xml
+++ b/robots-icebox/iCubLausanne01/hardware/FT/right_foot_strain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="right_foot_strain">
-    <param name="sensorName"> r_foot_ft_sensor </param>
+    <param name="sensorName"> r_foot_ft </param>
     <param name="frameName"> r_foot_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubLausanne01/hardware/FT/right_leg_strain.xml
+++ b/robots-icebox/iCubLausanne01/hardware/FT/right_leg_strain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="right_leg_strain">
-    <param name="sensorName"> r_leg_ft_sensor </param>
+    <param name="sensorName"> r_leg_ft </param>
     <param name="frameName"> r_leg_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubLausanne01/wrappers/FT/left_leg-FT_remapper.xml
+++ b/robots-icebox/iCubLausanne01/wrappers/FT/left_leg-FT_remapper.xml
@@ -6,7 +6,7 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (l_leg_ft_sensor l_foot_ft_sensor)
+          (l_leg_ft l_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/robots-icebox/iCubLausanne01/wrappers/FT/right_leg-FT_remapper.xml
+++ b/robots-icebox/iCubLausanne01/wrappers/FT/right_leg-FT_remapper.xml
@@ -6,7 +6,7 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (r_leg_ft_sensor r_foot_ft_sensor)
+          (r_leg_ft r_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/robots-icebox/iCubLausanne02/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/robots-icebox/iCubLausanne02/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_arm_ft_sensor   </param>
+                    <param name="id">                   l_arm_ft   </param>
                     <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_arm_ft_sensor   </param>
+                <param name="enabledSensors">           l_arm_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/robots-icebox/iCubLausanne02/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/robots-icebox/iCubLausanne02/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_leg_ft_sensor   </param>
+                    <param name="id">                   l_leg_ft   </param>
                     <param name="framename">            l_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_leg_ft_sensor   </param>
+                <param name="enabledSensors">           l_leg_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/robots-icebox/iCubLausanne02/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/robots-icebox/iCubLausanne02/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_foot_ft_sensor   </param>
+                    <param name="id">                   l_foot_ft   </param>
                     <param name="framename">            l_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:1                  </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_foot_ft_sensor   </param>
+                <param name="enabledSensors">           l_foot_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/robots-icebox/iCubLausanne02/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/robots-icebox/iCubLausanne02/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_arm_ft_sensor   </param>
+                    <param name="id">                   r_arm_ft   </param>
                     <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_arm_ft_sensor   </param>
+                <param name="enabledSensors">           r_arm_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/robots-icebox/iCubLausanne02/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/robots-icebox/iCubLausanne02/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_leg_ft_sensor   </param>
+                    <param name="id">                   r_leg_ft   </param>
                     <param name="framename">            r_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_leg_ft_sensor   </param>
+                <param name="enabledSensors">           r_leg_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/robots-icebox/iCubLausanne02/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/robots-icebox/iCubLausanne02/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_foot_ft_sensor   </param>
+                    <param name="id">                   r_foot_ft   </param>
                     <param name="framename">            r_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:1                  </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_foot_ft_sensor   </param>
+                <param name="enabledSensors">           r_foot_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/robots-icebox/iCubLausanne02/wrappers/FT/left_leg-FT_remapper.xml
+++ b/robots-icebox/iCubLausanne02/wrappers/FT/left_leg-FT_remapper.xml
@@ -6,7 +6,7 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (l_leg_ft_sensor l_foot_ft_sensor)
+          (l_leg_ft l_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/robots-icebox/iCubLausanne02/wrappers/FT/right_leg-FT_remapper.xml
+++ b/robots-icebox/iCubLausanne02/wrappers/FT/right_leg-FT_remapper.xml
@@ -6,7 +6,7 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (r_leg_ft_sensor r_foot_ft_sensor)
+          (r_leg_ft r_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/robots-icebox/iCubLethbridge01/hardware/FT/left_arm_strain.xml
+++ b/robots-icebox/iCubLethbridge01/hardware/FT/left_arm_strain.xml
@@ -3,7 +3,7 @@
 
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="left_arm_strain">
-    <param name="sensorName"> l_arm_ft_sensor </param>
+    <param name="sensorName"> l_arm_ft </param>
     <param name="frameName"> l_arm_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubLethbridge01/hardware/FT/left_leg_strain.xml
+++ b/robots-icebox/iCubLethbridge01/hardware/FT/left_leg_strain.xml
@@ -3,7 +3,7 @@
 
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="left_leg_strain">
-    <param name="sensorName"> l_leg_ft_sensor </param>
+    <param name="sensorName"> l_leg_ft </param>
     <param name="frameName"> l_leg_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubLethbridge01/hardware/FT/right_arm_strain.xml
+++ b/robots-icebox/iCubLethbridge01/hardware/FT/right_arm_strain.xml
@@ -3,7 +3,7 @@
 
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="right_arm_strain">
-    <param name="sensorName"> r_arm_ft_sensor </param>
+    <param name="sensorName"> r_arm_ft </param>
     <param name="frameName"> r_arm_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubLethbridge01/hardware/FT/right_foot_strain.xml
+++ b/robots-icebox/iCubLethbridge01/hardware/FT/right_foot_strain.xml
@@ -3,7 +3,7 @@
 
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="right_foot_strain">
-    <param name="sensorName"> r_foot_ft_sensor </param>
+    <param name="sensorName"> r_foot_ft </param>
     <param name="frameName"> r_foot_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubLethbridge01/hardware/FT/right_leg_strain.xml
+++ b/robots-icebox/iCubLethbridge01/hardware/FT/right_leg_strain.xml
@@ -3,7 +3,7 @@
 
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="right_leg_strain">
-    <param name="sensorName"> r_leg_ft_sensor </param>
+    <param name="sensorName"> r_leg_ft </param>
     <param name="frameName"> r_leg_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubLethbridge01/wrappers/FT/left_leg-FT_remapper.xml
+++ b/robots-icebox/iCubLethbridge01/wrappers/FT/left_leg-FT_remapper.xml
@@ -6,7 +6,7 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (l_leg_ft_sensor l_foot_ft_sensor)
+          (l_leg_ft l_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/robots-icebox/iCubLethbridge01/wrappers/FT/right_leg-FT_remapper.xml
+++ b/robots-icebox/iCubLethbridge01/wrappers/FT/right_leg-FT_remapper.xml
@@ -6,7 +6,7 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (r_leg_ft_sensor r_foot_ft_sensor)
+          (r_leg_ft r_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/robots-icebox/iCubLugano01/hardware/FT/left_arm_strain.xml
+++ b/robots-icebox/iCubLugano01/hardware/FT/left_arm_strain.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="left_arm_strain">
-    <param name="sensorName"> l_arm_ft_sensor </param>
+    <param name="sensorName"> l_arm_ft </param>
     <param name="frameName"> l_arm_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubLugano01/hardware/FT/right_arm_strain.xml
+++ b/robots-icebox/iCubLugano01/hardware/FT/right_arm_strain.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="right_arm_strain">
-    <param name="sensorName"> r_arm_ft_sensor </param>
+    <param name="sensorName"> r_arm_ft </param>
     <param name="frameName"> r_arm_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubManchester01/hardware/FT/left_arm_strain.xml
+++ b/robots-icebox/iCubManchester01/hardware/FT/left_arm_strain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="left_arm_strain">
-    <param name="sensorName"> l_arm_ft_sensor </param>
+    <param name="sensorName"> l_arm_ft </param>
     <param name="frameName"> l_arm_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubManchester01/hardware/FT/left_leg_strain.xml
+++ b/robots-icebox/iCubManchester01/hardware/FT/left_leg_strain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="left_leg_strain">
-    <param name="sensorName"> l_leg_ft_sensor </param>
+    <param name="sensorName"> l_leg_ft </param>
     <param name="frameName"> l_leg_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubManchester01/hardware/FT/right_arm_strain.xml
+++ b/robots-icebox/iCubManchester01/hardware/FT/right_arm_strain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="right_arm_strain">
-    <param name="sensorName"> r_arm_ft_sensor </param>
+    <param name="sensorName"> r_arm_ft </param>
     <param name="frameName"> r_arm_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubManchester01/hardware/FT/right_foot_strain.xml
+++ b/robots-icebox/iCubManchester01/hardware/FT/right_foot_strain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="right_foot_strain">
-    <param name="sensorName"> r_foot_ft_sensor </param>
+    <param name="sensorName"> r_foot_ft </param>
     <param name="frameName"> r_foot_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubManchester01/hardware/FT/right_leg_strain.xml
+++ b/robots-icebox/iCubManchester01/hardware/FT/right_leg_strain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="right_leg_strain">
-    <param name="sensorName"> r_leg_ft_sensor </param>
+    <param name="sensorName"> r_leg_ft </param>
     <param name="frameName"> r_leg_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubManchester01/wrappers/FT/left_leg-FT_remapper.xml
+++ b/robots-icebox/iCubManchester01/wrappers/FT/left_leg-FT_remapper.xml
@@ -6,7 +6,7 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (l_leg_ft_sensor l_foot_ft_sensor)
+          (l_leg_ft l_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/robots-icebox/iCubManchester01/wrappers/FT/right_leg-FT_remapper.xml
+++ b/robots-icebox/iCubManchester01/wrappers/FT/right_leg-FT_remapper.xml
@@ -6,7 +6,7 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (r_leg_ft_sensor r_foot_ft_sensor)
+          (r_leg_ft r_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/robots-icebox/iCubMoscow01/estimators/wholebodydynamics.xml
+++ b/robots-icebox/iCubMoscow01/estimators/wholebodydynamics.xml
@@ -45,7 +45,7 @@
         </group>
        
         <group name="FT_SECONDARY_CALIBRATION">
-             <param name="l_leg_ft_sensor"> 
+             <param name="l_leg_ft"> 
                    (5.969361e-01,2.428213e-02,-5.463457e-02,4.254463e-01,1.123516e+00,-1.303151e-01 
                     ,-2.818578e-02,6.863783e-01,2.028274e-02,6.585433e-01,1.573658e-01,1.544577e+00 
                     ,-3.915223e-02,3.971615e-02,9.679746e-01,-3.150958e-03,3.718397e-01,-8.653098e-02 
@@ -53,7 +53,7 @@
                     ,5.671831e-03,6.968371e-03,4.892937e-03,5.396529e-02,9.499420e-01,-1.575216e-01 
                     ,3.469447e-18,0,-7.993503e-20,0,0,1.000000e+00)</param>     
 
-             <param name="r_leg_ft_sensor">
+             <param name="r_leg_ft">
                    (7.619710e-01,-9.833019e-02,-5.603709e-02,-7.503703e-01,4.654638e-01,-2.100801e+00 
                    ,2.708629e-02,8.108288e-01,-3.377881e-03,8.122805e-01,4.181660e-02,8.531041e-01 
                    ,-7.067404e-02,-3.179978e-02,9.888732e-01,-4.080758e-02,5.046211e-01,-5.754858e-01 
@@ -90,12 +90,12 @@
                 <!-- imu -->
                 <elem name="imu">head-inertial</elem>
                 <!-- ft -->
-                <elem name="l_arm_ft_sensor">left_arm-eb1-j0_3-strain</elem>
-                <elem name="r_arm_ft_sensor">right_arm-eb3-j0_3-strain</elem>
-                <elem name="l_leg_ft_sensor">left_leg-eb6-j0_3-strain</elem>
-                <elem name="r_leg_ft_sensor">right_leg-eb8-j0_3-strain</elem>
-                <elem name="l_foot_ft_sensor">left_leg-eb7-j4_5-strain</elem>
-                <elem name="r_foot_ft_sensor">right_leg-eb9-j4_5-strain</elem>
+                <elem name="l_arm_ft">left_arm-eb1-j0_3-strain</elem>
+                <elem name="r_arm_ft">right_arm-eb3-j0_3-strain</elem>
+                <elem name="l_leg_ft">left_leg-eb6-j0_3-strain</elem>
+                <elem name="r_leg_ft">right_leg-eb8-j0_3-strain</elem>
+                <elem name="l_foot_ft">left_leg-eb7-j4_5-strain</elem>
+                <elem name="r_foot_ft">right_leg-eb9-j4_5-strain</elem>
             </paramlist>
         </action>
 

--- a/robots-icebox/iCubMoscow01/estimators/wholebodydynamics_standup.xml
+++ b/robots-icebox/iCubMoscow01/estimators/wholebodydynamics_standup.xml
@@ -46,7 +46,7 @@
         
        <group name="FT_SECONDARY_CALIBRATION">
 
-           <param name="r_leg_ft_sensor"> (1.165043e-01,-4.824760e-02,-2.838516e-03,-4.063452e-01,3.829723e+00,-4.049686e+00
+           <param name="r_leg_ft"> (1.165043e-01,-4.824760e-02,-2.838516e-03,-4.063452e-01,3.829723e+00,-4.049686e+00
            ,-1.646781e-02,1.028508e-01,1.218741e-03,-3.860480e+00,6.586313e-02,1.079024e-01
            ,-1.223875e-01,-1.720457e-01,9.950911e-01,-1.332774e+00,4.882303e-01,1.109860e+00
            ,-2.690149e-03,-1.097413e-02,1.942506e-03,9.459466e-01,2.006043e-02,4.074997e-02
@@ -80,12 +80,12 @@
                 <!-- imu -->
                 <elem name="imu">head-inertial</elem>
                 <!-- ft -->
-                <elem name="l_arm_ft_sensor">left_arm-eb1-j0_3-strain</elem>
-                <elem name="r_arm_ft_sensor">right_arm-eb3-j0_3-strain</elem>
-                <elem name="l_leg_ft_sensor">left_leg-eb6-j0_3-strain</elem>
-                <elem name="r_leg_ft_sensor">right_leg-eb8-j0_3-strain</elem>
-                <elem name="l_foot_ft_sensor">left_leg-eb7-j4_5-strain</elem>
-                <elem name="r_foot_ft_sensor">right_leg-eb9-j4_5-strain</elem>
+                <elem name="l_arm_ft">left_arm-eb1-j0_3-strain</elem>
+                <elem name="r_arm_ft">right_arm-eb3-j0_3-strain</elem>
+                <elem name="l_leg_ft">left_leg-eb6-j0_3-strain</elem>
+                <elem name="r_leg_ft">right_leg-eb8-j0_3-strain</elem>
+                <elem name="l_foot_ft">left_leg-eb7-j4_5-strain</elem>
+                <elem name="r_foot_ft">right_leg-eb9-j4_5-strain</elem>
             </paramlist>
         </action>
 

--- a/robots-icebox/iCubMoscow01/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/robots-icebox/iCubMoscow01/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_arm_ft_sensor   </param>
+                    <param name="id">                   l_arm_ft   </param>
                     <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_arm_ft_sensor   </param>
+                <param name="enabledSensors">           l_arm_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/robots-icebox/iCubMoscow01/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/robots-icebox/iCubMoscow01/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_leg_ft_sensor   </param>
+                    <param name="id">                   l_leg_ft   </param>
                     <param name="framename">            l_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_leg_ft_sensor   </param>
+                <param name="enabledSensors">           l_leg_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/robots-icebox/iCubMoscow01/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/robots-icebox/iCubMoscow01/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_foot_ft_sensor   </param>
+                    <param name="id">                   l_foot_ft   </param>
                     <param name="framename">            l_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_foot_ft_sensor   </param>
+                <param name="enabledSensors">           l_foot_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/robots-icebox/iCubMoscow01/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/robots-icebox/iCubMoscow01/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_arm_ft_sensor   </param>
+                    <param name="id">                   r_arm_ft   </param>
                     <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_arm_ft_sensor   </param>
+                <param name="enabledSensors">           r_arm_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/robots-icebox/iCubMoscow01/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/robots-icebox/iCubMoscow01/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_leg_ft_sensor   </param>
+                    <param name="id">                   r_leg_ft   </param>
                     <param name="framename">            r_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_leg_ft_sensor   </param>
+                <param name="enabledSensors">           r_leg_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/robots-icebox/iCubMoscow01/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/robots-icebox/iCubMoscow01/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_foot_ft_sensor   </param>
+                    <param name="id">                   r_foot_ft   </param>
                     <param name="framename">            r_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_foot_ft_sensor   </param>
+                <param name="enabledSensors">           r_foot_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/robots-icebox/iCubMoscow01/wrappers/FT/left_leg-FT_remapper.xml
+++ b/robots-icebox/iCubMoscow01/wrappers/FT/left_leg-FT_remapper.xml
@@ -6,7 +6,7 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (l_leg_ft_sensor l_foot_ft_sensor)
+          (l_leg_ft l_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/robots-icebox/iCubMoscow01/wrappers/FT/right_leg-FT_remapper.xml
+++ b/robots-icebox/iCubMoscow01/wrappers/FT/right_leg-FT_remapper.xml
@@ -6,7 +6,7 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (r_leg_ft_sensor r_foot_ft_sensor)
+          (r_leg_ft r_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/robots-icebox/iCubMunich01/hardware/FT/left_arm_strain.xml
+++ b/robots-icebox/iCubMunich01/hardware/FT/left_arm_strain.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="left_arm_strain">
-    <param name="sensorName"> l_arm_ft_sensor </param>
+    <param name="sensorName"> l_arm_ft </param>
     <param name="frameName"> l_arm_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubMunich01/hardware/FT/left_leg_strain.xml
+++ b/robots-icebox/iCubMunich01/hardware/FT/left_leg_strain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="left_leg_strain">
-    <param name="sensorName"> l_leg_ft_sensor </param>
+    <param name="sensorName"> l_leg_ft </param>
     <param name="frameName"> l_leg_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubMunich01/hardware/FT/right_arm_strain.xml
+++ b/robots-icebox/iCubMunich01/hardware/FT/right_arm_strain.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="right_arm_strain">
-    <param name="sensorName"> r_arm_ft_sensor </param>
+    <param name="sensorName"> r_arm_ft </param>
     <param name="frameName"> r_arm_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubMunich01/hardware/FT/right_leg_strain.xml
+++ b/robots-icebox/iCubMunich01/hardware/FT/right_leg_strain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="right_leg_strain">
-    <param name="sensorName"> r_leg_ft_sensor </param>
+    <param name="sensorName"> r_leg_ft </param>
     <param name="frameName"> r_leg_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubNottingham01/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/robots-icebox/iCubNottingham01/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_arm_ft_sensor   </param>
+                    <param name="id">                   l_arm_ft   </param>
                     <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_arm_ft_sensor   </param>
+                <param name="enabledSensors">           l_arm_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/robots-icebox/iCubNottingham01/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/robots-icebox/iCubNottingham01/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_leg_ft_sensor   </param>
+                    <param name="id">                   l_leg_ft   </param>
                     <param name="framename">            l_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_leg_ft_sensor   </param>
+                <param name="enabledSensors">           l_leg_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/robots-icebox/iCubNottingham01/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/robots-icebox/iCubNottingham01/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_foot_ft_sensor   </param>
+                    <param name="id">                   l_foot_ft   </param>
                     <param name="framename">            l_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:1                  </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_foot_ft_sensor   </param>
+                <param name="enabledSensors">           l_foot_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/robots-icebox/iCubNottingham01/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/robots-icebox/iCubNottingham01/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_arm_ft_sensor   </param>
+                    <param name="id">                   r_arm_ft   </param>
                     <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_arm_ft_sensor   </param>
+                <param name="enabledSensors">           r_arm_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/robots-icebox/iCubNottingham01/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/robots-icebox/iCubNottingham01/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_leg_ft_sensor   </param>
+                    <param name="id">                   r_leg_ft   </param>
                     <param name="framename">            r_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_leg_ft_sensor   </param>
+                <param name="enabledSensors">           r_leg_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/robots-icebox/iCubNottingham01/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/robots-icebox/iCubNottingham01/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_foot_ft_sensor   </param>
+                    <param name="id">                   r_foot_ft   </param>
                     <param name="framename">            r_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:1                  </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_foot_ft_sensor   </param>
+                <param name="enabledSensors">           r_foot_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/robots-icebox/iCubNottingham01/wrappers/FT/left_leg-FT_remapper.xml
+++ b/robots-icebox/iCubNottingham01/wrappers/FT/left_leg-FT_remapper.xml
@@ -6,7 +6,7 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (l_leg_ft_sensor l_foot_ft_sensor)
+          (l_leg_ft l_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/robots-icebox/iCubNottingham01/wrappers/FT/right_leg-FT_remapper.xml
+++ b/robots-icebox/iCubNottingham01/wrappers/FT/right_leg-FT_remapper.xml
@@ -6,7 +6,7 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (r_leg_ft_sensor r_foot_ft_sensor)
+          (r_leg_ft r_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/robots-icebox/iCubParis01/hardware/FT/left_arm_strain.xml
+++ b/robots-icebox/iCubParis01/hardware/FT/left_arm_strain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="left_arm_strain">
-    <param name="sensorName"> l_arm_ft_sensor </param>
+    <param name="sensorName"> l_arm_ft </param>
     <param name="frameName"> l_arm_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubParis01/hardware/FT/left_leg_strain.xml
+++ b/robots-icebox/iCubParis01/hardware/FT/left_leg_strain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="left_leg_strain">
-    <param name="sensorName"> l_leg_ft_sensor </param>
+    <param name="sensorName"> l_leg_ft </param>
     <param name="frameName"> l_leg_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubParis01/hardware/FT/right_arm_strain.xml
+++ b/robots-icebox/iCubParis01/hardware/FT/right_arm_strain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="right_arm_strain">
-    <param name="sensorName"> r_arm_ft_sensor </param>
+    <param name="sensorName"> r_arm_ft </param>
     <param name="frameName"> r_arm_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubParis01/hardware/FT/right_foot_strain.xml
+++ b/robots-icebox/iCubParis01/hardware/FT/right_foot_strain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="right_foot_strain">
-    <param name="sensorName"> r_foot_ft_sensor </param>
+    <param name="sensorName"> r_foot_ft </param>
     <param name="frameName"> r_foot_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubParis01/hardware/FT/right_leg_strain.xml
+++ b/robots-icebox/iCubParis01/hardware/FT/right_leg_strain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="right_leg_strain">
-    <param name="sensorName"> r_leg_ft_sensor </param>
+    <param name="sensorName"> r_leg_ft </param>
     <param name="frameName"> r_leg_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubParis01/wrappers/FT/left_leg-FT_remapper.xml
+++ b/robots-icebox/iCubParis01/wrappers/FT/left_leg-FT_remapper.xml
@@ -6,7 +6,7 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (l_leg_ft_sensor l_foot_ft_sensor)
+          (l_leg_ft l_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/robots-icebox/iCubParis01/wrappers/FT/right_leg-FT_remapper.xml
+++ b/robots-icebox/iCubParis01/wrappers/FT/right_leg-FT_remapper.xml
@@ -6,7 +6,7 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (r_leg_ft_sensor r_foot_ft_sensor)
+          (r_leg_ft r_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/robots-icebox/iCubParis02/hardware/FT/left_arm_strain.xml
+++ b/robots-icebox/iCubParis02/hardware/FT/left_arm_strain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="left_arm_strain">
-    <param name="sensorName"> l_arm_ft_sensor </param>
+    <param name="sensorName"> l_arm_ft </param>
     <param name="frameName"> l_arm_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubParis02/hardware/FT/left_leg_strain.xml
+++ b/robots-icebox/iCubParis02/hardware/FT/left_leg_strain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="left_leg_strain">
-    <param name="sensorName"> l_leg_ft_sensor </param>
+    <param name="sensorName"> l_leg_ft </param>
     <param name="frameName"> l_leg_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubParis02/hardware/FT/right_arm_strain.xml
+++ b/robots-icebox/iCubParis02/hardware/FT/right_arm_strain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="right_arm_strain">
-    <param name="sensorName"> r_arm_ft_sensor </param>
+    <param name="sensorName"> r_arm_ft </param>
     <param name="frameName"> r_arm_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubParis02/hardware/FT/right_foot_strain.xml
+++ b/robots-icebox/iCubParis02/hardware/FT/right_foot_strain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="right_foot_strain">
-    <param name="sensorName"> r_foot_ft_sensor </param>
+    <param name="sensorName"> r_foot_ft </param>
     <param name="frameName"> r_foot_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubParis02/hardware/FT/right_leg_strain.xml
+++ b/robots-icebox/iCubParis02/hardware/FT/right_leg_strain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="right_leg_strain">
-    <param name="sensorName"> r_leg_ft_sensor </param>
+    <param name="sensorName"> r_leg_ft </param>
     <param name="frameName"> r_leg_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubParis02/wrappers/FT/left_leg-FT_remapper.xml
+++ b/robots-icebox/iCubParis02/wrappers/FT/left_leg-FT_remapper.xml
@@ -6,7 +6,7 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (l_leg_ft_sensor l_foot_ft_sensor)
+          (l_leg_ft l_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/robots-icebox/iCubParis02/wrappers/FT/right_leg-FT_remapper.xml
+++ b/robots-icebox/iCubParis02/wrappers/FT/right_leg-FT_remapper.xml
@@ -6,7 +6,7 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (r_leg_ft_sensor r_foot_ft_sensor)
+          (r_leg_ft r_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/robots-icebox/iCubPisa01/hardware/FT/left_arm_strain.xml
+++ b/robots-icebox/iCubPisa01/hardware/FT/left_arm_strain.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="left_arm_strain">
-    <param name="sensorName"> l_arm_ft_sensor </param>
+    <param name="sensorName"> l_arm_ft </param>
     <param name="frameName"> l_arm_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubPisa01/hardware/FT/right_arm_strain.xml
+++ b/robots-icebox/iCubPisa01/hardware/FT/right_arm_strain.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="right_arm_strain">
-    <param name="sensorName"> r_arm_ft_sensor </param>
+    <param name="sensorName"> r_arm_ft </param>
     <param name="frameName"> r_arm_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubPlymouth01/hardware/FT/left_arm_strain.xml
+++ b/robots-icebox/iCubPlymouth01/hardware/FT/left_arm_strain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="left_arm_strain">
-    <param name="sensorName"> l_arm_ft_sensor </param>
+    <param name="sensorName"> l_arm_ft </param>
     <param name="frameName"> l_arm_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubPlymouth01/hardware/FT/left_leg_strain.xml
+++ b/robots-icebox/iCubPlymouth01/hardware/FT/left_leg_strain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="left_leg_strain">
-    <param name="sensorName"> l_leg_ft_sensor </param>
+    <param name="sensorName"> l_leg_ft </param>
     <param name="frameName"> l_leg_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubPlymouth01/hardware/FT/right_arm_strain.xml
+++ b/robots-icebox/iCubPlymouth01/hardware/FT/right_arm_strain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="right_arm_strain">
-    <param name="sensorName"> r_arm_ft_sensor </param>
+    <param name="sensorName"> r_arm_ft </param>
     <param name="frameName"> r_arm_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubPlymouth01/hardware/FT/right_leg_strain.xml
+++ b/robots-icebox/iCubPlymouth01/hardware/FT/right_leg_strain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="right_leg_strain">
-    <param name="sensorName"> r_leg_ft_sensor </param>
+    <param name="sensorName"> r_leg_ft </param>
     <param name="frameName"> r_leg_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubRome02/hardware/FT/left_arm_strain.xml
+++ b/robots-icebox/iCubRome02/hardware/FT/left_arm_strain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="left_arm_strain">
-    <param name="sensorName"> l_arm_ft_sensor </param>
+    <param name="sensorName"> l_arm_ft </param>
     <param name="frameName"> l_arm_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubRome02/hardware/FT/right_arm_strain.xml
+++ b/robots-icebox/iCubRome02/hardware/FT/right_arm_strain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="right_arm_strain">
-    <param name="sensorName"> r_arm_ft_sensor </param>
+    <param name="sensorName"> r_arm_ft </param>
     <param name="frameName"> r_arm_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubRome02/hardware/FT/right_foot_strain.xml
+++ b/robots-icebox/iCubRome02/hardware/FT/right_foot_strain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="right_foot_strain">
-    <param name="sensorName"> r_foot_ft_sensor </param>
+    <param name="sensorName"> r_foot_ft </param>
     <param name="frameName"> r_foot_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubSeoul01/hardware/FT/left_arm-strain.xml
+++ b/robots-icebox/iCubSeoul01/hardware/FT/left_arm-strain.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="left_arm_strain">
-    <param name="sensorName"> l_arm_ft_sensor </param>
+    <param name="sensorName"> l_arm_ft </param>
     <param name="frameName"> l_arm_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubSeoul01/hardware/FT/right_arm-strain.xml
+++ b/robots-icebox/iCubSeoul01/hardware/FT/right_arm-strain.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" type="canBusFtSensor" name="right_arm_strain">
-    <param name="sensorName"> r_arm_ft_sensor </param>
+    <param name="sensorName"> r_arm_ft </param>
     <param name="frameName"> r_arm_ft </param>
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/robots-icebox/iCubSheffield01/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/robots-icebox/iCubSheffield01/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_arm_ft_sensor   </param>
+                    <param name="id">                   l_arm_ft   </param>
                     <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_arm_ft_sensor   </param>
+                <param name="enabledSensors">           l_arm_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/robots-icebox/iCubSheffield01/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/robots-icebox/iCubSheffield01/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_arm_ft_sensor   </param>
+                    <param name="id">                   r_arm_ft   </param>
                     <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_arm_ft_sensor   </param>
+                <param name="enabledSensors">           r_arm_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/robots-icebox/iCubTwente01/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/robots-icebox/iCubTwente01/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_arm_ft_sensor   </param>
+                    <param name="id">                   l_arm_ft   </param>
                     <param name="framename">            l_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_arm_ft_sensor   </param>
+                <param name="enabledSensors">           l_arm_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/robots-icebox/iCubTwente01/hardware/FT/left_leg-eb6-j0_3-strain.xml
+++ b/robots-icebox/iCubTwente01/hardware/FT/left_leg-eb6-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_leg_ft_sensor   </param>
+                    <param name="id">                   l_leg_ft   </param>
                     <param name="framename">            l_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_leg_ft_sensor   </param>
+                <param name="enabledSensors">           l_leg_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/robots-icebox/iCubTwente01/hardware/FT/left_leg-eb7-j4_5-strain.xml
+++ b/robots-icebox/iCubTwente01/hardware/FT/left_leg-eb7-j4_5-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   l_foot_ft_sensor   </param>
+                    <param name="id">                   l_foot_ft   </param>
                     <param name="framename">            l_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:1                  </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           l_foot_ft_sensor   </param>
+                <param name="enabledSensors">           l_foot_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/robots-icebox/iCubTwente01/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/robots-icebox/iCubTwente01/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_arm_ft_sensor   </param>
+                    <param name="id">                   r_arm_ft   </param>
                     <param name="framename">            r_arm_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_arm_ft_sensor   </param>
+                <param name="enabledSensors">           r_arm_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/robots-icebox/iCubTwente01/hardware/FT/right_leg-eb8-j0_3-strain.xml
+++ b/robots-icebox/iCubTwente01/hardware/FT/right_leg-eb8-j0_3-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_leg_ft_sensor   </param>
+                    <param name="id">                   r_leg_ft   </param>
                     <param name="framename">            r_leg_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:13                 </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_leg_ft_sensor   </param>
+                <param name="enabledSensors">           r_leg_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/robots-icebox/iCubTwente01/hardware/FT/right_leg-eb9-j4_5-strain.xml
+++ b/robots-icebox/iCubTwente01/hardware/FT/right_leg-eb9-j4_5-strain.xml
@@ -30,7 +30,7 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">                   r_foot_ft_sensor   </param>
+                    <param name="id">                   r_foot_ft   </param>
                     <param name="framename">            r_foot_ft                </param>
                     <param name="type">                 eoas_strain             </param>
                     <param name="location">             CAN2:1                  </param>
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">
                 <param name="acquisitionRate">          10                      </param>
-                <param name="enabledSensors">           r_foot_ft_sensor   </param>
+                <param name="enabledSensors">           r_foot_ft   </param>
             </group>
 
             <group name="STRAIN_SETTINGS">

--- a/robots-icebox/iCubTwente01/wrappers/FT/left_leg-FT_remapper.xml
+++ b/robots-icebox/iCubTwente01/wrappers/FT/left_leg-FT_remapper.xml
@@ -6,7 +6,7 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (l_leg_ft_sensor l_foot_ft_sensor)
+          (l_leg_ft l_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/robots-icebox/iCubTwente01/wrappers/FT/right_leg-FT_remapper.xml
+++ b/robots-icebox/iCubTwente01/wrappers/FT/right_leg-FT_remapper.xml
@@ -6,7 +6,7 @@
         <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
              defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
         <param name="SixAxisForceTorqueSensorsNames">
-          (r_leg_ft_sensor r_foot_ft_sensor)
+          (r_leg_ft r_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">


### PR DESCRIPTION
Fix https://github.com/robotology/icub-models-generator/issues/242 .

icub-models 2.0.0 changed the name of the FT sensors in the URDF from being named `<identifier>_ft_sensor` (like `l_arm_ft_sensor`, `l_leg_ft_sensor`, ...) to `<identifier>_ft` (like `l_arm_ft`, `l_leg_ft`, ...). 
However, the yarprobotinterface configuration files continued to refer to the sensors as `<identifier>_ft_sensor`, creating errors for software that was trying to match sensors find in URDF and sensors as exposed by the YARP's multipleanalogsensorsserver device.

This PR changes all the instances of iCub configuration files to `<identifier>_ft`, restoring compatibility with icub-models 2.0.0 .

A similr PR done for ergoCub models is https://github.com/robotology/robots-configuration/pull/561 .


Note that the name of the joint to which the sensor is attached remained `<identifier>_ft_sensor`, both before and after icub-models 2.0.0 release.