### PR TITLE
Update maintained robots to the use of multipleanalogsensorsserver

### DIFF
--- a/R1SN001/wrappers/MAIS/left_hand-mais_wrapper.xml
+++ b/R1SN001/wrappers/MAIS/left_hand-mais_wrapper.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 
-    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_hand_as_wrapperMais" type="analogServer">
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_hand_as_wrapperMais" type="multipleanalogsensorsserver">
         <param name="period">       10                  </param>
-        <param name="name">     /cer/left_hand/analog:o           </param>
+        <param name="name">     /cer/left_hand/MAIS           </param>
 
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/R1SN001/wrappers/MAIS/right_hand-mais_wrapper.xml
+++ b/R1SN001/wrappers/MAIS/right_hand-mais_wrapper.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 
-    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_hand_as_wrapperMais" type="analogServer">
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_hand_as_wrapperMais" type="multipleanalogsensorsserver">
         <param name="period">       10                  </param>
-        <param name="name">     /cer/right_hand/analog:o          </param>
+        <param name="name">     /cer/right_hand/MAIS          </param>
 
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/R1SN002/wrappers/MAIS/left_hand-mais_wrapper.xml
+++ b/R1SN002/wrappers/MAIS/left_hand-mais_wrapper.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 
-    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_hand_as_wrapperMais" type="analogServer">
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_hand_as_wrapperMais" type="multipleanalogsensorsserver">
         <param name="period">       10                  </param>
-        <param name="name">     /cer/left_hand/analog:o           </param>
+        <param name="name">     /cer/left_hand/MAIS           </param>
 
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/R1SN002/wrappers/MAIS/right_hand-mais_wrapper.xml
+++ b/R1SN002/wrappers/MAIS/right_hand-mais_wrapper.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 
-    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_hand_as_wrapperMais" type="analogServer">
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_hand_as_wrapperMais" type="multipleanalogsensorsserver">
         <param name="period">       10                  </param>
-        <param name="name">     /cer/right_hand/analog:o          </param>
+        <param name="name">     /cer/right_hand/MAIS          </param>
 
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/R1SN003/wrappers/MAIS/left_hand-mais_wrapper.xml
+++ b/R1SN003/wrappers/MAIS/left_hand-mais_wrapper.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 
-    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_hand_as_wrapperMais" type="analogServer">
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_hand_as_wrapperMais" type="multipleanalogsensorsserver">
         <param name="period">       10                  </param>
-        <param name="name">     /cer/left_hand/analog:o           </param>
+        <param name="name">     /cer/left_hand/MAIS           </param>
 
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/R1SN003/wrappers/MAIS/right_hand-mais_wrapper.xml
+++ b/R1SN003/wrappers/MAIS/right_hand-mais_wrapper.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 
-    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_hand_as_wrapperMais" type="analogServer">
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_hand_as_wrapperMais" type="multipleanalogsensorsserver">
         <param name="period">       10                  </param>
-        <param name="name">     /cer/right_hand/analog:o          </param>
+        <param name="name">     /cer/right_hand/MAIS          </param>
 
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/ergoCubSN000/wrappers/MAIS/left_arm-mais_wrapper.xml
+++ b/ergoCubSN000/wrappers/MAIS/left_arm-mais_wrapper.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 
-    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mais_wrapper" type="analogServer">
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mais_wrapper" type="multipleanalogsensorsserver">
         <param name="period">       10                         </param>
-        <param name="name">       /ergocub/left_hand/analog:o      </param>
+        <param name="name">       /ergocub/left_hand/MAIS      </param>
         
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/ergoCubSN000/wrappers/MAIS/right_arm-mais_wrapper.xml
+++ b/ergoCubSN000/wrappers/MAIS/right_arm-mais_wrapper.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 
-   <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-mais_wrapper" type="analogServer">
+   <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-mais_wrapper" type="multipleanalogsensorsserver">
         <param name="period">      10                           </param>
-        <param name="name">       /ergocub/right_hand/analog:o     </param>
+        <param name="name">       /ergocub/right_hand/MAIS     </param>
 
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/ergoCubSN001/wrappers/MAIS/left_arm-mais_wrapper.xml
+++ b/ergoCubSN001/wrappers/MAIS/left_arm-mais_wrapper.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 
-    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mais_wrapper" type="analogServer">
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mais_wrapper" type="multipleanalogsensorsserver">
         <param name="period">       10                         </param>
-        <param name="name">       /ergocub/left_hand/analog:o      </param>
+        <param name="name">       /ergocub/left_hand/MAIS      </param>
         
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/ergoCubSN001/wrappers/MAIS/right_arm-mais_wrapper.xml
+++ b/ergoCubSN001/wrappers/MAIS/right_arm-mais_wrapper.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 
-   <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-mais_wrapper" type="analogServer">
+   <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-mais_wrapper" type="multipleanalogsensorsserver">
         <param name="period">      10                           </param>
-        <param name="name">       /ergocub/right_hand/analog:o     </param>
+        <param name="name">       /ergocub/right_hand/MAIS     </param>
 
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/experimentalSetups/R1hands070218/wrappers/MAIS/left_hand-mais_wrapper.xml
+++ b/experimentalSetups/R1hands070218/wrappers/MAIS/left_hand-mais_wrapper.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 
-    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_hand_as_wrapperMais" type="analogServer">
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_hand_as_wrapperMais" type="multipleanalogsensorsserver">
         <param name="period">       10                  </param>
-        <param name="name">     /cer/left_hand/analog:o           </param>
+        <param name="name">     /cer/left_hand/MAIS           </param>
 
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/experimentalSetups/R1hands070218/wrappers/MAIS/right_hand-mais_wrapper.xml
+++ b/experimentalSetups/R1hands070218/wrappers/MAIS/right_hand-mais_wrapper.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 
-    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_hand_as_wrapperMais" type="analogServer">
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_hand_as_wrapperMais" type="multipleanalogsensorsserver">
         <param name="period">       10                  </param>
-        <param name="name">     /cer/right_hand/analog:o          </param>
+        <param name="name">     /cer/right_hand/MAIS          </param>
 
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/experimentalSetups/arm-v3/wrappers/MAIS/left_hand-mais_wrapper.xml
+++ b/experimentalSetups/arm-v3/wrappers/MAIS/left_hand-mais_wrapper.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
  
-    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm_as_wrapperMais" type="analogServer">
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm_as_wrapperMais" type="multipleanalogsensorsserver">
         <param name="period">       10                  </param>
-        <param name="name">     /icub/left_hand/analog:o   </param>
+        <param name="name">     /icub/left_hand/MAIS   </param>
 
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/experimentalSetups/iCubGenova02-VelCtrl/wrappers/MAIS/left_arm-mais_wrapper.xml
+++ b/experimentalSetups/iCubGenova02-VelCtrl/wrappers/MAIS/left_arm-mais_wrapper.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
-    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mais_wrapper" type="analogServer">
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mais_wrapper" type="multipleanalogsensorsserver">
         <param name="period">       10                          </param>
-        <param name="name">       /icub/left_hand/analog:o      </param>
+        <param name="name">       /icub/left_hand/MAIS      </param>
         
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/experimentalSetups/iCubGenova02-VelCtrl/wrappers/MAIS/right_arm-mais_wrapper.xml
+++ b/experimentalSetups/iCubGenova02-VelCtrl/wrappers/MAIS/right_arm-mais_wrapper.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
-    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-mais_wrapper" type="analogServer">
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-mais_wrapper" type="multipleanalogsensorsserver">
         <param name="period">       10                  </param>
-    <param name="name">       /icub/right_hand/analog:o     </param>
+    <param name="name">       /icub/right_hand/MAIS     </param>
 
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/experimentalSetups/iCubGenovaV3-VelCtrl/wrappers/MAIS/left_arm-mais_wrapper.xml
+++ b/experimentalSetups/iCubGenovaV3-VelCtrl/wrappers/MAIS/left_arm-mais_wrapper.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 
-    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mais_wrapper" type="analogServer">
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mais_wrapper" type="multipleanalogsensorsserver">
         <param name="period">       10                         </param>
-        <param name="name">       /icub/left_hand/analog:o      </param>
+        <param name="name">       /icub/left_hand/MAIS      </param>
         
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/experimentalSetups/iCubGenovaV3-VelCtrl/wrappers/MAIS/right_arm-mais_wrapper.xml
+++ b/experimentalSetups/iCubGenovaV3-VelCtrl/wrappers/MAIS/right_arm-mais_wrapper.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 
-   <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-mais_wrapper" type="analogServer">
+   <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-mais_wrapper" type="multipleanalogsensorsserver">
         <param name="period">      10                           </param>
-        <param name="name">       /icub/right_hand/analog:o     </param>
+        <param name="name">       /icub/right_hand/MAIS     </param>
 
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/experimentalSetups/iCubGenovaV3/wrappers/MAIS/left_arm-mais_wrapper.xml
+++ b/experimentalSetups/iCubGenovaV3/wrappers/MAIS/left_arm-mais_wrapper.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 
-    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mais_wrapper" type="analogServer">
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mais_wrapper" type="multipleanalogsensorsserver">
         <param name="period">       10                         </param>
-        <param name="name">       /icub/left_hand/analog:o      </param>
+        <param name="name">       /icub/left_hand/MAIS      </param>
         
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/experimentalSetups/iCubGenovaV3/wrappers/MAIS/right_arm-mais_wrapper.xml
+++ b/experimentalSetups/iCubGenovaV3/wrappers/MAIS/right_arm-mais_wrapper.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 
-   <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-mais_wrapper" type="analogServer">
+   <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-mais_wrapper" type="multipleanalogsensorsserver">
         <param name="period">      10                           </param>
-        <param name="name">       /icub/right_hand/analog:o     </param>
+        <param name="name">       /icub/right_hand/MAIS     </param>
 
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/experimentalSetups/mc4plus-jig_2boards_mais/wrappers/MAIS/mc4plusjig-mais2_wrapper.xml
+++ b/experimentalSetups/mc4plus-jig_2boards_mais/wrappers/MAIS/mc4plusjig-mais2_wrapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
 
-	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="devmc4plusjig_mais2_wrapper" type="analogServer">
+	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="devmc4plusjig_mais2_wrapper" type="multipleanalogsensorsserver">
         <param name="name">     /iCubExpSetupMC4PLUSjig/mais2/mais    </param>
         <param name="period">   10                                   </param>
 

--- a/experimentalSetups/mc4plus-jig_2boards_mais/wrappers/MAIS/mc4plusjig-mais_wrapper.xml
+++ b/experimentalSetups/mc4plus-jig_2boards_mais/wrappers/MAIS/mc4plusjig-mais_wrapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
 
-	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="devmc4plusjig_mais_wrapper" type="analogServer">
+	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="devmc4plusjig_mais_wrapper" type="multipleanalogsensorsserver">
         <param name="period">   10                                  </param>
         <param name="name">     /icub/mais/mais   </param>
 

--- a/iCubDijon01/wrappers/MAIS/left_hand_mais_wrapper.xml
+++ b/iCubDijon01/wrappers/MAIS/left_hand_mais_wrapper.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
-	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_hand_as_wrapper" type="analogServer">
+	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_hand_as_wrapper" type="multipleanalogsensorsserver">
 		<param name="period">       10  				</param>
-		<param name="name">     /icub/left_hand/analog:o				</param>
+		<param name="name">     /icub/left_hand/MAIS				</param>
 		
 		<action phase="startup" level="5" type="attach">
 		    <paramlist name="networks">

--- a/iCubDijon01/wrappers/MAIS/right_hand_mais_wrapper.xml
+++ b/iCubDijon01/wrappers/MAIS/right_hand_mais_wrapper.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
-	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_hand_as_wrapper" type="analogServer">
+	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_hand_as_wrapper" type="multipleanalogsensorsserver">
 		<param name="period">       10  				</param>
-		<param name="name">     /icub/right_hand/analog:o				</param>
+		<param name="name">     /icub/right_hand/MAIS				</param>
 		
 		<action phase="startup" level="5" type="attach">
 		    <paramlist name="networks">

--- a/iCubEdinburgh01/wrappers/MAIS/left_arm-mais_wrapper.xml
+++ b/iCubEdinburgh01/wrappers/MAIS/left_arm-mais_wrapper.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 
-    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mais_wrapper" type="analogServer">
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mais_wrapper" type="multipleanalogsensorsserver">
         <param name="period">       10                         </param>
-        <param name="name">       /icub/left_hand/analog:o      </param>
+        <param name="name">       /icub/left_hand/MAIS      </param>
         
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubEdinburgh01/wrappers/MAIS/right_arm-mais_wrapper.xml
+++ b/iCubEdinburgh01/wrappers/MAIS/right_arm-mais_wrapper.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 
-   <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-mais_wrapper" type="analogServer">
+   <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-mais_wrapper" type="multipleanalogsensorsserver">
         <param name="period">      10                           </param>
-        <param name="name">       /icub/right_hand/analog:o     </param>
+        <param name="name">       /icub/right_hand/MAIS     </param>
 
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubErzelli01/wrappers/MAIS/left_arm-mais_wrapper.xml
+++ b/iCubErzelli01/wrappers/MAIS/left_arm-mais_wrapper.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 
-    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mais_wrapper" type="analogServer">
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mais_wrapper" type="multipleanalogsensorsserver">
         <param name="period">       10                         </param>
-        <param name="name">       /icub/left_hand/analog:o      </param>
+        <param name="name">       /icub/left_hand/MAIS      </param>
         
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubErzelli01/wrappers/MAIS/right_arm-mais_wrapper.xml
+++ b/iCubErzelli01/wrappers/MAIS/right_arm-mais_wrapper.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 
-   <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-mais_wrapper" type="analogServer">
+   <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-mais_wrapper" type="multipleanalogsensorsserver">
         <param name="period">      10                           </param>
-        <param name="name">       /icub/right_hand/analog:o     </param>
+        <param name="name">       /icub/right_hand/MAIS     </param>
 
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubErzelli02/wrappers/MAIS/left_arm-mais_wrapper.xml
+++ b/iCubErzelli02/wrappers/MAIS/left_arm-mais_wrapper.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 
-    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mais_wrapper" type="analogServer">
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mais_wrapper" type="multipleanalogsensorsserver">
         <param name="period">       10                         </param>
-        <param name="name">       /icub/left_hand/analog:o      </param>
+        <param name="name">       /icub/left_hand/MAIS      </param>
         
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubErzelli02/wrappers/MAIS/right_arm-mais_wrapper.xml
+++ b/iCubErzelli02/wrappers/MAIS/right_arm-mais_wrapper.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 
-   <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-mais_wrapper" type="analogServer">
+   <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-mais_wrapper" type="multipleanalogsensorsserver">
         <param name="period">      10                           </param>
-        <param name="name">       /icub/right_hand/analog:o     </param>
+        <param name="name">       /icub/right_hand/MAIS     </param>
 
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubGenova02/wrappers/MAIS/left_arm-mais_wrapper.xml
+++ b/iCubGenova02/wrappers/MAIS/left_arm-mais_wrapper.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
-    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mais_wrapper" type="analogServer">
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mais_wrapper" type="multipleanalogsensorsserver">
         <param name="period">       10                          </param>
-        <param name="name">       /icub/left_hand/analog:o      </param>
+        <param name="name">       /icub/left_hand/MAIS      </param>
         
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubGenova02/wrappers/MAIS/right_arm-mais_wrapper.xml
+++ b/iCubGenova02/wrappers/MAIS/right_arm-mais_wrapper.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
-    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-mais_wrapper" type="analogServer">
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-mais_wrapper" type="multipleanalogsensorsserver">
         <param name="period">       10                  </param>
-    <param name="name">       /icub/right_hand/analog:o     </param>
+    <param name="name">       /icub/right_hand/MAIS     </param>
 
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubGenova03/wrappers/MAIS/left_hand_mais_wrapper.xml
+++ b/iCubGenova03/wrappers/MAIS/left_hand_mais_wrapper.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
-	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_hand_as_wrapper" type="analogServer">
+	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_hand_as_wrapper" type="multipleanalogsensorsserver">
 		<param name="period">       10  				</param>
-<param name="name">     /icub/left_hand/analog:o </param>
+<param name="name">     /icub/left_hand/MAIS </param>
 		
 		<action phase="startup" level="5" type="attach">
 		    <paramlist name="networks">

--- a/iCubGenova03/wrappers/MAIS/right_hand_mais_wrapper.xml
+++ b/iCubGenova03/wrappers/MAIS/right_hand_mais_wrapper.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
-	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_hand_as_wrapper" type="analogServer">
+	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_hand_as_wrapper" type="multipleanalogsensorsserver">
 		<param name="period">       10  				</param>
-<param name="name">     /icub/right_hand/analog:o </param>
+<param name="name">     /icub/right_hand/MAIS </param>
 		
 		<action phase="startup" level="5" type="attach">
 		    <paramlist name="networks">

--- a/iCubGenova07/wrappers/MAIS/left_arm-mais_wrapper.xml
+++ b/iCubGenova07/wrappers/MAIS/left_arm-mais_wrapper.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 
-    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mais_wrapper" type="analogServer">
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mais_wrapper" type="multipleanalogsensorsserver">
         <param name="period">       10                         </param>
-        <param name="name">       /icub/left_hand/analog:o      </param>
+        <param name="name">       /icub/left_hand/MAIS      </param>
         
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubGenova07/wrappers/MAIS/right_arm-mais_wrapper.xml
+++ b/iCubGenova07/wrappers/MAIS/right_arm-mais_wrapper.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 
-   <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-mais_wrapper" type="analogServer">
+   <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-mais_wrapper" type="multipleanalogsensorsserver">
         <param name="period">      10                           </param>
-        <param name="name">       /icub/right_hand/analog:o     </param>
+        <param name="name">       /icub/right_hand/MAIS     </param>
 
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubGenova08/wrappers/MAIS/left_arm-mais_wrapper.xml
+++ b/iCubGenova08/wrappers/MAIS/left_arm-mais_wrapper.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 
-    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mais_wrapper" type="analogServer">
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mais_wrapper" type="multipleanalogsensorsserver">
         <param name="period">       10                         </param>
-        <param name="name">       /icub/left_hand/analog:o      </param>
+        <param name="name">       /icub/left_hand/MAIS      </param>
         
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubGenova08/wrappers/MAIS/right_arm-mais_wrapper.xml
+++ b/iCubGenova08/wrappers/MAIS/right_arm-mais_wrapper.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 
-   <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-mais_wrapper" type="analogServer">
+   <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-mais_wrapper" type="multipleanalogsensorsserver">
         <param name="period">      10                           </param>
-        <param name="name">       /icub/right_hand/analog:o     </param>
+        <param name="name">       /icub/right_hand/MAIS     </param>
 
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubGenova10/wrappers/MAIS/left_arm-mais_wrapper.xml
+++ b/iCubGenova10/wrappers/MAIS/left_arm-mais_wrapper.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 
-    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mais_wrapper" type="analogServer">
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mais_wrapper" type="multipleanalogsensorsserver">
         <param name="period">       10                         </param>
-        <param name="name">       /icub/left_hand/analog:o      </param>
+        <param name="name">       /icub/left_hand/MAIS      </param>
         
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubGenova10/wrappers/MAIS/right_arm-mais_wrapper.xml
+++ b/iCubGenova10/wrappers/MAIS/right_arm-mais_wrapper.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 
-   <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-mais_wrapper" type="analogServer">
+   <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-mais_wrapper" type="multipleanalogsensorsserver">
         <param name="period">      10                           </param>
-        <param name="name">       /icub/right_hand/analog:o     </param>
+        <param name="name">       /icub/right_hand/MAIS     </param>
 
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubGenova11/wrappers/MAIS/left_arm-mais_wrapper.xml
+++ b/iCubGenova11/wrappers/MAIS/left_arm-mais_wrapper.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 
-    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mais_wrapper" type="analogServer">
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mais_wrapper" type="multipleanalogsensorsserver">
         <param name="period">       10                         </param>
-        <param name="name">       /icub/left_hand/analog:o      </param>
+        <param name="name">       /icub/left_hand/MAIS      </param>
         
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubGenova11/wrappers/MAIS/right_arm-mais_wrapper.xml
+++ b/iCubGenova11/wrappers/MAIS/right_arm-mais_wrapper.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 
-   <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-mais_wrapper" type="analogServer">
+   <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-mais_wrapper" type="multipleanalogsensorsserver">
         <param name="period">      10                           </param>
-        <param name="name">       /icub/right_hand/analog:o     </param>
+        <param name="name">       /icub/right_hand/MAIS     </param>
 
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubGrenoble01/wrappers/MAIS/left_hand_mais_wrapper.xml
+++ b/iCubGrenoble01/wrappers/MAIS/left_hand_mais_wrapper.xml
@@ -2,9 +2,9 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
 
-	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_hand_as_wrapper" type="analogServer">
+	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_hand_as_wrapper" type="multipleanalogsensorsserver">
 		<param name="period">       10  				</param>
-<param name="name">     /icub/left_hand/analog:o </param>
+<param name="name">     /icub/left_hand/MAIS </param>
 
 		<action phase="startup" level="5" type="attach">
 		    <paramlist name="networks">

--- a/iCubGrenoble01/wrappers/MAIS/right_hand_mais_wrapper.xml
+++ b/iCubGrenoble01/wrappers/MAIS/right_hand_mais_wrapper.xml
@@ -2,9 +2,9 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
 
-	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_hand_as_wrapper" type="analogServer">
+	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_hand_as_wrapper" type="multipleanalogsensorsserver">
 		<param name="period">       10  				</param>
-<param name="name">     /icub/right_hand/analog:o </param>
+<param name="name">     /icub/right_hand/MAIS </param>
 
 		<action phase="startup" level="5" type="attach">
 		    <paramlist name="networks">

--- a/iCubHertfordshire01/wrappers/MAIS/left_hand_mais_wrapper.xml
+++ b/iCubHertfordshire01/wrappers/MAIS/left_hand_mais_wrapper.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
-	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_hand_as_wrapper" type="analogServer">
+	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_hand_as_wrapper" type="multipleanalogsensorsserver">
 		<param name="period">       10  				</param>
-<param name="name">     /icub/left_hand/analog:o </param>
+<param name="name">     /icub/left_hand/MAIS </param>
 		
 		<action phase="startup" level="5" type="attach">
 		    <paramlist name="networks">

--- a/iCubHertfordshire01/wrappers/MAIS/right_hand_mais_wrapper.xml
+++ b/iCubHertfordshire01/wrappers/MAIS/right_hand_mais_wrapper.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
-	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_hand_as_wrapper" type="analogServer">
+	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_hand_as_wrapper" type="multipleanalogsensorsserver">
 		<param name="period">       10  				</param>
-<param name="name">     /icub/right_hand/analog:o </param>
+<param name="name">     /icub/right_hand/MAIS </param>
 		
 		<action phase="startup" level="5" type="attach">
 		    <paramlist name="networks">

--- a/iCubLisboa01/wrappers/MAIS/left_arm-mais_wrapper.xml
+++ b/iCubLisboa01/wrappers/MAIS/left_arm-mais_wrapper.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 
-    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mais_wrapper" type="analogServer">
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mais_wrapper" type="multipleanalogsensorsserver">
         <param name="period">       10                         </param>
-        <param name="name">       /icub/left_hand/analog:o      </param>
+        <param name="name">       /icub/left_hand/MAIS      </param>
         
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubLisboa01/wrappers/MAIS/right_arm-mais_wrapper.xml
+++ b/iCubLisboa01/wrappers/MAIS/right_arm-mais_wrapper.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 
-   <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-mais_wrapper" type="analogServer">
+   <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-mais_wrapper" type="multipleanalogsensorsserver">
         <param name="period">      10                           </param>
-        <param name="name">       /icub/right_hand/analog:o     </param>
+        <param name="name">       /icub/right_hand/MAIS     </param>
 
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubLondon01/wrappers/MAIS/left_hand_mais_wrapper.xml
+++ b/iCubLondon01/wrappers/MAIS/left_hand_mais_wrapper.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
-	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_hand_as_wrapper" type="analogServer">
+	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_hand_as_wrapper" type="multipleanalogsensorsserver">
 		<param name="period">       10  				</param>
-		<param name="name">     /icub/left_hand/analog:o				</param>
+		<param name="name">     /icub/left_hand/MAIS				</param>
 		
 		<action phase="startup" level="5" type="attach">
 		    <paramlist name="networks">

--- a/iCubLondon01/wrappers/MAIS/right_hand_mais_wrapper.xml
+++ b/iCubLondon01/wrappers/MAIS/right_hand_mais_wrapper.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
-	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_hand_as_wrapper" type="analogServer">
+	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_hand_as_wrapper" type="multipleanalogsensorsserver">
 		<param name="period">       10  				</param>
-		<param name="name">     /icub/right_hand/analog:o				</param>
+		<param name="name">     /icub/right_hand/MAIS				</param>
 		
 		<action phase="startup" level="5" type="attach">
 		    <paramlist name="networks">

--- a/iCubNancy01/wrappers/MAIS/left_arm-mais_wrapper.xml
+++ b/iCubNancy01/wrappers/MAIS/left_arm-mais_wrapper.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
-    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mais_wrapper" type="analogServer">
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mais_wrapper" type="multipleanalogsensorsserver">
         <param name="period">       10                          </param>
-        <param name="name">       /icub/left_hand/analog:o      </param>
+        <param name="name">       /icub/left_hand/MAIS      </param>
         
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubNancy01/wrappers/MAIS/right_arm-mais_wrapper.xml
+++ b/iCubNancy01/wrappers/MAIS/right_arm-mais_wrapper.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
-    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-mais_wrapper" type="analogServer">
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-mais_wrapper" type="multipleanalogsensorsserver">
         <param name="period">       10                  </param>
-    <param name="name">       /icub/right_hand/analog:o     </param>
+    <param name="name">       /icub/right_hand/MAIS     </param>
 
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubPrague01/wrappers/MAIS/left_arm-mais_wrapper.xml
+++ b/iCubPrague01/wrappers/MAIS/left_arm-mais_wrapper.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 
-    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mais_wrapper" type="analogServer">
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mais_wrapper" type="multipleanalogsensorsserver">
         <param name="period">       10                         </param>
-        <param name="name">       /icub/left_hand/analog:o      </param>
+        <param name="name">       /icub/left_hand/MAIS      </param>
         
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubPrague01/wrappers/MAIS/right_arm-mais_wrapper.xml
+++ b/iCubPrague01/wrappers/MAIS/right_arm-mais_wrapper.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 
-   <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-mais_wrapper" type="analogServer">
+   <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-mais_wrapper" type="multipleanalogsensorsserver">
         <param name="period">      10                           </param>
-        <param name="name">       /icub/right_hand/analog:o     </param>
+        <param name="name">       /icub/right_hand/MAIS     </param>
 
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubShanghai01/wrappers/MAIS/left_arm-mais_wrapper.xml
+++ b/iCubShanghai01/wrappers/MAIS/left_arm-mais_wrapper.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 
-    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mais_wrapper" type="analogServer">
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mais_wrapper" type="multipleanalogsensorsserver">
         <param name="period">       10                         </param>
-        <param name="name">       /icub/left_hand/analog:o      </param>
+        <param name="name">       /icub/left_hand/MAIS      </param>
         
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubShanghai01/wrappers/MAIS/right_arm-mais_wrapper.xml
+++ b/iCubShanghai01/wrappers/MAIS/right_arm-mais_wrapper.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 
-   <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-mais_wrapper" type="analogServer">
+   <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-mais_wrapper" type="multipleanalogsensorsserver">
         <param name="period">      10                           </param>
-        <param name="name">       /icub/right_hand/analog:o     </param>
+        <param name="name">       /icub/right_hand/MAIS     </param>
 
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubShenzhen01/wrappers/MAIS/left_arm-mais_wrapper.xml
+++ b/iCubShenzhen01/wrappers/MAIS/left_arm-mais_wrapper.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 
-    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mais_wrapper" type="analogServer">
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mais_wrapper" type="multipleanalogsensorsserver">
         <param name="period">       10                         </param>
-        <param name="name">       /icub/left_hand/analog:o      </param>
+        <param name="name">       /icub/left_hand/MAIS      </param>
         
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubShenzhen01/wrappers/MAIS/right_arm-mais_wrapper.xml
+++ b/iCubShenzhen01/wrappers/MAIS/right_arm-mais_wrapper.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 
-   <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-mais_wrapper" type="analogServer">
+   <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-mais_wrapper" type="multipleanalogsensorsserver">
         <param name="period">      10                           </param>
-        <param name="name">       /icub/right_hand/analog:o     </param>
+        <param name="name">       /icub/right_hand/MAIS     </param>
 
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubSingapore01/wrappers/MAIS/left_arm-mais_wrapper.xml
+++ b/iCubSingapore01/wrappers/MAIS/left_arm-mais_wrapper.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 
-    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mais_wrapper" type="analogServer">
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mais_wrapper" type="multipleanalogsensorsserver">
         <param name="period">       10                         </param>
-        <param name="name">       /icub/left_hand/analog:o      </param>
+        <param name="name">       /icub/left_hand/MAIS      </param>
         
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubSingapore01/wrappers/MAIS/right_arm-mais_wrapper.xml
+++ b/iCubSingapore01/wrappers/MAIS/right_arm-mais_wrapper.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 
-   <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-mais_wrapper" type="analogServer">
+   <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-mais_wrapper" type="multipleanalogsensorsserver">
         <param name="period">      10                           </param>
-        <param name="name">       /icub/right_hand/analog:o     </param>
+        <param name="name">       /icub/right_hand/MAIS     </param>
 
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubTokyo01/wrappers/MAIS/left_hand_mais_wrapper.xml
+++ b/iCubTokyo01/wrappers/MAIS/left_hand_mais_wrapper.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>    
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
-	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_hand_as_wrapper" type="analogServer">
+	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_hand_as_wrapper" type="multipleanalogsensorsserver">
 		<param name="period">       10  				</param>
-		<param name="name">     /icub/left_hand/analog:o			</param>
+		<param name="name">     /icub/left_hand/MAIS			</param>
 		
 		<action phase="startup" level="5" type="attach">
 		    <paramlist name="networks">

--- a/iCubTokyo01/wrappers/MAIS/right_hand_mais_wrapper.xml
+++ b/iCubTokyo01/wrappers/MAIS/right_hand_mais_wrapper.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>    
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
-	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_hand_as_wrapper" type="analogServer">
+	<device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_hand_as_wrapper" type="multipleanalogsensorsserver">
 		<param name="period">       10  				</param>
-		<param name="name">     /icub/right_hand/analog:o				</param>
+		<param name="name">     /icub/right_hand/MAIS				</param>
 		
 		<action phase="startup" level="5" type="attach">
 		    <paramlist name="networks">

--- a/iCubValparaiso01/wrappers/MAIS/left_arm-mais_wrapper.xml
+++ b/iCubValparaiso01/wrappers/MAIS/left_arm-mais_wrapper.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 
-    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mais_wrapper" type="analogServer">
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mais_wrapper" type="multipleanalogsensorsserver">
         <param name="period">       10                         </param>
-        <param name="name">       /icub/left_hand/analog:o      </param>
+        <param name="name">       /icub/left_hand/MAIS      </param>
         
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubValparaiso01/wrappers/MAIS/right_arm-mais_wrapper.xml
+++ b/iCubValparaiso01/wrappers/MAIS/right_arm-mais_wrapper.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 
-   <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-mais_wrapper" type="analogServer">
+   <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-mais_wrapper" type="multipleanalogsensorsserver">
         <param name="period">      10                           </param>
-        <param name="name">       /icub/right_hand/analog:o     </param>
+        <param name="name">       /icub/right_hand/MAIS     </param>
 
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubWaterloo01/wrappers/MAIS/left_arm-mais_wrapper.xml
+++ b/iCubWaterloo01/wrappers/MAIS/left_arm-mais_wrapper.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 
-    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mais_wrapper" type="analogServer">
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mais_wrapper" type="multipleanalogsensorsserver">
         <param name="period">       10                         </param>
-        <param name="name">       /icub/left_hand/analog:o      </param>
+        <param name="name">       /icub/left_hand/MAIS      </param>
         
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubWaterloo01/wrappers/MAIS/right_arm-mais_wrapper.xml
+++ b/iCubWaterloo01/wrappers/MAIS/right_arm-mais_wrapper.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 
-   <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-mais_wrapper" type="analogServer">
+   <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-mais_wrapper" type="multipleanalogsensorsserver">
         <param name="period">      10                           </param>
-        <param name="name">       /icub/right_hand/analog:o     </param>
+        <param name="name">       /icub/right_hand/MAIS     </param>
 
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubZagreb01/wrappers/MAIS/left_arm-mais_wrapper.xml
+++ b/iCubZagreb01/wrappers/MAIS/left_arm-mais_wrapper.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 
-    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mais_wrapper" type="analogServer">
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mais_wrapper" type="multipleanalogsensorsserver">
         <param name="period">       10                         </param>
-        <param name="name">       /icub/left_hand/analog:o      </param>
+        <param name="name">       /icub/left_hand/MAIS      </param>
         
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubZagreb01/wrappers/MAIS/right_arm-mais_wrapper.xml
+++ b/iCubZagreb01/wrappers/MAIS/right_arm-mais_wrapper.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 
-   <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-mais_wrapper" type="analogServer">
+   <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-mais_wrapper" type="multipleanalogsensorsserver">
         <param name="period">      10                           </param>
-        <param name="name">       /icub/right_hand/analog:o     </param>
+        <param name="name">       /icub/right_hand/MAIS     </param>
 
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">


### PR DESCRIPTION
As agreed, updated all robots except for `robots-icebox`: 

- device `analogServer` becomes `multipleanalogsensorsserver`
- port `analog:o` becomes `MAIS`

cc @Nicogene @pattacini 