### PR TITLE
Add battery configuration files

### DIFF
--- a/experimentalSetups/battery/ergocub_battery.xml
+++ b/experimentalSetups/battery/ergocub_battery.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<robot name="ergoCubSN000" xmlns:xi="http://www.w3.org/2001/XInclude">
+<devices>
+    <!-- battery -->
+    <xi:include href="wrappers/battery/ergobattery.xml" /> 
+    <xi:include href="hardware/battery/ergocubbattery.xml" /> 
+    
+</devices>
+</robot> 
+

--- a/experimentalSetups/battery/ergocub_battery_couple.xml
+++ b/experimentalSetups/battery/ergocub_battery_couple.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<robot name="ergoCubSN000" xmlns:xi="http://www.w3.org/2001/XInclude">
+<devices>
+    <!-- battery BAT -->
+    <xi:include href="wrappers/battery/ergobattery_bat.xml" /> 
+    <xi:include href="hardware/battery/ergocubbattery_bat.xml" /> 
+    
+    <!-- battery BMS -->
+    <xi:include href="wrappers/battery/ergobattery_bms.xml" /> 
+    <xi:include href="hardware/battery/ergocubbattery_bms.xml" /> 
+</devices>
+</robot> 
+

--- a/experimentalSetups/battery/firmwareupdater.ini
+++ b/experimentalSetups/battery/firmwareupdater.ini
@@ -1,0 +1,2 @@
+[DRIVERS]
+ETH "eth"

--- a/experimentalSetups/battery/general.xml
+++ b/experimentalSetups/battery/general.xml
@@ -1,0 +1,10 @@
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="ergoCubSN000" build="1">
+  
+  <group name="GENERAL">
+      <param name="skipCalibration">    false  </param>
+      <param name="useRawEncoderData">  false  </param>
+      <param name="useLimitedPWM">      false  </param>
+      <param name="verbose">            false  </param>
+  </group>
+</params>

--- a/experimentalSetups/battery/hardware/battery/ergocubbattery.xml
+++ b/experimentalSetups/battery/hardware/battery/ergocubbattery.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE device PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="ergocub_battery" type="embObjBattery">  
+
+	<xi:include href="../../general.xml" />
+    <xi:include href="../electronics/battery_eb1-j0_1-eln.xml" />
+
+    <group name="SERVICE">
+
+        <param name="type"> eomn_serv_AS_battery </param>
+
+        <group name="PROPERTIES">
+
+            <group name="CANBOARDS">
+                <param name="type">                 bat             </param>
+
+                <group name="PROTOCOL">
+                    <param name="major">            0                   </param>
+                    <param name="minor">            0                   </param>
+                </group>
+                <group name="FIRMWARE">
+                    <param name="major">            1                   </param>
+                    <param name="minor">            3                   </param>
+                    <param name="build">            0                   </param>
+                </group>
+            </group>
+
+            <group name="SENSORS">
+                <param name="id">                   battery1        </param>
+                <param name="board">                bat             </param>
+                <param name="location">             CAN1:1          </param>
+            </group>
+
+        </group>
+
+
+        <group name="SETTINGS">
+            <param name="enabledSensors">            battery1        </param>
+            <param name="acquisitionRate">           1000            </param>   <!-- msec -->
+        </group>
+
+
+    </group>         
+
+</device>    
+          

--- a/experimentalSetups/battery/hardware/battery/ergocubbattery_bat.xml
+++ b/experimentalSetups/battery/hardware/battery/ergocubbattery_bat.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE device PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="ergocub_battery_bat" type="embObjBattery">  
+
+	<xi:include href="../../general.xml" />
+    <xi:include href="../electronics/battery_eb1-j0_1-eln.xml" />
+
+    <group name="SERVICE">
+
+        <param name="type"> eomn_serv_AS_battery </param>
+
+        <group name="PROPERTIES">
+
+            <group name="CANBOARDS">
+                <param name="type">                 bat             </param>
+
+                <group name="PROTOCOL">
+                    <param name="major">            0                   </param>
+                    <param name="minor">            0                   </param>
+                </group>
+                <group name="FIRMWARE">
+                    <param name="major">            1                   </param>
+                    <param name="minor">            3                   </param>
+                    <param name="build">            0                   </param>
+                </group>
+            </group>
+
+            <group name="SENSORS">
+                <param name="id">                   battery1        </param>
+                <param name="board">                bat             </param>
+                <param name="location">             CAN1:1          </param>
+            </group>
+
+        </group>
+
+
+        <group name="SETTINGS">
+            <param name="enabledSensors">            battery1        </param>
+            <param name="acquisitionRate">           1000            </param>   <!-- msec -->
+        </group>
+
+
+    </group>         
+
+</device>    
+          

--- a/experimentalSetups/battery/hardware/battery/ergocubbattery_bms.xml
+++ b/experimentalSetups/battery/hardware/battery/ergocubbattery_bms.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE device PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="ergocub_battery_bms" type="embObjBattery">  
+
+	<xi:include href="../../general.xml" />
+    <xi:include href="../electronics/battery_eb2-j0_1-eln.xml" />
+
+    <group name="SERVICE">
+
+        <param name="type"> eomn_serv_AS_battery </param>
+
+        <group name="PROPERTIES">
+
+            <group name="CANBOARDS">
+                <param name="type">                 bms             </param>
+
+                <group name="PROTOCOL">
+                    <param name="major">            0                   </param>
+                    <param name="minor">            0                   </param>
+                </group>
+                <group name="FIRMWARE">
+                    <param name="major">            1                   </param>
+                    <param name="minor">            2                   </param>
+                    <param name="build">            0                   </param>
+                </group>
+            </group>
+
+            <group name="SENSORS">
+                <param name="id">                   battery1        </param>
+                <param name="board">                bms             </param>
+                <param name="location">             CAN1:1          </param>
+            </group>
+
+        </group>
+
+
+        <group name="SETTINGS">
+            <param name="enabledSensors">            battery1        </param>
+            <param name="acquisitionRate">           1000            </param>   <!-- msec -->
+        </group>
+
+
+    </group>         
+
+</device>    
+          

--- a/experimentalSetups/battery/hardware/electronics/battery_eb1-j0_1-eln.xml
+++ b/experimentalSetups/battery/hardware/electronics/battery_eb1-j0_1-eln.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="ergoCubSN000" build="1">
+
+    <xi:include href="./pc104.xml" />
+    
+    <group name="ETH_BOARD">
+   
+        <group name="ETH_BOARD_PROPERTIES">
+            <param name="IpAddress">                10.0.1.1                </param>
+            <param name="IpPort">                   12345                   </param>
+            <param name="Type">                     ems4                    </param>
+            <param name="maxSizeRXpacket">          768                     </param>
+            <param name="maxSizeROP">               384                     </param>
+        </group>
+
+        <group name="ETH_BOARD_SETTINGS">
+            <param name="Name">                     "battery_eb1-j0_1-eln"     </param> 
+            <group name="RUNNINGMODE">
+                <param name="period">                   1000                </param>
+                <param name="maxTimeOfRXactivity">      400                 </param>
+                <param name="maxTimeOfDOactivity">      300                 </param>   
+                <param name="maxTimeOfTXactivity">      300                 </param>                
+                <param name="TXrateOfRegularROPs">      2                   </param> 
+            </group>              
+        </group>                 
+        
+        <group name="ETH_BOARD_ACTIONS">
+            <group name="MONITOR_ITS_PRESENCE">
+                <param name="enabled">                  true                </param> 
+                <param name="timeout">                  0.020               </param> 
+                <param name="periodOfMissingReport">    60.0                </param> 
+            </group>
+        </group>
+
+    </group>  
+    
+</params>

--- a/experimentalSetups/battery/hardware/electronics/battery_eb2-j0_1-eln.xml
+++ b/experimentalSetups/battery/hardware/electronics/battery_eb2-j0_1-eln.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="ergoCubSN000" build="1">
+
+    <xi:include href="./pc104.xml" />
+    
+    <group name="ETH_BOARD">
+   
+        <group name="ETH_BOARD_PROPERTIES">
+            <param name="IpAddress">                10.0.1.2                </param>
+            <param name="IpPort">                   12345                   </param>
+            <param name="Type">                     ems4                    </param>
+            <param name="maxSizeRXpacket">          768                     </param>
+            <param name="maxSizeROP">               384                     </param>
+        </group>
+
+        <group name="ETH_BOARD_SETTINGS">
+            <param name="Name">                     "battery_eb2-j0_1-eln"     </param> 
+            <group name="RUNNINGMODE">
+                <param name="period">                   1000                </param>
+                <param name="maxTimeOfRXactivity">      400                 </param>
+                <param name="maxTimeOfDOactivity">      300                 </param>   
+                <param name="maxTimeOfTXactivity">      300                 </param>                
+                <param name="TXrateOfRegularROPs">      2                   </param> 
+            </group>              
+        </group>                 
+        
+        <group name="ETH_BOARD_ACTIONS">
+            <group name="MONITOR_ITS_PRESENCE">
+                <param name="enabled">                  true                </param> 
+                <param name="timeout">                  0.020               </param> 
+                <param name="periodOfMissingReport">    60.0                </param> 
+            </group>
+        </group>
+
+    </group>  
+    
+</params>

--- a/experimentalSetups/battery/hardware/electronics/pc104.xml
+++ b/experimentalSetups/battery/hardware/electronics/pc104.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="ergoCubSN000" build="1">
+
+    <group name="PC104">
+        <param name="PC104IpAddress">           10.0.1.104      </param>
+        <param name="PC104IpPort">              12345           </param>
+        <param name="PC104TXrate">              1               </param> 
+        <param name="PC104RXrate">              2               </param>
+    </group>
+
+        <group name="DEBUG">
+        <param name="embBoardsConnected"> 1 </param>
+    </group>
+
+</params>
+

--- a/experimentalSetups/battery/wrappers/battery/ergobattery.xml
+++ b/experimentalSetups/battery/wrappers/battery/ergobattery.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="ergocub_battery-nws_yarp" type="battery_nws_yarp">
+
+      <param name="period">           1.0             </param>
+      <param name="name">        /ergocub/battery     </param>
+      <param name="enable_log">        0              </param>
+      <param name="enable_shutdown">   0              </param>
+
+      <action phase="startup" level="5" type="attach">
+         <paramlist name="networks">
+            <elem name="ergocub_battery">  ergocub_battery </elem>
+         </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+  </device>
+

--- a/experimentalSetups/battery/wrappers/battery/ergobattery_bat.xml
+++ b/experimentalSetups/battery/wrappers/battery/ergobattery_bat.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="ergocub_battery-nws_yarp" type="battery_nws_yarp">
+
+      <param name="period">           1.0             </param>
+      <param name="name">        /ergocub/battery/bat </param>
+      <param name="enable_log">        0              </param>
+      <param name="enable_shutdown">   0              </param>
+
+      <action phase="startup" level="5" type="attach">
+         <paramlist name="networks">
+            <elem name="ergocub_battery_bat">  ergocub_battery_bat </elem>
+         </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+  </device>
+

--- a/experimentalSetups/battery/wrappers/battery/ergobattery_bms.xml
+++ b/experimentalSetups/battery/wrappers/battery/ergobattery_bms.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+  <device xmlns:xi="http://www.w3.org/2001/XInclude" name="ergocub_battery-nws_yarp" type="battery_nws_yarp">
+
+      <param name="period">           1.0        </param>
+      <param name="name">        /ergocub/battery/bms </param>
+      <param name="enable_log">        0         </param>
+      <param name="enable_shutdown">   0         </param>
+
+      <action phase="startup" level="5" type="attach">
+         <paramlist name="networks">
+            <elem name="ergocub_battery_bms">  ergocub_battery_bms </elem>
+         </paramlist>
+      </action>
+
+      <action phase="shutdown" level="5" type="detach" />
+  </device>
+

--- a/experimentalSetups/battery/yarprobotinterface.ini
+++ b/experimentalSetups/battery/yarprobotinterface.ini
@@ -1,1 +1,1 @@
-config ./icub_battery.xml
+config ./ergocub_battery_couple.xml


### PR DESCRIPTION
This PR brings the following changes:
- Update the battery experimental setup
- Now the `experimentalSetups/battery` configuration can be used with:
    - only the BAT board connected to the EMS
    - only the BMS board connected to the EMS
    - both BAT and BMS boards connected to different EMS boards as for the `ergoCub` robot  

- Update test battery files to used both BMS and BAT streaming to different ports using the coupled battery bms+bat together