### PR TITLE
Update ergocubSN000 battery conf files

### DIFF
--- a/ergoCubSN000/battery_test.xml
+++ b/ergoCubSN000/battery_test.xml
@@ -5,12 +5,12 @@
 
   <devices>
     <!-- battery BAT -->
-    <xi:include href="wrappers/battery/ergobattery_bat.xml" /> 
-    <xi:include href="hardware/battery/ergocubbattery_bat.xml" /> 
+    <xi:include href="wrappers/battery/battery_bat.xml" /> 
+    <xi:include href="hardware/battery/battery_bat.xml" /> 
     
     <!-- battery BMS -->
-    <xi:include href="wrappers/battery/ergobattery_bms.xml" /> 
-    <xi:include href="hardware/battery/ergocubbattery_bms.xml" /> 
+    <xi:include href="wrappers/battery/battery_bms.xml" /> 
+    <xi:include href="hardware/battery/battery_bms.xml" /> 
   </devices>
 
 </robot>

--- a/ergoCubSN000/battery_test.xml
+++ b/ergoCubSN000/battery_test.xml
@@ -4,8 +4,13 @@
 <robot name="ergoCubSN000" build="1" portprefix="/ergocub" xmlns:xi="http://www.w3.org/2001/XInclude">
 
   <devices>
-    <xi:include href="hardware/battery/battery.xml" />
-    <xi:include href="wrappers/battery/battery.xml" />
+    <!-- battery BAT -->
+    <xi:include href="wrappers/battery/ergobattery_bat.xml" /> 
+    <xi:include href="hardware/battery/ergocubbattery_bat.xml" /> 
+    
+    <!-- battery BMS -->
+    <xi:include href="wrappers/battery/ergobattery_bms.xml" /> 
+    <xi:include href="hardware/battery/ergocubbattery_bms.xml" /> 
   </devices>
 
 </robot>

--- a/ergoCubSN000/ergocub_all.xml
+++ b/ergoCubSN000/ergocub_all.xml
@@ -115,9 +115,13 @@
     <xi:include href="wrappers/inertials/left_foot-imu_wrapper.xml" />
     <xi:include href="wrappers/inertials/right_foot-imu_wrapper.xml" />
     
-    <!-- BATTERY-->
-    <xi:include href="hardware/battery/battery.xml" />
-    <xi:include href="wrappers/battery/battery.xml" />
+    <!-- battery BAT -->
+    <xi:include href="wrappers/battery/ergobattery_bat.xml" /> 
+    <xi:include href="hardware/battery/ergocubbattery_bat.xml" /> 
+    
+    <!-- battery BMS -->
+    <xi:include href="wrappers/battery/ergobattery_bms.xml" /> 
+    <xi:include href="hardware/battery/ergocubbattery_bms.xml" /> 
 
     <!--  CALIBRATORS -->
     <xi:include href="calibrators/torso-calib.xml" />

--- a/ergoCubSN000/ergocub_all.xml
+++ b/ergoCubSN000/ergocub_all.xml
@@ -116,12 +116,12 @@
     <xi:include href="wrappers/inertials/right_foot-imu_wrapper.xml" />
     
     <!-- battery BAT -->
-    <xi:include href="wrappers/battery/ergobattery_bat.xml" /> 
-    <xi:include href="hardware/battery/ergocubbattery_bat.xml" /> 
+    <xi:include href="wrappers/battery/battery_bat.xml" /> 
+    <xi:include href="hardware/battery/battery_bat.xml" /> 
     
     <!-- battery BMS -->
-    <xi:include href="wrappers/battery/ergobattery_bms.xml" /> 
-    <xi:include href="hardware/battery/ergocubbattery_bms.xml" /> 
+    <xi:include href="wrappers/battery/battery_bms.xml" /> 
+    <xi:include href="hardware/battery/battery_bms.xml" /> 
 
     <!--  CALIBRATORS -->
     <xi:include href="calibrators/torso-calib.xml" />

--- a/ergoCubSN000/ergocub_all_ros2.xml
+++ b/ergoCubSN000/ergocub_all_ros2.xml
@@ -100,9 +100,13 @@
     <xi:include href="wrappers/inertials/waist-inertials_wrapper.xml" />
 
     
-    <!-- BATTERY-->
-    <xi:include href="hardware/battery/battery.xml" />
-    <xi:include href="wrappers/battery/battery.xml" />
+    <!-- battery BAT -->
+    <xi:include href="wrappers/battery/ergobattery_bat.xml" /> 
+    <xi:include href="hardware/battery/ergocubbattery_bat.xml" /> 
+    
+    <!-- battery BMS -->
+    <xi:include href="wrappers/battery/ergobattery_bms.xml" /> 
+    <xi:include href="hardware/battery/ergocubbattery_bms.xml" /> 
 
     <!--  CALIBRATORS -->
     <xi:include href="calibrators/torso-calib.xml" />

--- a/ergoCubSN000/ergocub_all_ros2.xml
+++ b/ergoCubSN000/ergocub_all_ros2.xml
@@ -101,12 +101,12 @@
 
     
     <!-- battery BAT -->
-    <xi:include href="wrappers/battery/ergobattery_bat.xml" /> 
-    <xi:include href="hardware/battery/ergocubbattery_bat.xml" /> 
+    <xi:include href="wrappers/battery/battery_bat.xml" /> 
+    <xi:include href="hardware/battery/battery_bat.xml" /> 
     
     <!-- battery BMS -->
-    <xi:include href="wrappers/battery/ergobattery_bms.xml" /> 
-    <xi:include href="hardware/battery/ergocubbattery_bms.xml" /> 
+    <xi:include href="wrappers/battery/battery_bms.xml" /> 
+    <xi:include href="hardware/battery/battery_bms.xml" /> 
 
     <!--  CALIBRATORS -->
     <xi:include href="calibrators/torso-calib.xml" />

--- a/ergoCubSN000/ergocub_wbd.xml
+++ b/ergoCubSN000/ergocub_wbd.xml
@@ -112,9 +112,13 @@
     <xi:include href="wrappers/inertials/left_foot-imu_wrapper.xml" />
     <xi:include href="wrappers/inertials/right_foot-imu_wrapper.xml" />
     
-    <!-- BATTERY-->
-    <xi:include href="hardware/battery/battery.xml" />
-    <xi:include href="wrappers/battery/battery.xml" />
+    <!-- battery BAT -->
+    <xi:include href="wrappers/battery/ergobattery_bat.xml" /> 
+    <xi:include href="hardware/battery/ergocubbattery_bat.xml" /> 
+    
+    <!-- battery BMS -->
+    <xi:include href="wrappers/battery/ergobattery_bms.xml" /> 
+    <xi:include href="hardware/battery/ergocubbattery_bms.xml" /> 
 
     <xi:include href="hardware/battery/battery_bat.xml" />
     <xi:include href="wrappers/battery/battery_bat.xml" />

--- a/ergoCubSN000/ergocub_wbd.xml
+++ b/ergoCubSN000/ergocub_wbd.xml
@@ -113,15 +113,12 @@
     <xi:include href="wrappers/inertials/right_foot-imu_wrapper.xml" />
     
     <!-- battery BAT -->
-    <xi:include href="wrappers/battery/ergobattery_bat.xml" /> 
-    <xi:include href="hardware/battery/ergocubbattery_bat.xml" /> 
+    <xi:include href="wrappers/battery/battery_bat.xml" /> 
+    <xi:include href="hardware/battery/battery_bat.xml" /> 
     
     <!-- battery BMS -->
-    <xi:include href="wrappers/battery/ergobattery_bms.xml" /> 
-    <xi:include href="hardware/battery/ergocubbattery_bms.xml" /> 
-
-    <xi:include href="hardware/battery/battery_bat.xml" />
-    <xi:include href="wrappers/battery/battery_bat.xml" />
+    <xi:include href="wrappers/battery/battery_bms.xml" /> 
+    <xi:include href="hardware/battery/battery_bms.xml" /> 
 
     <!--  CALIBRATORS -->
     <xi:include href="calibrators/torso-calib.xml" />

--- a/ergoCubSN000/ergocub_wbd_ros2.xml
+++ b/ergoCubSN000/ergocub_wbd_ros2.xml
@@ -111,12 +111,12 @@
     <xi:include href="wrappers/inertials/right_foot-imu_wrapper.xml" />
     
     <!-- battery BAT -->
-    <xi:include href="wrappers/battery/ergobattery_bat.xml" /> 
-    <xi:include href="hardware/battery/ergocubbattery_bat.xml" /> 
+    <xi:include href="wrappers/battery/battery_bat.xml" /> 
+    <xi:include href="hardware/battery/battery_bat.xml" /> 
     
     <!-- battery BMS -->
-    <xi:include href="wrappers/battery/ergobattery_bms.xml" /> 
-    <xi:include href="hardware/battery/ergocubbattery_bms.xml" /> 
+    <xi:include href="wrappers/battery/battery_bms.xml" /> 
+    <xi:include href="hardware/battery/battery_bms.xml" /> 
 
     <!--  CALIBRATORS -->
     <xi:include href="calibrators/torso-calib.xml" />

--- a/ergoCubSN000/ergocub_wbd_ros2.xml
+++ b/ergoCubSN000/ergocub_wbd_ros2.xml
@@ -110,9 +110,13 @@
     <xi:include href="wrappers/inertials/left_foot-imu_wrapper.xml" />
     <xi:include href="wrappers/inertials/right_foot-imu_wrapper.xml" />
     
-    <!-- BATTERY-->
-    <xi:include href="hardware/battery/battery.xml" />
-    <xi:include href="wrappers/battery/battery.xml" />
+    <!-- battery BAT -->
+    <xi:include href="wrappers/battery/ergobattery_bat.xml" /> 
+    <xi:include href="hardware/battery/ergocubbattery_bat.xml" /> 
+    
+    <!-- battery BMS -->
+    <xi:include href="wrappers/battery/ergobattery_bms.xml" /> 
+    <xi:include href="hardware/battery/ergocubbattery_bms.xml" /> 
 
     <!--  CALIBRATORS -->
     <xi:include href="calibrators/torso-calib.xml" />

--- a/ergoCubSN000/hardware/battery/battery_bat.xml
+++ b/ergoCubSN000/hardware/battery/battery_bat.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE device PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
-<device xmlns:xi="http://www.w3.org/2001/XInclude" name="canbattery" type="embObjBattery">
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="battery_bat" type="embObjBattery">
 
     <xi:include href="../../general.xml" />
-    <xi:include href="../electronics/left_arm-eb2-j0_1-eln.xml" />
+    <xi:include href="../electronics/right_arm-eb1-j0_1-eln.xml" />
 
     <group name="SERVICE">
 
@@ -13,7 +13,7 @@
         <group name="PROPERTIES">
 
             <group name="CANBOARDS">
-                <param name="type">                 bms             </param>
+                <param name="type">                 bat             </param>
 
                 <group name="PROTOCOL">
                     <param name="major">            0                   </param>
@@ -21,15 +21,15 @@
                 </group>
                 <group name="FIRMWARE">
                     <param name="major">            1                   </param>
-                    <param name="minor">            2                   </param>
+                    <param name="minor">            3                   </param>
                     <param name="build">            0                   </param>
                 </group>
             </group>
 
             <group name="SENSORS">
                 <param name="id">                   battery1        </param>
-                <param name="board">                bms             </param>
-                <param name="location">             CAN1:1          </param>
+                <param name="board">                bat             </param>
+                <param name="location">             CAN2:1          </param>
             </group>
 
         </group>

--- a/ergoCubSN000/hardware/battery/battery_bms.xml
+++ b/ergoCubSN000/hardware/battery/battery_bms.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE device PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="battery_bms" type="embObjBattery">
+
+    <xi:include href="../../general.xml" />
+    <xi:include href="../electronics/left_arm-eb2-j0_1-eln.xml" />
+
+    <group name="SERVICE">
+
+        <param name="type"> eomn_serv_AS_battery </param>
+
+        <group name="PROPERTIES">
+
+            <group name="CANBOARDS">
+                <param name="type">                 bms             </param>
+
+                <group name="PROTOCOL">
+                    <param name="major">            0                   </param>
+                    <param name="minor">            0                   </param>
+                </group>
+                <group name="FIRMWARE">
+                    <param name="major">            0                   </param>
+                    <param name="minor">            0                   </param>
+                    <param name="build">            0                   </param>
+                </group>
+            </group>
+
+            <group name="SENSORS">
+                <param name="id">                   battery1        </param>
+                <param name="board">                bms             </param>
+                <param name="location">             CAN2:1          </param>
+            </group>
+
+        </group>
+
+
+        <group name="SETTINGS">
+            <param name="enabledSensors">            battery1        </param>
+            <param name="acquisitionRate">           1000            </param>   <!-- msec -->
+        </group>
+
+
+    </group>
+
+</device>
+

--- a/ergoCubSN000/wrappers/battery/battery_bat.xml
+++ b/ergoCubSN000/wrappers/battery/battery_bat.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="battery_wrapper" type="battery_nws_yarp">
+    <param name="period">       1.0                     </param>
+    <param name="name">       /ergocub/battery/bat      </param>
+
+    <action phase="startup" level="5" type="attach">
+        <paramlist name="networks">
+        <!-- The param value must match the device name in the corresponding body_part-ebX-jA_B-hw.xml file -->
+            <elem name="battery">  battery_bat </elem>
+        </paramlist>
+    </action>
+
+    <action phase="shutdown" level="5" type="detach" />
+</device>
+

--- a/ergoCubSN000/wrappers/battery/battery_bms.xml
+++ b/ergoCubSN000/wrappers/battery/battery_bms.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="battery_wrapper" type="battery_nws_yarp">
-    <param name="period">       1.0                 </param>
-    <param name="name">       /ergocub/battery      </param>
+    <param name="period">       1.0                     </param>
+    <param name="name">       /ergocub/battery/bms      </param>
 
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">
-        <!-- The param value must match the device name in the corresponding body_part-ebX-jA_B-strain.xml file -->
-            <elem name="battery">  canbattery </elem>
+        <!-- The param value must match the device name in the corresponding hardware/battery/battery_type.xml file -->
+            <elem name="battery">  battery_bms </elem>
         </paramlist>
     </action>
 

--- a/ergoCubSN001/battery_test.xml
+++ b/ergoCubSN001/battery_test.xml
@@ -4,8 +4,13 @@
 <robot name="ergoCubSN001" build="1" portprefix="/ergocub" xmlns:xi="http://www.w3.org/2001/XInclude">
 
   <devices>
-    <xi:include href="hardware/battery/battery.xml" />
-    <xi:include href="wrappers/battery/battery.xml" />
+    <!-- battery BAT -->
+    <xi:include href="wrappers/battery/battery_bat.xml" /> 
+    <xi:include href="hardware/battery/battery_bat.xml" /> 
+    
+    <!-- battery BMS -->
+    <xi:include href="wrappers/battery/battery_bms.xml" /> 
+    <xi:include href="hardware/battery/battery_bms.xml" /> 
   </devices>
 
 </robot>

--- a/ergoCubSN001/ergocub_all.xml
+++ b/ergoCubSN001/ergocub_all.xml
@@ -115,9 +115,13 @@
     <xi:include href="wrappers/inertials/left_foot-imu_wrapper.xml" />
     <xi:include href="wrappers/inertials/right_foot-imu_wrapper.xml" />
     
-    <!-- BATTERY-->
-    <xi:include href="hardware/battery/battery.xml" />
-    <xi:include href="wrappers/battery/battery.xml" />
+    <!-- BATTERY BAT -->
+    <xi:include href="wrappers/battery/battery_bat.xml" /> 
+    <xi:include href="hardware/battery/battery_bat.xml" /> 
+    
+    <!-- BATTERY BMS -->
+    <xi:include href="wrappers/battery/battery_bms.xml" /> 
+    <xi:include href="hardware/battery/battery_bms.xml" /> 
 
     <!--  CALIBRATORS -->
     <xi:include href="calibrators/torso-calib.xml" />

--- a/ergoCubSN001/ergocub_all_ros2.xml
+++ b/ergoCubSN001/ergocub_all_ros2.xml
@@ -100,9 +100,13 @@
     <xi:include href="wrappers/inertials/waist-inertials_wrapper.xml" />
 
     
-    <!-- BATTERY-->
-    <xi:include href="hardware/battery/battery.xml" />
-    <xi:include href="wrappers/battery/battery.xml" />
+    <!-- BATTERY BAT -->
+    <xi:include href="wrappers/battery/battery_bat.xml" /> 
+    <xi:include href="hardware/battery/battery_bat.xml" /> 
+    
+    <!-- BATTERY BMS -->
+    <xi:include href="wrappers/battery/battery_bms.xml" /> 
+    <xi:include href="hardware/battery/battery_bms.xml" /> 
 
     <!--  CALIBRATORS -->
     <xi:include href="calibrators/torso-calib.xml" />

--- a/ergoCubSN001/ergocub_wbd.xml
+++ b/ergoCubSN001/ergocub_wbd.xml
@@ -112,9 +112,13 @@
     <xi:include href="wrappers/inertials/left_foot-imu_wrapper.xml" />
     <xi:include href="wrappers/inertials/right_foot-imu_wrapper.xml" />
     
-    <!-- BATTERY-->
-    <xi:include href="hardware/battery/battery.xml" />
-    <xi:include href="wrappers/battery/battery.xml" />
+    <!-- BATTERY BAT -->
+    <xi:include href="wrappers/battery/battery_bat.xml" /> 
+    <xi:include href="hardware/battery/battery_bat.xml" /> 
+    
+    <!-- BATTERY BMS -->
+    <xi:include href="wrappers/battery/battery_bms.xml" /> 
+    <xi:include href="hardware/battery/battery_bms.xml" /> 
 
     <!--  CALIBRATORS -->
     <xi:include href="calibrators/torso-calib.xml" />

--- a/ergoCubSN001/ergocub_wbd_ros2.xml
+++ b/ergoCubSN001/ergocub_wbd_ros2.xml
@@ -110,9 +110,13 @@
     <xi:include href="wrappers/inertials/left_foot-imu_wrapper.xml" />
     <xi:include href="wrappers/inertials/right_foot-imu_wrapper.xml" />
     
-    <!-- BATTERY-->
-    <xi:include href="hardware/battery/battery.xml" />
-    <xi:include href="wrappers/battery/battery.xml" />
+    <!-- BATTERY BAT -->
+    <xi:include href="wrappers/battery/battery_bat.xml" /> 
+    <xi:include href="hardware/battery/battery_bat.xml" /> 
+    
+    <!-- BATTERY BMS -->
+    <xi:include href="wrappers/battery/battery_bms.xml" /> 
+    <xi:include href="hardware/battery/battery_bms.xml" /> 
 
     <!--  CALIBRATORS -->
     <xi:include href="calibrators/torso-calib.xml" />

--- a/ergoCubSN001/hardware/battery/battery_bat.xml
+++ b/ergoCubSN001/hardware/battery/battery_bat.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE device PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
-<device xmlns:xi="http://www.w3.org/2001/XInclude" name="canbattery" type="embObjBattery">
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="battery_bat" type="embObjBattery">
 
     <xi:include href="../../general.xml" />
-    <xi:include href="../electronics/left_arm-eb2-j0_1-eln.xml" />
+    <xi:include href="../electronics/right_arm-eb1-j0_1-eln.xml" />
 
     <group name="SERVICE">
 
@@ -13,7 +13,7 @@
         <group name="PROPERTIES">
 
             <group name="CANBOARDS">
-                <param name="type">                 bms             </param>
+                <param name="type">                 bat             </param>
 
                 <group name="PROTOCOL">
                     <param name="major">            0                   </param>
@@ -21,15 +21,15 @@
                 </group>
                 <group name="FIRMWARE">
                     <param name="major">            1                   </param>
-                    <param name="minor">            2                   </param>
+                    <param name="minor">            3                   </param>
                     <param name="build">            0                   </param>
                 </group>
             </group>
 
             <group name="SENSORS">
                 <param name="id">                   battery1        </param>
-                <param name="board">                bms             </param>
-                <param name="location">             CAN1:1          </param>
+                <param name="board">                bat             </param>
+                <param name="location">             CAN2:1          </param>
             </group>
 
         </group>

--- a/ergoCubSN001/hardware/battery/battery_bms.xml
+++ b/ergoCubSN001/hardware/battery/battery_bms.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE device PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="battery_bms" type="embObjBattery">
+
+    <xi:include href="../../general.xml" />
+    <xi:include href="../electronics/left_arm-eb2-j0_1-eln.xml" />
+
+    <group name="SERVICE">
+
+        <param name="type"> eomn_serv_AS_battery </param>
+
+        <group name="PROPERTIES">
+
+            <group name="CANBOARDS">
+                <param name="type">                 bms             </param>
+
+                <group name="PROTOCOL">
+                    <param name="major">            0                   </param>
+                    <param name="minor">            0                   </param>
+                </group>
+                <group name="FIRMWARE">
+                    <param name="major">            1                   </param>
+                    <param name="minor">            3                   </param>
+                    <param name="build">            0                   </param>
+                </group>
+            </group>
+
+            <group name="SENSORS">
+                <param name="id">                   battery1        </param>
+                <param name="board">                bms             </param>
+                <param name="location">             CAN2:1          </param>
+            </group>
+
+        </group>
+
+
+        <group name="SETTINGS">
+            <param name="enabledSensors">            battery1        </param>
+            <param name="acquisitionRate">           1000            </param>   <!-- msec -->
+        </group>
+
+
+    </group>
+
+</device>
+

--- a/ergoCubSN001/wrappers/battery/battery_bat.xml
+++ b/ergoCubSN001/wrappers/battery/battery_bat.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="battery_wrapper" type="battery_nws_yarp">
+    <param name="period">       1.0                 </param>
+    <param name="name">       /ergocub/battery/bat      </param>
+
+    <action phase="startup" level="5" type="attach">
+        <paramlist name="networks">
+        <!-- The param value must match the device name in the corresponding body_part-ebX-jA_B-strain.xml file -->
+            <elem name="battery">  battery_bat </elem>
+        </paramlist>
+    </action>
+
+    <action phase="shutdown" level="5" type="detach" />
+</device>
+

--- a/ergoCubSN001/wrappers/battery/battery_bms.xml
+++ b/ergoCubSN001/wrappers/battery/battery_bms.xml
@@ -2,12 +2,12 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="battery_wrapper" type="battery_nws_yarp">
     <param name="period">       1.0                 </param>
-    <param name="name">       /ergocub/battery      </param>
+    <param name="name">       /ergocub/battery/bms      </param>
 
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">
         <!-- The param value must match the device name in the corresponding body_part-ebX-jA_B-strain.xml file -->
-            <elem name="battery">  canbattery </elem>
+            <elem name="battery">  battery_bms </elem>
         </paramlist>
     </action>
 


### PR DESCRIPTION
This PR brings the following changes for ergoCubSN000 (I suppose these can be copied as they are in ergocubSN001 - after revision):
- Add conf files for bat and bms in hw and wrapper
- Update the yarprobotinterface conf files
- Set to use CAN2:1
- Define separate ports on wrapppers for bat and bms devices