### PR TITLE
[ergoCubSN001] Updates config files for the new 2FOC FW version (V3.6)

### DIFF
--- a/ergoCubSN001/hardware/motorControl/left_arm-eb2-j0_1-mc_service.xml
+++ b/ergoCubSN001/hardware/motorControl/left_arm-eb2-j0_1-mc_service.xml
@@ -21,8 +21,8 @@
                 </group>                    
                 <group name="FIRMWARE">
                     <param name="major">            3           </param>    
-                    <param name="minor">            3           </param> 
-                    <param name="build">            10          </param>
+                    <param name="minor">            6           </param> 
+                    <param name="build">            21          </param>
                 </group>
             </group>
             
@@ -44,10 +44,10 @@
                 </group>        
                 
                 <group name="ENCODER2">
-                    <param name="type">             roie                roie                </param> <!-- lcore oppure roie ????? -->
+                    <param name="type">             roie                roie                </param> 
                     <param name="port">             CAN1:1:0            CAN1:2:0            </param>
                     <param name="position">         atmotor             atmotor             </param>
-                    <param name="resolution">       14400               14400               </param> <!-- segno da vedersi -->
+                    <param name="resolution">       3600                3600                </param> 
                     <param name="tolerance">        3.6                 3.6                 </param>  
                 </group> 
  

--- a/ergoCubSN001/hardware/motorControl/left_arm-eb4-j2_3-mc_service.xml
+++ b/ergoCubSN001/hardware/motorControl/left_arm-eb4-j2_3-mc_service.xml
@@ -21,8 +21,8 @@
                 </group>                    
                 <group name="FIRMWARE">
                     <param name="major">            3           </param>    
-                    <param name="minor">            3           </param> 
-                    <param name="build">            10          </param>
+                    <param name="minor">            6           </param> 
+                    <param name="build">            21          </param>
                 </group>
             </group>
             
@@ -44,10 +44,10 @@
                 </group>        
                 
                 <group name="ENCODER2">
-                    <param name="type">             roie                roie                </param> <!-- lcore oppure roie ????? -->
+                    <param name="type">             roie                roie                </param> 
                     <param name="port">             CAN1:1:0            CAN1:2:0            </param>
                     <param name="position">         atmotor             atmotor             </param>
-                    <param name="resolution">       14400               14400               </param> <!-- segno da vedersi -->
+                    <param name="resolution">       3600                3600                </param> 
                     <param name="tolerance">        3.6                 3.6                 </param>  
                 </group> 
  

--- a/ergoCubSN001/hardware/motorControl/left_leg-eb8-j0_3-mc_service.xml
+++ b/ergoCubSN001/hardware/motorControl/left_leg-eb8-j0_3-mc_service.xml
@@ -21,8 +21,8 @@
                 </group>                    
                 <group name="FIRMWARE">
                     <param name="major">            3           </param>    
-                    <param name="minor">            3           </param> 
-                    <param name="build">            10          </param>
+                    <param name="minor">            6           </param> 
+                    <param name="build">            21          </param>
                 </group>
             </group>
             
@@ -39,7 +39,7 @@
                     <param name="type">             amo                 amo         amo        amo       </param>  
                     <param name="port">             CONN:P6             CONN:P8     CONN:P7    CONN:P9   </param>
                     <param name="position">         atjoint             atjoint     atjoint    atjoint   </param>
-                    <param name="resolution">       16384               16384       16384      -16384     </param> 
+                    <param name="resolution">       16384               16384       16384      -16384    </param> 
                     <param name="tolerance">        0.703               0.703       0.703      0.703     </param>  
                 </group>        
                 
@@ -47,7 +47,7 @@
                     <param name="type">             roie                roie       roie       roie       </param>
                     <param name="port">             CAN1:1:0            CAN1:2:0   CAN1:3:0   CAN1:4:0   </param>
                     <param name="position">         atmotor             atmotor    atmotor    atmotor    </param>
-                    <param name="resolution">       14400               14400      14400      14400      </param>
+                    <param name="resolution">       3600                3600       3600       3600       </param>
                     <param name="tolerance">        3.6                 3.6        3.6        3.6        </param>  
                 </group> 
  

--- a/ergoCubSN001/hardware/motorControl/left_leg-eb9-j4_5-mc_service.xml
+++ b/ergoCubSN001/hardware/motorControl/left_leg-eb9-j4_5-mc_service.xml
@@ -21,8 +21,8 @@
                 </group>                    
                 <group name="FIRMWARE">
                     <param name="major">            3           </param>    
-                    <param name="minor">            3           </param> 
-                    <param name="build">            10          </param>
+                    <param name="minor">            6           </param> 
+                    <param name="build">            21          </param>
                 </group>
             </group>
             
@@ -38,15 +38,15 @@
                     <param name="type">             amo                amo                 </param>  
                     <param name="port">             CONN:P6            CONN:P7             </param>
                     <param name="position">         atjoint            atjoint             </param> 
-                    <param name="resolution">       16384              -16384             </param>
-                    <param name="tolerance">        0.703               0.703               </param>  
+                    <param name="resolution">       16384              -16384              </param>
+                    <param name="tolerance">        0.703               0.703              </param>  
                 </group>        
                 
                 <group name="ENCODER2">
                     <param name="type">           roie                roie                </param>
-                    <param name="port">           CAN1:1:0             CAN1:2:0            </param>
+                    <param name="port">           CAN1:1:0            CAN1:2:0            </param>
                     <param name="position">       atmotor             atmotor             </param>
-                    <param name="resolution">     14400               14400               </param>
+                    <param name="resolution">     3600                3600                </param>
                     <param name="tolerance">      3.6                 3.6                 </param>  
                 </group> 
  

--- a/ergoCubSN001/hardware/motorControl/right_arm-eb1-j0_1-mc_service.xml
+++ b/ergoCubSN001/hardware/motorControl/right_arm-eb1-j0_1-mc_service.xml
@@ -21,8 +21,8 @@
                 </group>                    
                 <group name="FIRMWARE">
                     <param name="major">            3           </param>    
-                    <param name="minor">            3           </param> 
-                    <param name="build">            10          </param>
+                    <param name="minor">            6           </param> 
+                    <param name="build">            21          </param>
                 </group>
             </group>
             
@@ -39,15 +39,15 @@
                     <param name="type">             amo                 amo                 </param>  
                     <param name="port">             CONN:P6             CONN:P8             </param>
                     <param name="position">         atjoint             atjoint             </param> 
-                    <param name="resolution">       16384              -16384               </param>  <!-- segno da vedersi -->
+                    <param name="resolution">       16384              -16384               </param>  
                     <param name="tolerance">        0.703               0.703               </param>  
                 </group>        
                 
                 <group name="ENCODER2">
-                    <param name="type">             roie                roie                </param> <!-- lcore oppure roie ????? -->
+                    <param name="type">             roie                roie                </param> 
                     <param name="port">             CAN1:1:0            CAN1:2:0            </param>
                     <param name="position">         atmotor             atmotor             </param>
-                    <param name="resolution">       14400               14400               </param> <!-- segno da vedersi -->
+                    <param name="resolution">       3600                3600                </param> 
                     <param name="tolerance">        3.6                 3.6                 </param>  
                 </group> 
  

--- a/ergoCubSN001/hardware/motorControl/right_arm-eb3-j2_3-mc_service.xml
+++ b/ergoCubSN001/hardware/motorControl/right_arm-eb3-j2_3-mc_service.xml
@@ -21,8 +21,8 @@
                 </group>                    
                 <group name="FIRMWARE">
                     <param name="major">            3           </param>    
-                    <param name="minor">            3           </param> 
-                    <param name="build">            10          </param>
+                    <param name="minor">            6           </param> 
+                    <param name="build">            21          </param>
                 </group>
             </group>
             
@@ -44,10 +44,10 @@
                 </group>        
                 
                 <group name="ENCODER2">
-                    <param name="type">             roie                roie                </param> <!-- lcore oppure roie ????? -->
+                    <param name="type">             roie                roie                </param> 
                     <param name="port">             CAN1:1:0            CAN1:2:0            </param>
                     <param name="position">         atmotor             atmotor             </param>
-                    <param name="resolution">       14400               14400               </param> <!-- segno da vedersi -->
+                    <param name="resolution">       3600                3600                </param> 
                     <param name="tolerance">        3.6                 3.6                 </param>  
                 </group> 
  

--- a/ergoCubSN001/hardware/motorControl/right_leg-eb6-j0_3-mc_service.xml
+++ b/ergoCubSN001/hardware/motorControl/right_leg-eb6-j0_3-mc_service.xml
@@ -21,8 +21,8 @@
                 </group>                    
                 <group name="FIRMWARE">
                     <param name="major">            3           </param>    
-                    <param name="minor">            3           </param> 
-                    <param name="build">            10          </param>
+                    <param name="minor">            6           </param> 
+                    <param name="build">            21          </param>
                 </group>
             </group>
             
@@ -39,7 +39,7 @@
                     <param name="type">             amo                 amo         amo         amo       </param>  
                     <param name="port">             CONN:P6             CONN:P8     CONN:P7     CONN:P9   </param>
                     <param name="position">         atjoint             atjoint     atjoint     atjoint   </param>
-                    <param name="resolution">      -16384              -16384      -16384      16384     </param>      
+                    <param name="resolution">       -16384              -16384      -16384      16384     </param>      
                     <param name="tolerance">        0.703               0.703       0.703       0.703     </param>  
                 </group>        
                 
@@ -47,7 +47,7 @@
                     <param name="type">             roie                roie       roie       roie       </param>
                     <param name="port">             CAN1:1:0            CAN1:2:0   CAN1:3:0   CAN1:4:0   </param>
                     <param name="position">         atmotor             atmotor    atmotor    atmotor    </param>
-                    <param name="resolution">       14400               14400      14400      14400      </param>
+                    <param name="resolution">       3600                3600       3600       3600       </param>
                     <param name="tolerance">        3.6                 3.6        3.6        3.6        </param>  
                 </group> 
  

--- a/ergoCubSN001/hardware/motorControl/right_leg-eb7-j4_5-mc_service.xml
+++ b/ergoCubSN001/hardware/motorControl/right_leg-eb7-j4_5-mc_service.xml
@@ -21,8 +21,8 @@
                 </group>                    
                 <group name="FIRMWARE">
                     <param name="major">            3           </param>    
-                    <param name="minor">            3           </param> 
-                    <param name="build">            10          </param>
+                    <param name="minor">            6           </param> 
+                    <param name="build">            21          </param>
                 </group>
             </group>
             
@@ -44,9 +44,9 @@
                 
                 <group name="ENCODER2">
                     <param name="type">         roie                roie                </param>
-                    <param name="port">         CAN1:1:0             CAN1:2:0            </param>
+                    <param name="port">         CAN1:1:0            CAN1:2:0            </param>
                     <param name="position">     atmotor             atmotor             </param>
-                    <param name="resolution">   14400               14400               </param>
+                    <param name="resolution">   3600                3600                </param>
                     <param name="tolerance">    3.6                 3.6                 </param>  
                 </group> 
  

--- a/ergoCubSN001/hardware/motorControl/torso-eb5-j0_2-mc_service.xml
+++ b/ergoCubSN001/hardware/motorControl/torso-eb5-j0_2-mc_service.xml
@@ -21,8 +21,8 @@
                 </group>                    
                 <group name="FIRMWARE">
                     <param name="major">            3           </param>    
-                    <param name="minor">            3           </param> 
-                    <param name="build">            10          </param>
+                    <param name="minor">            6           </param> 
+                    <param name="build">            21          </param>
                 </group>
             </group>
             
@@ -48,7 +48,7 @@
                     <param name="type">             roie                roie                roie                </param>
                     <param name="port">             CAN1:2:0            CAN1:3:0            CAN1:1:0            </param>
                     <param name="position">         atmotor             atmotor             atmotor             </param>
-                    <param name="resolution">       14400               14400               14400               </param>
+                    <param name="resolution">       3600                3600                3600               </param>
                     <param name="tolerance">        3.6                 3.6                 3.6                 </param>  
                 </group> 
  


### PR DESCRIPTION
## What changes:

This PR updates the configuration files of ergoCubSN001 after the new 2FOC Firmware version (V3.6).

This is the last version of this firmware: https://github.com/robotology/icub-firmware-build/pull/103

## Note

I didn't updated ergoCubSN000 configurations files, because the robot boards are not yet updated.

cc @valegagge @ale-git 