### PR TITLE
[ergoCubSN001] update all configuration files after testing

### DIFF
--- a/ergoCubSN001/calibrators/head-calib.xml
+++ b/ergoCubSN001/calibrators/head-calib.xml
@@ -20,7 +20,7 @@
         <!-- joint name                         neck-pitch  neck-roll   neck-yaw    eyes-tilt -->
         <group name="CALIBRATION">
             <param name="calibrationType">      12          12          12          12         </param>
-            <param name="calibration1">   	    62951      -44411      61615	    52575      </param>
+            <param name="calibration1">   	    62951      -44411       13160	    28977      </param>
             <param name="calibration2">         0           0           0	        0          </param>
             <param name="calibration3">         0           0           0           0          </param>
 
@@ -49,4 +49,3 @@
         <action phase="interrupt3" level="1" type="abort" />
 
     </device>
-

--- a/ergoCubSN001/calibrators/left_arm-calib.xml
+++ b/ergoCubSN001/calibrators/left_arm-calib.xml
@@ -6,32 +6,32 @@
 	<xi:include href="../general.xml" />
 
 	<group name="GENERAL">
-		<param name="joints">13</param>		<!-- the number of joints of the robot part -->
+		<param name="joints">4</param>		<!-- the number of joints of the robot part -->
 		<param name="deviceName"> Left_Arm_Calibrator </param>
 	</group>
 
 	<group name="HOME">
 	<!--                                shoulder-pitch    shoulder-roll    shoulder-yaw    elbow    wrist-yaw    wrist-roll    wrist-pitch    thumb_add    thumb_oc    index_add    index_oc    middle_oc    ring_pinky_oc -->
-		<param name="positionHome">            5                 30              0           10         0            0             0             30.00        0.00        0.00         0.00        0.00           0.00    </param>
-		<param name="velocityHome">            10                10              10          10         10           10            10            40.00        40.00       40.00        40.00       40.00          40.00    </param>
+		<param name="positionHome">            5                 30              0           10    <!--     0            0             0             30.00        0.00        0.00         0.00        0.00           0.00  -->  </param>
+		<param name="velocityHome">            10                10              10          10    <!--    10           10            10            40.00        40.00       40.00        40.00       40.00          40.00  -->  </param>
 	</group>
 	<group name="CALIBRATION">
-		<param name="calibrationType">        10                 10              10          10         12           12            12            12           14          12           14          14             14       </param>
-		<param name="calibration1">           4000               -3000           -3000       4000       17565        8161          21461         0            300         0            300         300            300      </param>
-		<param name="calibration2">	          0                  0               0           0          0            0             0             0            0           0            0           0              0        </param>
-		<param name="calibration3">           0                  0               0           0          0            0             0             0            1           0            0           0              1        </param>
-		<param name="calibration4">           0                  0               0           0          0            0             0             0            32768       0            0           0              0        </param>
-		<param name="calibration5">           0                  0               0           0          0            0             0             0            18277       0            47003       47513          54558    </param>
-		<param name="calibrationZero">        35                -15             -52          -5         0            0             0             0            0           0            0           0              0        </param>
-		<param name="calibrationDelta">       0                  0               0           0          0            0             0             0            0           0            0           0              0        </param>
-		<param name="startupPosition">        34                 50              -10         90         0.0          0.0           0.0           0.0          4.0         0.0          4.0         4.0            4.0      </param>
-		<param name="startupVelocity">        10.0               10.0            10.0        10.0       10.0         10.0          10.0          100.0        100.0       0.0          100         100.0          100.0    </param>
-		<param name="startupMaxPwm">          8000               8000            8000        8000       16000        16000         16000         0            0           0            0           0              0        </param>
-		<param name="startupPosThreshold">    2                  2               2           2          2            2             2             90           5          90            5           5              5        </param>
+		<param name="calibrationType">        10                 10              10          10    <!--     12           12            12            12           14          12           14          14             14    -->   </param>
+		<param name="calibration1">           4000               -3000           -3000       4000  <!--    17565        8161          21461         0            300         0            300         300            300    -->  </param>
+		<param name="calibration2">	          0                  0               0           0     <!--     0            0             0             0            0           0            0           0              0     -->   </param>
+		<param name="calibration3">           0                  0               0           0     <!--     0            0             0             0            1           0            0           0              1     -->  </param>
+		<param name="calibration4">           0                  0               0           0     <!--     0            0             0             0            32768       0            0           0              0     -->   </param>
+		<param name="calibration5">           0                  0               0           0     <!--     0            0             0             0            18277       0            47003       47513          54558 -->   </param>
+		<param name="calibrationZero">        35                -15             -52          -5    <!--     0            0             0             0            0           0            0           0              0     -->   </param>
+		<param name="calibrationDelta">       0                  0               0           0     <!--    0            0             0             0            0           0            0           0              0      -->  </param>
+		<param name="startupPosition">        34                 50              -10         90    <!--     0.0          0.0           0.0           0.0          4.0         0.0          4.0         4.0            4.0   -->   </param>
+		<param name="startupVelocity">        10.0               10.0            10.0        10.0  <!--     10.0         10.0          10.0          100.0        100.0       0.0          100         100.0          100.0 -->   </param>
+		<param name="startupMaxPwm">          8000               8000            8000        8000  <!--     16000        16000         16000         0            0           0            0           0              0     -->   </param>
+		<param name="startupPosThreshold">    2                  2               2           2     <!--     2            2             2             90           5          90            5           5              5     -->   </param>
 	</group>
 
 <!--	<param name="CALIB_ORDER"> (4 5 6) (3) (2) (0) (1) (7 8) (9) (10 11 12) </param> --> <!-- Don't remove this line -->
-	<param name="CALIB_ORDER"> (4 5 6) (3) (2) (0) (1) (7 8) (10 11 12) </param> 
+	<param name="CALIB_ORDER"> (3) (2) (0) (1) </param> 
 
 	<action phase="startup" level="10" type="calibrate">
 		<param name="target">left_arm-mc_remapper</param>
@@ -44,6 +44,3 @@
 	<action phase="interrupt3" level="1" type="abort" />
 
 </device>
-
-
-

--- a/ergoCubSN001/calibrators/right_arm-calib.xml
+++ b/ergoCubSN001/calibrators/right_arm-calib.xml
@@ -6,33 +6,33 @@
 	<xi:include href="../general.xml" />
 
 	<group name="GENERAL">
-		<param name="joints">13</param>		<!-- the number of joints of the robot part -->
+		<param name="joints">4</param>		<!-- the number of joints of the robot part -->
 		<param name="deviceName"> Right_Arm_Calibrator </param>
 	</group>
 
 	<group name="HOME">
 	<!-- For calib6 to set calibration5, i.e. target just multiply desidered pos in deg by 182,044444 (2^(16)/360) -->
     <!--                                shoulder-pitch    shoulder-roll    shoulder-yaw    elbow    wrist-yaw    wrist-roll    wrist-pitch    thumb_add    thumb_oc    index_add    index_oc    middle_oc    ring_pinky_oc -->
-		<param name="positionHome">            5                30              0           10         0             0              0            30.00        0.00        30.00        0.00        0.00        0.00       </param>
-		<param name="velocityHome">            10               10              10          10         10            10             10           40.00        40.00       40.00        40.00       40.00       40.00       </param>
+		<param name="positionHome">            5                30              0           10     <!--    0             0              0            30.00        0.00        30.00        0.00        0.00        0.00    -->   </param>
+		<param name="velocityHome">            10               10              10          10     <!--    10            10             10           40.00        40.00       40.00        40.00       40.00       40.00   -->    </param>
 	</group>
 	<group name="CALIBRATION">
-		<param name="calibrationType">         10                10             10          10         12            12             12           12           14          12           14          14          14          </param>
-		<param name="calibration1">           -4000              3000           3000       -4000       11796         13254          16440        0            300         0            300         300         300         </param>
-		<param name="calibration2">	           0                 0              0           0          0             0              0            0            0           0            0           0           0           </param>
-		<param name="calibration3">            0                 0              0           0          0             0              0            0            1           0            1           0           0           </param>
-		<param name="calibration4">            0                 0              0           0          0             0              0            0            32768       0            0           0           0           </param>
-		<param name="calibration5">            0                 0              0           0          0             0              0            0            2366        0            53484       45147       12415        </param>
-		<param name="calibrationZero">         35               -15            -52         -5          0             0              0            0            0           0            0           0           0           </param>
-		<param name="calibrationDelta">        0                 0              0           0          0             0              0            0            0           0            0           0           0           </param>
-		<param name="startupPosition">         34                50             -10         90         0.0           0.0            0.0          0.0          4.0         0.0          4.0         4.0         4.0         </param>
-		<param name="startupVelocity">         10.0              10.0           10.0        10.0       10.0          10.0           10.0         30.0         30.0        30.0         30.0        30.0        30.0        </param>
-		<param name="startupMaxPwm">           8000              8000           8000        8000       16000         16000          16000        0            0           0            0           0           0           </param>
-		<param name="startupPosThreshold">     2                 2              2           2          2             2              2            90           5           90           5           5           5           </param>
+		<param name="calibrationType">         10                10             10          10     <!--   12            12             12           12           14          12           14          14          14      -->    </param>
+		<param name="calibration1">           -4000              3000           3000       -4000   <!--    11796         13254          16440        0            300         0            300         300         300    -->     </param>
+		<param name="calibration2">	           0                 0              0           0      <!--    0             0              0            0            0           0            0           0           0      -->     </param>
+		<param name="calibration3">            0                 0              0           0      <!--    0             0              0            0            1           0            1           0           0      -->     </param>
+		<param name="calibration4">            0                 0              0           0      <!--    0             0              0            0            32768       0            0           0           0      -->     </param>
+		<param name="calibration5">            0                 0              0           0      <!--    0             0              0            0            2366        0            53484       45147       12415  -->      </param>
+		<param name="calibrationZero">         35               -15            -52         -5      <!--    0             0              0            0            0           0            0           0           0      -->     </param>
+		<param name="calibrationDelta">        0                 0              0           0      <!--    0             0              0            0            0           0            0           0           0      -->     </param>
+		<param name="startupPosition">         34                50             -10         90     <!--    0.0           0.0            0.0          0.0          4.0         0.0          4.0         4.0         4.0    -->     </param>
+		<param name="startupVelocity">         10.0              10.0           10.0        10.0   <!--    10.0          10.0           10.0         30.0         30.0        30.0         30.0        30.0        30.0   -->     </param>
+		<param name="startupMaxPwm">           8000              8000           8000        8000   <!--    16000         16000          16000        0            0           0            0           0           0      -->     </param>
+		<param name="startupPosThreshold">     2                 2              2           2      <!--    2             2              2            90           5           90           5           5           5      -->     </param>
 	</group>
 
 <!--	<param name="CALIB_ORDER"> (4 5 6) (3) (2) (0) (1) (7 8) (9) (10 11 12) </param> --> <!-- Don't remove this line -->
-	<param name="CALIB_ORDER"> (4 5 6) (3) (2) (0) (1) (7 8) (10 11 12) </param>
+	<param name="CALIB_ORDER"> (3) (2) (0) (1) </param>
 
 	
 	<action phase="startup" level="10" type="calibrate">
@@ -46,6 +46,3 @@
 	<action phase="interrupt3" level="1" type="abort" />
 
 </device>
-
-
-

--- a/ergoCubSN001/calibrators/torso-calib.xml
+++ b/ergoCubSN001/calibrators/torso-calib.xml
@@ -21,7 +21,7 @@
 <!--                                                roll                    pitch                  yaw                          -->
 <param name="calibrationType">                      12                      12                     12                      </param>
 
-<param name="calibration1">	                        38354                   67734                  6013                    </param>
+<param name="calibration1">	                        48756                   22272                  26900                    </param>
 <param name="calibration2">                         0                       0                      0                       </param> 
 <param name="calibration3">                         0                       0                      0                       </param> 
                                                                                                    
@@ -52,4 +52,3 @@
 		<action phase="interrupt3" level="1" type="abort" />
 
 	</device>
-

--- a/ergoCubSN001/calibrators/torso-calib.xml
+++ b/ergoCubSN001/calibrators/torso-calib.xml
@@ -21,7 +21,7 @@
 <!--                                                roll                    pitch                  yaw                          -->
 <param name="calibrationType">                      12                      12                     12                      </param>
 
-<param name="calibration1">	                        48756                   22272                  26900                    </param>
+<param name="calibration1">	                        48803                   22272                  26900                    </param>
 <param name="calibration2">                         0                       0                      0                       </param> 
 <param name="calibration3">                         0                       0                      0                       </param> 
                                                                                                    

--- a/ergoCubSN001/ergocub_all.xml
+++ b/ergoCubSN001/ergocub_all.xml
@@ -106,12 +106,16 @@
     <!-- FT SENSORS - IMU -->
     <xi:include href="hardware/inertials/left_arm-eb2-j0_1-inertial.xml" />
     <xi:include href="hardware/inertials/right_arm-eb1-j0_1-inertial.xml" />
+    <xi:include href="hardware/inertials/left_leg-eb8-j0_3-inertial.xml" />
+    <xi:include href="hardware/inertials/right_leg-eb6-j0_3-inertial.xml" />
     <xi:include href="hardware/inertials/left_leg-eb9-j4_5-inertial.xml" />
     <xi:include href="hardware/inertials/right_leg-eb7-j4_5-inertial.xml" />
 
     <!-- FT SENSORS - IMU - MULTIPLE ANALOG SENSOR SERVERS -->
     <xi:include href="wrappers/inertials/left_arm-imu_wrapper.xml" />
     <xi:include href="wrappers/inertials/right_arm-imu_wrapper.xml" />
+    <xi:include href="wrappers/inertials/left_leg-imu_wrapper.xml" />
+    <xi:include href="wrappers/inertials/right_leg-imu_wrapper.xml" />
     <xi:include href="wrappers/inertials/left_foot-imu_wrapper.xml" />
     <xi:include href="wrappers/inertials/right_foot-imu_wrapper.xml" />
     

--- a/ergoCubSN001/ergocub_all.xml
+++ b/ergoCubSN001/ergocub_all.xml
@@ -9,17 +9,17 @@
 
     <devices>
 
-    <!-- POS4 -->
+    <!-- POS4 
     <xi:include href="wrappers/POS/right_hand-pos_wrapper4.xml" />
     <xi:include href="hardware/POS/right_hand-pos4.xml" />
     <xi:include href="wrappers/POS/left_hand-pos_wrapper4.xml" />
-    <xi:include href="hardware/POS/left_hand-pos4.xml" />
+    <xi:include href="hardware/POS/left_hand-pos4.xml" /> -->
 
-    <!-- POS2 -->
+    <!-- POS2 
     <xi:include href="wrappers/POS/right_hand-pos_wrapper2.xml" />
     <xi:include href="hardware/POS/right_hand-pos2.xml" />
     <xi:include href="wrappers/POS/left_hand-pos_wrapper2.xml" />
-    <xi:include href="hardware/POS/left_hand-pos2.xml" />
+    <xi:include href="hardware/POS/left_hand-pos2.xml" /> -->
 
     <!-- motor controllers wrappers -->
     <xi:include href="wrappers/motorControl/left_leg-mc_wrapper.xml" />
@@ -51,16 +51,16 @@
     <!-- LEFT ARM -->
     <xi:include href="hardware/motorControl/left_arm-eb2-j0_1-mc.xml" />
     <xi:include href="hardware/motorControl/left_arm-eb4-j2_3-mc.xml" />
-    <xi:include href="hardware/motorControl/left_arm-eb31-j4_6-mc.xml" />
+   <!-- <xi:include href="hardware/motorControl/left_arm-eb31-j4_6-mc.xml" />
     <xi:include href="hardware/motorControl/left_arm-eb23-j7_10-mc.xml" />
-    <xi:include href="hardware/motorControl/left_arm-eb25-j11_12-mc.xml" />
+    <xi:include href="hardware/motorControl/left_arm-eb25-j11_12-mc.xml" /> -->
 
     <!-- RIGHT ARM -->
     <xi:include href="hardware/motorControl/right_arm-eb1-j0_1-mc.xml" />
     <xi:include href="hardware/motorControl/right_arm-eb3-j2_3-mc.xml" />
-    <xi:include href="hardware/motorControl/right_arm-eb30-j4_6-mc.xml" />
+    <!--<xi:include href="hardware/motorControl/right_arm-eb30-j4_6-mc.xml" />
     <xi:include href="hardware/motorControl/right_arm-eb22-j7_10-mc.xml" />
-    <xi:include href="hardware/motorControl/right_arm-eb24-j11_12-mc.xml" />
+    <xi:include href="hardware/motorControl/right_arm-eb24-j11_12-mc.xml" /> -->
 
     <!-- LEFT LEG -->
     <xi:include href="hardware/motorControl/left_leg-eb8-j0_3-mc.xml" />
@@ -97,11 +97,11 @@
     <xi:include href="hardware/inertials/waist-inertial.xml" />
     <xi:include href="wrappers/inertials/waist-inertials_wrapper.xml" />
 
-    <!-- IMU - MTB4 BOARDS -->
+    <!-- IMU - MTB4 BOARDS 
     <xi:include href="hardware/inertials/left_arm-eb4-j2_3-inertial.xml" />
     <xi:include href="wrappers/inertials/left_arm-inertials_wrapper.xml" />
     <xi:include href="hardware/inertials/right_arm-eb3-j2_3-inertial.xml" />
-    <xi:include href="wrappers/inertials/right_arm-inertials_wrapper.xml" />
+    <xi:include href="wrappers/inertials/right_arm-inertials_wrapper.xml" /> -->
 
     <!-- FT SENSORS - IMU -->
     <xi:include href="hardware/inertials/left_arm-eb2-j0_1-inertial.xml" />

--- a/ergoCubSN001/hardware/FT/left_arm-eb2-j0_1-strain.xml
+++ b/ergoCubSN001/hardware/FT/left_arm-eb2-j0_1-strain.xml
@@ -25,7 +25,7 @@
                     </group>                    
                     <group name="FIRMWARE">
                         <param name="major">            2                       </param>    
-                        <param name="minor">            2                       </param>
+                        <param name="minor">            3                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>

--- a/ergoCubSN001/hardware/FT/left_leg-eb8-j0_3-strain.xml
+++ b/ergoCubSN001/hardware/FT/left_leg-eb8-j0_3-strain.xml
@@ -16,7 +16,7 @@
             <group name="PROPERTIES">
 
                 <group name="CANBOARDS">
-                    <param name="type">                 strain2            </param>
+                    <param name="type">                 strain2c            </param>
 
                     <group name="PROTOCOL">
                         <param name="major">            2                       </param>
@@ -24,7 +24,7 @@
                     </group>
                     <group name="FIRMWARE">
                         <param name="major">            2                       </param>
-                        <param name="minor">            2                       </param>
+                        <param name="minor">            3                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
@@ -53,8 +53,3 @@
         </group>
 
   </device>
-
-
-
-
-

--- a/ergoCubSN001/hardware/FT/left_leg-eb9-j4_5-strain.xml
+++ b/ergoCubSN001/hardware/FT/left_leg-eb9-j4_5-strain.xml
@@ -24,7 +24,7 @@
                     </group>                    
                     <group name="FIRMWARE">
                         <param name="major">            2   		            </param>    
-                        <param name="minor">            2 		            </param>
+                        <param name="minor">            3 		            </param>
                         <param name="build">            0  		       </param>
                     </group>
                 </group>

--- a/ergoCubSN001/hardware/FT/right_arm-eb1-j0_1-strain.xml
+++ b/ergoCubSN001/hardware/FT/right_arm-eb1-j0_1-strain.xml
@@ -25,7 +25,7 @@
                     </group>                    
                     <group name="FIRMWARE">
                         <param name="major">            2                       </param>    
-                        <param name="minor">            2                       </param>
+                        <param name="minor">            3                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>

--- a/ergoCubSN001/hardware/FT/right_leg-eb6-j0_3-strain.xml
+++ b/ergoCubSN001/hardware/FT/right_leg-eb6-j0_3-strain.xml
@@ -16,7 +16,7 @@
             <group name="PROPERTIES">
 
                 <group name="CANBOARDS">
-                    <param name="type">                 strain2            </param>
+                    <param name="type">                 strain2c            </param>
 
                     <group name="PROTOCOL">
                         <param name="major">            2                       </param>
@@ -24,7 +24,7 @@
                     </group>
                     <group name="FIRMWARE">
                         <param name="major">            2                       </param>
-                        <param name="minor">            2                       </param>
+                        <param name="minor">            3                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
@@ -54,8 +54,3 @@
 
 
   </device>
-
-
-
-
-

--- a/ergoCubSN001/hardware/FT/right_leg-eb7-j4_5-strain.xml
+++ b/ergoCubSN001/hardware/FT/right_leg-eb7-j4_5-strain.xml
@@ -24,7 +24,7 @@
                     </group>                    
                     <group name="FIRMWARE">
                         <param name="major">            2   		            </param>    
-                        <param name="minor">            2  		            </param>
+                        <param name="minor">            3  		            </param>
                         <param name="build">            0  		       </param>
                     </group>
                 </group>

--- a/ergoCubSN001/hardware/inertials/head-inertial.xml
+++ b/ergoCubSN001/hardware/inertials/head-inertial.xml
@@ -24,7 +24,7 @@
                     </group>
                     <group name="FIRMWARE">
                         <param name="major">            1                   </param>
-                        <param name="minor">            3                   </param>
+                        <param name="minor">            4                   </param>
                         <param name="build">            0                   </param>
                     </group>
                 </group>
@@ -50,5 +50,3 @@
         </group>
 
     </device>
-
-

--- a/ergoCubSN001/hardware/inertials/right_arm-eb1-j0_1-inertial.xml
+++ b/ergoCubSN001/hardware/inertials/right_arm-eb1-j0_1-inertial.xml
@@ -22,8 +22,8 @@
                     </group>
 
                     <group name="FIRMWARE">
-                        <param name="major">            2                   </param>
-                        <param name="minor">            2                   </param>
+                        <param name="major">            0                   </param>
+                        <param name="minor">            0                   </param>
                         <param name="build">            0                   </param>
                     </group>
                 </group>

--- a/ergoCubSN001/hardware/mechanicals/left_arm-eb2-j0_1-mec.xml
+++ b/ergoCubSN001/hardware/mechanicals/left_arm-eb2-j0_1-mec.xml
@@ -34,7 +34,7 @@
         <param name="HasRotorEncoder">          1                   1                   </param>
         <param name="HasRotorEncoderIndex">     1                   1                   </param>
         <param name="HasSpeedEncoder">          0                   0                   </param>
-        <param name="RotorIndexOffset">         146                 278                 </param>
+        <param name="RotorIndexOffset">         227                 284                 </param>
         <param name="MotorPoles">               8                   8                   </param>
     </group>
 

--- a/ergoCubSN001/hardware/mechanicals/left_arm-eb2-j0_1-mec.xml
+++ b/ergoCubSN001/hardware/mechanicals/left_arm-eb2-j0_1-mec.xml
@@ -34,7 +34,7 @@
         <param name="HasRotorEncoder">          1                   1                   </param>
         <param name="HasRotorEncoderIndex">     1                   1                   </param>
         <param name="HasSpeedEncoder">          0                   0                   </param>
-        <param name="RotorIndexOffset">         227                 284                 </param>
+        <param name="RotorIndexOffset">         214                 284                 </param>
         <param name="MotorPoles">               8                   8                   </param>
     </group>
 

--- a/ergoCubSN001/hardware/mechanicals/left_arm-eb4-j2_3-mec.xml
+++ b/ergoCubSN001/hardware/mechanicals/left_arm-eb4-j2_3-mec.xml
@@ -30,11 +30,11 @@
 		<param name="Verbose">          0                   0                   </param>
         <param name="AutoCalibration">          0                   0                   </param>
         <param name="HasHallSensor">            0                   0                   </param>
-        <param name="HasTempSensor">            0                   0                   </param> <!-- pero' ha il sensore di temp, quindi ... metti 1 -->
+        <param name="HasTempSensor">            0                   0                   </param> 
         <param name="HasRotorEncoder">          1                   1                   </param>
         <param name="HasRotorEncoderIndex">     1                   1                   </param>
         <param name="HasSpeedEncoder">          0                   0                   </param>
-        <param name="RotorIndexOffset">         252                 17                   </param>
+        <param name="RotorIndexOffset">         252                 96                  </param>
         <param name="MotorPoles">               8                   8                   </param>
     </group>
 

--- a/ergoCubSN001/hardware/mechanicals/left_arm-eb4-j2_3-mec.xml
+++ b/ergoCubSN001/hardware/mechanicals/left_arm-eb4-j2_3-mec.xml
@@ -34,7 +34,7 @@
         <param name="HasRotorEncoder">          1                   1                   </param>
         <param name="HasRotorEncoderIndex">     1                   1                   </param>
         <param name="HasSpeedEncoder">          0                   0                   </param>
-        <param name="RotorIndexOffset">         252                 96                  </param>
+        <param name="RotorIndexOffset">         1                   96                  </param>
         <param name="MotorPoles">               8                   8                   </param>
     </group>
 

--- a/ergoCubSN001/hardware/mechanicals/right_arm-eb1-j0_1-mec.xml
+++ b/ergoCubSN001/hardware/mechanicals/right_arm-eb1-j0_1-mec.xml
@@ -34,7 +34,7 @@
         <param name="HasRotorEncoder">          1                   1                   </param>
         <param name="HasRotorEncoderIndex">     1                   1                   </param>
         <param name="HasSpeedEncoder">          0                   0                   </param>
-        <param name="RotorIndexOffset">         286                 177                 </param>
+        <param name="RotorIndexOffset">         270                 177                 </param>
         <param name="MotorPoles">               8                   8                   </param>
     </group>
 

--- a/ergoCubSN001/hardware/mechanicals/right_arm-eb1-j0_1-mec.xml
+++ b/ergoCubSN001/hardware/mechanicals/right_arm-eb1-j0_1-mec.xml
@@ -34,7 +34,7 @@
         <param name="HasRotorEncoder">          1                   1                   </param>
         <param name="HasRotorEncoderIndex">     1                   1                   </param>
         <param name="HasSpeedEncoder">          0                   0                   </param>
-        <param name="RotorIndexOffset">         227                 177                 </param>
+        <param name="RotorIndexOffset">         286                 177                 </param>
         <param name="MotorPoles">               8                   8                   </param>
     </group>
 

--- a/ergoCubSN001/hardware/mechanicals/right_arm-eb3-j2_3-mec.xml
+++ b/ergoCubSN001/hardware/mechanicals/right_arm-eb3-j2_3-mec.xml
@@ -34,7 +34,7 @@
         <param name="HasRotorEncoder">          1                   1                   </param>
         <param name="HasRotorEncoderIndex">     1                   1                   </param>
         <param name="HasSpeedEncoder">          0                   0                   </param>
-        <param name="RotorIndexOffset">         74                  59                  </param>
+        <param name="RotorIndexOffset">         205                 59                  </param>
         <param name="MotorPoles">               8                   8                   </param>
     </group>
 

--- a/ergoCubSN001/hardware/mechanicals/right_arm-eb3-j2_3-mec.xml
+++ b/ergoCubSN001/hardware/mechanicals/right_arm-eb3-j2_3-mec.xml
@@ -30,11 +30,11 @@
         <param name="AutoCalibration">          0                   0                   </param>
         <param name="Verbose">                  0                   0                   </param>
         <param name="HasHallSensor">            0                   0                   </param>
-        <param name="HasTempSensor">            0                   0                   </param> <!-- pero' ha il sensore di temp, quindi ... metti 1 -->
+        <param name="HasTempSensor">            0                   0                   </param> 
         <param name="HasRotorEncoder">          1                   1                   </param>
         <param name="HasRotorEncoderIndex">     1                   1                   </param>
         <param name="HasSpeedEncoder">          0                   0                   </param>
-        <param name="RotorIndexOffset">         74                  333                 </param>
+        <param name="RotorIndexOffset">         74                  59                  </param>
         <param name="MotorPoles">               8                   8                   </param>
     </group>
 

--- a/ergoCubSN001/hardware/mechanicals/torso-eb5-j0_2-mec.xml
+++ b/ergoCubSN001/hardware/mechanicals/torso-eb5-j0_2-mec.xml
@@ -33,7 +33,7 @@
         <param name="HasRotorEncoder">      1                   1                1                  </param>
         <param name="HasRotorEncoderIndex"> 1                   1                1                  </param>
         <param name="HasSpeedEncoder">      0                   0                0                  </param>
-        <param name="RotorIndexOffset">     66                  85               228                </param>
+        <param name="RotorIndexOffset">     155                 134              328                </param>
         <param name="MotorPoles">           8                   8                8                  </param>
    </group>
 

--- a/ergoCubSN001/hardware/motorControl/head-eb21-j2_3-mc_service.xml
+++ b/ergoCubSN001/hardware/motorControl/head-eb21-j2_3-mc_service.xml
@@ -24,10 +24,10 @@
                 </group>
 
                 <group name="ENCODER1">
-                    <param name="type">             aea                 aea        </param>
+                    <param name="type">             aea3                aea3       </param>
                     <param name="port">             CONN:P11            CONN:P10   </param>
                     <param name="position">         atjoint             atjoint    </param>
-                    <param name="resolution">       4096                4096       </param>
+                    <param name="resolution">       16384               16384      </param>
                     <param name="tolerance">        0.703               0.703      </param>
                 </group>
 
@@ -36,7 +36,7 @@
                     <param name="port">             CONN:P3             CONN:P4     </param>
                     <param name="position">         atmotor             atmotor     </param>
                     <param name="resolution">       2048                2048        </param>
-                    <param name="tolerance">         0                0             </param>
+                    <param name="tolerance">         0                  0           </param>
                 </group>
             </group>
 
@@ -46,4 +46,3 @@
 
 
 </params>
-

--- a/ergoCubSN001/hardware/motorControl/left_arm-eb2-j0_1-mc_service.xml
+++ b/ergoCubSN001/hardware/motorControl/left_arm-eb2-j0_1-mc_service.xml
@@ -21,8 +21,8 @@
                 </group>                    
                 <group name="FIRMWARE">
                     <param name="major">            3           </param>    
-                    <param name="minor">            6           </param> 
-                    <param name="build">            21          </param>
+                    <param name="minor">            3           </param> 
+                    <param name="build">            20          </param>
                 </group>
             </group>
             
@@ -36,7 +36,7 @@
                 </group>
                 
                 <group name="ENCODER1">  
-                    <param name="type">             amo                 amo                 </param>  
+                    <param name="type">             none                none                </param>  
                     <param name="port">             CONN:P6             CONN:P8             </param>
                     <param name="position">         atjoint             atjoint             </param> 
                     <param name="resolution">      -16384               16384               </param>
@@ -47,7 +47,7 @@
                     <param name="type">             roie                roie                </param> 
                     <param name="port">             CAN1:1:0            CAN1:2:0            </param>
                     <param name="position">         atmotor             atmotor             </param>
-                    <param name="resolution">       3600                3600                </param> 
+                    <param name="resolution">       14400               14400               </param> 
                     <param name="tolerance">        3.6                 3.6                 </param>  
                 </group> 
  
@@ -59,4 +59,3 @@
     
   
 </params>
-

--- a/ergoCubSN001/hardware/motorControl/left_arm-eb4-j2_3-mc.xml
+++ b/ergoCubSN001/hardware/motorControl/left_arm-eb4-j2_3-mc.xml
@@ -14,8 +14,8 @@
         <param name="jntPosMax">                80                  105                  </param>
         <param name="jntPosMin">                -50                 -3                  </param>
         <param name="jntVelMax">                120                 120                 </param>
-        <param name="motorNominalCurrents">     5000                5000                </param>
-        <param name="motorPeakCurrents">        9000                9000                </param>
+        <param name="motorNominalCurrents">     8000                5000                </param>
+        <param name="motorPeakCurrents">        10000               9000                </param>
         <param name="motorOverloadCurrents">    15000               15000               </param>
         <param name="motorPwmLimit">            8000                8000                </param>
     </group>
@@ -150,6 +150,3 @@
     </group>
 
 </device>
-
-
-

--- a/ergoCubSN001/hardware/motorControl/left_arm-eb4-j2_3-mc_service.xml
+++ b/ergoCubSN001/hardware/motorControl/left_arm-eb4-j2_3-mc_service.xml
@@ -21,8 +21,8 @@
                 </group>                    
                 <group name="FIRMWARE">
                     <param name="major">            3           </param>    
-                    <param name="minor">            6           </param> 
-                    <param name="build">            21          </param>
+                    <param name="minor">            3           </param> 
+                    <param name="build">            20          </param>
                 </group>
             </group>
             
@@ -47,7 +47,7 @@
                     <param name="type">             roie                roie                </param> 
                     <param name="port">             CAN1:1:0            CAN1:2:0            </param>
                     <param name="position">         atmotor             atmotor             </param>
-                    <param name="resolution">       3600                3600                </param> 
+                    <param name="resolution">       14400               14400               </param> 
                     <param name="tolerance">        3.6                 3.6                 </param>  
                 </group> 
  
@@ -59,4 +59,3 @@
     
   
 </params>
-

--- a/ergoCubSN001/hardware/motorControl/left_leg-eb8-j0_3-mc_service.xml
+++ b/ergoCubSN001/hardware/motorControl/left_leg-eb8-j0_3-mc_service.xml
@@ -21,8 +21,8 @@
                 </group>                    
                 <group name="FIRMWARE">
                     <param name="major">            3           </param>    
-                    <param name="minor">            6           </param> 
-                    <param name="build">            21          </param>
+                    <param name="minor">            3           </param> 
+                    <param name="build">            20          </param>
                 </group>
             </group>
             
@@ -47,7 +47,7 @@
                     <param name="type">             roie                roie       roie       roie       </param>
                     <param name="port">             CAN1:1:0            CAN1:2:0   CAN1:3:0   CAN1:4:0   </param>
                     <param name="position">         atmotor             atmotor    atmotor    atmotor    </param>
-                    <param name="resolution">       3600                3600       3600       3600       </param>
+                    <param name="resolution">       14400               14400      14400      14400      </param>
                     <param name="tolerance">        3.6                 3.6        3.6        3.6        </param>  
                 </group> 
  

--- a/ergoCubSN001/hardware/motorControl/left_leg-eb9-j4_5-mc_service.xml
+++ b/ergoCubSN001/hardware/motorControl/left_leg-eb9-j4_5-mc_service.xml
@@ -21,8 +21,8 @@
                 </group>                    
                 <group name="FIRMWARE">
                     <param name="major">            3           </param>    
-                    <param name="minor">            6           </param> 
-                    <param name="build">            21          </param>
+                    <param name="minor">            3           </param> 
+                    <param name="build">            20          </param>
                 </group>
             </group>
             
@@ -46,7 +46,7 @@
                     <param name="type">           roie                roie                </param>
                     <param name="port">           CAN1:1:0            CAN1:2:0            </param>
                     <param name="position">       atmotor             atmotor             </param>
-                    <param name="resolution">     3600                3600                </param>
+                    <param name="resolution">     14400               14400               </param>
                     <param name="tolerance">      3.6                 3.6                 </param>  
                 </group> 
  

--- a/ergoCubSN001/hardware/motorControl/right_arm-eb1-j0_1-mc_service.xml
+++ b/ergoCubSN001/hardware/motorControl/right_arm-eb1-j0_1-mc_service.xml
@@ -21,8 +21,8 @@
                 </group>                    
                 <group name="FIRMWARE">
                     <param name="major">            3           </param>    
-                    <param name="minor">            6           </param> 
-                    <param name="build">            21          </param>
+                    <param name="minor">            3           </param> 
+                    <param name="build">            20          </param>
                 </group>
             </group>
             
@@ -36,7 +36,7 @@
                 </group>
                 
                 <group name="ENCODER1">  
-                    <param name="type">             amo                 amo                 </param>  
+                    <param name="type">             none                none                </param>  
                     <param name="port">             CONN:P6             CONN:P8             </param>
                     <param name="position">         atjoint             atjoint             </param> 
                     <param name="resolution">       16384              -16384               </param>  
@@ -47,7 +47,7 @@
                     <param name="type">             roie                roie                </param> 
                     <param name="port">             CAN1:1:0            CAN1:2:0            </param>
                     <param name="position">         atmotor             atmotor             </param>
-                    <param name="resolution">       3600                3600                </param> 
+                    <param name="resolution">       14400               14400               </param> 
                     <param name="tolerance">        3.6                 3.6                 </param>  
                 </group> 
  
@@ -59,4 +59,3 @@
     
   
 </params>
-

--- a/ergoCubSN001/hardware/motorControl/right_arm-eb3-j2_3-mc.xml
+++ b/ergoCubSN001/hardware/motorControl/right_arm-eb3-j2_3-mc.xml
@@ -14,8 +14,8 @@
         <param name="jntPosMax">                80                  105                  </param>
         <param name="jntPosMin">                -50                 -3                  </param>
         <param name="jntVelMax">                120                 120                 </param>
-        <param name="motorNominalCurrents">     5000                5000                </param>
-        <param name="motorPeakCurrents">        9000                9000                </param>
+        <param name="motorNominalCurrents">     8000                5000                </param>
+        <param name="motorPeakCurrents">        10000               9000                </param>
         <param name="motorOverloadCurrents">    15000               15000               </param>
         <param name="motorPwmLimit">            8000                8000                </param>
     </group>
@@ -152,6 +152,3 @@
     </group>
 
   </device>
-
-
-

--- a/ergoCubSN001/hardware/motorControl/right_arm-eb3-j2_3-mc_service.xml
+++ b/ergoCubSN001/hardware/motorControl/right_arm-eb3-j2_3-mc_service.xml
@@ -21,8 +21,8 @@
                 </group>                    
                 <group name="FIRMWARE">
                     <param name="major">            3           </param>    
-                    <param name="minor">            6           </param> 
-                    <param name="build">            21          </param>
+                    <param name="minor">            3           </param> 
+                    <param name="build">            20          </param>
                 </group>
             </group>
             
@@ -47,7 +47,7 @@
                     <param name="type">             roie                roie                </param> 
                     <param name="port">             CAN1:1:0            CAN1:2:0            </param>
                     <param name="position">         atmotor             atmotor             </param>
-                    <param name="resolution">       3600                3600                </param> 
+                    <param name="resolution">       14400               14400               </param> 
                     <param name="tolerance">        3.6                 3.6                 </param>  
                 </group> 
  
@@ -59,4 +59,3 @@
     
   
 </params>
-

--- a/ergoCubSN001/hardware/motorControl/right_leg-eb6-j0_3-mc_service.xml
+++ b/ergoCubSN001/hardware/motorControl/right_leg-eb6-j0_3-mc_service.xml
@@ -21,8 +21,8 @@
                 </group>                    
                 <group name="FIRMWARE">
                     <param name="major">            3           </param>    
-                    <param name="minor">            6           </param> 
-                    <param name="build">            21          </param>
+                    <param name="minor">            3           </param> 
+                    <param name="build">            20          </param>
                 </group>
             </group>
             
@@ -47,7 +47,7 @@
                     <param name="type">             roie                roie       roie       roie       </param>
                     <param name="port">             CAN1:1:0            CAN1:2:0   CAN1:3:0   CAN1:4:0   </param>
                     <param name="position">         atmotor             atmotor    atmotor    atmotor    </param>
-                    <param name="resolution">       3600                3600       3600       3600       </param>
+                    <param name="resolution">       14400               14400      14400      14400      </param>
                     <param name="tolerance">        3.6                 3.6        3.6        3.6        </param>  
                 </group> 
  

--- a/ergoCubSN001/hardware/motorControl/right_leg-eb7-j4_5-mc_service.xml
+++ b/ergoCubSN001/hardware/motorControl/right_leg-eb7-j4_5-mc_service.xml
@@ -21,8 +21,8 @@
                 </group>                    
                 <group name="FIRMWARE">
                     <param name="major">            3           </param>    
-                    <param name="minor">            6           </param> 
-                    <param name="build">            21          </param>
+                    <param name="minor">            3           </param> 
+                    <param name="build">            20          </param>
                 </group>
             </group>
             
@@ -46,7 +46,7 @@
                     <param name="type">         roie                roie                </param>
                     <param name="port">         CAN1:1:0            CAN1:2:0            </param>
                     <param name="position">     atmotor             atmotor             </param>
-                    <param name="resolution">   3600                3600                </param>
+                    <param name="resolution">   14400               14400               </param>
                     <param name="tolerance">    3.6                 3.6                 </param>  
                 </group> 
  

--- a/ergoCubSN001/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/ergoCubSN001/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -48,9 +48,9 @@
         <param name="outputType">             pwm                   </param>
         <param name="fbkControlUnits">        metric_units          </param>
         <param name="outputControlUnits">     machine_units         </param>
-        <param name="kp">          10000       10000       -1500        </param>
+        <param name="kp">          10000       -10000       -1500        </param>
         <param name="kd">           0           0           0           </param>
-        <param name="ki">           8000        5000       -1000        </param>
+        <param name="ki">           8000        -5000       -1000        </param>
         <param name="maxOutput">   10000       10000        8000        </param>
         <param name="maxInt">      10000        5000        1000        </param>
         <param name="stictionUp">   0           0           0           </param>
@@ -122,5 +122,3 @@
     </group>
 
 </device>
-
-

--- a/ergoCubSN001/hardware/motorControl/torso-eb5-j0_2-mc_service.xml
+++ b/ergoCubSN001/hardware/motorControl/torso-eb5-j0_2-mc_service.xml
@@ -21,8 +21,8 @@
                 </group>                    
                 <group name="FIRMWARE">
                     <param name="major">            3           </param>    
-                    <param name="minor">            6           </param> 
-                    <param name="build">            21          </param>
+                    <param name="minor">            3           </param> 
+                    <param name="build">            20          </param>
                 </group>
             </group>
             
@@ -48,7 +48,7 @@
                     <param name="type">             roie                roie                roie                </param>
                     <param name="port">             CAN1:2:0            CAN1:3:0            CAN1:1:0            </param>
                     <param name="position">         atmotor             atmotor             atmotor             </param>
-                    <param name="resolution">       3600                3600                3600               </param>
+                    <param name="resolution">       14400               14400               14400               </param>
                     <param name="tolerance">        3.6                 3.6                 3.6                 </param>  
                 </group> 
  
@@ -62,4 +62,3 @@
     
   
 </params>
-

--- a/ergoCubSN001/la.xml
+++ b/ergoCubSN001/la.xml
@@ -9,13 +9,13 @@
 
     <devices>
 
-    <!-- POS4 -->
+    <!-- POS4 
     <xi:include href="wrappers/POS/left_hand-pos_wrapper4.xml" /> 
-    <xi:include href="hardware/POS/left_hand-pos4.xml" />
+    <xi:include href="hardware/POS/left_hand-pos4.xml" /> -->
 
-    <!-- POS2 -->
+    <!-- POS2 
     <xi:include href="wrappers/POS/left_hand-pos_wrapper2.xml" /> 
-    <xi:include href="hardware/POS/left_hand-pos2.xml" />
+    <xi:include href="hardware/POS/left_hand-pos2.xml" /> -->
 
     <!-- motor controllers wrappers -->
     <xi:include href="wrappers/motorControl/left_arm-mc_wrapper.xml" />
@@ -25,17 +25,17 @@
     <!-- LEFT ARM -->
     <xi:include href="hardware/motorControl/left_arm-eb2-j0_1-mc.xml" />
     <xi:include href="hardware/motorControl/left_arm-eb4-j2_3-mc.xml" />
-    <xi:include href="hardware/motorControl/left_arm-eb31-j4_6-mc.xml" />
+ <!--   <xi:include href="hardware/motorControl/left_arm-eb31-j4_6-mc.xml" />
     <xi:include href="hardware/motorControl/left_arm-eb23-j7_10-mc.xml" />
-    <xi:include href="hardware/motorControl/left_arm-eb25-j11_12-mc.xml" />
+    <xi:include href="hardware/motorControl/left_arm-eb25-j11_12-mc.xml" /> -->
 
 
     <!--  CALIBRATORS -->
     <xi:include href="calibrators/left_arm-calib.xml" />
 
-    <!-- IMU -->
+    <!-- IMU 
     <xi:include href="hardware/inertials/left_arm-eb4-j2_3-inertial.xml"/>
-    <xi:include href="wrappers/inertials/left_arm-inertials_wrapper.xml"/>
+    <xi:include href="wrappers/inertials/left_arm-inertials_wrapper.xml"/> -->
 
   </devices>
 </robot>

--- a/ergoCubSN001/ra.xml
+++ b/ergoCubSN001/ra.xml
@@ -9,13 +9,13 @@
 
     <devices>
 
-    <!-- POS4 -->
+    <!-- POS4 
     <xi:include href="wrappers/POS/right_hand-pos_wrapper4.xml" /> 
-    <xi:include href="hardware/POS/right_hand-pos4.xml" />
+    <xi:include href="hardware/POS/right_hand-pos4.xml" />-->
 
-    <!-- POS2 -->
+    <!-- POS2 
     <xi:include href="wrappers/POS/right_hand-pos_wrapper2.xml" /> 
-    <xi:include href="hardware/POS/right_hand-pos2.xml" />
+    <xi:include href="hardware/POS/right_hand-pos2.xml" />-->
 
     <!-- motor controllers wrappers -->
     <xi:include href="wrappers/motorControl/right_arm-mc_wrapper.xml" />
@@ -25,17 +25,17 @@
     <!-- RIGHT ARM -->
     <xi:include href="hardware/motorControl/right_arm-eb1-j0_1-mc.xml" />
     <xi:include href="hardware/motorControl/right_arm-eb3-j2_3-mc.xml" />
-    <xi:include href="hardware/motorControl/right_arm-eb30-j4_6-mc.xml" /> 
+   <!-- <xi:include href="hardware/motorControl/right_arm-eb30-j4_6-mc.xml" /> 
     <xi:include href="hardware/motorControl/right_arm-eb22-j7_10-mc.xml" />
-    <xi:include href="hardware/motorControl/right_arm-eb24-j11_12-mc.xml" />
+    <xi:include href="hardware/motorControl/right_arm-eb24-j11_12-mc.xml" />-->
 
 
     <!--  CALIBRATORS --> 
     <xi:include href="calibrators/right_arm-calib.xml" />
 
-    <!-- IMU -->
+    <!-- IMU 
     <xi:include href="hardware/inertials/right_arm-eb3-j2_3-inertial.xml"/>
-    <xi:include href="wrappers/inertials/right_arm-inertials_wrapper.xml"/>
+    <xi:include href="wrappers/inertials/right_arm-inertials_wrapper.xml"/>-->
 
   </devices>
 </robot>

--- a/ergoCubSN001/wrappers/motorControl/left_arm-mc_remapper.xml
+++ b/ergoCubSN001/wrappers/motorControl/left_arm-mc_remapper.xml
@@ -2,15 +2,15 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mc_remapper" type="controlboardremapper">
-    <param name="axesNames">(l_shoulder_pitch,l_shoulder_roll,l_shoulder_yaw,l_elbow,l_wrist_yaw,l_wrist_roll,l_wrist_pitch,l_thumb_add,l_thumb_oc,l_index_add,l_index_oc,l_middle_oc,l_ring_pinky_oc)</param>
-    <param name="joints"> 13 </param>
+    <param name="axesNames">(l_shoulder_pitch,l_shoulder_roll,l_shoulder_yaw,l_elbow)</param><!--,l_wrist_yaw,l_wrist_roll,l_wrist_pitch,l_thumb_add,l_thumb_oc,l_index_add,l_index_oc,l_middle_oc,l_ring_pinky_oc)</param>-->
+    <param name="joints"> 4 </param>
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">
             <elem name="left_arm_joints1"> left_arm-eb2-j0_1-mc   </elem>
             <elem name="left_arm_joints2"> left_arm-eb4-j2_3-mc   </elem>
-            <elem name="left_arm_joints3"> left_arm-eb31-j4_6-mc  </elem>
+          <!--  <elem name="left_arm_joints3"> left_arm-eb31-j4_6-mc  </elem>
             <elem name="left_arm_joints4"> left_arm-eb23-j7_10-mc </elem>
-            <elem name="left_arm_joints5"> left_arm-eb25-j11_12-mc </elem>
+            <elem name="left_arm_joints5"> left_arm-eb25-j11_12-mc </elem> -->
         </paramlist>
     </action>
     <action phase="shutdown" level="20" type="detach" />

--- a/ergoCubSN001/wrappers/motorControl/right_arm-mc_remapper.xml
+++ b/ergoCubSN001/wrappers/motorControl/right_arm-mc_remapper.xml
@@ -2,15 +2,15 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-mc_remapper" type="controlboardremapper">
-    <param name="axesNames">(r_shoulder_pitch,r_shoulder_roll,r_shoulder_yaw,r_elbow,r_wrist_yaw,r_wrist_roll,r_wrist_pitch,r_thumb_add,r_thumb_oc,r_index_add,r_index_oc,r_middle_oc,r_ring_pinky_oc)</param>
-    <param name="joints"> 13 </param>
+    <param name="axesNames">(r_shoulder_pitch,r_shoulder_roll,r_shoulder_yaw,r_elbow)</param><!--r_wrist_yaw,r_wrist_roll,r_wrist_pitch,r_thumb_add,r_thumb_oc,r_index_add,r_index_oc,r_middle_oc,r_ring_pinky_oc)</param>-->
+    <param name="joints"> 4 </param>
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">
             <elem name="right_arm_joints1"> right_arm-eb1-j0_1-mc    </elem>
-            <elem name="right_arm_joints2"> right_arm-eb3-j2_3-mc    </elem>
-            <elem name="right_arm_joints3"> right_arm-eb30-j4_6-mc   </elem>
+            <elem name="right_arm_joints2"> right_arm-eb3-j2_3-mc    </elem>        
+         <!--   <elem name="right_arm_joints3"> right_arm-eb30-j4_6-mc   </elem>
             <elem name="right_arm_joints4"> right_arm-eb22-j7_10-mc  </elem>
-            <elem name="right_arm_joints5"> right_arm-eb24-j11_12-mc </elem>
+            <elem name="right_arm_joints5"> right_arm-eb24-j11_12-mc </elem> -->
         </paramlist>
     </action>
     <action phase="shutdown" level="20" type="detach" />


### PR DESCRIPTION
## What changes:

This PR updates the ergoCubSN001 configuration files as a result of calibration and testing.

## Note:

- The robot was tested and released without lowerarm.

- Incremental calibration of the torso has not yet been set as the robot is currently on the pole and therefore not recommended.

- The 2FOC firmware is currently version v3.3.20, and not the experimental V3.6.

- Current limits of the shoulder yaw have been slightly because the harmonic drives are still a bit hard, and therefore consume more current than normal.

- The roll and pitch AMOs of both shoulders were disabled due to malfunction. The control is with LCORE5 only.

- I reversed the pid sign of the pitch torso since the coupling was moving backwards, it is still not clear why it was doing that, but the intention is to figure out the reason to bring the PIDs to the original sign.