### PR TITLE
[iCubGenova11] Left thumb oppose new calibration value

### DIFF
--- a/iCubGenova11/calibrators/left_arm-calib.xml
+++ b/iCubGenova11/calibrators/left_arm-calib.xml
@@ -20,8 +20,8 @@
 			<param name="calibration1">          58559   	 22639     48830      51983    -1500    450   11679   0     0     0     0     0     0      0      0     0     </param>
 			<param name="calibration2">	          0          0          0          0	   16384     0      0     0     0    9102  9102  9102  9102   9102   9102  10000  </param>
 			<param name="calibration3">           0          0          0          0	     0       0      0     0     0    -1     1    -1     1     -1      1     1     </param>
-			<param name="calibration4">           0          0          0          0         0       0      0     3140  1780  255   480   255   491    255    494   780   </param>
-			<param name="calibration5">           0          0          0          0         0       0      0     3295  2665  0     18   0     18     0      11    198   </param>
+			<param name="calibration4">           0          0          0          0         0       0      0     3140  1150  255   480   255   491    255    494   780   </param>
+			<param name="calibration5">           0          0          0          0         0       0      0     3295  3450  0     18   0     18     0      11    198   </param>
 			<param name="calibrationZero">        0          0          0          0         0       0      0     0     0     0     0     0     0      0      0     0     </param>
 			<param name="calibrationDelta">       0          -9.2       -17.1      -2.7       0       0      0     0     0     0     0     0     0      0      0     0     </param>
 						                                                         


### PR DESCRIPTION
## What changes:

This PR update the calibration value of the left thumb oppose due this support issue:

- https://github.com/robotology/icub-tech-support/issues/1668

cc @sgiraz @xEnVrE 