### PR TITLE
[iCubGenova03] left index distal PID changing

### DIFF
--- a/iCubGenova03/hardware/motorControl/icub_left_hand.xml
+++ b/iCubGenova03/hardware/motorControl/icub_left_hand.xml
@@ -59,9 +59,9 @@
 </group>       
  
 <group name="POS_PIDS">      
-<param name="kp">           -8000         -8000         -8000          -8000         8000          -8000         -8000         120           </param>       
-<param name="kd">           -32000        -32000        -32000         -32000        32000         -32000        -32000        1250          </param>       
-<param name="ki">           -5            -5            -5             -5            5             -5            -5            0             </param>       
+<param name="kp">           -8000         -8000         -8000          -8000         -8000          -8000         -8000         120           </param>       
+<param name="kd">           -32000        -32000        -32000         -32000        -32000         -32000        -32000        1250          </param>       
+<param name="ki">           -5            -5            -5             -5            -5             -5            -5            0             </param>       
 <param name="maxOutput">       1333          1333          1333          1333          1333          1333          1333          1333          </param>       
 <param name="maxInt">       1333          1333          1333          1333          1333          1333          1333          1333          </param>       
 <param name="shift">        10            10            10            8             10            10            10            4             </param>       


### PR DESCRIPTION
## What changes:

This PR reverse the PID of the left index distal due this support issue:

- https://github.com/robotology/icub-tech-support/issues/1563

cc @sgiraz @MissingSignal @Matilde-Antonj