### PR TITLE
[ergoCubSN00x] Hip Roll maxOutput tuning

### DIFF
--- a/ergoCubSN000/hardware/motorControl/left_leg-eb8-j0_3-mc.xml
+++ b/ergoCubSN000/hardware/motorControl/left_leg-eb8-j0_3-mc.xml
@@ -51,7 +51,7 @@
         <param name="kp">                       -5000               7000        -3000   -10000      </param>
         <param name="kd">                       0                   0           0        0       </param>
         <param name="ki">                       -1500               5000        -200    -1500       </param>
-        <param name="maxOutput">               12000               12000       12000    16000      </param>
+        <param name="maxOutput">               12000               10000       12000    16000      </param>
         <param name="maxInt">                   1500                5000        750      2000      </param>
         <param name="stictionUp">               0                   0           0        0       </param>
         <param name="stictionDown">             0                   0           0        0       </param>

--- a/ergoCubSN000/hardware/motorControl/right_leg-eb6-j0_3-mc.xml
+++ b/ergoCubSN000/hardware/motorControl/right_leg-eb6-j0_3-mc.xml
@@ -51,7 +51,7 @@
         <param name="kp">                       5000                -25000    3000     10000    </param>
         <param name="kd">                       0                   0         0        0      </param>
         <param name="ki">                       1500                -5000     200      1500    </param>
-        <param name="maxOutput">               12000               11000     12000    16000    </param>
+        <param name="maxOutput">               12000               10000     12000    16000    </param>
         <param name="maxInt">                   1500                5000      2000     2000   </param>
         <param name="stictionUp">               0                   0         0        0      </param>
         <param name="stictionDown">             0                   0         0        0     </param>

--- a/ergoCubSN001/hardware/motorControl/left_leg-eb8-j0_3-mc.xml
+++ b/ergoCubSN001/hardware/motorControl/left_leg-eb8-j0_3-mc.xml
@@ -51,7 +51,7 @@
         <param name="kp">                       -5000               7000        -3000   -10000      </param>
         <param name="kd">                       0                   0           0        0       </param>
         <param name="ki">                       -1500               5000        -200    -1500       </param>
-        <param name="maxOutput">               12000               12000       12000    16000      </param>
+        <param name="maxOutput">               12000               10000       12000    16000      </param>
         <param name="maxInt">                   1500                5000        750      2000      </param>
         <param name="stictionUp">               0                   0           0        0       </param>
         <param name="stictionDown">             0                   0           0        0       </param>

--- a/ergoCubSN001/hardware/motorControl/right_leg-eb6-j0_3-mc.xml
+++ b/ergoCubSN001/hardware/motorControl/right_leg-eb6-j0_3-mc.xml
@@ -51,7 +51,7 @@
         <param name="kp">                       5000                -25000    3000     10000    </param>
         <param name="kd">                       0                   0         0        0      </param>
         <param name="ki">                       1500                -5000     200      1500    </param>
-        <param name="maxOutput">               12000               11000     12000    16000    </param>
+        <param name="maxOutput">               12000               10000     12000    16000    </param>
         <param name="maxInt">                   1500                5000      2000     2000   </param>
         <param name="stictionUp">               0                   0         0        0      </param>
         <param name="stictionDown">             0                   0         0        0     </param>


### PR DESCRIPTION
## What Changes:

This PR reduce the maxOutput of hip roll of both robots to avoid overcurrent during walking.

 cc @GiulioRomualdi @S-Dafarra 