### PR TITLE
wrist mk2.1 configuration files used for ROM tests

### DIFF
--- a/experimentalSetups/wristMK2.1_SN002F/IMU_new_forearm-no_hand.xml
+++ b/experimentalSetups/wristMK2.1_SN002F/IMU_new_forearm-no_hand.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+    <robot name="new_forearm" build="1" portprefix="/nfa" xmlns:xi="http://www.w3.org/2001/XInclude">
+        <params>
+            <xi:include href="hardware/electronics/pc104.xml" />
+        </params>
+
+        <devices>
+    
+            <!-- WRIST MC -->
+            <xi:include href="hardware/motorControl/wrist-eb2-j0_2-mc.xml" />
+            <xi:include href="wrappers/motorControl/wrist-mc_wrapper.xml" />  
+            <xi:include href="wrappers/motorControl/wrist-mc_remapper.xml" />  
+    
+            <!--  CALIBRATORS -->  
+            <xi:include href="calibrators/wrist-calib.xml" />
+            
+            <!-- multienc  >
+            <xi:include href="hardware/multienc/wrist-eb2-j0_2-multienc.xml" />
+            <xi:include href="wrappers/multienc/wrist-multienc_wrapper.xml" />  
+            
+            <!--IMERTIALS>
+            <xi:include href="hardware/inertials/wrist-eb2-j0_2-inertial.xml" />
+            <xi:include href="wrappers/inertials/wrist-imu_wrapper.xml" />
+     -->   
+        
+    </devices>
+</robot>

--- a/experimentalSetups/wristMK2.1_SN002F/calibrators/wrist-calib.xml
+++ b/experimentalSetups/wristMK2.1_SN002F/calibrators/wrist-calib.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="wrist-calibrator" type="parametricCalibratorEth">
+
+    <xi:include href="../general.xml" />
+
+    <group name="GENERAL">
+        <param name="joints"> 3 </param> <!-- the number of joints of the robot part -->
+        <param name="deviceName"> Wrist_Calibrator </param>
+    </group>
+
+    <group name="HOME">
+        <param name="positionHome">                     0       0       0       </param>
+        <param name="velocityHome">                     10      10      10      </param>
+    </group>
+
+    <group name="CALIBRATION">
+        <param name="calibrationType">                  12      12      12      </param>
+
+        <!--param name="calibration1">                     729     15429   11211   </param-->
+        <param name="calibration1">               11443.0 11188.0 23850.0   </param>
+        <!--param name="calibration1">               -21434.0 -21264.0 -8858.0   </param-->
+        <param name="calibration2">                     0       0       0       </param>
+        <param name="calibration3">                     0       0       0       </param>
+        <param name="calibration4">                     0       0       0       </param>
+        <param name="calibration5">                     0       0       0       </param>
+        <param name="calibrationZero">                  0       0       0       </param>
+        <param name="calibrationDelta">                 0       0       0       </param>
+
+        <param name="startupPosition">                  0.0     0.0     0.0     </param>
+        <param name="startupVelocity">                  10.0    10.0    10.0    </param>
+        <param name="startupMaxPwm">                    16000   16000   16000   </param>
+        <param name="startupPosThreshold">              2       2       2       </param>
+    </group>
+
+    <param name="CALIB_ORDER"> (0 1 2) </param>
+
+    <action phase="startup" level="10" type="calibrate">
+        <param name="target">wrist-mc_remapper</param>
+    </action>
+
+    <action phase="interrupt1" level="1" type="park">
+        <param name="target">wrist-mc_remapper</param>
+    </action>
+
+    <action phase="interrupt3" level="1" type="abort" />
+
+</device>

--- a/experimentalSetups/wristMK2.1_SN002F/firmwareupdater.ini
+++ b/experimentalSetups/wristMK2.1_SN002F/firmwareupdater.ini
@@ -1,0 +1,2 @@
+[DRIVERS]
+ETH "eth"

--- a/experimentalSetups/wristMK2.1_SN002F/general.xml
+++ b/experimentalSetups/wristMK2.1_SN002F/general.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="nfa" build="1">
+  
+  <group name="GENERAL">
+      <param name="skipCalibration">    false  </param>
+      <param name="useRawEncoderData">  false  </param>
+      <param name="useLimitedPWM">      false  </param>
+      <param name="verbose">            false  </param>
+  </group>
+</params>

--- a/experimentalSetups/wristMK2.1_SN002F/hardware/electronics/pc104.xml
+++ b/experimentalSetups/wristMK2.1_SN002F/hardware/electronics/pc104.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="new_forearm" build="1">
+
+    <group name="PC104">
+        <param name="PC104IpAddress">           10.0.1.104      </param>
+        <param name="PC104IpPort">              12345           </param>
+        <param name="PC104TXrate">              1               </param> 
+        <param name="PC104RXrate">              5               </param>
+    </group>
+
+</params>
+

--- a/experimentalSetups/wristMK2.1_SN002F/hardware/electronics/wrist-eb2-j0_2-eln.xml
+++ b/experimentalSetups/wristMK2.1_SN002F/hardware/electronics/wrist-eb2-j0_2-eln.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="nfa" build="1">
+
+    <xi:include href="./pc104.xml" />
+
+    <group name="ETH_BOARD">
+
+        <group name="ETH_BOARD_PROPERTIES">
+            <param name="IpAddress">                10.0.1.1                </param>
+            <param name="IpPort">                   12345                   </param>
+            <param name="Type">                     amc                    </param>
+            <param name="maxSizeRXpacket">          768                     </param>
+            <param name="maxSizeROP">               384                     </param>
+        </group>
+
+        <group name="ETH_BOARD_SETTINGS">
+            <param name="Name">                     "wrist-eb2-j0_2"        </param>
+            <group name="RUNNINGMODE">
+                <param name="period">                   1000                </param>
+                <param name="maxTimeOfRXactivity">      300                 </param>
+                <param name="maxTimeOfDOactivity">      350                 </param>
+                <param name="maxTimeOfTXactivity">      350                 </param>
+                <param name="TXrateOfRegularROPs">      2                   </param>
+            </group>
+        </group>
+
+        <group name="ETH_BOARD_ACTIONS">
+            <group name="MONITOR_ITS_PRESENCE">
+                <param name="enabled">                  true                </param>
+                <param name="timeout">                  0.020               </param>
+                <param name="periodOfMissingReport">    60.0                </param>
+            </group>
+        </group>
+
+    </group>
+
+</params>
+

--- a/experimentalSetups/wristMK2.1_SN002F/hardware/inertials/right_arm-eb3-j2_3-inertial.xml
+++ b/experimentalSetups/wristMK2.1_SN002F/hardware/inertials/right_arm-eb3-j2_3-inertial.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+   
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-eb3-j2_3-inertial" type="embObjIMU">
+    
+        <xi:include href="../../general.xml" />     
+
+        <xi:include href="../../hardware/electronics/right_arm-eb3-j2_3-eln.xml" />
+        
+        <group name="SERVICE">
+        
+            <param name="type"> eomn_serv_AS_inertials3 </param>                
+        
+            <group name="PROPERTIES">
+            
+                <group name="CANBOARDS">
+                    <param name="type">                 mtb4                </param>
+
+                    <group name="PROTOCOL">
+                        <param name="major">            2                   </param>    
+                        <param name="minor">            0                   </param>     
+                    </group>                    
+                    <group name="FIRMWARE">
+                        <param name="major">            1                   </param>    
+                        <param name="minor">            4                   </param> 
+                        <param name="build">            7                   </param>
+                    </group>
+                </group>
+
+                <group name="SENSORS">
+
+                    <param name="id">                   IDacc                IDgyr
+                    </param>
+
+                    <param name="sensorName">           r_hand_acc           r_hand_gyro
+                    </param>
+
+                    <param name="type">                 eoas_imu_acc         eoas_imu_gyr        
+                    </param>
+
+                    <param name="boardType">            mtb4                 mtb4        
+                    </param>
+
+                    <param name="location">             CAN2:2               CAN2:2
+                    </param>            
+                </group>
+                                            
+            </group>
+            
+            <group name="SETTINGS"> 
+                <param name="acquisitionRate"> 50 </param>
+                <param name="enabledSensors">  IDacc IDgyr </param>                
+            </group>
+            
+        </group>        
+        
+    </device>

--- a/experimentalSetups/wristMK2.1_SN002F/hardware/inertials/wrist-eb2-j0_2-inertial.xml
+++ b/experimentalSetups/wristMK2.1_SN002F/hardware/inertials/wrist-eb2-j0_2-inertial.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="wrist-eb2-j0_2-inertial" type="embObjIMU">
+    
+        <xi:include href="../../general.xml" />     
+
+        <xi:include href="../../hardware/electronics/wrist-eb2-j0_2-eln.xml" />
+        
+        <group name="SERVICE">
+        
+            <param name="type"> eomn_serv_AS_inertials3 </param>                
+        
+            <group name="PROPERTIES">
+            
+                <group name="CANBOARDS">
+                    <param name="type">                 mtb4                </param>
+
+                    <group name="PROTOCOL">
+                        <param name="major">            2                   </param>    
+                        <param name="minor">            0                   </param>     
+                    </group>                    
+                    <group name="FIRMWARE">
+                        <param name="major">            1                   </param>    
+                        <param name="minor">            4                   </param> 
+                        <param name="build">            7                   </param>
+                    </group>
+                </group>
+
+                <group name="SENSORS">
+
+                    <param name="id">               IDacc                   IDgyr
+                    </param>
+
+                    <param name="sensorName">       l_hand_acc              l_hand_gyro
+                    </param>
+
+                    <param name="type">             eoas_imu_acc            eoas_imu_gyr        
+                    </param>
+
+                    <param name="boardType">        mtb4                    mtb4        
+                    </param>
+
+                    <param name="location">         CAN2:10                  CAN2:10
+                    </param>            
+                </group>
+                                            
+            </group>
+            
+            <group name="SETTINGS"> 
+                <param name="acquisitionRate"> 50 </param>
+                <param name="enabledSensors">  IDacc IDgyr </param>                
+            </group>
+            
+        </group>        
+        
+    </device>

--- a/experimentalSetups/wristMK2.1_SN002F/hardware/mechanicals/wrist-eb2-j0_2-mec.xml
+++ b/experimentalSetups/wristMK2.1_SN002F/hardware/mechanicals/wrist-eb2-j0_2-mec.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="nfa" build="1">
+    <group name="GENERAL">
+        <param name="MotioncontrolVersion"> 6 </param>
+        <param name="Joints"> 3 </param>
+        <param name="AxisMap">               0             1             2           </param>
+        <param name="AxisName">         "wrist_yaw"   "wrist_roll" "wrist_pitch"     </param>
+        <param name="AxisType">         "revolute"    "revolute"    "revolute"       </param>
+        <param name="Encoder">          182.044       182.044       182.044          </param>
+        <param name="fullscalePWM">     32000         32000         32000            </param>
+        <param name="ampsToSensor">     1000.0        1000.0        1000.0           </param>
+        <param name="Gearbox_M2J">     -392       -392.0       -392         </param>
+        <param name="Gearbox_E2J">      2.0       2.0         2.0            </param>
+        <param name="useMotorSpeedFbk"> 0             0             0                </param>
+        <param name="MotorType">        "FAULHABER"   "FAULHABER"   "FAULHABER"      </param>
+        <param name="Verbose">      0   </param>
+    </group>
+
+    <group name="LIMITS">
+        <param name="hardwareJntPosMax">     180           180           180         </param>
+        <param name="hardwareJntPosMin">    -180          -180          -180         </param>
+        <param name="rotorPosMin">           0             0             0           </param>
+        <param name="rotorPosMax">           0             0             0           </param>
+    </group>
+
+    <group name="AMCBLDC">
+        <param name="HasHallSensor">         1             1             1           </param>
+        <param name="HasTempSensor">         0             0             0           </param>
+        <param name="HasRotorEncoder">       0             0             0           </param>
+        <param name="HasRotorEncoderIndex">  0             0             0           </param>
+        <param name="HasSpeedEncoder">       0             0             0           </param>
+        <param name="RotorIndexOffset">      0             0             0           </param>
+        <param name="MotorPoles">            14            14            14          </param>
+   </group>
+
+    <group name="COUPLINGS">
+
+        <param name ="matrixJ2M">
+            1.0 0.0 0.0 0.0
+            0.0 1.0 0.0 0.0
+            0.0 0.0 1.0 0.0
+            0.0 0.0 0.0 1.0
+        </param>
+
+        <param name ="matrixM2J">
+            1.0 0.0 0.0 0.0
+            0.0 1.0 0.0 0.0
+            0.0 0.0 1.0 0.0
+            0.0 0.0 0.0 1.0
+        </param>
+
+        <param name ="matrixE2J">
+            1.00    0.00    0.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00    0.00    0.00
+            0.00    0.00    1.00    0.00    0.00    0.00
+            0.00    0.00    0.00    1.00    0.00    0.00
+        </param>
+
+    </group>
+
+    <group name="JOINTSET_CFG">
+        <param name= "numberofsets"> 1 </param>
+        <group name="JOINTSET_0">
+            <param name="listofjoints">  0 1 2         </param>
+            <param name="constraint">    ergocubwrist  </param>         
+            <param name="param1">        21            </param>
+            <param name="param2">        0             </param> <!-- 0:left 1: right-->
+        <!--     
+            <param name="constraint">    none          </param> 
+            <param name="param1">        0             </param>
+            <param name="param2">        0             </param> <!-- calibration set -->
+        </group>
+    </group>
+
+</params>

--- a/experimentalSetups/wristMK2.1_SN002F/hardware/motorControl/wrist-eb2-j0_2-mc.xml
+++ b/experimentalSetups/wristMK2.1_SN002F/hardware/motorControl/wrist-eb2-j0_2-mc.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="wrist-eb2-j0_2-mc" type="embObjMotionControl">
+
+    <xi:include href="../../general.xml" />
+    <xi:include href="../../hardware/electronics/wrist-eb2-j0_2-eln.xml" />
+    <xi:include href="../../hardware/mechanicals/wrist-eb2-j0_2-mec.xml" />
+    <xi:include href="./wrist-eb2-j0_2-mc_service.xml" />
+
+    <!-- joint number                           0                   1                   2               -->
+    <!-- joint name -->
+    <group name="LIMITS">
+        <param name="jntPosMax">                180                 100                 100                 </param>
+        <param name="jntPosMin">               -180                -100                -100                 </param>
+        <param name="jntVelMax">                90                  90                  90                  </param>
+        <param name="motorNominalCurrents">     200                 200                 200                 </param>
+        <param name="motorPeakCurrents">        350                 350                 350                 </param>
+        <param name="motorOverloadCurrents">    370                 370                 370                 </param>
+        <param name="motorPwmLimit">            16000               16000               16000               </param>
+    </group>
+
+    <group name="TIMEOUTS">
+        <param name="velocity">                 100                 100                 100                 </param>
+    </group>
+
+    <group name="IMPEDANCE">
+        <param name="stiffness">                0                   0                   0                   </param>
+        <param name="damping">                  0                   0                   0                   </param>
+    </group>
+
+    <group name="CONTROLS">
+        <param name="positionControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="mixedControl">             POS_PID_DEFAULT     POS_PID_DEFAULT     POS_PID_DEFAULT     </param>
+        <param name="torqueControl">            none                none                none                </param>
+        <param name="currentPid">               2FOC_CUR_CONTROL    2FOC_CUR_CONTROL    2FOC_CUR_CONTROL    </param>
+        <param name="speedPid">                 2FOC_VEL_CONTROL    2FOC_VEL_CONTROL    2FOC_VEL_CONTROL    </param>
+    </group>
+
+
+    <!-- default position PID: begin -->
+
+    <group name="POS_PID_DEFAULT">
+        <param name="controlLaw">             minjerk               </param>
+        <param name="outputType">             current               </param>
+        <param name="fbkControlUnits">        metric_units          </param>
+        <param name="outputControlUnits">     machine_units         </param>
+        <param name="kp">          -200         -200        -200    </param>
+        <param name="kd">          -8           -8          -8      </param>
+        <param name="ki">          -220         -220        -220    </param>
+        <param name="maxOutput">    750         750         750     </param>
+        <param name="maxInt">       200         200         200     </param>
+        <param name="stictionUp">   0           0           0       </param>
+        <param name="stictionDown"> 0           0           0       </param>
+        <param name="kff">          0           0           0       </param>
+    </group>
+
+    <!-- default position PID: end -->
+
+
+    <!-- other default PIDs: begin -->
+
+    <group name="2FOC_CUR_CONTROL">
+        <param name="controlLaw">           low_lev_current     </param>
+        <param name="fbkControlUnits">      machine_units       </param>
+        <param name="outputControlUnits">   machine_units       </param>
+        <param name="kp">                   2           2           2       </param>
+        <param name="kd">                   0           0           0       </param>
+        <param name="ki">                   500         500         500     </param>
+        <param name="shift">                0           0           0       </param>
+        <param name="maxOutput">            32000       32000       32000   </param>
+        <param name="maxInt">               32000       32000       32000   </param>
+        <param name="kff">                  0            0          0       </param>
+    </group>
+
+    <group name="2FOC_VEL_CONTROL">
+        <param name="controlLaw">           low_lev_speed       </param>
+        <param name="fbkControlUnits">      machine_units       </param>
+        <param name="outputControlUnits">   machine_units       </param>
+        <param name="kff">                  0           0           0       </param>
+        <param name="kp">                   12          12          12      </param>
+        <param name="kd">                   0           0           0       </param>
+        <param name="ki">                   16          16          16      </param>
+        <param name="shift">                10          10          10      </param>
+        <param name="maxOutput">            32000       32000       32000   </param>
+        <param name="maxInt">               32000       32000       32000   </param>
+    </group>
+
+    <!-- other default PIDs: end -->
+
+
+    <!-- custom PIDs: begin -->
+
+    <!-- custom PIDs: end -->
+
+</device>
+
+

--- a/experimentalSetups/wristMK2.1_SN002F/hardware/motorControl/wrist-eb2-j0_2-mc_service.xml
+++ b/experimentalSetups/wristMK2.1_SN002F/hardware/motorControl/wrist-eb2-j0_2-mc_service.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="nfa" build="1">
+
+    <group name="SERVICE">
+
+        <param name="type"> eomn_serv_MC_foc </param>
+
+        <group name="PROPERTIES">
+
+            <group name="ETHBOARD">
+                <param name="type">                 amc        </param>
+            </group>
+
+            <group name="CANBOARDS">
+                <param name="type">                 amcbldc     </param>
+                <group name="PROTOCOL">
+                    <param name="major">            2           </param>
+                    <param name="minor">            0           </param>
+                </group>
+                <group name="FIRMWARE">
+                    <param name="major">            2           </param>
+                    <param name="minor">            0           </param>
+                    <param name="build">            4          </param>
+                </group>
+            </group>
+
+            <group name="JOINTMAPPING">
+
+                <group name="ACTUATOR">
+                    <param name="type">             foc                 foc                 foc         </param>
+                    <param name="port">             CAN1:1:0            CAN1:2:0            CAN1:3:0    </param>
+                </group>
+
+                <group name="ENCODER1">
+                    <param name="type">             aea3                aea3                aea3         </param>
+                    <param name="port">             CONN:J5_X1          CONN:J5_X2          CONN:J5_X3  </param>
+                    <param name="position">         atjoint             atjoint             atjoint     </param>
+                    <param name="resolution">       16384               16384               16384        </param>
+                    <param name="tolerance">        0.4                 0.4                 0.4         </param>
+                </group>
+
+                <group name="ENCODER2">
+                    <param name="type">             none                none                none        </param>
+                    <param name="port">             CAN1:1:0            CAN1:2:0            CAN1:3:0    </param>
+                    <param name="position">         atmotor             atmotor             atmotor     </param>
+                    <param name="resolution">       0                   0                   0           </param>
+                    <param name="tolerance">        0                   0                   0           </param>
+                </group>
+
+            </group>
+
+        </group>
+
+    </group>
+
+</params>

--- a/experimentalSetups/wristMK2.1_SN002F/hardware/multienc/wrist-eb2-j0_2-multienc.xml
+++ b/experimentalSetups/wristMK2.1_SN002F/hardware/multienc/wrist-eb2-j0_2-multienc.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="wrist_multienc" type="embObjMultiEnc"> 
+        <xi:include href="general.xml" />
+        <xi:include href="hardware/electronics/wrist-eb2-j0_2-eln.xml" />
+        <group name="JOINTS">
+            <param name="listofjoints"> 0 1 2</param>
+            <param name="encoderConversionFactor"> 1.0 1.0 1.0 </param>
+        </group>
+    </device> 
+    

--- a/experimentalSetups/wristMK2.1_SN002F/new_forearm-no_hand.xml
+++ b/experimentalSetups/wristMK2.1_SN002F/new_forearm-no_hand.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+    <robot name="new_forearm" build="1" portprefix="/nfa" xmlns:xi="http://www.w3.org/2001/XInclude">
+        <params>
+            <xi:include href="hardware/electronics/pc104.xml" />
+        </params>
+
+        <devices>
+    
+            <!-- WRIST MC -->
+            <xi:include href="hardware/motorControl/wrist-eb2-j0_2-mc.xml" />
+            <xi:include href="wrappers/motorControl/wrist-mc_wrapper.xml" />  
+            <xi:include href="wrappers/motorControl/wrist-mc_remapper.xml" />  
+    
+            <!--  CALIBRATORS -->  
+            <xi:include href="calibrators/wrist-calib.xml" />
+            
+            <!-- multienc  >
+            <xi:include href="hardware/multienc/wrist-eb2-j0_2-multienc.xml" />
+            <xi:include href="wrappers/multienc/wrist-multienc_wrapper.xml" />  
+            
+            <!-- IMERTIALS>
+            <xi:include href="hardware/inertials/wrist-eb2-j0_2-inertial.xml" />
+            <xi:include href="wrappers/inertials/wrist-imu_wrapper.xml" /-->
+        
+        
+    </devices>
+</robot>

--- a/experimentalSetups/wristMK2.1_SN002F/sequence-close-open.posleft_hand_mc
+++ b/experimentalSetups/wristMK2.1_SN002F/sequence-close-open.posleft_hand_mc
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Sequence_posleft_hand_mc TotPositions="5" ReferencePart="left_hand_mc">
+    <Position Index="0" Timing="1.00">
+        <JointPositions Count="4">
+            <PosValue>10.00</PosValue>
+            <PosValue>10.00</PosValue>
+            <PosValue>10.00</PosValue>
+            <PosValue>10.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="4">
+            <SpeedValue>40.00</SpeedValue>
+            <SpeedValue>40.00</SpeedValue>
+            <SpeedValue>40.00</SpeedValue>
+            <SpeedValue>40.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="1" Timing="1.00">
+        <JointPositions Count="4">
+            <PosValue>70.00</PosValue>
+            <PosValue>10.00</PosValue>
+            <PosValue>10.00</PosValue>
+            <PosValue>10.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="4">
+            <SpeedValue>40.00</SpeedValue>
+            <SpeedValue>40.00</SpeedValue>
+            <SpeedValue>40.00</SpeedValue>
+            <SpeedValue>40.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="2" Timing="1.00">
+        <JointPositions Count="4">
+            <PosValue>70.00</PosValue>
+            <PosValue>70.00</PosValue>
+            <PosValue>10.00</PosValue>
+            <PosValue>10.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="4">
+            <SpeedValue>40.00</SpeedValue>
+            <SpeedValue>40.00</SpeedValue>
+            <SpeedValue>40.00</SpeedValue>
+            <SpeedValue>40.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="3" Timing="1.00">
+        <JointPositions Count="4">
+            <PosValue>70.00</PosValue>
+            <PosValue>70.00</PosValue>
+            <PosValue>70.00</PosValue>
+            <PosValue>10.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="4">
+            <SpeedValue>40.00</SpeedValue>
+            <SpeedValue>40.00</SpeedValue>
+            <SpeedValue>40.00</SpeedValue>
+            <SpeedValue>40.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="4" Timing="1.00">
+        <JointPositions Count="4">
+            <PosValue>70.00</PosValue>
+            <PosValue>70.00</PosValue>
+            <PosValue>70.00</PosValue>
+            <PosValue>70.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="4">
+            <SpeedValue>40.00</SpeedValue>
+            <SpeedValue>40.00</SpeedValue>
+            <SpeedValue>40.00</SpeedValue>
+            <SpeedValue>40.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+</Sequence_posleft_hand_mc>

--- a/experimentalSetups/wristMK2.1_SN002F/sequences/-30_20_20_-20.poswrist_mc
+++ b/experimentalSetups/wristMK2.1_SN002F/sequences/-30_20_20_-20.poswrist_mc
@@ -1,0 +1,259 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Sequence_poswrist_mc TotPositions="1" ReferencePart="wrist_mc">
+    <Position Index="0" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="1" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="2" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>20.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="3" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>20.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="6" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>20.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="7" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>20.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+    <Position Index="8" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="9" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="10" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-30.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="11" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-30.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="12" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-30.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="13" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-30.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="14" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-30.00</PosValue>
+            <PosValue>-20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="15" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-30.00</PosValue>
+            <PosValue>-20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+    <Position Index="16" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>-20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="17" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>-20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="22" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>20.00</PosValue>
+            <PosValue>-20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="23" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>20.00</PosValue>
+            <PosValue>-20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="24" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>20.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="25" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>20.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+    <Position Index="18" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+</Sequence_poswrist_mc>

--- a/experimentalSetups/wristMK2.1_SN002F/sequences/25_20_-10.poswrist_mc
+++ b/experimentalSetups/wristMK2.1_SN002F/sequences/25_20_-10.poswrist_mc
@@ -1,0 +1,259 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Sequence_poswrist_mc TotPositions="1" ReferencePart="wrist_mc">
+    <Position Index="0" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="1" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="2" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>25.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="3" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>25.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="6" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>25.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="7" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>25.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+    <Position Index="8" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="9" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="10" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-25.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="11" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-25.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="12" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-25.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="13" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-25.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="14" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-25.00</PosValue>
+            <PosValue>-10.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="15" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-25.00</PosValue>
+            <PosValue>-10.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+    <Position Index="16" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>-10.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="17" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>-10.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="22" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>25.00</PosValue>
+            <PosValue>-10.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="23" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>25.00</PosValue>
+            <PosValue>-10.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="24" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>25.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="25" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>25.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+    <Position Index="18" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+</Sequence_poswrist_mc>

--- a/experimentalSetups/wristMK2.1_SN002F/sequences/30_-20_10_-10.poswrist_mc
+++ b/experimentalSetups/wristMK2.1_SN002F/sequences/30_-20_10_-10.poswrist_mc
@@ -1,0 +1,259 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Sequence_poswrist_mc TotPositions="1" ReferencePart="wrist_mc">
+    <Position Index="0" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="1" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="2" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="3" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="6" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>10.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="7" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>10.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+    <Position Index="8" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>10.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="9" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>10.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="10" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-20.00</PosValue>
+            <PosValue>10.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="11" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-20.00</PosValue>
+            <PosValue>10.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="12" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-20.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="13" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-20.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="14" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-20.00</PosValue>
+            <PosValue>-10.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="15" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-20.00</PosValue>
+            <PosValue>-10.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+    <Position Index="16" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>-10.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="17" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>-10.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="22" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>-10.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="23" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>-10.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="24" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="25" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+    <Position Index="18" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+</Sequence_poswrist_mc>

--- a/experimentalSetups/wristMK2.1_SN002F/sequences/30_-20_15_-15.poswrist_mc
+++ b/experimentalSetups/wristMK2.1_SN002F/sequences/30_-20_15_-15.poswrist_mc
@@ -1,0 +1,259 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Sequence_poswrist_mc TotPositions="1" ReferencePart="wrist_mc">
+    <Position Index="0" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="1" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="2" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="3" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="6" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>15.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="7" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>15.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+    <Position Index="8" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>15.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="9" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>15.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="10" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-20.00</PosValue>
+            <PosValue>15.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="11" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-20.00</PosValue>
+            <PosValue>15.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="12" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-20.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="13" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-20.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="14" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-20.00</PosValue>
+            <PosValue>-15.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="15" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-20.00</PosValue>
+            <PosValue>-15.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+    <Position Index="16" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>-15.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="17" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>-15.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="22" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>-15.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="23" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>-15.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="24" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="25" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+    <Position Index="18" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+</Sequence_poswrist_mc>

--- a/experimentalSetups/wristMK2.1_SN002F/sequences/30_-20_20_-10.poswrist_mc
+++ b/experimentalSetups/wristMK2.1_SN002F/sequences/30_-20_20_-10.poswrist_mc
@@ -1,0 +1,259 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Sequence_poswrist_mc TotPositions="1" ReferencePart="wrist_mc">
+    <Position Index="0" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="1" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="2" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="3" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="6" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="7" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+    <Position Index="8" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="9" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="10" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-20.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="11" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-20.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="12" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-20.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="13" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-20.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="14" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-20.00</PosValue>
+            <PosValue>-10.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="15" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-20.00</PosValue>
+            <PosValue>-10.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+    <Position Index="16" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>-10.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="17" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>-10.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="22" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>-10.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="23" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>-10.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="24" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="25" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+    <Position Index="18" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+</Sequence_poswrist_mc>

--- a/experimentalSetups/wristMK2.1_SN002F/sequences/30_-20_20_-20.poswrist_mc
+++ b/experimentalSetups/wristMK2.1_SN002F/sequences/30_-20_20_-20.poswrist_mc
@@ -1,0 +1,259 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Sequence_poswrist_mc TotPositions="1" ReferencePart="wrist_mc">
+    <Position Index="0" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="1" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="2" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="3" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="6" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="7" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+    <Position Index="8" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="9" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="10" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-20.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="11" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-20.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="12" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-20.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="13" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-20.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="14" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-20.00</PosValue>
+            <PosValue>-20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="15" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-20.00</PosValue>
+            <PosValue>-20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+    <Position Index="16" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>-20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="17" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>-20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="22" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>-20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="23" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>-20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="24" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="25" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+    <Position Index="18" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+</Sequence_poswrist_mc>

--- a/experimentalSetups/wristMK2.1_SN002F/sequences/30_-20_20_-20_-90.poswrist_mc
+++ b/experimentalSetups/wristMK2.1_SN002F/sequences/30_-20_20_-20_-90.poswrist_mc
@@ -1,0 +1,259 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Sequence_poswrist_mc TotPositions="1" ReferencePart="wrist_mc">
+    <Position Index="0" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>-85.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="1" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>-85.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="2" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>-85.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="3" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>-85.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="6" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>-85.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="7" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>-85.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+    <Position Index="8" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>-85.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="9" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>-85.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="10" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>-85.00</PosValue>
+            <PosValue>-20.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="11" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>-85.00</PosValue>
+            <PosValue>-20.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="12" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>-85.00</PosValue>
+            <PosValue>-20.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="13" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>-85.00</PosValue>
+            <PosValue>-20.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="14" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>-85.00</PosValue>
+            <PosValue>-20.00</PosValue>
+            <PosValue>-20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="15" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>-85.00</PosValue>
+            <PosValue>-20.00</PosValue>
+            <PosValue>-20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+    <Position Index="16" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>-85.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>-20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="17" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>-85.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>-20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="22" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>-85.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>-20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="23" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>-85.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>-20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="24" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>-85.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="25" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>-85.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+    <Position Index="18" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>-85.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+</Sequence_poswrist_mc>

--- a/experimentalSetups/wristMK2.1_SN002F/sequences/30_-20_20_-20_180.poswrist_mc
+++ b/experimentalSetups/wristMK2.1_SN002F/sequences/30_-20_20_-20_180.poswrist_mc
@@ -1,0 +1,259 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Sequence_poswrist_mc TotPositions="1" ReferencePart="wrist_mc">
+    <Position Index="0" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>180.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="1" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>180.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="2" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>180.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="3" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>180.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="6" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>180.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="7" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>180.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+    <Position Index="8" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>180.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="9" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>180.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="10" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>180.00</PosValue>
+            <PosValue>-20.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="11" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>180.00</PosValue>
+            <PosValue>-20.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="12" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>180.00</PosValue>
+            <PosValue>-20.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="13" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>180.00</PosValue>
+            <PosValue>-20.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="14" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>180.00</PosValue>
+            <PosValue>-20.00</PosValue>
+            <PosValue>-20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="15" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>180.00</PosValue>
+            <PosValue>-20.00</PosValue>
+            <PosValue>-20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+    <Position Index="16" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>180.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>-20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="17" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>180.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>-20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="22" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>180.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>-20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="23" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>180.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>-20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="24" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>180.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="25" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>180.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+    <Position Index="18" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>180.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+</Sequence_poswrist_mc>

--- a/experimentalSetups/wristMK2.1_SN002F/sequences/30_-20_20_-20_90.poswrist_mc
+++ b/experimentalSetups/wristMK2.1_SN002F/sequences/30_-20_20_-20_90.poswrist_mc
@@ -1,0 +1,259 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Sequence_poswrist_mc TotPositions="1" ReferencePart="wrist_mc">
+    <Position Index="0" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>90.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="1" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>90.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="2" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>90.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="3" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>90.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="6" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>90.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="7" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>90.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+    <Position Index="8" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>90.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="9" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>90.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="10" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>90.00</PosValue>
+            <PosValue>-20.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="11" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>90.00</PosValue>
+            <PosValue>-20.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="12" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>90.00</PosValue>
+            <PosValue>-20.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="13" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>90.00</PosValue>
+            <PosValue>-20.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="14" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>90.00</PosValue>
+            <PosValue>-20.00</PosValue>
+            <PosValue>-20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="15" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>90.00</PosValue>
+            <PosValue>-20.00</PosValue>
+            <PosValue>-20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+    <Position Index="16" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>90.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>-20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="17" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>90.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>-20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="22" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>90.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>-20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="23" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>90.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>-20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="24" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>90.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="25" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>90.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+    <Position Index="18" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>90.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+</Sequence_poswrist_mc>

--- a/experimentalSetups/wristMK2.1_SN002F/sequences/30_-25_20_-10.poswrist_mc
+++ b/experimentalSetups/wristMK2.1_SN002F/sequences/30_-25_20_-10.poswrist_mc
@@ -1,0 +1,259 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Sequence_poswrist_mc TotPositions="1" ReferencePart="wrist_mc">
+    <Position Index="0" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="1" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="2" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="3" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="6" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="7" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+    <Position Index="8" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="9" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="10" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-25.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="11" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-25.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="12" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-25.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="13" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-25.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="14" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-25.00</PosValue>
+            <PosValue>-10.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="15" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-25.00</PosValue>
+            <PosValue>-10.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+    <Position Index="16" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>-10.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="17" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>-10.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="22" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>-10.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="23" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>-10.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="24" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="25" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+    <Position Index="18" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+</Sequence_poswrist_mc>

--- a/experimentalSetups/wristMK2.1_SN002F/sequences/30_20_-10.poswrist_mc
+++ b/experimentalSetups/wristMK2.1_SN002F/sequences/30_20_-10.poswrist_mc
@@ -1,0 +1,259 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Sequence_poswrist_mc TotPositions="1" ReferencePart="wrist_mc">
+    <Position Index="0" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="1" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="2" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="3" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="6" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="7" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+    <Position Index="8" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="9" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="10" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-30.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="11" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-30.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="12" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-30.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="13" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-30.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="14" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-30.00</PosValue>
+            <PosValue>-10.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="15" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-30.00</PosValue>
+            <PosValue>-10.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+    <Position Index="16" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>-10.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="17" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>-10.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="22" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>-10.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="23" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>-10.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="24" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="25" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+    <Position Index="18" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+</Sequence_poswrist_mc>

--- a/experimentalSetups/wristMK2.1_SN002F/sequences/dof.poswrist_mc
+++ b/experimentalSetups/wristMK2.1_SN002F/sequences/dof.poswrist_mc
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Sequence_poswrist_mc TotPositions="1" ReferencePart="wrist_mc">
+    <Position Index="0" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="1" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>40.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="2" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>5.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="3" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="4" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="5" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-30.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="6" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="7" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>-30.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+</Sequence_poswrist_mc>

--- a/experimentalSetups/wristMK2.1_SN002F/sequences/inverse_30_-20_20_-20.poswrist_mc
+++ b/experimentalSetups/wristMK2.1_SN002F/sequences/inverse_30_-20_20_-20.poswrist_mc
@@ -1,0 +1,259 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Sequence_poswrist_mc TotPositions="1" ReferencePart="wrist_mc">
+    <Position Index="0" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="1" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="2" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="3" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="6" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>-20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="7" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>-20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+    <Position Index="8" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>-20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="9" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>-20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="10" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-20.00</PosValue>
+            <PosValue>-20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="11" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-20.00</PosValue>
+            <PosValue>-20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="12" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-20.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="13" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-20.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="14" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-20.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="15" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-20.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+    <Position Index="16" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="17" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="22" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="23" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="24" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="25" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+    <Position Index="18" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+</Sequence_poswrist_mc>

--- a/experimentalSetups/wristMK2.1_SN002F/sequences/inverted.poswrist_mc
+++ b/experimentalSetups/wristMK2.1_SN002F/sequences/inverted.poswrist_mc
@@ -1,0 +1,260 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Sequence_poswrist_mc TotPositions="1" ReferencePart="wrist_mc">
+    <Position Index="0" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="1" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="22" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-28.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="23" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-28.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="4" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-28.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="5" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-28.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="6" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="7" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="8" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>32.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="9" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>32.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="10" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>32.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="11" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>32.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="12" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>32.00</PosValue>
+            <PosValue>-20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="13" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>32.00</PosValue>
+            <PosValue>-20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="14" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>-20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="15" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>-20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+    <Position Index="16" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-28.00</PosValue>
+            <PosValue>-20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="17" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-28.00</PosValue>
+            <PosValue>-20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+    <Position Index="18" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-28.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+    <Position Index="19" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-28.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+    <Position Index="20" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+</Sequence_poswrist_mc>

--- a/experimentalSetups/wristMK2.1_SN002F/sequences/log-wrist-joints/CMakeLists.txt
+++ b/experimentalSetups/wristMK2.1_SN002F/sequences/log-wrist-joints/CMakeLists.txt
@@ -1,0 +1,14 @@
+################################################################################
+#                                                                              #
+# Copyright (C) 2020 Fondazione Istitito Italiano di Tecnologia (IIT)          #
+# All Rights Reserved.                                                         #
+#                                                                              #
+################################################################################
+
+cmake_minimum_required(VERSION 3.12)
+project(logwristjoints)
+
+find_package(YARP REQUIRED)
+add_executable(${PROJECT_NAME})
+target_sources(${PROJECT_NAME} PRIVATE src/main.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE ${YARP_LIBRARIES})

--- a/experimentalSetups/wristMK2.1_SN002F/sequences/log-wrist-joints/README.md
+++ b/experimentalSetups/wristMK2.1_SN002F/sequences/log-wrist-joints/README.md
@@ -1,0 +1,29 @@
+# Log wrist joints data
+This Yarp application can be used to read the following information from the control boards of the wrist:
+
+- Motor PID reference
+- Motor PID error
+- Motor PID output
+- Roll, pitch, yaw angles 
+
+## Compile the code
+In order to compile the [code](src/main.cpp) do :
+
+```console
+mkdir build
+cd build 
+ccmake .. # select your preferred options
+make
+```
+
+## Usage
+First make sure that `yarpserver` is running.
+Navigate to the `build` folder you created above, and in a terminal launch the binary with `./logwristjoints`.
+The application accepts the following arguments:
+- `--remote`: the remote port to connect to - default `/nfa_wrist/mc`
+- `--period`: the period in seconds at which the logging thread runs - default 0.01sec
+- `--file`: the file in which the logged data is stored - default `log.csv`
+
+The file is saved to disk when you exit the application with ctrl-C (SIGINT).
+The output file will be located in the `build` folder, and it will be made by records with comma-delimited columns. Each column has a properly defined header.
+

--- a/experimentalSetups/wristMK2.1_SN002F/sequences/log-wrist-joints/src/main.cpp
+++ b/experimentalSetups/wristMK2.1_SN002F/sequences/log-wrist-joints/src/main.cpp
@@ -1,0 +1,225 @@
+/******************************************************************************
+ *                                                                            *
+ * Copyright (C) 2021 Fondazione Istituto Italiano di Tecnologia (IIT)        *
+ * All Rights Reserved.                                                       *
+ *                                                                            *
+ ******************************************************************************/
+
+#include <yarp/dev/ControlBoardInterfaces.h>
+#include <yarp/dev/PolyDriver.h>
+#include <yarp/os/LogStream.h>
+#include <yarp/os/Network.h>
+#include <yarp/os/PeriodicThread.h>
+#include <yarp/os/Property.h>
+#include <yarp/os/ResourceFinder.h>
+#include <yarp/os/Time.h>
+
+#include <fstream>
+#include <string>
+#include <vector>
+#include <signal.h>
+
+ /******************************************************************************/
+struct DataExperiment {
+  double pwm;
+  double pid_out;
+  double enc;
+  double ref;
+  double err;
+  double target;
+  double taskspace_enc;
+  double current;
+};
+
+constexpr int PITCH_JOINT_ID = 2;
+constexpr int ROLL_JOINT_ID = 1;
+constexpr int YAW_JOINT_ID = 0;
+
+
+bool TERMINATED = false;
+
+/******************************************************************************/
+// The function to be called when ctrl-c (SIGINT) is sent to process
+void signal_callback_handler(int signum) {
+  // Terminate program
+  TERMINATED = true;
+}
+
+class ReadThread : public yarp::os::PeriodicThread {
+private:
+  yarp::dev::PolyDriver driver;
+  yarp::dev::IEncoders* iEnc{ nullptr };
+  yarp::dev::IPidControl* iPidCtrl{ nullptr };
+  yarp::dev::IPositionControl* iPosCtrl{ nullptr };
+  yarp::dev::IAmplifierControl* iAmplifier{ nullptr };
+  
+  
+  std::ofstream file_output;
+  std::string remote;
+  std::string fname;
+  std::vector<DataExperiment> yaw_data;
+  std::vector<DataExperiment> roll_data;
+  std::vector<DataExperiment> pitch_data;
+  std::vector<double> time_vector;
+  double t0;
+
+public:
+  ReadThread(const yarp::conf::float64_t period, const std::string& remote_port, const std::string& filename)
+    : PeriodicThread(period) {
+    remote = remote_port;
+    fname = filename;
+  }
+
+  bool threadInit() {
+    yInfo() << "ReadThread starting";
+
+    yarp::os::Property conf;
+    conf.put("device", "remote_controlboard");
+    conf.put("remote", remote);
+    conf.put("local", "/logger");
+
+    if (!driver.open(conf)) {
+      yError() << "Failed to connect to" << remote;
+      return false;
+    }
+
+    if (!(driver.view(iEnc))) {
+      yError() << "Failed to open encoder interface";
+      driver.close();
+      return false;
+    }
+
+    if (!(driver.view(iAmplifier))) {
+      yError() << "Failed to open amplifier interface";
+      driver.close();
+      return false;
+    }
+    
+    if (!(driver.view(iPidCtrl))) {
+      yError() << "Failed to open PID control interface";
+      driver.close();
+      return false;
+    }
+
+    if (!(driver.view(iPosCtrl))) {
+      yError() << "Failed to open position control interface";
+      driver.close();
+      return false;
+    }
+
+    file_output.open(fname);
+
+    if (!file_output.is_open()) {
+      yError() << "Failed to open "
+        << fname;
+      driver.close();
+      return false;
+    }
+
+    file_output << "Time"<< ","<< "Mot0_Pwm"<< ","<< "Mot1_Pwm"<< ","<< "Mot2_Pwm"<< ","
+      << "Mot0_Ref"<< ","<< "Mot1_Ref"<< ","<< "Mot2_Ref"<< ","
+      << "Mot0_Err"<< ","<< "Mot1_Err"<< ","<< "Mot2_Err" << "," 
+      << "Roll"<< ","<< "Pitch"<< ","<< "Yaw" << ","<< "Curr2 " << ","<< " Curr0" << ","<< "Curr1" << ","<< "setRoll"<< ","<<"setPitch"<< ","<< "setYaw" << std::endl;
+    t0 = yarp::os::Time::now();
+
+    return true;
+  }
+
+  void run() {
+    DataExperiment yaw_d;
+    DataExperiment roll_d;
+    DataExperiment pitch_d;
+    time_vector.push_back(static_cast<double>(yarp::os::Time::now() - t0));
+
+    iEnc->getEncoder(YAW_JOINT_ID, &yaw_d.taskspace_enc);
+    iEnc->getEncoder(ROLL_JOINT_ID, &roll_d.taskspace_enc);
+    iEnc->getEncoder(PITCH_JOINT_ID, &pitch_d.taskspace_enc);
+    
+    iAmplifier->getCurrent(YAW_JOINT_ID, &yaw_d.current); 
+    iAmplifier->getCurrent(PITCH_JOINT_ID, &pitch_d.current);
+    iAmplifier->getCurrent(ROLL_JOINT_ID, &roll_d.current);
+    
+    iPidCtrl->getPidReference(yarp::dev::VOCAB_PIDTYPE_POSITION, YAW_JOINT_ID,
+      &yaw_d.ref);
+    iPidCtrl->getPidReference(yarp::dev::VOCAB_PIDTYPE_POSITION, ROLL_JOINT_ID,
+      &roll_d.ref);
+    iPidCtrl->getPidReference(yarp::dev::VOCAB_PIDTYPE_POSITION, PITCH_JOINT_ID,
+      &pitch_d.ref);
+
+    if (!iPosCtrl->getTargetPosition(YAW_JOINT_ID, &yaw_d.target))
+      yWarning() << "Cannot retrieve yaw tg";
+    if (!iPosCtrl->getTargetPosition(ROLL_JOINT_ID, &roll_d.target))
+      yWarning() << "Cannot retrieve roll tg";
+    if (!iPosCtrl->getTargetPosition(PITCH_JOINT_ID, &pitch_d.target))
+      yWarning() << "Cannot retrieve pitch tg";
+
+    iPidCtrl->getPidError(yarp::dev::VOCAB_PIDTYPE_POSITION, YAW_JOINT_ID, &yaw_d.err);
+    iPidCtrl->getPidError(yarp::dev::VOCAB_PIDTYPE_POSITION, ROLL_JOINT_ID, &roll_d.err);
+    iPidCtrl->getPidError(yarp::dev::VOCAB_PIDTYPE_POSITION, PITCH_JOINT_ID, &pitch_d.err);
+
+    iPidCtrl->getPidOutput(yarp::dev::VOCAB_PIDTYPE_POSITION, YAW_JOINT_ID, &yaw_d.pwm);
+    iPidCtrl->getPidOutput(yarp::dev::VOCAB_PIDTYPE_POSITION, ROLL_JOINT_ID, &roll_d.pwm);
+    iPidCtrl->getPidOutput(yarp::dev::VOCAB_PIDTYPE_POSITION, PITCH_JOINT_ID, &pitch_d.pwm);
+
+    yaw_data.push_back(std::move(yaw_d));
+    roll_data.push_back(std::move(roll_d));
+    pitch_data.push_back(std::move(pitch_d));
+  }
+
+  void threadRelease() {
+    for (uint32_t i = 0; i < roll_data.size(); ++i) {
+      file_output << time_vector[i] << "," << yaw_data[i].pwm << ","
+        << roll_data[i].pwm << "," << pitch_data[i].pwm << ","
+        << yaw_data[i].ref << "," << roll_data[i].ref << ","
+        << pitch_data[i].ref << "," << yaw_data[i].err << ","
+        << roll_data[i].err << "," << pitch_data[i].err << ","
+        << roll_data[i].taskspace_enc << "," << pitch_data[i].taskspace_enc << "," 
+        << yaw_data[i].taskspace_enc << ","<< roll_data[i].current << "," << pitch_data[i].current << "," 
+        << yaw_data[i].current << "," << roll_data[i].target << "," << pitch_data[i].target << "," 
+        << yaw_data[i].target << "," << std::endl;
+    }
+    yInfo() << "Saved data";
+
+    // Close I/O resources
+    file_output.close();
+    driver.close();
+
+    yInfo() << "Done.";
+  }
+};
+
+/****************************************************************q`**************/
+int main(int argc, char* argv[]) {
+  // Register signal and signal handler
+  signal(SIGINT, signal_callback_handler);
+
+  yarp::os::Network yarp;
+  if (!yarp.checkNetwork()) {
+    yError() << "Unable to find YARP server!";
+    return EXIT_FAILURE;
+  }
+
+  yarp::os::ResourceFinder rf;
+  rf.configure(argc, argv);
+
+  auto remote = rf.check("remote", yarp::os::Value("/nfa/wrist_mc")).asString();
+  auto filename = rf.check("file", yarp::os::Value("log.csv")).asString();
+  auto period = rf.check("period", yarp::os::Value(0.01)).asFloat64();
+
+  ReadThread read_thread(period, remote, filename);
+
+  yInfo() << "Started recording...";
+  read_thread.start();
+
+  while (!TERMINATED) {
+    yInfo() << "Recording data...";
+    yarp::os::Time::delay(5);
+  }
+
+  if (TERMINATED) {
+    yInfo() << "Catched SIGINT, saving data to file...";
+    read_thread.stop();
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/experimentalSetups/wristMK2.1_SN002F/sequences/log-wrist-joints/utils/roll-trajectory.poswrist_mc
+++ b/experimentalSetups/wristMK2.1_SN002F/sequences/log-wrist-joints/utils/roll-trajectory.poswrist_mc
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Sequence_poswrist_mc TotPositions="8" ReferencePart="wrist_mc">
+    <Position Index="0" Timing="2.00">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>29.70</SpeedValue>
+            <SpeedValue>29.70</SpeedValue>
+            <SpeedValue>29.70</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="1" Timing="3.00">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>46.02</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>29.70</SpeedValue>
+            <SpeedValue>29.70</SpeedValue>
+            <SpeedValue>29.70</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="2" Timing="3.00">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>29.70</SpeedValue>
+            <SpeedValue>29.70</SpeedValue>
+            <SpeedValue>29.70</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="3" Timing="3.00">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-59.12</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>29.70</SpeedValue>
+            <SpeedValue>29.70</SpeedValue>
+            <SpeedValue>29.70</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="4" Timing="3.00">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>29.70</SpeedValue>
+            <SpeedValue>29.70</SpeedValue>
+            <SpeedValue>29.70</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="5" Timing="3.00">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>47.38</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>29.70</SpeedValue>
+            <SpeedValue>29.70</SpeedValue>
+            <SpeedValue>29.70</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="6" Timing="5.00">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-55.85</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>29.70</SpeedValue>
+            <SpeedValue>29.70</SpeedValue>
+            <SpeedValue>29.70</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="7" Timing="3.00">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>29.70</SpeedValue>
+            <SpeedValue>29.70</SpeedValue>
+            <SpeedValue>29.70</SpeedValue>
+        </JointVelocities>
+    </Position>
+</Sequence_poswrist_mc>

--- a/experimentalSetups/wristMK2.1_SN002F/sequences/log-wrist-joints/utils/yscope.xml
+++ b/experimentalSetups/wristMK2.1_SN002F/sequences/log-wrist-joints/utils/yscope.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<portscope rows="3" columns="1" carrier="mcast">
+    <plot gridx="0"
+          gridy="0"
+          title="Yaw"
+          size="60"
+          minval="-100"
+          maxval="100"
+          bgcolor="white">
+        <graph remote="/nfa_wrist/mc/state:o"
+               index="0"
+               color="Blue"
+               title="Yaw" />
+    </plot>
+    <plot gridx="0"
+          gridy="1"
+          title="Pitch"
+          size="60"
+          minval="-100"
+          maxval="100"
+          bgcolor="white">
+        <graph remote="/nfa_wrist/mc/state:o"
+               index="1"
+               color="Red"
+               title="Pitch" />
+    </plot>
+    <plot gridx="0"
+          gridy="2"
+          title="Roll"
+          minval="-100"
+          maxval="100"
+          size="60"
+          bgcolor="white">
+        <graph remote="/nfa_wrist/mc/state:o"
+               index="2"
+               color="Green"
+               title="Roll" />
+    </plot>
+</portscope>
+

--- a/experimentalSetups/wristMK2.1_SN002F/sequences/nominal.poswrist_mc
+++ b/experimentalSetups/wristMK2.1_SN002F/sequences/nominal.poswrist_mc
@@ -1,0 +1,260 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Sequence_poswrist_mc TotPositions="1" ReferencePart="wrist_mc">
+    <Position Index="0" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="1" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="2" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-28.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="3" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-28.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="4" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-28.00</PosValue>
+            <PosValue>-20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="5" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-28.00</PosValue>
+            <PosValue>-20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="6" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>-20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="7" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>-20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="8" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>32.00</PosValue>
+            <PosValue>-20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="9" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>32.00</PosValue>
+            <PosValue>-20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="10" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>32.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="11" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>32.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="12" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>32.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="13" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>32.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="14" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="15" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+    <Position Index="16" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-28.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="17" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-28.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+    <Position Index="18" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-28.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+    <Position Index="19" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-28.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+    <Position Index="20" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+</Sequence_poswrist_mc>

--- a/experimentalSetups/wristMK2.1_SN002F/sequences/only_roll-25_+50.poswrist_mc
+++ b/experimentalSetups/wristMK2.1_SN002F/sequences/only_roll-25_+50.poswrist_mc
@@ -1,0 +1,187 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Sequence_poswrist_mc TotPositions="1" ReferencePart="wrist_mc">
+    <Position Index="0" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="1" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="2" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="3" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="6" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>40.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="7" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>40.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+    <Position Index="8" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>50.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="9" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>50.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="10" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="11" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="12" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-10.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="13" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-10.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="14" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-25.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="15" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-25.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+    <Position Index="16" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+
+</Sequence_poswrist_mc>

--- a/experimentalSetups/wristMK2.1_SN002F/sequences/ppp.poswrist_mc
+++ b/experimentalSetups/wristMK2.1_SN002F/sequences/ppp.poswrist_mc
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Sequence_poswrist_mc TotPositions="1" ReferencePart="wrist_mc">
+    <Position Index="0" Timing="0.10">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="1" Timing="0.10">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="2" Timing="0.10">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>-30.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="3" Timing="0.10">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+            <PosValue>30.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="4" Timing="0.10">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>30.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="5" Timing="0.10">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-30.00</PosValue>
+            <PosValue>30.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="6" Timing="0.10">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-30.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="7" Timing="0.10">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-30.00</PosValue>
+            <PosValue>-30.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="8" Timing="0.10">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>-30.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="9" Timing="0.10">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>20.00</PosValue>
+            <PosValue>-20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+        <Position Index="10" Timing="0.10">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>20.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+</Sequence_poswrist_mc>

--- a/experimentalSetups/wristMK2.1_SN002F/sequences/reduced.poswrist_mc
+++ b/experimentalSetups/wristMK2.1_SN002F/sequences/reduced.poswrist_mc
@@ -1,0 +1,234 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Sequence_poswrist_mc TotPositions="1" ReferencePart="wrist_mc">
+    <Position Index="0" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="1" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="2" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>20.00</PosValue>
+            <PosValue>-20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="3" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>20.00</PosValue>
+            <PosValue>-20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="4" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>20.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="5" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>20.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="6" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>20.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="7" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>20.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="8" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="9" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="10" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-20.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="11" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-20.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="12" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-20.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="13" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-20.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="14" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-20.00</PosValue>
+            <PosValue>-20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="15" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-20.00</PosValue>
+            <PosValue>-20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+    <Position Index="16" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>-20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="17" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>-20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+    <Position Index="18" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+</Sequence_poswrist_mc>

--- a/experimentalSetups/wristMK2.1_SN002F/sequences/safe.poswrist_mc
+++ b/experimentalSetups/wristMK2.1_SN002F/sequences/safe.poswrist_mc
@@ -1,0 +1,259 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Sequence_poswrist_mc TotPositions="1" ReferencePart="wrist_mc">
+    <Position Index="0" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="1" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="2" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>25.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="3" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>25.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="6" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>25.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="7" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>25.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+    <Position Index="8" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="9" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="10" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-25.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="11" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-25.00</PosValue>
+            <PosValue>20.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="12" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-25.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="13" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-25.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="14" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-25.00</PosValue>
+            <PosValue>-10.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="15" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>-25.00</PosValue>
+            <PosValue>-10.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+    <Position Index="16" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>-10.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="17" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>-10.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="22" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>25.00</PosValue>
+            <PosValue>-10.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="23" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>25.00</PosValue>
+            <PosValue>-10.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="24" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>25.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+    <Position Index="25" Timing="4.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>25.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+    <Position Index="18" Timing="2.0">
+        <JointPositions Count="3">
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+            <PosValue>0.00</PosValue>
+        </JointPositions>
+        <JointVelocities Count="3">
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+            <SpeedValue>10.00</SpeedValue>
+        </JointVelocities>
+    </Position>
+
+</Sequence_poswrist_mc>

--- a/experimentalSetups/wristMK2.1_SN002F/sequences/yarpscope_joints.xml
+++ b/experimentalSetups/wristMK2.1_SN002F/sequences/yarpscope_joints.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<portscope rows="3" columns="1" carrier="mcast">
+    <plot gridx="0"
+          gridy="0"
+          hspan="1"
+          vspan="1"
+          title="Yaw"
+          size="1000"
+          minval="-10"
+          maxval="10"
+          bgcolor="LightSlateGrey">
+        <graph remote="/nfa/wrist_mc/state:o"
+               index="0"
+               color="Red"
+               title="Graph 0"
+               type="lines"
+               size="3" />
+    </plot>
+    <plot gridx="0"
+          gridy="1"
+          hspan="1"
+          vspan="1"
+          title="Roll"
+          size="1000"
+          minval="-10"
+          maxval="10"
+          bgcolor="LightSlateGrey">
+        <graph remote="/nfa/wrist_mc/state:o"
+               index="1"
+               color="Red"
+               title="Graph 1"
+               size="3"
+               type="lines" />
+    </plot>
+    <plot gridx="0"
+          gridy="2"
+          hspan="1"
+          vspan="1"
+          title="Pitch"
+          size="1000"
+          minval="-10"
+          maxval="10"
+          bgcolor="LightSlateGrey">
+        <graph remote="/nfa/wrist_mc/state:o"
+               index="2"
+               color="Red"
+               title="Graph 2"
+               size="3"
+               type="lines" />
+    </plot>
+</portscope>

--- a/experimentalSetups/wristMK2.1_SN002F/wrappers/inertials/wrist-imu_wrapper.xml
+++ b/experimentalSetups/wristMK2.1_SN002F/wrappers/inertials/wrist-imu_wrapper.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="wrist-imu_wrapper" type="multipleanalogsensorsserver">
+        <param name="period">       10                  </param>
+        <param name="name">     /nfa/wrist/imu   </param>
+
+
+        <action phase="startup" level="5" type="attach">
+            <paramlist name="networks">
+                <!-- The name of the element can be any string (we use SetOfInertials to better express its nature).
+                     Its value must match the device name in the corresponding body_part-jx_y-inertials.xml file
+                     or in body_part-ebX-inertials.xml -->
+                <elem name="SetOfInertials">wrist-eb2-j0_2-inertial</elem>
+            </paramlist>
+        </action>
+
+        <action phase="shutdown" level="5" type="detach" />
+    </device>

--- a/experimentalSetups/wristMK2.1_SN002F/wrappers/inertials/wrist-inertials_remapper.xml
+++ b/experimentalSetups/wristMK2.1_SN002F/wrappers/inertials/wrist-inertials_remapper.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="wrist-inertials_remapper" type="multipleanalogsensorsremapper">
+        <param name="period">       10                  </param>
+        <!-- The below parameter names are set from the macro MAS_getTagFromEnum(enum MAS_SensorType) + "Names"
+             defined in <yarp/dev/MultipleAnalogSensorsInterfaces.h> and respective device source file -->
+        <param name="ThreeAxisLinearAccelerometersNames">
+          (l_hand  l_hand_gyro)
+        </param>
+        <action phase="startup" level="5" type="attach">
+            <paramlist name="networks">
+                <!-- The name of the element can be any string (we use SetOfInertials to better express its nature).
+                     Its value must match the device name in the corresponding body_part-jx_y-inertials.xml file
+                     or in body_part-ebX-inertials.xml -->
+                <elem name="wrist_inertial1">  wrist-eb2-j0_2-inertials </elem>
+            </paramlist>
+        </action>
+
+        <action phase="shutdown" level="5" type="detach" />
+    </device>

--- a/experimentalSetups/wristMK2.1_SN002F/wrappers/motorControl/wrist-mc_remapper.xml
+++ b/experimentalSetups/wristMK2.1_SN002F/wrappers/motorControl/wrist-mc_remapper.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="wrist-mc_remapper" type="controlboardremapper">
+    <paramlist name="networks">
+        <elem name="FirstSetOfJoints">  0  2  0  2 </elem>
+    </paramlist>
+    <param name="joints"> 3 </param>
+    <action phase="startup" level="5" type="attach">
+        <paramlist name="networks">
+            <elem name="FirstSetOfJoints">  wrist-eb2-j0_2-mc    </elem>
+        </paramlist>
+    </action>
+    <action phase="shutdown" level="20" type="detach" />
+</device>

--- a/experimentalSetups/wristMK2.1_SN002F/wrappers/motorControl/wrist-mc_wrapper.xml
+++ b/experimentalSetups/wristMK2.1_SN002F/wrappers/motorControl/wrist-mc_wrapper.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="wrist-mc_wrapper" type="controlBoard_nws_yarp">
+        <param name="name"> /nfa/wrist_mc </param>
+        <action phase="startup" level="10" type="attach">
+            <param name="device"> wrist-mc_remapper </param>
+        </action>
+        <action phase="shutdown" level="15" type="detach" />
+    </device>

--- a/experimentalSetups/wristMK2.1_SN002F/wrist2_1-encoder_read.xml
+++ b/experimentalSetups/wristMK2.1_SN002F/wrist2_1-encoder_read.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+    <robot name="new_forearm" build="1" portprefix="/nfa" xmlns:xi="http://www.w3.org/2001/XInclude">
+        <params>
+            <xi:include href="hardware/electronics/pc104.xml" />
+        </params>
+
+        <devices>
+    
+            <!-- WRIST MC -->
+            <xi:include href="hardware/motorControl/wrist-eb2-j0_2-mc.xml" />
+            <xi:include href="wrappers/motorControl/wrist-mc_wrapper.xml" />  
+            <xi:include href="wrappers/motorControl/wrist-mc_remapper.xml" />  
+    
+            <!--  CALIBRATORS -->  
+            <xi:include href="calibrators/wrist-calib.xml" />
+            
+            <!-- multienc  -->
+            <xi:include href="hardware/multienc/wrist-eb2-j0_2-multienc.xml" />
+            <xi:include href="wrappers/multienc/wrist-multienc_wrapper.xml" />  
+            
+            <!-- IMERTIALS>
+            <xi:include href="hardware/inertials/wrist-eb2-j0_2-inertial.xml" />
+            <xi:include href="wrappers/inertials/wrist-imu_wrapper.xml" /-->
+        
+        
+    </devices>
+</robot>

--- a/experimentalSetups/wristMK2.1_SN002F/yarpmotorgui.ini
+++ b/experimentalSetups/wristMK2.1_SN002F/yarpmotorgui.ini
@@ -1,0 +1,4 @@
+robot nfa
+
+parts (wrist_mc)
+

--- a/experimentalSetups/wristMK2.1_SN002F/yarprobotinterface.ini
+++ b/experimentalSetups/wristMK2.1_SN002F/yarprobotinterface.ini
@@ -1,0 +1,2 @@
+config ./new_forearm-no_hand.xml
+


### PR DESCRIPTION
here the full set of configuration files for forearm setup used in the ROM tests is collected. 
also the motorgui sequence files to explore the ROM limits are presented. 
only the AMC + AMC-BLDC boards are used here, with AEA3 encoders