### PR TITLE
Feature/temperature reading

### DIFF
--- a/ergoCubSN001/hardware/mechanicals/left_arm-eb2-j0_1-mec.xml
+++ b/ergoCubSN001/hardware/mechanicals/left_arm-eb2-j0_1-mec.xml
@@ -30,7 +30,7 @@
 	<param name="Verbose">                      0                   0                   </param>
         <param name="AutoCalibration">          0                   0                   </param>
         <param name="HasHallSensor">            0                   0                   </param>
-        <param name="HasTempSensor">            0                   0                   </param> <!-- pero' ha il sensore di temp, quindi ... metti 1 -->
+        <param name="TemperatureSensorType">    NONE                NONE                </param> <!-- if using set it to PT100. HasTempSensor is gonna be deprecated -->
         <param name="HasRotorEncoder">          1                   1                   </param>
         <param name="HasRotorEncoderIndex">     1                   1                   </param>
         <param name="HasSpeedEncoder">          0                   0                   </param>

--- a/ergoCubSN001/hardware/mechanicals/left_arm-eb4-j2_3-mec.xml
+++ b/ergoCubSN001/hardware/mechanicals/left_arm-eb4-j2_3-mec.xml
@@ -30,7 +30,7 @@
 		<param name="Verbose">          0                   0                   </param>
         <param name="AutoCalibration">          0                   0                   </param>
         <param name="HasHallSensor">            0                   0                   </param>
-        <param name="HasTempSensor">            0                   0                   </param> 
+        <param name="TemperatureSensorType">    NONE                NONE                </param> <!-- if using set it to PT100. HasTempSensor is gonna be deprecated-->
         <param name="HasRotorEncoder">          1                   1                   </param>
         <param name="HasRotorEncoderIndex">     1                   1                   </param>
         <param name="HasSpeedEncoder">          0                   0                   </param>

--- a/ergoCubSN001/hardware/mechanicals/left_leg-eb8-j0_3-mec.xml
+++ b/ergoCubSN001/hardware/mechanicals/left_leg-eb8-j0_3-mec.xml
@@ -28,8 +28,8 @@
     <group name="2FOC">
         <param name="AutoCalibration">            0             0     0     0     </param>
         <param name="Verbose">                    0             0     0     0     </param>
-        <param name="HasHallSensor">              0             0     0     0     </param>
-        <param name="HasTempSensor">              0             0     0     0     </param>
+        <param name="HasHallSensor">              0             0     0     0     </param> 
+        <param name="TemperatureSensorType">   NONE          NONE  NONE  NONE     </param> <!-- if using set it to PT100. HasTempSensor is gonna be deprecated -->
         <param name="HasRotorEncoder">            1             1     1     1     </param>
         <param name="HasRotorEncoderIndex">       1             1     1     1     </param>
         <param name="HasSpeedEncoder">            0             0     0     0     </param>

--- a/ergoCubSN001/hardware/mechanicals/left_leg-eb9-j4_5-mec.xml
+++ b/ergoCubSN001/hardware/mechanicals/left_leg-eb9-j4_5-mec.xml
@@ -30,7 +30,7 @@
         <param name="AutoCalibration">           0             0   </param>
         <param name="Verbose">                   0             0   </param>
         <param name="HasHallSensor">             0             0   </param>
-        <param name="HasTempSensor">             0             0   </param>
+        <param name="TemperatureSensorType">    NONE        NONE   </param> <!-- if using set it to PT100. HasTempSensor is gonna be deprecated -->
         <param name="HasRotorEncoder">           1             1   </param>
         <param name="HasRotorEncoderIndex">      1             1   </param>
         <param name="HasSpeedEncoder">           0             0   </param>

--- a/ergoCubSN001/hardware/mechanicals/right_arm-eb1-j0_1-mec.xml
+++ b/ergoCubSN001/hardware/mechanicals/right_arm-eb1-j0_1-mec.xml
@@ -30,7 +30,7 @@
         <param name="AutoCalibration">          0                   0                   </param>
         <param name="Verbose">                  0                   0                   </param>	
         <param name="HasHallSensor">            0                   0                   </param>
-        <param name="HasTempSensor">            0                   0                   </param> <!-- pero' ha il sensore di temp, quindi ... metti 1 -->
+        <param name="TemperatureSensorType">    NONE             NONE                   </param> <!-- if using set it to PT100. HasTempSensor is gonna be deprecated -->
         <param name="HasRotorEncoder">          1                   1                   </param>
         <param name="HasRotorEncoderIndex">     1                   1                   </param>
         <param name="HasSpeedEncoder">          0                   0                   </param>

--- a/ergoCubSN001/hardware/mechanicals/right_arm-eb3-j2_3-mec.xml
+++ b/ergoCubSN001/hardware/mechanicals/right_arm-eb3-j2_3-mec.xml
@@ -30,7 +30,7 @@
         <param name="AutoCalibration">          0                   0                   </param>
         <param name="Verbose">                  0                   0                   </param>
         <param name="HasHallSensor">            0                   0                   </param>
-        <param name="HasTempSensor">            0                   0                   </param> 
+        <param name="TemperatureSensorType">    NONE             NONE                   </param> <!-- if using set it to PT100. HasTempSensor is gonna be deprecated --> 
         <param name="HasRotorEncoder">          1                   1                   </param>
         <param name="HasRotorEncoderIndex">     1                   1                   </param>
         <param name="HasSpeedEncoder">          0                   0                   </param>

--- a/ergoCubSN001/hardware/mechanicals/right_leg-eb6-j0_3-mec.xml
+++ b/ergoCubSN001/hardware/mechanicals/right_leg-eb6-j0_3-mec.xml
@@ -32,7 +32,7 @@
         <param name="AutoCalibration">       0             0        0   0  </param>
         <param name="Verbose">               0             0        0   0  </param>
         <param name="HasHallSensor">         0             0        0   0  </param>
-        <param name="HasTempSensor">         0             0        0   0  </param>
+        <param name="TemperatureSensorType">  NONE       NONE    NONE NONE </param> <!-- if using set it to PT100. HasTempSensor is gonna be deprecated -->
         <param name="HasRotorEncoder">       1             1        1   1  </param>
         <param name="HasRotorEncoderIndex">  1             1        1   1  </param>
         <param name="HasSpeedEncoder">       0             0        0   0  </param>

--- a/ergoCubSN001/hardware/mechanicals/right_leg-eb7-j4_5-mec.xml
+++ b/ergoCubSN001/hardware/mechanicals/right_leg-eb7-j4_5-mec.xml
@@ -29,7 +29,7 @@
         <param name="AutoCalibration">                0             0       </param>
         <param name="Verbose">                        0             0       </param>	
         <param name="HasHallSensor">                  0             0       </param>
-        <param name="HasTempSensor">                  0             0       </param>
+        <param name="TemperatureSensorType">       NONE          NONE       </param> <!-- if using set it to PT100. HasTempSensor is gonna be deprecated -->
         <param name="HasRotorEncoder">                1             1       </param>
         <param name="HasRotorEncoderIndex">           1             1       </param>
         <param name="HasSpeedEncoder">                0             0       </param>

--- a/ergoCubSN001/hardware/mechanicals/torso-eb5-j0_2-mec.xml
+++ b/ergoCubSN001/hardware/mechanicals/torso-eb5-j0_2-mec.xml
@@ -29,7 +29,7 @@
 		<param name="Verbose">              0                   0                0                  </param>
         <param name="AutoCalibration">      0                   0                0                  </param>
         <param name="HasHallSensor">        0                   0                0                  </param>
-        <param name="HasTempSensor">        0                   0                0                  </param>
+        <param name="TemperatureSensorType">    NONE         NONE             NONE                  </param> <!-- if using set it to PT100. HasTempSensor is gonna be deprecated -->
         <param name="HasRotorEncoder">      1                   1                1                  </param>
         <param name="HasRotorEncoderIndex"> 1                   1                1                  </param>
         <param name="HasSpeedEncoder">      0                   0                0                  </param>

--- a/ergoCubSN001/hardware/motorControl/left_arm-eb2-j0_1-mc.xml
+++ b/ergoCubSN001/hardware/motorControl/left_arm-eb2-j0_1-mc.xml
@@ -18,6 +18,8 @@
         <param name="motorPeakCurrents">        12000               12000               </param>
         <param name="motorOverloadCurrents">    15000               15000               </param>
         <param name="motorPwmLimit">            8000                8000                </param>
+        <!-- <param name="hardwareTemperatureLimits"> 110                110                 </param>
+        <param name="warningTemperatureLimits">  90                 90                  </param> keep commented until TemperatureSensorType is not ENABLE by setting it different from NONE-->
     </group>
 
     <group name="TIMEOUTS">

--- a/ergoCubSN001/hardware/motorControl/left_arm-eb4-j2_3-mc.xml
+++ b/ergoCubSN001/hardware/motorControl/left_arm-eb4-j2_3-mc.xml
@@ -18,6 +18,8 @@
         <param name="motorPeakCurrents">        10000               9000                </param>
         <param name="motorOverloadCurrents">    15000               15000               </param>
         <param name="motorPwmLimit">            8000                8000                </param>
+        <!-- <param name="hardwareTemperatureLimits"> 110                110                 </param>
+        <param name="warningTemperatureLimits">  90                 90                  </param> keep commented until TemperatureSensorType is not ENABLE by setting it different from NONE-->
     </group>
 
     <group name="TIMEOUTS">

--- a/ergoCubSN001/hardware/motorControl/left_leg-eb8-j0_3-mc.xml
+++ b/ergoCubSN001/hardware/motorControl/left_leg-eb8-j0_3-mc.xml
@@ -14,11 +14,13 @@
     <group name="LIMITS">
         <param name="jntPosMax">                 102                 108       78        5      </param>
         <param name="jntPosMin">                -42                 -15      -78        -103    </param>
-        <param name="jntVelMax">                240                 240       240       240    </param>
-        <param name="motorNominalCurrents">     15000               15000     5000      10000  </param>
-        <param name="motorPeakCurrents">        20000               20000     10000     15000  </param>
-        <param name="motorOverloadCurrents">    30000               30000     15000     20000  </param>
-        <param name="motorPwmLimit">            16000               16000     16000     16000  </param>
+        <param name="jntVelMax">                240                 240       240       240     </param>
+        <param name="motorNominalCurrents">     15000               15000     5000      10000   </param>
+        <param name="motorPeakCurrents">        20000               20000     10000     15000   </param>
+        <param name="motorOverloadCurrents">    30000               30000     15000     20000   </param>
+        <param name="motorPwmLimit">            16000               16000     16000     16000   </param>
+        <!-- <param name="hardwareTemperatureLimits"> 110                110         110       110   </param>
+        <param name="warningTemperatureLimits">   90                 90           90        90  </param> keep commented until TemperatureSensorType is not ENABLE by setting it different from NONE-->
     </group>
 
     <group name="TIMEOUTS">
@@ -51,7 +53,7 @@
         <param name="kp">                       -5000               7000        -3000   -10000      </param>
         <param name="kd">                       0                   0           0        0       </param>
         <param name="ki">                       -1500               5000        -200    -1500       </param>
-        <param name="maxOutput">               12000               10000       12000    16000      </param>
+        <param name="maxOutput">               12000                10000       12000    16000      </param>
         <param name="maxInt">                   1500                5000        750      2000      </param>
         <param name="stictionUp">               0                   0           0        0       </param>
         <param name="stictionDown">             0                   0           0        0       </param>

--- a/ergoCubSN001/hardware/motorControl/left_leg-eb9-j4_5-mc.xml
+++ b/ergoCubSN001/hardware/motorControl/left_leg-eb9-j4_5-mc.xml
@@ -11,13 +11,15 @@
     <!-- joint name                                     ankle_pitch          ankle_roll         -->
     <!-- joint number                                       0                   1               -->
     <group name="LIMITS">
-        <param name="jntPosMax">                  43                  23                  </param>
-        <param name="jntPosMin">                 -43                 -23                 </param>
-        <param name="jntVelMax">                  240                 240                 </param>
-        <param name="motorNominalCurrents">       10000               10000               </param>
-        <param name="motorPeakCurrents">          15000               15000               </param>
-        <param name="motorOverloadCurrents">      30000               30000               </param>
-        <param name="motorPwmLimit">              16000               16000               </param>
+        <param name="jntPosMax">                  43                  23                   </param>
+        <param name="jntPosMin">                 -43                 -23                   </param>
+        <param name="jntVelMax">                  240                 240                  </param>
+        <param name="motorNominalCurrents">       10000               10000                </param>
+        <param name="motorPeakCurrents">          15000               15000                </param>
+        <param name="motorOverloadCurrents">      30000               30000                </param>
+        <param name="motorPwmLimit">              16000               16000                </param>
+        <!-- <param name="hardwareTemperatureLimits">    110                 110                </param>
+        <param name="warningTemperatureLimits">      90                  90                </param> keep commented until TemperatureSensorType is not ENABLE by setting it different from NONE-->
     </group>
 
     <group name="TIMEOUTS">

--- a/ergoCubSN001/hardware/motorControl/right_arm-eb1-j0_1-mc.xml
+++ b/ergoCubSN001/hardware/motorControl/right_arm-eb1-j0_1-mc.xml
@@ -19,6 +19,8 @@
         <param name="motorPeakCurrents">        12000               12000               </param>
         <param name="motorOverloadCurrents">    15000               15000               </param>
         <param name="motorPwmLimit">            8000                8000                </param>
+        <!-- <param name="hardwareTemperatureLimits"> 110                110                 </param>
+        <param name="warningTemperatureLimits">  90                 90                  </param> keep commented until TemperatureSensorType is not ENABLE by setting it different from NONE-->
     </group>
 
     <group name="TIMEOUTS">

--- a/ergoCubSN001/hardware/motorControl/right_arm-eb3-j2_3-mc.xml
+++ b/ergoCubSN001/hardware/motorControl/right_arm-eb3-j2_3-mc.xml
@@ -18,6 +18,8 @@
         <param name="motorPeakCurrents">        10000               9000                </param>
         <param name="motorOverloadCurrents">    15000               15000               </param>
         <param name="motorPwmLimit">            8000                8000                </param>
+        <!-- <param name="hardwareTemperatureLimits"> 110                110                 </param>
+        <param name="warningTemperatureLimits">  90                 90                  </param> keep commented until TemperatureSensorType is not ENABLE by setting it different from NONE-->
     </group>
 
     <group name="TIMEOUTS">

--- a/ergoCubSN001/hardware/motorControl/right_leg-eb6-j0_3-mc.xml
+++ b/ergoCubSN001/hardware/motorControl/right_leg-eb6-j0_3-mc.xml
@@ -14,11 +14,13 @@
     <group name="LIMITS">
         <param name="jntPosMax">                 102                 108       78        5      </param>
         <param name="jntPosMin">                -42                 -15      -78        -103    </param>
-        <param name="jntVelMax">                240                 240       240      240    </param>
-        <param name="motorNominalCurrents">     15000               15000     5000     10000  </param>
-        <param name="motorPeakCurrents">        20000               20000     10000    15000  </param>
-        <param name="motorOverloadCurrents">    30000               30000     15000    20000  </param>
-        <param name="motorPwmLimit">            16000               16000     16000    16000  </param>
+        <param name="jntVelMax">                240                 240       240      240      </param>
+        <param name="motorNominalCurrents">     15000               15000     5000     10000    </param>
+        <param name="motorPeakCurrents">        20000               20000     10000    15000    </param>
+        <param name="motorOverloadCurrents">    30000               30000     15000    20000    </param>
+        <param name="motorPwmLimit">            16000               16000     16000    16000    </param>
+        <!-- <param name="hardwareTemperatureLimits"> 110                110         110      110    </param>
+        <param name="warningTemperatureLimits">  90                 90          90       90     </param> keep commented until TemperatureSensorType is not ENABLE by setting it different from NONE-->
     </group>
 
     <group name="TIMEOUTS">

--- a/ergoCubSN001/hardware/motorControl/right_leg-eb7-j4_5-mc.xml
+++ b/ergoCubSN001/hardware/motorControl/right_leg-eb7-j4_5-mc.xml
@@ -11,13 +11,15 @@
     <!-- joint name                                     ankle_pitch          ankle_roll         -->
     <!-- joint number                                       0                   1               -->
     <group name="LIMITS">
-        <param name="jntPosMax">                  43                  23                  </param>
-        <param name="jntPosMin">                 -43                 -23                 </param>
+        <param name="jntPosMax">                  43                  23                   </param>
+        <param name="jntPosMin">                 -43                 -23                   </param>
         <param name="jntVelMax">                   240                 240                 </param>
         <param name="motorNominalCurrents">        10000               10000               </param>
         <param name="motorPeakCurrents">           15000               15000               </param>
         <param name="motorOverloadCurrents">       30000               30000               </param>
         <param name="motorPwmLimit">               16000               16000               </param>
+        <!-- <param name="hardwareTemperatureLimits">     110                110                </param>
+        <param name="warningTemperatureLimits">      90                 90                 </param> keep commented until TemperatureSensorType is not ENABLE by setting it different from NONE-->
     </group>
 
     <group name="TIMEOUTS">

--- a/ergoCubSN001/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/ergoCubSN001/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -20,6 +20,8 @@
         <param name="motorPeakCurrents">        14000               17000               10000               </param>
         <param name="motorOverloadCurrents">    18000               18000               15000               </param>
         <param name="motorPwmLimit">            16000               16000               16000               </param>
+        <!-- <param name="hardwareTemperatureLimits"> 110                110                   110               </param>
+        <param name="warningTemperatureLimits">  90                 90                    90                </param>       keep commented until TemperatureSensorType is not ENABLE by setting it different from NONE-->
     </group>
 
     <group name="TIMEOUTS">

--- a/iCubTemplates/iCubTemplateV6_0/hardware/mechanicals/body_part-ebX-jA_B-mec.xml
+++ b/iCubTemplates/iCubTemplateV6_0/hardware/mechanicals/body_part-ebX-jA_B-mec.xml
@@ -28,15 +28,21 @@
 
 
     <group name="2FOC"> <!-- this group must be present only if the service of controlled is eomn_serv_MC_foc -->
-        <param name="Verbose">               0  </param> <!-- If 1, it enables debug prints of 2FOC boards. It is optional and its default value is 1. -->
-        <param name="AutoCalibration">       0  </param> <!-- If 1, it enables AutoCalibration procedure of optical encoder. It is optional and its default value is 0. -->
-        <param name="HasHallSensor">         0  </param> <!-- Indicates if hall sensors are connected to 2FOC board -->
-        <param name="HasTempSensor">         0  </param> <!-- Indicates if temperature ensor  are connected to 2FOC board -->
-        <param name="HasRotorEncoder">       0  </param> <!-- Indicates if rotor has encoder   -->
-        <param name="HasRotorEncoderIndex">  0  </param> <!-- Indicates if the rotor encoder has index -->
-        <param name="HasSpeedEncoder">       0  </param> <!-- It is as an alternative to rotorEncoder. It is not used for FOC controller. -->
-        <param name="RotorIndexOffset">      0  </param> <!-- Rotor index offset between first electric sector and encoder index [degree] -->
-        <param name="MotorPoles">            1  </param> <!--  Number of poles of motor -->
+        <param name="Verbose">               0    </param> <!-- If 1, it enables debug prints of 2FOC boards. It is optional and its default value is 1. -->
+        <param name="AutoCalibration">       0    </param> <!-- If 1, it enables AutoCalibration procedure of optical encoder. It is optional and its default value is 0. -->
+        <param name="HasHallSensor">         0    </param> <!-- Indicates if hall sensors are connected to 2FOC board -->
+        <param name="HasTempSensor">         0    </param> <!-- Indicates if the temperature sensors are connected to 2FOC board.
+                                                                It will be soon DEPRECATED in favour of TemperatureSensorType. 
+                                                                If you want to configure the temperature sensor you have to use the TemperatureSensorType instead of set this to 1. -->
+        <param name="TemperatureSensorType"> NONE </param> <!-- Indicates the type of temperature sensor mounted on this motor.
+                                                                It is going to SUBSTITUTE the param HasTempSensor, which is going to be deprecated.
+                                                                Currently the availbale values are PT100, PT1000, NONE (used if motor is equipped with no sensors)
+                                                                If set, the user MUST also set the hardwareTemperatureLimit and the warningTemperatureLimit in motorControl configuration file.-->
+        <param name="HasRotorEncoder">       0    </param> <!-- Indicates if rotor has encoder   -->
+        <param name="HasRotorEncoderIndex">  0    </param> <!-- Indicates if the rotor encoder has index -->
+        <param name="HasSpeedEncoder">       0    </param> <!-- It is as an alternative to rotorEncoder. It is not used for FOC controller. -->
+        <param name="RotorIndexOffset">      0    </param> <!-- Rotor index offset between first electric sector and encoder index [degree] -->
+        <param name="MotorPoles">            1    </param> <!--  Number of poles of motor -->
     </group>
 
 

--- a/iCubTemplates/iCubTemplateV6_0/hardware/motorControl/body_part--ebX-jA_B-mc.xml
+++ b/iCubTemplates/iCubTemplateV6_0/hardware/motorControl/body_part--ebX-jA_B-mc.xml
@@ -17,6 +17,16 @@
                                                                  use this value for the integration of I2T. It is expressed in [mA]. In datasheet it is found under the name "peak stall current".      -->
         <param name="motorOverloadCurrents">  100  </param> <!-- It is the current which instantaneously damages the motor. It is expressed in [mA]. 
                                                                  However, this value is not used by 2FOC FW. Keep it fixed at 21000.  -->
+
+        <param name="hardwareTemperatureLimits"> 110 </param> <!-- It is the max temperature that the motor linked to this joint can reach. It should be defined from Datasheet
+                                                                  The motor should never overcome this temperature. The 2FOC board would use this value to generate a overHeating error if it is overcome
+                                                                  It is expressed here in Celsius Degree [℃] and the max suggested value is 110-->
+        <param name="warningTemperatureLimits">  90 </param> <!-- It is the warning temperature that the motor linked to this joint can reach. It should be defined from the user depending on the use case
+                                                                  The motor could reach this temperature but it is suggested to have working conditions far fromm it.
+                                                                  It MUST be set lower than the 85% of the hardwareTemperatureLimit otherwise the embObjMotionControl will raise an error.
+                                                                  If overcome the embObjMotionControl will send a warning suggesting to modify working conditions such as reducing the PWM and thus the Currents fed to the motor
+                                                                  It is expressed here in Celsius Degree [℃] -->
+
         <param name="motorPwmLimit">          100  </param> <!-- Limit of max PWM which can be applied to the motor. Max value is 32000. This threshold is used after decoupling.  -->
     </group>
 


### PR DESCRIPTION
This PR brings the following changes:
- update the ergocubSN001 configuration files with the `TemperatureSensorType` values for all the necessary joints and set it to NONE so that we have back-compatibility and add the `hardwareTemperatureLimits` and the `warningTemperatureLimits` and keep them commented for back-compatibility (default suggested values are provided in the commented line in the file)
- update the Template v6 with all the necessary info for filling the conf files with the new parameters