### PR TITLE
Add friction + coulomb + threshold parameters  

### DIFF
--- a/ergoCubSN000/hardware/motorControl/left_arm-eb2-j0_1-mc.xml
+++ b/ergoCubSN000/hardware/motorControl/left_arm-eb2-j0_1-mc.xml
@@ -73,7 +73,10 @@
         <param name="stictionUp">           0           0       </param>
         <param name="stictionDown">         0           0       </param>
         <param name="kff">                  1           1       </param>
-        <param name="kbemf">                0.0043      0.0037  </param>
+        <param name="viscousPos">           0.0043      0.0037  </param>
+        <param name="viscousNeg">           0.0043      0.0037  </param>
+        <param name="coulombPos">           0           0       </param>
+        <param name="coulombNeg">           0           0       </param>
         <param name="velocityThres">        0           0       </param>
         <param name="filterType">           0           0       </param>
         <param name="ktau">                 0.86        0.7     </param>
@@ -127,7 +130,10 @@
         <param name="stictionUp">     0          0         </param>
         <param name="stictionDown">   0          0         </param>
         <param name="kff">            1          1         </param>
-        <param name="kbemf">          0.0001     0.0001    </param>
+        <param name="viscousPos">     0.0001     0.0001    </param>
+        <param name="viscousNeg">     0.0001     0.0001    </param>
+        <param name="coulombPos">     0          0         </param>
+        <param name="coulombNeg">     0          0         </param>
         <param name="velocityThres">  0          0         </param>
         <param name="filterType">     0          0         </param>
         <param name="ktau">           250        200       </param>

--- a/ergoCubSN000/hardware/motorControl/left_arm-eb2-j0_1-mc.xml
+++ b/ergoCubSN000/hardware/motorControl/left_arm-eb2-j0_1-mc.xml
@@ -74,6 +74,7 @@
         <param name="stictionDown">         0           0       </param>
         <param name="kff">                  1           1       </param>
         <param name="kbemf">                0.0043      0.0037  </param>
+        <param name="velocityThres">        0           0       </param>
         <param name="filterType">           0           0       </param>
         <param name="ktau">                 0.86        0.7     </param>
     </group>
@@ -127,6 +128,7 @@
         <param name="stictionDown">   0          0         </param>
         <param name="kff">            1          1         </param>
         <param name="kbemf">          0.0001     0.0001    </param>
+        <param name="velocityThres">  0          0         </param>
         <param name="filterType">     0          0         </param>
         <param name="ktau">           250        200       </param>
     </group>

--- a/ergoCubSN000/hardware/motorControl/left_arm-eb4-j2_3-mc.xml
+++ b/ergoCubSN000/hardware/motorControl/left_arm-eb4-j2_3-mc.xml
@@ -74,6 +74,7 @@
         <param name="stictionDown">         0           0       </param>
         <param name="kff">                  1           1       </param>
         <param name="kbemf">                0.003     -0.0023   </param>
+        <param name="velocityThres">        0           0       </param>
         <param name="filterType">           0           0       </param>
         <param name="ktau">                 0.9         -0.7    </param>
     </group>
@@ -127,6 +128,7 @@
         <param name="stictionDown">   0          0         </param>
         <param name="kff">            1          1         </param>
         <param name="kbemf">          0.0001    -0.0002    </param>
+        <param name="velocityThres">  0          0         </param>
         <param name="filterType">     0          0         </param>
         <param name="ktau">           50        -300       </param>
     </group>

--- a/ergoCubSN000/hardware/motorControl/left_arm-eb4-j2_3-mc.xml
+++ b/ergoCubSN000/hardware/motorControl/left_arm-eb4-j2_3-mc.xml
@@ -73,7 +73,10 @@
         <param name="stictionUp">           0           0       </param>
         <param name="stictionDown">         0           0       </param>
         <param name="kff">                  1           1       </param>
-        <param name="kbemf">                0.003     -0.0023   </param>
+        <param name="viscousPos">           0.003     -0.0023   </param>
+        <param name="viscousNeg">           0.003     -0.0023   </param>
+        <param name="coulombPos">           0           0       </param>
+        <param name="coulombNeg">           0           0       </param>
         <param name="velocityThres">        0           0       </param>
         <param name="filterType">           0           0       </param>
         <param name="ktau">                 0.9         -0.7    </param>
@@ -127,7 +130,10 @@
         <param name="stictionUp">     0          0         </param>
         <param name="stictionDown">   0          0         </param>
         <param name="kff">            1          1         </param>
-        <param name="kbemf">          0.0001    -0.0002    </param>
+        <param name="viscousPos">     0          0         </param>
+        <param name="viscousNeg">     0          0         </param>
+        <param name="coulombPos">     0          0         </param>
+        <param name="coulombNeg">     0          0         </param>
         <param name="velocityThres">  0          0         </param>
         <param name="filterType">     0          0         </param>
         <param name="ktau">           50        -300       </param>

--- a/ergoCubSN000/hardware/motorControl/left_leg-eb8-j0_3-mc.xml
+++ b/ergoCubSN000/hardware/motorControl/left_leg-eb8-j0_3-mc.xml
@@ -75,6 +75,7 @@
         <param name="stictionDown">    0          0           0          0        </param>
         <param name="kff">             1          1           1          1        </param>
         <param name="kbemf">           0          0           0          0        </param>
+        <param name="velocityThres">   0          0           0          0        </param>
         <param name="filterType">      0          0           0          0        </param>
         <param name="ktau">         -0.51       0.56       -0.62      -0.52        </param>
     </group>
@@ -127,6 +128,7 @@
         <param name="stictionDown">   0          0         0         0         </param>
         <param name="kff">            1          1         1         1         </param>
         <param name="kbemf">         -0.0001     0.0001   -0.0005   -0.0003    </param>
+        <param name="velocityThres">  0          0         0         0         </param>
         <param name="filterType">     0          0         0         0         </param>
         <param name="ktau">          -40         50       -150      -110       </param>
     </group>

--- a/ergoCubSN000/hardware/motorControl/left_leg-eb8-j0_3-mc.xml
+++ b/ergoCubSN000/hardware/motorControl/left_leg-eb8-j0_3-mc.xml
@@ -74,7 +74,10 @@
         <param name="stictionUp">      0          0           0          0        </param>
         <param name="stictionDown">    0          0           0          0        </param>
         <param name="kff">             1          1           1          1        </param>
-        <param name="kbemf">           0          0           0          0        </param>
+        <param name="viscousPos">      0          0           0          0        </param>
+        <param name="viscousNeg">      0          0           0          0        </param>
+        <param name="coulombPos">      0          0           0          0        </param>
+        <param name="coulombNeg">      0          0           0          0        </param>
         <param name="velocityThres">   0          0           0          0        </param>
         <param name="filterType">      0          0           0          0        </param>
         <param name="ktau">         -0.51       0.56       -0.62      -0.52        </param>
@@ -127,7 +130,10 @@
         <param name="stictionUp">     0          0         0         0         </param>
         <param name="stictionDown">   0          0         0         0         </param>
         <param name="kff">            1          1         1         1         </param>
-        <param name="kbemf">         -0.0001     0.0001   -0.0005   -0.0003    </param>
+        <param name="viscousPos">    -0.0001     0.0001   -0.0005   -0.0003    </param>
+        <param name="viscousNeg">    -0.0001     0.0001   -0.0005   -0.0003    </param>
+        <param name="coulombPos">     0          0         0         0         </param>
+        <param name="coulombNeg">     0          0         0         0         </param>
         <param name="velocityThres">  0          0         0         0         </param>
         <param name="filterType">     0          0         0         0         </param>
         <param name="ktau">          -40         50       -150      -110       </param>

--- a/ergoCubSN000/hardware/motorControl/left_leg-eb9-j4_5-mc.xml
+++ b/ergoCubSN000/hardware/motorControl/left_leg-eb9-j4_5-mc.xml
@@ -73,7 +73,10 @@
         <param name="stictionUp">            0          0             </param>
         <param name="stictionDown">          0          0             </param>
         <param name="kff">                   1          1             </param>
-        <param name="kbemf">                 0          0             </param>
+        <param name="viscousPos">            0          0             </param>
+        <param name="viscousNeg">            0          0             </param>
+        <param name="coulombPos">            0          0             </param>
+        <param name="coulombNeg">            0          0             </param>
         <param name="velocityThres">         0          0             </param>
         <param name="filterType">            0          0             </param>
         <param name="ktau">                  -0.65      -0.50           </param>
@@ -126,7 +129,10 @@
         <param name="stictionUp">          0           0            </param>
         <param name="stictionDown">        0           0            </param>
         <param name="kff">                 1           1            </param>
-        <param name="kbemf">              -0.0009     -0.0003       </param>
+        <param name="viscousPos">         -0.0009     -0.0003       </param>
+        <param name="viscousNeg">         -0.0009     -0.0003       </param>
+        <param name="coulombPos">          0           0            </param>
+        <param name="coulombNeg">          0           0            </param>
         <param name="velocityThres">       0           0            </param>
         <param name="filterType">          0           0            </param>
         <param name="ktau">               -128.81     -160          </param>

--- a/ergoCubSN000/hardware/motorControl/left_leg-eb9-j4_5-mc.xml
+++ b/ergoCubSN000/hardware/motorControl/left_leg-eb9-j4_5-mc.xml
@@ -74,6 +74,7 @@
         <param name="stictionDown">          0          0             </param>
         <param name="kff">                   1          1             </param>
         <param name="kbemf">                 0          0             </param>
+        <param name="velocityThres">         0          0             </param>
         <param name="filterType">            0          0             </param>
         <param name="ktau">                  -0.65      -0.50           </param>
     </group>
@@ -126,6 +127,7 @@
         <param name="stictionDown">        0           0            </param>
         <param name="kff">                 1           1            </param>
         <param name="kbemf">              -0.0009     -0.0003       </param>
+        <param name="velocityThres">       0           0            </param>
         <param name="filterType">          0           0            </param>
         <param name="ktau">               -128.81     -160          </param>
     </group>

--- a/ergoCubSN000/hardware/motorControl/right_arm-eb1-j0_1-mc.xml
+++ b/ergoCubSN000/hardware/motorControl/right_arm-eb1-j0_1-mc.xml
@@ -107,6 +107,7 @@
         <param name="stictionDown">      0          0            </param>
         <param name="kff">               1          1            </param>
         <param name="kbemf">            -0.004    -0.004       </param>
+        <param name="velocityThres">     0          0            </param>
         <param name="filterType">        0          0            </param>
         <param name="ktau">             -0.86       -0.72         </param>
     </group>    
@@ -129,6 +130,7 @@
         <param name="stictionDown">   0          0         </param>
         <param name="kff">            1          1         </param>
         <param name="kbemf">         -0.0001    -0.0001    </param>
+        <param name="velocityThres">  0          0         </param>
         <param name="filterType">     0          0         </param>
         <param name="ktau">          -250       -200       </param>
     </group>

--- a/ergoCubSN000/hardware/motorControl/right_arm-eb1-j0_1-mc.xml
+++ b/ergoCubSN000/hardware/motorControl/right_arm-eb1-j0_1-mc.xml
@@ -106,7 +106,10 @@
         <param name="stictionUp">        0          0            </param>
         <param name="stictionDown">      0          0            </param>
         <param name="kff">               1          1            </param>
-        <param name="kbemf">            -0.004    -0.004       </param>
+        <param name="viscousPos">       -0.004    -0.004         </param>
+        <param name="viscousNeg">       -0.004    -0.004         </param>
+        <param name="coulombPos">        0          0            </param>
+        <param name="coulombNeg">        0          0            </param>
         <param name="velocityThres">     0          0            </param>
         <param name="filterType">        0          0            </param>
         <param name="ktau">             -0.86       -0.72         </param>
@@ -129,7 +132,10 @@
         <param name="stictionUp">     0          0         </param>
         <param name="stictionDown">   0          0         </param>
         <param name="kff">            1          1         </param>
-        <param name="kbemf">         -0.0001    -0.0001    </param>
+        <param name="viscousPos">    -0.0001    -0.0001    </param>
+        <param name="viscousNeg">    -0.0001    -0.0001    </param>
+        <param name="coulombPos">     0          0         </param>
+        <param name="coulombNeg">     0          0         </param>
         <param name="velocityThres">  0          0         </param>
         <param name="filterType">     0          0         </param>
         <param name="ktau">          -250       -200       </param>

--- a/ergoCubSN000/hardware/motorControl/right_arm-eb3-j2_3-mc.xml
+++ b/ergoCubSN000/hardware/motorControl/right_arm-eb3-j2_3-mc.xml
@@ -74,7 +74,10 @@
         <param name="stictionUp">        0          0            </param>
         <param name="stictionDown">      0          0            </param>
         <param name="kff">               1          1            </param>
-        <param name="kbemf">            -0.003      0.0023       </param>
+        <param name="viscousPos">       -0.003      0.0023       </param>
+        <param name="viscousNeg">       -0.003      0.0023       </param>
+        <param name="coulombPos">        0          0            </param>
+        <param name="coulombNeg">        0          0            </param>
         <param name="velocityThres">     0          0            </param>
         <param name="filterType">        0          0            </param>
         <param name="ktau">             -0.9        0.7          </param>
@@ -129,7 +132,10 @@
         <param name="stictionUp">     0          0         </param>
         <param name="stictionDown">   0          0         </param>
         <param name="kff">            1          1         </param>
-        <param name="kbemf">         -0.0001     0.0002    </param>
+        <param name="viscousPos">    -0.0001     0.0002    </param>
+        <param name="viscousNeg">    -0.0001     0.0002    </param>
+        <param name="coulombPos">     0          0         </param>
+        <param name="coulombNeg">     0          0         </param>
         <param name="velocityThres">  0          0         </param>
         <param name="filterType">     0          0         </param>
         <param name="ktau">          -50         300       </param>

--- a/ergoCubSN000/hardware/motorControl/right_arm-eb3-j2_3-mc.xml
+++ b/ergoCubSN000/hardware/motorControl/right_arm-eb3-j2_3-mc.xml
@@ -75,6 +75,7 @@
         <param name="stictionDown">      0          0            </param>
         <param name="kff">               1          1            </param>
         <param name="kbemf">            -0.003      0.0023       </param>
+        <param name="velocityThres">     0          0            </param>
         <param name="filterType">        0          0            </param>
         <param name="ktau">             -0.9        0.7          </param>
     </group>
@@ -129,6 +130,7 @@
         <param name="stictionDown">   0          0         </param>
         <param name="kff">            1          1         </param>
         <param name="kbemf">         -0.0001     0.0002    </param>
+        <param name="velocityThres">  0          0         </param>
         <param name="filterType">     0          0         </param>
         <param name="ktau">          -50         300       </param>
     </group>

--- a/ergoCubSN000/hardware/motorControl/right_leg-eb6-j0_3-mc.xml
+++ b/ergoCubSN000/hardware/motorControl/right_leg-eb6-j0_3-mc.xml
@@ -75,6 +75,7 @@
         <param name="stictionDown">    0       0          0    0       </param>
         <param name="kff">             1       1          1    1       </param>
         <param name="kbemf">           0       0          0    0       </param>
+        <param name="velocityThres">   0       0          0    0       </param>
         <param name="filterType">      0       0          0    0       </param>
         <param name="ktau">         -0.52    0.46      -0.56   0.68         </param>
     </group>
@@ -127,6 +128,7 @@
         <param name="stictionDown">   0          0         0         0         </param>
         <param name="kff">            1          1         1         1         </param>
         <param name="kbemf">          0.0001    -0.0001    0.0005    0.0003    </param>
+        <param name="velocityThres">  0          0         0         0         </param>
         <param name="filterType">     0          0         0         0         </param>
         <param name="ktau">           40        -50        150       110       </param>
     </group>

--- a/ergoCubSN000/hardware/motorControl/right_leg-eb6-j0_3-mc.xml
+++ b/ergoCubSN000/hardware/motorControl/right_leg-eb6-j0_3-mc.xml
@@ -74,7 +74,10 @@
         <param name="stictionUp">      0       0          0    0       </param>
         <param name="stictionDown">    0       0          0    0       </param>
         <param name="kff">             1       1          1    1       </param>
-        <param name="kbemf">           0       0          0    0       </param>
+        <param name="viscousPos">      0       0          0    0       </param>
+        <param name="viscousNeg">      0       0          0    0       </param>
+        <param name="coulombPos">      0       0          0    0       </param>
+        <param name="coulombNeg">      0       0          0    0       </param>
         <param name="velocityThres">   0       0          0    0       </param>
         <param name="filterType">      0       0          0    0       </param>
         <param name="ktau">         -0.52    0.46      -0.56   0.68         </param>
@@ -127,7 +130,10 @@
         <param name="stictionUp">     0          0         0         0         </param>
         <param name="stictionDown">   0          0         0         0         </param>
         <param name="kff">            1          1         1         1         </param>
-        <param name="kbemf">          0.0001    -0.0001    0.0005    0.0003    </param>
+        <param name="viscousPos">     0.0001    -0.0001    0.0005    0.0003    </param>
+        <param name="viscousNeg">     0.0001    -0.0001    0.0005    0.0003    </param>
+        <param name="coulombPos">     0          0         0         0         </param>
+        <param name="coulombNeg">     0          0         0         0         </param>
         <param name="velocityThres">  0          0         0         0         </param>
         <param name="filterType">     0          0         0         0         </param>
         <param name="ktau">           40        -50        150       110       </param>

--- a/ergoCubSN000/hardware/motorControl/right_leg-eb7-j4_5-mc.xml
+++ b/ergoCubSN000/hardware/motorControl/right_leg-eb7-j4_5-mc.xml
@@ -74,6 +74,7 @@
         <param name="stictionDown">           0          0  </param>
         <param name="kff">                    1          1  </param>
         <param name="kbemf">                  0          0  </param>
+        <param name="velocityThres">          0          0  </param>
         <param name="filterType">             0          0  </param>
         <param name="ktau">                 0.72      0.56    </param>
     </group>
@@ -126,6 +127,7 @@
         <param name="stictionDown">       0          0            </param>
         <param name="kff">                1          1            </param>
         <param name="kbemf">              0.0009     0.0003       </param>
+        <param name="velocityThres">      0          0            </param>
         <param name="filterType">         0          0            </param>
         <param name="ktau">               128.81     160          </param>
     </group>

--- a/ergoCubSN000/hardware/motorControl/right_leg-eb7-j4_5-mc.xml
+++ b/ergoCubSN000/hardware/motorControl/right_leg-eb7-j4_5-mc.xml
@@ -73,7 +73,10 @@
         <param name="stictionUp">             0          0  </param>
         <param name="stictionDown">           0          0  </param>
         <param name="kff">                    1          1  </param>
-        <param name="kbemf">                  0          0  </param>
+        <param name="viscousPos">             0          0  </param>
+        <param name="viscousNeg">             0          0  </param>
+        <param name="coulombPos">             0          0  </param>
+        <param name="coulombNeg">             0          0  </param>
         <param name="velocityThres">          0          0  </param>
         <param name="filterType">             0          0  </param>
         <param name="ktau">                 0.72      0.56    </param>
@@ -126,7 +129,10 @@
         <param name="stictionUp">         0          0            </param>
         <param name="stictionDown">       0          0            </param>
         <param name="kff">                1          1            </param>
-        <param name="kbemf">              0.0009     0.0003       </param>
+        <param name="viscousPos">         0.0009     0.0003       </param>
+        <param name="viscousNeg">         0.0009     0.0003       </param>
+        <param name="coulombPos">         0          0            </param>
+        <param name="coulombNeg">         0          0            </param>
         <param name="velocityThres">      0          0            </param>
         <param name="filterType">         0          0            </param>
         <param name="ktau">               128.81     160          </param>

--- a/ergoCubSN000/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/ergoCubSN000/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0          0          0  </param>
         <param name="stictionDown">    0          0          0  </param>
         <param name="kff">             1          1          1  </param>
-        <param name="kbemf">       0.0016     0.003     -0.003  </param>
+        <param name="viscousPos">      0.0016     0.003     -0.003  </param>
+        <param name="viscousNeg">      0.0016     0.003     -0.003  </param>
+        <param name="coulombPos">      0          0          0  </param>
+        <param name="coulombNeg">      0          0          0  </param>
         <param name="velocityThres">   0          0          0  </param>
         <param name="filterType">      0          0          0  </param>
         <param name="ktau">         0.63       0.63      -0.63  </param>

--- a/ergoCubSN000/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/ergoCubSN000/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    0          0          0  </param>
         <param name="kff">             1          1          1  </param>
         <param name="kbemf">       0.0016     0.003     -0.003  </param>
+        <param name="velocityThres">   0          0          0  </param>
         <param name="filterType">      0          0          0  </param>
         <param name="ktau">         0.63       0.63      -0.63  </param>
     </group>

--- a/ergoCubSN001/hardware/motorControl/left_arm-eb2-j0_1-mc.xml
+++ b/ergoCubSN001/hardware/motorControl/left_arm-eb2-j0_1-mc.xml
@@ -76,6 +76,7 @@
         <param name="stictionDown">         0           0       </param>
         <param name="kff">                  1           1       </param>
         <param name="kbemf">                0.0043      0.0037  </param>
+        <param name="velocityThres">        0           0       </param>
         <param name="filterType">           0           0       </param>
         <param name="ktau">                 0.86        0.7     </param>
     </group>
@@ -129,6 +130,7 @@
         <param name="stictionDown">   0          0         </param>
         <param name="kff">            1          1         </param>
         <param name="kbemf">          0.0001     0.0001    </param>
+        <param name="velocityThres">  0          0         </param>
         <param name="filterType">     0          0         </param>
         <param name="ktau">           250        200       </param>
     </group>

--- a/ergoCubSN001/hardware/motorControl/left_arm-eb2-j0_1-mc.xml
+++ b/ergoCubSN001/hardware/motorControl/left_arm-eb2-j0_1-mc.xml
@@ -75,7 +75,10 @@
         <param name="stictionUp">           0           0       </param>
         <param name="stictionDown">         0           0       </param>
         <param name="kff">                  1           1       </param>
-        <param name="kbemf">                0.0043      0.0037  </param>
+        <param name="viscousPos">           0           0       </param>
+        <param name="viscousNeg">           0           0       </param>
+        <param name="coulombPos">           0           0       </param>
+        <param name="coulombNeg">           0           0       </param>
         <param name="velocityThres">        0           0       </param>
         <param name="filterType">           0           0       </param>
         <param name="ktau">                 0.86        0.7     </param>
@@ -129,7 +132,10 @@
         <param name="stictionUp">     0          0         </param>
         <param name="stictionDown">   0          0         </param>
         <param name="kff">            1          1         </param>
-        <param name="kbemf">          0.0001     0.0001    </param>
+        <param name="viscousPos">     0          0         </param>
+        <param name="viscousNeg">     0          0         </param>
+        <param name="coulombPos">     0          0         </param>
+        <param name="coulombNeg">     0          0         </param>
         <param name="velocityThres">  0          0         </param>
         <param name="filterType">     0          0         </param>
         <param name="ktau">           250        200       </param>

--- a/ergoCubSN001/hardware/motorControl/left_arm-eb4-j2_3-mc.xml
+++ b/ergoCubSN001/hardware/motorControl/left_arm-eb4-j2_3-mc.xml
@@ -76,6 +76,7 @@
         <param name="stictionDown">         0           0       </param>
         <param name="kff">                  1           1       </param>
         <param name="kbemf">                0.003     -0.0023   </param>
+        <param name="velocityThres">        0           0       </param>
         <param name="filterType">           0           0       </param>
         <param name="ktau">                 0.9         -0.7    </param>
     </group>
@@ -129,6 +130,7 @@
         <param name="stictionDown">   0          0         </param>
         <param name="kff">            1          1         </param>
         <param name="kbemf">          0.0001    -0.0002    </param>
+        <param name="velocityThres">  0          0         </param>
         <param name="filterType">     0          0         </param>
         <param name="ktau">           50        -300       </param>
     </group>

--- a/ergoCubSN001/hardware/motorControl/left_arm-eb4-j2_3-mc.xml
+++ b/ergoCubSN001/hardware/motorControl/left_arm-eb4-j2_3-mc.xml
@@ -75,7 +75,10 @@
         <param name="stictionUp">           0           0       </param>
         <param name="stictionDown">         0           0       </param>
         <param name="kff">                  1           1       </param>
-        <param name="kbemf">                0.003     -0.0023   </param>
+        <param name="viscousPos">           0.003     -0.0023   </param>
+        <param name="viscousNeg">           0.003     -0.0023   </param>
+        <param name="coulombPos">           0           0       </param>
+        <param name="coulombNeg">           0           0       </param>
         <param name="velocityThres">        0           0       </param>
         <param name="filterType">           0           0       </param>
         <param name="ktau">                 0.9         -0.7    </param>
@@ -129,7 +132,10 @@
         <param name="stictionUp">     0          0         </param>
         <param name="stictionDown">   0          0         </param>
         <param name="kff">            1          1         </param>
-        <param name="kbemf">          0.0001    -0.0002    </param>
+        <param name="viscousPos">     0.0001    -0.0002    </param>
+        <param name="viscousNeg">     0.0001    -0.0002    </param>
+        <param name="coulombPos">     0          0         </param>
+        <param name="coulombNeg">     0          0         </param>
         <param name="velocityThres">  0          0         </param>
         <param name="filterType">     0          0         </param>
         <param name="ktau">           50        -300       </param>

--- a/ergoCubSN001/hardware/motorControl/left_leg-eb8-j0_3-mc.xml
+++ b/ergoCubSN001/hardware/motorControl/left_leg-eb8-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    0          0           0          0        </param>
         <param name="kff">             1          1           1          1        </param>
         <param name="kbemf">           0          0           0          0        </param>
+        <param name="velocityThres">   0          0           0          0        </param>
         <param name="filterType">      0          0           0          0        </param>
         <param name="ktau">         -0.51       0.56       -0.62      -0.52        </param>
     </group>
@@ -129,6 +130,7 @@
         <param name="stictionDown">   0          0         0         0         </param>
         <param name="kff">            1          1         1         1         </param>
         <param name="kbemf">         -0.0001     0.0001   -0.0005   -0.0003    </param>
+        <param name="velocityThres">  0          0         0         0         </param>
         <param name="filterType">     0          0         0         0         </param>
         <param name="ktau">          -40         50       -150      -110       </param>
     </group>

--- a/ergoCubSN001/hardware/motorControl/left_leg-eb8-j0_3-mc.xml
+++ b/ergoCubSN001/hardware/motorControl/left_leg-eb8-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0          0           0          0        </param>
         <param name="stictionDown">    0          0           0          0        </param>
         <param name="kff">             1          1           1          1        </param>
-        <param name="kbemf">           0          0           0          0        </param>
+        <param name="viscousPos">      0          0           0          0        </param>
+        <param name="viscousNeg">      0          0           0          0        </param>
+        <param name="coulombPos">      0          0           0          0        </param>
+        <param name="coulombNeg">      0          0           0          0        </param>
         <param name="velocityThres">   0          0           0          0        </param>
         <param name="filterType">      0          0           0          0        </param>
         <param name="ktau">         -0.51       0.56       -0.62      -0.52        </param>
@@ -129,7 +132,10 @@
         <param name="stictionUp">     0          0         0         0         </param>
         <param name="stictionDown">   0          0         0         0         </param>
         <param name="kff">            1          1         1         1         </param>
-        <param name="kbemf">         -0.0001     0.0001   -0.0005   -0.0003    </param>
+        <param name="viscousPos">    -0.0001     0.0001   -0.0005   -0.0003    </param>
+        <param name="viscousNeg">    -0.0001     0.0001   -0.0005   -0.0003    </param>
+        <param name="coulombPos">     0          0         0         0         </param>
+        <param name="coulombNeg">     0          0         0         0         </param>
         <param name="velocityThres">  0          0         0         0         </param>
         <param name="filterType">     0          0         0         0         </param>
         <param name="ktau">          -40         50       -150      -110       </param>

--- a/ergoCubSN001/hardware/motorControl/left_leg-eb9-j4_5-mc.xml
+++ b/ergoCubSN001/hardware/motorControl/left_leg-eb9-j4_5-mc.xml
@@ -76,6 +76,7 @@
         <param name="stictionDown">          0          0             </param>
         <param name="kff">                   1          1             </param>
         <param name="kbemf">                 0          0             </param>
+        <param name="velocityThres">         0          0             </param>
         <param name="filterType">            0          0             </param>
         <param name="ktau">                  -0.65      -0.50           </param>
     </group>
@@ -128,6 +129,7 @@
         <param name="stictionDown">        0           0            </param>
         <param name="kff">                 1           1            </param>
         <param name="kbemf">              -0.0009     -0.0003       </param>
+        <param name="velocityThres">       0           0            </param>
         <param name="filterType">          0           0            </param>
         <param name="ktau">               -128.81     -160          </param>
     </group>

--- a/ergoCubSN001/hardware/motorControl/left_leg-eb9-j4_5-mc.xml
+++ b/ergoCubSN001/hardware/motorControl/left_leg-eb9-j4_5-mc.xml
@@ -75,7 +75,10 @@
         <param name="stictionUp">            0          0             </param>
         <param name="stictionDown">          0          0             </param>
         <param name="kff">                   1          1             </param>
-        <param name="kbemf">                 0          0             </param>
+        <param name="viscousPos">            0          0             </param>
+        <param name="viscousNeg">            0          0             </param>
+        <param name="coulombPos">            0          0             </param>
+        <param name="coulombNeg">            0          0             </param>
         <param name="velocityThres">         0          0             </param>
         <param name="filterType">            0          0             </param>
         <param name="ktau">                  -0.65      -0.50           </param>
@@ -128,7 +131,10 @@
         <param name="stictionUp">          0           0            </param>
         <param name="stictionDown">        0           0            </param>
         <param name="kff">                 1           1            </param>
-        <param name="kbemf">              -0.0009     -0.0003       </param>
+        <param name="viscousPos">         -0.0009     -0.0003       </param>
+        <param name="viscousNeg">         -0.0009     -0.0003       </param>
+        <param name="coulombPos">          0           0            </param>
+        <param name="coulombNeg">          0           0            </param>
         <param name="velocityThres">       0           0            </param>
         <param name="filterType">          0           0            </param>
         <param name="ktau">               -128.81     -160          </param>

--- a/ergoCubSN001/hardware/motorControl/right_arm-eb1-j0_1-mc.xml
+++ b/ergoCubSN001/hardware/motorControl/right_arm-eb1-j0_1-mc.xml
@@ -108,7 +108,10 @@
         <param name="stictionUp">        0          0            </param>
         <param name="stictionDown">      0          0            </param>
         <param name="kff">               1          1            </param>
-        <param name="kbemf">            -0.004    -0.004       </param>
+        <param name="viscousPos">       -0.004    -0.004         </param>
+        <param name="viscousNeg">       -0.004    -0.004         </param>
+        <param name="coulombPos">        0          0            </param>
+        <param name="coulombNeg">        0          0            </param>
         <param name="velocityThres">     0          0            </param>
         <param name="filterType">        0          0            </param>
         <param name="ktau">             -0.86       -0.72         </param>
@@ -131,7 +134,10 @@
         <param name="stictionUp">     0          0         </param>
         <param name="stictionDown">   0          0         </param>
         <param name="kff">            1          1         </param>
-        <param name="kbemf">         -0.0001    -0.0001    </param>
+        <param name="viscousPos">    -0.0001    -0.0001    </param>
+        <param name="viscousNeg">    -0.0001    -0.0001    </param>
+        <param name="coulombPos">     0          0         </param>
+        <param name="coulombNeg">     0          0         </param>
         <param name="velocityThres">  0          0         </param>
         <param name="filterType">     0          0         </param>
         <param name="ktau">          -250       -200       </param>

--- a/ergoCubSN001/hardware/motorControl/right_arm-eb1-j0_1-mc.xml
+++ b/ergoCubSN001/hardware/motorControl/right_arm-eb1-j0_1-mc.xml
@@ -109,6 +109,7 @@
         <param name="stictionDown">      0          0            </param>
         <param name="kff">               1          1            </param>
         <param name="kbemf">            -0.004    -0.004       </param>
+        <param name="velocityThres">     0          0            </param>
         <param name="filterType">        0          0            </param>
         <param name="ktau">             -0.86       -0.72         </param>
     </group>    
@@ -131,6 +132,7 @@
         <param name="stictionDown">   0          0         </param>
         <param name="kff">            1          1         </param>
         <param name="kbemf">         -0.0001    -0.0001    </param>
+        <param name="velocityThres">  0          0         </param>
         <param name="filterType">     0          0         </param>
         <param name="ktau">          -250       -200       </param>
     </group>

--- a/ergoCubSN001/hardware/motorControl/right_arm-eb3-j2_3-mc.xml
+++ b/ergoCubSN001/hardware/motorControl/right_arm-eb3-j2_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">      0          0            </param>
         <param name="kff">               1          1            </param>
         <param name="kbemf">            -0.003      0.0023       </param>
+        <param name="velocityThres">     0          0            </param>
         <param name="filterType">        0          0            </param>
         <param name="ktau">             -0.9        0.7          </param>
     </group>
@@ -131,6 +132,7 @@
         <param name="stictionDown">   0          0         </param>
         <param name="kff">            1          1         </param>
         <param name="kbemf">         -0.0001     0.0002    </param>
+        <param name="velocityThres">  0          0         </param>
         <param name="filterType">     0          0         </param>
         <param name="ktau">          -50         300       </param>
     </group>

--- a/ergoCubSN001/hardware/motorControl/right_arm-eb3-j2_3-mc.xml
+++ b/ergoCubSN001/hardware/motorControl/right_arm-eb3-j2_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">        0          0            </param>
         <param name="stictionDown">      0          0            </param>
         <param name="kff">               1          1            </param>
-        <param name="kbemf">            -0.003      0.0023       </param>
+        <param name="viscousPos">       -0.003      0.0023       </param>
+        <param name="viscousNeg">       -0.003      0.0023       </param>
+        <param name="coulombPos">        0          0            </param>
+        <param name="coulombNeg">        0          0            </param>
         <param name="velocityThres">     0          0            </param>
         <param name="filterType">        0          0            </param>
         <param name="ktau">             -0.9        0.7          </param>
@@ -131,7 +134,10 @@
         <param name="stictionUp">     0          0         </param>
         <param name="stictionDown">   0          0         </param>
         <param name="kff">            1          1         </param>
-        <param name="kbemf">         -0.0001     0.0002    </param>
+        <param name="viscousPos">     -0.0001     0.0002   </param>
+        <param name="viscousNeg">     -0.0001     0.0002   </param>
+        <param name="coulombPos">     0          0         </param>
+        <param name="coulombNeg">     0          0         </param>
         <param name="velocityThres">  0          0         </param>
         <param name="filterType">     0          0         </param>
         <param name="ktau">          -50         300       </param>

--- a/ergoCubSN001/hardware/motorControl/right_leg-eb6-j0_3-mc.xml
+++ b/ergoCubSN001/hardware/motorControl/right_leg-eb6-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0       0          0    0       </param>
         <param name="stictionDown">    0       0          0    0       </param>
         <param name="kff">             1       1          1    1       </param>
-        <param name="kbemf">           0       0          0    0       </param>
+        <param name="viscousPos">      0       0          0    0       </param>
+        <param name="viscousNeg">      0       0          0    0       </param>
+        <param name="coulombPos">      0       0          0    0       </param>
+        <param name="coulombNeg">      0       0          0    0       </param>
         <param name="velocityThres">   0       0          0    0       </param>
         <param name="filterType">      0       0          0    0       </param>
         <param name="ktau">         -0.52    0.46      -0.56   0.68         </param>
@@ -129,7 +132,10 @@
         <param name="stictionUp">     0          0         0         0         </param>
         <param name="stictionDown">   0          0         0         0         </param>
         <param name="kff">            1          1         1         1         </param>
-        <param name="kbemf">          0.0001    -0.0001    0.0005    0.0003    </param>
+        <param name="viscousPos">     0.0001    -0.0001    0.0005    0.0003    </param>
+        <param name="viscousNeg">     0.0001    -0.0001    0.0005    0.0003    </param>
+        <param name="coulombPos">     0          0         0         0         </param>
+        <param name="coulombNeg">     0          0         0         0         </param>
         <param name="velocityThres">  0          0         0         0         </param>
         <param name="filterType">     0          0         0         0         </param>
         <param name="ktau">           40        -50        150       110       </param>

--- a/ergoCubSN001/hardware/motorControl/right_leg-eb6-j0_3-mc.xml
+++ b/ergoCubSN001/hardware/motorControl/right_leg-eb6-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    0       0          0    0       </param>
         <param name="kff">             1       1          1    1       </param>
         <param name="kbemf">           0       0          0    0       </param>
+        <param name="velocityThres">   0       0          0    0       </param>
         <param name="filterType">      0       0          0    0       </param>
         <param name="ktau">         -0.52    0.46      -0.56   0.68         </param>
     </group>
@@ -129,6 +130,7 @@
         <param name="stictionDown">   0          0         0         0         </param>
         <param name="kff">            1          1         1         1         </param>
         <param name="kbemf">          0.0001    -0.0001    0.0005    0.0003    </param>
+        <param name="velocityThres">  0          0         0         0         </param>
         <param name="filterType">     0          0         0         0         </param>
         <param name="ktau">           40        -50        150       110       </param>
     </group>

--- a/ergoCubSN001/hardware/motorControl/right_leg-eb7-j4_5-mc.xml
+++ b/ergoCubSN001/hardware/motorControl/right_leg-eb7-j4_5-mc.xml
@@ -75,7 +75,10 @@
         <param name="stictionUp">             0          0  </param>
         <param name="stictionDown">           0          0  </param>
         <param name="kff">                    1          1  </param>
-        <param name="kbemf">                  0          0  </param>
+        <param name="viscousPos">             0          0  </param>
+        <param name="viscousNeg">             0          0  </param>
+        <param name="coulombPos">             0          0  </param>
+        <param name="coulombNeg">             0          0  </param>
         <param name="velocityThres">          0          0  </param>
         <param name="filterType">             0          0  </param>
         <param name="ktau">                 0.72      0.56    </param>
@@ -128,7 +131,10 @@
         <param name="stictionUp">         0          0            </param>
         <param name="stictionDown">       0          0            </param>
         <param name="kff">                1          1            </param>
-        <param name="kbemf">              0.0009     0.0003       </param>
+        <param name="viscousPos">         0.0009     0.0003       </param>
+        <param name="viscousNeg">         0.0009     0.0003       </param>
+        <param name="coulombPos">         0          0            </param>
+        <param name="coulombNeg">         0          0            </param>
         <param name="velocityThres">      0          0            </param>
         <param name="filterType">         0          0            </param>
         <param name="ktau">               128.81     160          </param>

--- a/ergoCubSN001/hardware/motorControl/right_leg-eb7-j4_5-mc.xml
+++ b/ergoCubSN001/hardware/motorControl/right_leg-eb7-j4_5-mc.xml
@@ -76,6 +76,7 @@
         <param name="stictionDown">           0          0  </param>
         <param name="kff">                    1          1  </param>
         <param name="kbemf">                  0          0  </param>
+        <param name="velocityThres">          0          0  </param>
         <param name="filterType">             0          0  </param>
         <param name="ktau">                 0.72      0.56    </param>
     </group>
@@ -128,6 +129,7 @@
         <param name="stictionDown">       0          0            </param>
         <param name="kff">                1          1            </param>
         <param name="kbemf">              0.0009     0.0003       </param>
+        <param name="velocityThres">      0          0            </param>
         <param name="filterType">         0          0            </param>
         <param name="ktau">               128.81     160          </param>
     </group>

--- a/ergoCubSN001/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/ergoCubSN001/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -78,7 +78,10 @@
         <param name="stictionUp">      0          0          0  </param>
         <param name="stictionDown">    0          0          0  </param>
         <param name="kff">             1          1          1  </param>
-        <param name="kbemf">       0.0016     0.003     -0.003  </param>
+        <param name="viscousPos">      0.0016     0.003     -0.003  </param>
+        <param name="viscousNeg">      0.0016     0.003     -0.003  </param>
+        <param name="coulombPos">      0          0          0  </param>
+        <param name="coulombNeg">      0          0          0  </param>
         <param name="velocityThres">   0          0          0  </param>
         <param name="filterType">      0          0          0  </param>
         <param name="ktau">         0.63       0.63      -0.63  </param>

--- a/ergoCubSN001/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/ergoCubSN001/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -79,6 +79,7 @@
         <param name="stictionDown">    0          0          0  </param>
         <param name="kff">             1          1          1  </param>
         <param name="kbemf">       0.0016     0.003     -0.003  </param>
+        <param name="velocityThres">   0          0          0  </param>
         <param name="filterType">      0          0          0  </param>
         <param name="ktau">         0.63       0.63      -0.63  </param>
     </group>

--- a/iCubEdinburgh01/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
+++ b/iCubEdinburgh01/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
@@ -72,8 +72,11 @@
         <param name="stictionUp">0 0 0 0</param>       
         <param name="stictionDown">0 0 0 0</param>    
         <param name="kff">             1          1          1          1      </param>  
-        <param name="kbemf">0 0 0 0</param>    
-        <param name="velocityThres">   0          0          0          0   </param>
+        <param name="viscousPos">      0          0          0          0      </param>
+        <param name="viscousNeg">      0          0          0          0      </param>
+        <param name="coulombPos">      0          0          0          0      </param>
+        <param name="coulombNeg">      0          0          0          0      </param>
+        <param name="velocityThres">   0          0          0          0      </param>
         <param name="filterType">      0          0          0          0      </param>    
         <param name="ktau">0 0 0 0</param>             
     </group>

--- a/iCubEdinburgh01/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
+++ b/iCubEdinburgh01/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
@@ -73,6 +73,7 @@
         <param name="stictionDown">0 0 0 0</param>    
         <param name="kff">             1          1          1          1      </param>  
         <param name="kbemf">0 0 0 0</param>    
+        <param name="velocityThres">   0          0          0          0   </param>
         <param name="filterType">      0          0          0          0      </param>    
         <param name="ktau">0 0 0 0</param>             
     </group>

--- a/iCubEdinburgh01/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
+++ b/iCubEdinburgh01/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
@@ -72,7 +72,10 @@
             <param name="stictionUp">0 0 0 0</param>
             <param name="stictionDown">0 0 0 0</param>
             <param name="kff">             0           0           0           0      </param>
-            <param name="kbemf">0 0 0 0</param>
+            <param name="viscousPos">      0           0           0           0      </param>
+            <param name="viscousNeg">      0           0           0           0      </param>
+            <param name="coulombPos">      0           0           0           0      </param>
+            <param name="coulombNeg">      0           0           0           0      </param>
             <param name="velocityThres">   0           0           0           0      </param>
             <param name="filterType">      0           0           0           0      </param>
             <param name="ktau">0 0 0 0</param>

--- a/iCubEdinburgh01/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
+++ b/iCubEdinburgh01/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
@@ -73,6 +73,7 @@
             <param name="stictionDown">0 0 0 0</param>
             <param name="kff">             0           0           0           0      </param>
             <param name="kbemf">0 0 0 0</param>
+            <param name="velocityThres">   0           0           0           0      </param>
             <param name="filterType">      0           0           0           0      </param>
             <param name="ktau">0 0 0 0</param>
         </group>

--- a/iCubEdinburgh01/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
+++ b/iCubEdinburgh01/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
@@ -69,6 +69,7 @@
         <param name="stictionDown">0 0 0 0</param>       
         <param name="kff">             1          1          1          1     </param>      
         <param name="kbemf">0 0 0 0</param>     
+        <param name="velocityThres">   0          0          0          0     </param>
         <param name="filterType">      0          0          0          0     </param>              
         <param name="ktau">0 0 0 0</param>      
     </group>

--- a/iCubEdinburgh01/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
+++ b/iCubEdinburgh01/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
@@ -68,7 +68,10 @@
         <param name="stictionUp">0 0 0 0</param>       
         <param name="stictionDown">0 0 0 0</param>       
         <param name="kff">             1          1          1          1     </param>      
-        <param name="kbemf">0 0 0 0</param>     
+        <param name="viscousPos">      0          0          0          0      </param>
+        <param name="viscousNeg">      0          0          0          0      </param>
+        <param name="coulombPos">      0          0          0          0      </param>
+        <param name="coulombNeg">      0          0          0          0      </param>
         <param name="velocityThres">   0          0          0          0     </param>
         <param name="filterType">      0          0          0          0     </param>              
         <param name="ktau">0 0 0 0</param>      

--- a/iCubEdinburgh01/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
+++ b/iCubEdinburgh01/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
@@ -70,7 +70,10 @@
         <param name="stictionUp">0 0</param>       
         <param name="stictionDown">0 0</param>   
         <param name="kff">          1            1              </param>         
-        <param name="kbemf">0 0</param>      
+        <param name="viscousPos">   0            0              </param>
+        <param name="viscousNeg">   0            0              </param>
+        <param name="coulombPos">   0            0              </param>
+        <param name="coulombNeg">   0            0              </param>
         <param name="velocityThres">0            0              </param>
         <param name="filterType">   0            0              </param>                 
         <param name="ktau">0 0</param>          

--- a/iCubEdinburgh01/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
+++ b/iCubEdinburgh01/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
@@ -71,6 +71,7 @@
         <param name="stictionDown">0 0</param>   
         <param name="kff">          1            1              </param>         
         <param name="kbemf">0 0</param>      
+        <param name="velocityThres">0            0              </param>
         <param name="filterType">   0            0              </param>                 
         <param name="ktau">0 0</param>          
     </group>

--- a/iCubEdinburgh01/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
+++ b/iCubEdinburgh01/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
@@ -73,6 +73,7 @@
             <param name="stictionDown">0 0 0 0</param>     
             <param name="kff">             0           0           0           0    </param>    
             <param name="kbemf">0 0 0 0</param>     
+            <param name="velocityThres">   0           0           0           0    </param>
             <param name="filterType">      0           0           0           0    </param>     
             <param name="ktau">0 0 0 0</param>   
         </group>

--- a/iCubEdinburgh01/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
+++ b/iCubEdinburgh01/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
@@ -72,7 +72,10 @@
             <param name="stictionUp">0 0 0 0</param>     
             <param name="stictionDown">0 0 0 0</param>     
             <param name="kff">             0           0           0           0    </param>    
-            <param name="kbemf">0 0 0 0</param>     
+            <param name="viscousPos">      0           0           0           0    </param>
+            <param name="viscousNeg">      0           0           0           0    </param>
+            <param name="coulombPos">      0           0           0           0    </param>
+            <param name="coulombNeg">      0           0           0           0    </param>
             <param name="velocityThres">   0           0           0           0    </param>
             <param name="filterType">      0           0           0           0    </param>     
             <param name="ktau">0 0 0 0</param>   

--- a/iCubEdinburgh01/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
+++ b/iCubEdinburgh01/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
@@ -70,7 +70,10 @@
         <param name="stictionUp">0 0 0 0</param>   
         <param name="stictionDown">0 0 0 0</param>   
         <param name="kff">             1          1          1          1     </param>  
-        <param name="kbemf">0 0 0 0</param>
+        <param name="viscousPos">      0          0          0          0     </param>
+        <param name="viscousNeg">      0          0          0          0     </param>
+        <param name="coulombPos">      0          0          0          0     </param>
+        <param name="coulombNeg">      0          0          0          0     </param>
         <param name="velocityThres">   0          0          0          0     </param>
         <param name="filterType">      0          0          0          0     </param>   
         <param name="ktau">0 0 0 0</param>         

--- a/iCubEdinburgh01/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
+++ b/iCubEdinburgh01/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
@@ -71,6 +71,7 @@
         <param name="stictionDown">0 0 0 0</param>   
         <param name="kff">             1          1          1          1     </param>  
         <param name="kbemf">0 0 0 0</param>
+        <param name="velocityThres">   0          0          0          0     </param>
         <param name="filterType">      0          0          0          0     </param>   
         <param name="ktau">0 0 0 0</param>         
     </group>

--- a/iCubEdinburgh01/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
+++ b/iCubEdinburgh01/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
@@ -72,6 +72,7 @@
         <param name="stictionDown">0 0 0 0</param>       
         <param name="kff">             1          1          1          1     </param>  
         <param name="kbemf">0 0 0 0</param>            
+        <param name="velocityThres">   0          0          0          0     </param>
         <param name="filterType">      0          0          0          0     </param>     
         <param name="ktau">0 0 0 0</param>          
     </group>

--- a/iCubEdinburgh01/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
+++ b/iCubEdinburgh01/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
@@ -71,7 +71,10 @@
         <param name="stictionUp">0 0 0 0</param>       
         <param name="stictionDown">0 0 0 0</param>       
         <param name="kff">             1          1          1          1     </param>  
-        <param name="kbemf">0 0 0 0</param>            
+        <param name="viscousPos">      0          0          0          0      </param>
+        <param name="viscousNeg">      0          0          0          0      </param>
+        <param name="coulombPos">      0          0          0          0      </param>
+        <param name="coulombNeg">      0          0          0          0      </param>
         <param name="velocityThres">   0          0          0          0     </param>
         <param name="filterType">      0          0          0          0     </param>     
         <param name="ktau">0 0 0 0</param>          

--- a/iCubEdinburgh01/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
+++ b/iCubEdinburgh01/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
@@ -71,6 +71,7 @@
         <param name="stictionDown">0 0</param>       
         <param name="kff">           1           1             </param>      
         <param name="kbemf">0 0</param>  
+        <param name="velocityThres"> 0           0             </param>
         <param name="filterType">    0           0             </param>  
         <param name="ktau">0 0</param>        
     </group>

--- a/iCubEdinburgh01/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
+++ b/iCubEdinburgh01/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
@@ -70,7 +70,10 @@
         <param name="stictionUp">0 0</param>       
         <param name="stictionDown">0 0</param>       
         <param name="kff">           1           1             </param>      
-        <param name="kbemf">0 0</param>  
+        <param name="viscousPos">    0           0             </param>
+        <param name="viscousNeg">    0           0             </param>
+        <param name="coulombPos">    0           0             </param>
+        <param name="coulombNeg">    0           0             </param>
         <param name="velocityThres"> 0           0             </param>
         <param name="filterType">    0           0             </param>  
         <param name="ktau">0 0</param>        

--- a/iCubEdinburgh01/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubEdinburgh01/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -63,6 +63,7 @@
         <param name="stictionDown">0 0 0</param>       
         <param name="kff">             1          1          1  </param>   
         <param name="kbemf">0 0 0</param>    
+        <param name="velocityThres">   0          0          0  </param>
         <param name="filterType">      0          0          0  </param>           
         <param name="ktau">0 0 0</param>  
     </group>    

--- a/iCubEdinburgh01/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubEdinburgh01/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -62,7 +62,10 @@
         <param name="stictionUp">0 0 0</param>       
         <param name="stictionDown">0 0 0</param>       
         <param name="kff">             1          1          1  </param>   
-        <param name="kbemf">0 0 0</param>    
+        <param name="viscousPos">      0          0          0   </param>
+        <param name="viscousNeg">      0          0          0   </param>
+        <param name="coulombPos">      0          0          0   </param>
+        <param name="coulombNeg">      0          0          0   </param>
         <param name="velocityThres">   0          0          0  </param>
         <param name="filterType">      0          0          0  </param>           
         <param name="ktau">0 0 0</param>  

--- a/iCubErzelli01/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
+++ b/iCubErzelli01/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">         0           0           0           0       </param>
         <param name="kff">                  1           1           1           1       </param>
         <param name="kbemf">                0           0           0           0       </param>
+        <param name="velocityThres">        0           0           0           0       </param>
         <param name="filterType">           0           0           0           0       </param>
         <param name="ktau">                 0           0           0           0       </param>
     </group>

--- a/iCubErzelli01/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
+++ b/iCubErzelli01/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">           0           0           0           0       </param>
         <param name="stictionDown">         0           0           0           0       </param>
         <param name="kff">                  1           1           1           1       </param>
-        <param name="kbemf">                0           0           0           0       </param>
+        <param name="viscousPos">           0           0           0           0       </param>
+        <param name="viscousNeg">           0           0           0           0       </param>
+        <param name="coulombPos">           0           0           0           0       </param>
+        <param name="coulombNeg">           0           0           0           0       </param>
         <param name="velocityThres">        0           0           0           0       </param>
         <param name="filterType">           0           0           0           0       </param>
         <param name="ktau">                 0           0           0           0       </param>

--- a/iCubErzelli01/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
+++ b/iCubErzelli01/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0           0           0           0      </param>
         <param name="stictionDown">    0           0           0           0      </param>
         <param name="kff">             0           0           0           0      </param>
-        <param name="kbemf">           0           0           0           0      </param>
+        <param name="viscousPos">      0           0           0           0      </param>
+        <param name="viscousNeg">      0           0           0           0      </param>
+        <param name="coulombPos">      0           0           0           0      </param>
+        <param name="coulombNeg">      0           0           0           0      </param>
         <param name="velocityThres">   0           0           0           0      </param>
         <param name="filterType">      0           0           0           0      </param>
         <param name="ktau">            0           0           0           0      </param>

--- a/iCubErzelli01/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
+++ b/iCubErzelli01/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    0           0           0           0      </param>
         <param name="kff">             0           0           0           0      </param>
         <param name="kbemf">           0           0           0           0      </param>
+        <param name="velocityThres">   0           0           0           0      </param>
         <param name="filterType">      0           0           0           0      </param>
         <param name="ktau">            0           0           0           0      </param>
     </group>

--- a/iCubErzelli01/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
+++ b/iCubErzelli01/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    0          0          0          0     </param>
         <param name="kff">             1          1          1          1     </param>
         <param name="kbemf">           0          0          0          0     </param>
+        <param name="velocityThres">   0          0          0          0     </param>
         <param name="filterType">      0          0          0          0     </param>
         <param name="ktau">            0          0          0          0     </param>
     </group>

--- a/iCubErzelli01/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
+++ b/iCubErzelli01/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0          0          0          0     </param>
         <param name="stictionDown">    0          0          0          0     </param>
         <param name="kff">             1          1          1          1     </param>
-        <param name="kbemf">           0          0          0          0     </param>
+        <param name="viscousPos">      0          0          0          0     </param>
+        <param name="viscousNeg">      0          0          0          0     </param>
+        <param name="coulombPos">      0          0          0          0     </param>
+        <param name="coulombNeg">      0          0          0          0     </param>
         <param name="velocityThres">   0          0          0          0     </param>
         <param name="filterType">      0          0          0          0     </param>
         <param name="ktau">            0          0          0          0     </param>

--- a/iCubErzelli01/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
+++ b/iCubErzelli01/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
@@ -78,6 +78,7 @@
         <param name="stictionDown"> 0           0           </param>
         <param name="kff">          1           1           </param>
         <param name="kbemf">        0           0           </param>
+        <param name="velocityThres">0           0           </param>
         <param name="filterType">   0           0           </param>
         <param name="ktau">         0           0           </param>
     </group>

--- a/iCubErzelli01/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
+++ b/iCubErzelli01/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
@@ -77,7 +77,10 @@
         <param name="stictionUp">   0           0           </param>
         <param name="stictionDown"> 0           0           </param>
         <param name="kff">          1           1           </param>
-        <param name="kbemf">        0           0           </param>
+        <param name="viscousPos">   0           0           </param>
+        <param name="viscousNeg">   0           0           </param>
+        <param name="coulombPos">   0           0           </param>
+        <param name="coulombNeg">   0           0           </param>
         <param name="velocityThres">0           0           </param>
         <param name="filterType">   0           0           </param>
         <param name="ktau">         0           0           </param>

--- a/iCubErzelli01/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
+++ b/iCubErzelli01/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0           0           0           0    </param>
         <param name="stictionDown">    0           0           0           0    </param>
         <param name="kff">             0           0           0           0    </param>
-        <param name="kbemf">           0           0           0           0    </param>
+        <param name="viscousPos">      0           0           0           0    </param>
+        <param name="viscousNeg">      0           0           0           0    </param>
+        <param name="coulombPos">      0           0           0           0    </param>
+        <param name="coulombNeg">      0           0           0           0    </param>
         <param name="velocityThres">   0           0           0           0    </param>
         <param name="filterType">      0           0           0           0    </param>
         <param name="ktau">            0           0           0           0    </param>

--- a/iCubErzelli01/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
+++ b/iCubErzelli01/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    0           0           0           0    </param>
         <param name="kff">             0           0           0           0    </param>
         <param name="kbemf">           0           0           0           0    </param>
+        <param name="velocityThres">   0           0           0           0    </param>
         <param name="filterType">      0           0           0           0    </param>
         <param name="ktau">            0           0           0           0    </param>
     </group>

--- a/iCubErzelli01/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
+++ b/iCubErzelli01/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    0          0          0          0   </param>
         <param name="kff">             1          1          1          1   </param>
         <param name="kbemf">           0          0          0          0   </param>
+        <param name="velocityThres">   0          0          0          0   </param>
         <param name="filterType">      0          0          0          0   </param>
         <param name="ktau">            0          0          0          0   </param>
     </group>

--- a/iCubErzelli01/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
+++ b/iCubErzelli01/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0          0          0          0   </param>
         <param name="stictionDown">    0          0          0          0   </param>
         <param name="kff">             1          1          1          1   </param>
-        <param name="kbemf">           0          0          0          0   </param>
+        <param name="viscousPos">      0          0          0          0   </param>
+        <param name="viscousNeg">      0          0          0          0   </param>
+        <param name="coulombPos">      0          0          0          0   </param>
+        <param name="coulombNeg">      0          0          0          0   </param>
         <param name="velocityThres">   0          0          0          0   </param>
         <param name="filterType">      0          0          0          0   </param>
         <param name="ktau">            0          0          0          0   </param>

--- a/iCubErzelli01/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
+++ b/iCubErzelli01/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    0          0          0          0       </param>
         <param name="kff">             1          1          1          1       </param>
         <param name="kbemf">           0          0          0          0       </param>
+        <param name="velocityThres">   0          0          0          0       </param>
         <param name="filterType">      0          0          0          0       </param>
        <param name="ktau">             0          0          0          0       </param>
     </group>

--- a/iCubErzelli01/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
+++ b/iCubErzelli01/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0          0          0          0       </param>
         <param name="stictionDown">    0          0          0          0       </param>
         <param name="kff">             1          1          1          1       </param>
-        <param name="kbemf">           0          0          0          0       </param>
+        <param name="viscousPos">      0          0          0          0       </param>
+        <param name="viscousNeg">      0          0          0          0       </param>
+        <param name="coulombPos">      0          0          0          0       </param>
+        <param name="coulombNeg">      0          0          0          0       </param>
         <param name="velocityThres">   0          0          0          0       </param>
         <param name="filterType">      0          0          0          0       </param>
        <param name="ktau">             0          0          0          0       </param>

--- a/iCubErzelli01/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
+++ b/iCubErzelli01/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    0          0             </param>
         <param name="kff">             1          1             </param>
         <param name="kbemf">           0          0             </param>
+        <param name="velocityThres">   0          0             </param>
         <param name="filterType">      0          0             </param>
         <param name="ktau">            0          0             </param>
     </group>

--- a/iCubErzelli01/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
+++ b/iCubErzelli01/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0          0             </param>
         <param name="stictionDown">    0          0             </param>
         <param name="kff">             1          1             </param>
-        <param name="kbemf">           0          0             </param>
+        <param name="viscousPos">      0          0             </param>
+        <param name="viscousNeg">      0          0             </param>
+        <param name="coulombPos">      0          0             </param>
+        <param name="coulombNeg">      0          0             </param>
         <param name="velocityThres">   0          0             </param>
         <param name="filterType">      0          0             </param>
         <param name="ktau">            0          0             </param>

--- a/iCubErzelli01/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubErzelli01/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0          0          0  </param>
         <param name="stictionDown">    0          0          0  </param>
         <param name="kff">             1          1          1  </param>
-        <param name="kbemf">           0          0          0  </param>
+        <param name="viscousPos">      0          0          0  </param>
+        <param name="viscousNeg">      0          0          0  </param>
+        <param name="coulombPos">      0          0          0  </param>
+        <param name="coulombNeg">      0          0          0  </param>
         <param name="velocityThres">   0          0          0  </param>
         <param name="filterType">      0          0          0  </param>
         <param name="ktau">            0          0          0  </param>

--- a/iCubErzelli01/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubErzelli01/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    0          0          0  </param>
         <param name="kff">             1          1          1  </param>
         <param name="kbemf">           0          0          0  </param>
+        <param name="velocityThres">   0          0          0  </param>
         <param name="filterType">      0          0          0  </param>
         <param name="ktau">            0          0          0  </param>
     </group>

--- a/iCubErzelli02/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">         0           0           0           0       </param>
         <param name="kff">                  1           1           1           1       </param>
         <param name="kbemf">                0           0           0           0       </param>
+        <param name="velocityThres">        0           0           0           0       </param>
         <param name="filterType">           0           0           0           0       </param>
         <param name="ktau">                 0           0           0           0       </param>
     </group>

--- a/iCubErzelli02/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">           0           0           0           0       </param>
         <param name="stictionDown">         0           0           0           0       </param>
         <param name="kff">                  1           1           1           1       </param>
-        <param name="kbemf">                0           0           0           0       </param>
+        <param name="viscousPos">           0           0           0           0       </param>
+        <param name="viscousNeg">           0           0           0           0       </param>
+        <param name="coulombPos">           0           0           0           0       </param>
+        <param name="coulombNeg">           0           0           0           0       </param>
         <param name="velocityThres">        0           0           0           0       </param>
         <param name="filterType">           0           0           0           0       </param>
         <param name="ktau">                 0           0           0           0       </param>

--- a/iCubErzelli02/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0           0           0           0      </param>
         <param name="stictionDown">    0           0           0           0      </param>
         <param name="kff">             0           0           0           0      </param>
-        <param name="kbemf">           0           0           0           0      </param>
+        <param name="viscousPos">      0           0           0           0      </param>
+        <param name="viscousNeg">      0           0           0           0      </param>
+        <param name="coulombPos">      0           0           0           0      </param>
+        <param name="coulombNeg">      0           0           0           0      </param>
         <param name="velocityThres">   0           0           0           0      </param>
         <param name="filterType">      0           0           0           0      </param>
         <param name="ktau">            0           0           0           0      </param>

--- a/iCubErzelli02/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    0           0           0           0      </param>
         <param name="kff">             0           0           0           0      </param>
         <param name="kbemf">           0           0           0           0      </param>
+        <param name="velocityThres">   0           0           0           0      </param>
         <param name="filterType">      0           0           0           0      </param>
         <param name="ktau">            0           0           0           0      </param>
     </group>

--- a/iCubErzelli02/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    0          0          0          0     </param>
         <param name="kff">             1          1          1          1     </param>
         <param name="kbemf">           0          0          0          0     </param>
+        <param name="velocityThres">   0          0          0          0     </param>
         <param name="filterType">      0          0          0          0     </param>
         <param name="ktau">            0          0          0          0     </param>
     </group>

--- a/iCubErzelli02/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0          0          0          0     </param>
         <param name="stictionDown">    0          0          0          0     </param>
         <param name="kff">             1          1          1          1     </param>
-        <param name="kbemf">           0          0          0          0     </param>
+        <param name="viscousPos">      0          0          0          0     </param>
+        <param name="viscousNeg">      0          0          0          0     </param>
+        <param name="coulombPos">      0          0          0          0     </param>
+        <param name="coulombNeg">      0          0          0          0     </param>
         <param name="velocityThres">   0          0          0          0     </param>
         <param name="filterType">      0          0          0          0     </param>
         <param name="ktau">            0          0          0          0     </param>

--- a/iCubErzelli02/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
@@ -78,6 +78,7 @@
         <param name="stictionDown"> 0           0           </param>
         <param name="kff">          1           1           </param>
         <param name="kbemf">        0           0           </param>
+        <param name="velocityThres">0           0           </param>
         <param name="filterType">   0           0           </param>
         <param name="ktau">         0           0           </param>
     </group>

--- a/iCubErzelli02/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
@@ -77,7 +77,10 @@
         <param name="stictionUp">   0           0           </param>
         <param name="stictionDown"> 0           0           </param>
         <param name="kff">          1           1           </param>
-        <param name="kbemf">        0           0           </param>
+        <param name="viscousPos">   0           0           </param>
+        <param name="viscousNeg">   0           0           </param>
+        <param name="coulombPos">   0           0           </param>
+        <param name="coulombNeg">   0           0           </param>
         <param name="velocityThres">0           0           </param>
         <param name="filterType">   0           0           </param>
         <param name="ktau">         0           0           </param>

--- a/iCubErzelli02/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0           0           0           0    </param>
         <param name="stictionDown">    0           0           0           0    </param>
         <param name="kff">             0           0           0           0    </param>
-        <param name="kbemf">           0           0           0           0    </param>
+        <param name="viscousPos">      0           0           0           0    </param>
+        <param name="viscousNeg">      0           0           0           0    </param>
+        <param name="coulombPos">      0           0           0           0    </param>
+        <param name="coulombNeg">      0           0           0           0    </param>
         <param name="velocityThres">   0           0           0           0    </param>
         <param name="filterType">      0           0           0           0    </param>
         <param name="ktau">            0           0           0           0    </param>

--- a/iCubErzelli02/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    0           0           0           0    </param>
         <param name="kff">             0           0           0           0    </param>
         <param name="kbemf">           0           0           0           0    </param>
+        <param name="velocityThres">   0           0           0           0    </param>
         <param name="filterType">      0           0           0           0    </param>
         <param name="ktau">            0           0           0           0    </param>
     </group>

--- a/iCubErzelli02/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    0          0          0          0   </param>
         <param name="kff">             1          1          1          1   </param>
         <param name="kbemf">           0          0          0          0   </param>
+        <param name="velocityThres">   0          0          0          0   </param>
         <param name="filterType">      0          0          0          0   </param>
         <param name="ktau">            0          0          0          0   </param>
     </group>

--- a/iCubErzelli02/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0          0          0          0   </param>
         <param name="stictionDown">    0          0          0          0   </param>
         <param name="kff">             1          1          1          1   </param>
-        <param name="kbemf">           0          0          0          0   </param>
+        <param name="viscousPos">      0          0          0          0   </param>
+        <param name="viscousNeg">      0          0          0          0   </param>
+        <param name="coulombPos">      0          0          0          0   </param>
+        <param name="coulombNeg">      0          0          0          0   </param>
         <param name="velocityThres">   0          0          0          0   </param>
         <param name="filterType">      0          0          0          0   </param>
         <param name="ktau">            0          0          0          0   </param>

--- a/iCubErzelli02/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    0          0          0          0       </param>
         <param name="kff">             1          1          1          1       </param>
         <param name="kbemf">           0          0          0          0       </param>
+        <param name="velocityThres">   0          0          0          0       </param>
         <param name="filterType">      0          0          0          0       </param>
        <param name="ktau">             0          0          0          0       </param>
     </group>

--- a/iCubErzelli02/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0          0          0          0       </param>
         <param name="stictionDown">    0          0          0          0       </param>
         <param name="kff">             1          1          1          1       </param>
-        <param name="kbemf">           0          0          0          0       </param>
+        <param name="viscousPos">      0          0          0          0       </param>
+        <param name="viscousNeg">      0          0          0          0       </param>
+        <param name="coulombPos">      0          0          0          0       </param>
+        <param name="coulombNeg">      0          0          0          0       </param>
         <param name="velocityThres">   0          0          0          0       </param>
         <param name="filterType">      0          0          0          0       </param>
        <param name="ktau">             0          0          0          0       </param>

--- a/iCubErzelli02/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    0          0             </param>
         <param name="kff">             1          1             </param>
         <param name="kbemf">           0          0             </param>
+        <param name="velocityThres">   0          0             </param>
         <param name="filterType">      0          0             </param>
         <param name="ktau">            0          0             </param>
     </group>

--- a/iCubErzelli02/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0          0             </param>
         <param name="stictionDown">    0          0             </param>
         <param name="kff">             1          1             </param>
-        <param name="kbemf">           0          0             </param>
+        <param name="viscousPos">      0          0             </param>
+        <param name="viscousNeg">      0          0             </param>
+        <param name="coulombPos">      0          0             </param>
+        <param name="coulombNeg">      0          0             </param>
         <param name="velocityThres">   0          0             </param>
         <param name="filterType">      0          0             </param>
         <param name="ktau">            0          0             </param>

--- a/iCubErzelli02/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0          0          0  </param>
         <param name="stictionDown">    0          0          0  </param>
         <param name="kff">             1          1          1  </param>
-        <param name="kbemf">           0          0          0  </param>
+        <param name="viscousPos">      0          0          0  </param>
+        <param name="viscousNeg">      0          0          0  </param>
+        <param name="coulombPos">      0          0          0  </param>
+        <param name="coulombNeg">      0          0          0  </param>
         <param name="velocityThres">   0          0          0  </param>
         <param name="filterType">      0          0          0  </param>
         <param name="ktau">            0          0          0  </param>

--- a/iCubErzelli02/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    0          0          0  </param>
         <param name="kff">             1          1          1  </param>
         <param name="kbemf">           0          0          0  </param>
+        <param name="velocityThres">   0          0          0  </param>
         <param name="filterType">      0          0          0  </param>
         <param name="ktau">            0          0          0  </param>
     </group>

--- a/iCubGenova02/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
+++ b/iCubGenova02/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">         0           0           0           0       </param>
         <param name="kff">                  1           1           1           1       </param>
         <param name="kbemf">                0.0032      0.0006      0.0007      0.0007  </param>
+        <param name="velocityThres">        0           0           0           0       </param>
         <param name="filterType">           0           0           0           0       </param>
         <param name="ktau">                 0.68        1.7         1.45        1.55    </param>
     </group>

--- a/iCubGenova02/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
+++ b/iCubGenova02/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">           0           0           0           0       </param>
         <param name="stictionDown">         0           0           0           0       </param>
         <param name="kff">                  1           1           1           1       </param>
-        <param name="kbemf">                0.0032      0.0006      0.0007      0.0007  </param>
+        <param name="viscousPos">           0.0032      0.0006      0.0007      0.0007  </param>
+        <param name="viscousNeg">           0.0032      0.0006      0.0007      0.0007  </param>
+        <param name="coulombPos">           0           0           0           0       </param>
+        <param name="coulombNeg">           0           0           0           0       </param>
         <param name="velocityThres">        0           0           0           0       </param>
         <param name="filterType">           0           0           0           0       </param>
         <param name="ktau">                 0.68        1.7         1.45        1.55    </param>

--- a/iCubGenova02/hardware/motorControl/left_arm-eb2-j4_15-mc.xml
+++ b/iCubGenova02/hardware/motorControl/left_arm-eb2-j4_15-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">         0       0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="kff">                  0       0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="kbemf">                0       0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="velocityThres">        0       0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="filterType">           0       0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="ktau">                0.03     0      0      0      0      0      0      0      0      0      0      0    </param>
     </group>

--- a/iCubGenova02/hardware/motorControl/left_arm-eb2-j4_15-mc.xml
+++ b/iCubGenova02/hardware/motorControl/left_arm-eb2-j4_15-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">           0       0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="stictionDown">         0       0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="kff">                  0       0      0      0      0      0      0      0      0      0      0      0    </param>
-        <param name="kbemf">                0       0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="viscousPos">           0       0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="viscousNeg">           0       0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="coulombPos">           0       0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="coulombNeg">           0       0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="velocityThres">        0       0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="filterType">           0       0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="ktau">                0.03     0      0      0      0      0      0      0      0      0      0      0    </param>

--- a/iCubGenova02/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
+++ b/iCubGenova02/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    0          0          0          0     </param>
         <param name="kff">             1          1          1          1     </param>
         <param name="kbemf">        -0.003      0.0026       0       -0.0028  </param>
+        <param name="velocityThres">   0          0          0          0     </param>
         <param name="filterType">      0          0          0          0     </param>
         <param name="ktau">         -0.5        0.76      -0.62      -0.74    </param>
     </group>

--- a/iCubGenova02/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
+++ b/iCubGenova02/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0          0          0          0     </param>
         <param name="stictionDown">    0          0          0          0     </param>
         <param name="kff">             1          1          1          1     </param>
-        <param name="kbemf">        -0.003      0.0026       0       -0.0028  </param>
+        <param name="viscousPos">      -0.003     0.0026     0         -0.0028     </param>
+        <param name="viscousNeg">      -0.003     0.0026     0         -0.0028     </param>
+        <param name="coulombPos">      0          0          0          0     </param>
+        <param name="coulombNeg">      0          0          0          0     </param>
         <param name="velocityThres">   0          0          0          0     </param>
         <param name="filterType">      0          0          0          0     </param>
         <param name="ktau">         -0.5        0.76      -0.62      -0.74    </param>

--- a/iCubGenova02/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
+++ b/iCubGenova02/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">     0          0             </param>
         <param name="stictionDown">   0          0             </param>
         <param name="kff">            1          1             </param>
-        <param name="kbemf">          0          0             </param>
+        <param name="viscousPos">     0          0             </param>
+        <param name="viscousNeg">     0          0             </param>
+        <param name="coulombPos">     0          0             </param>
+        <param name="coulombNeg">     0          0             </param>
         <param name="velocityThres">  0          0             </param>
         <param name="filterType">     0          0             </param>
         <param name="ktau">          0.7        0.8            </param>

--- a/iCubGenova02/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
+++ b/iCubGenova02/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">   0          0             </param>
         <param name="kff">            1          1             </param>
         <param name="kbemf">          0          0             </param>
+        <param name="velocityThres">  0          0             </param>
         <param name="filterType">     0          0             </param>
         <param name="ktau">          0.7        0.8            </param>
     </group>

--- a/iCubGenova02/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
+++ b/iCubGenova02/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0          0          0          0     </param>
         <param name="stictionDown">    0          0          0          0     </param>
         <param name="kff">             1          1          1          1     </param>
-        <param name="kbemf">        -0.0030    -0.0003    -0.0007    -0.0007  </param>
+        <param name="viscousPos">     -0.0030    -0.0003    -0.0007    -0.0007      </param>
+        <param name="viscousNeg">     -0.0030    -0.0003    -0.0007    -0.0007      </param>
+        <param name="coulombPos">      0          0          0          0     </param>
+        <param name="coulombNeg">      0          0          0          0     </param>
         <param name="velocityThres">   0          0          0          0     </param>
         <param name="filterType">      0          0          0          0     </param>
         <param name="ktau">         -0.7       -1.6       -1.45      -1.55    </param>

--- a/iCubGenova02/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
+++ b/iCubGenova02/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    0          0          0          0     </param>
         <param name="kff">             1          1          1          1     </param>
         <param name="kbemf">        -0.0030    -0.0003    -0.0007    -0.0007  </param>
+        <param name="velocityThres">   0          0          0          0     </param>
         <param name="filterType">      0          0          0          0     </param>
         <param name="ktau">         -0.7       -1.6       -1.45      -1.55    </param>
     </group>

--- a/iCubGenova02/hardware/motorControl/right_arm-eb4-j4_15-mc.xml
+++ b/iCubGenova02/hardware/motorControl/right_arm-eb4-j4_15-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">        0      0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="stictionDown">      0      0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="kff">               0      0      0      0      0      0      0      0      0      0      0      0    </param>
-        <param name="kbemf">             0      0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="viscousPos">        0      0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="viscousNeg">        0      0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="coulombPos">        0      0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="coulombNeg">        0      0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="velocityThres">     0      0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="filterType">        0      0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="ktau">             0.03    0      0      0      0      0      0      0      0      0      0      0     </param>

--- a/iCubGenova02/hardware/motorControl/right_arm-eb4-j4_15-mc.xml
+++ b/iCubGenova02/hardware/motorControl/right_arm-eb4-j4_15-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">      0      0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="kff">               0      0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="kbemf">             0      0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="velocityThres">     0      0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="filterType">        0      0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="ktau">             0.03    0      0      0      0      0      0      0      0      0      0      0     </param>
     </group>

--- a/iCubGenova02/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
+++ b/iCubGenova02/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0          0          0          0     </param>
         <param name="stictionDown">    0          0          0          0     </param>
         <param name="kff">             1          1          1          1     </param>
-        <param name="kbemf">         0.0035    -0.0024       0        0.0025  </param>
+        <param name="viscousPos">      0.0035    -0.0024     0          0.0025     </param>
+        <param name="viscousNeg">      0.0035    -0.0024     0          0.0025     </param>
+        <param name="coulombPos">      0          0          0          0     </param>
+        <param name="coulombNeg">      0          0          0          0     </param>
         <param name="velocityThres">   0          0          0          0     </param>
         <param name="filterType">      0          0          0          0     </param>
         <param name="ktau">          0.5       -0.75       0.68       0.8     </param>

--- a/iCubGenova02/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
+++ b/iCubGenova02/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    0          0          0          0     </param>
         <param name="kff">             1          1          1          1     </param>
         <param name="kbemf">         0.0035    -0.0024       0        0.0025  </param>
+        <param name="velocityThres">   0          0          0          0     </param>
         <param name="filterType">      0          0          0          0     </param>
         <param name="ktau">          0.5       -0.75       0.68       0.8     </param>
     </group>

--- a/iCubGenova02/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
+++ b/iCubGenova02/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0          0             </param>
         <param name="stictionDown">    0          0             </param>
         <param name="kff">             1          1             </param>
-        <param name="kbemf">           0          0             </param>
+        <param name="viscousPos">      0          0             </param>
+        <param name="viscousNeg">      0          0             </param>
+        <param name="coulombPos">      0          0             </param>
+        <param name="coulombNeg">      0          0             </param>
         <param name="velocityThres">   0          0             </param>
         <param name="filterType">      0          0             </param>
         <param name="ktau">          -0.8       -0.8            </param>

--- a/iCubGenova02/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
+++ b/iCubGenova02/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    0          0             </param>
         <param name="kff">             1          1             </param>
         <param name="kbemf">           0          0             </param>
+        <param name="velocityThres">   0          0             </param>
         <param name="filterType">      0          0             </param>
         <param name="ktau">          -0.8       -0.8            </param>
     </group>

--- a/iCubGenova02/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubGenova02/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0          0          0  </param>
         <param name="stictionDown">    0          0          0  </param>
         <param name="kff">             1          1          1  </param>
-        <param name="kbemf">      -0.0016    -0.003     -0.003  </param>
+        <param name="viscousPos">      -0.0016   -0.003     -0.003  </param>
+        <param name="viscousNeg">      -0.0016   -0.003     -0.003  </param>
+        <param name="coulombPos">      0          0          0  </param>
+        <param name="coulombNeg">      0          0          0  </param>
         <param name="velocityThres">   0          0          0  </param>
         <param name="filterType">      0          0          0  </param>
         <param name="ktau">        -0.63      -0.63      -0.80  </param>

--- a/iCubGenova02/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubGenova02/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    0          0          0  </param>
         <param name="kff">             1          1          1  </param>
         <param name="kbemf">      -0.0016    -0.003     -0.003  </param>
+        <param name="velocityThres">   0          0          0  </param>
         <param name="filterType">      0          0          0  </param>
         <param name="ktau">        -0.63      -0.63      -0.80  </param>
     </group>

--- a/iCubGenova07/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
+++ b/iCubGenova07/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">         -0.7        -0.7       -0.8         -1.2    </param>
         <param name="kff">                  1           1           1           1       </param>
         <param name="kbemf">                0.0030      0.0006      0.0007      0.0007  </param>
+        <param name="velocityThres">        0           0           0           0       </param>
         <param name="filterType">           0           0           0           0       </param>
         <param name="ktau">                 180         464         463         449     </param>
     </group>

--- a/iCubGenova07/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
+++ b/iCubGenova07/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">           0.5         0.5         1           1.7     </param>
         <param name="stictionDown">         -0.7        -0.7       -0.8         -1.2    </param>
         <param name="kff">                  1           1           1           1       </param>
-        <param name="kbemf">                0.0030      0.0006      0.0007      0.0007  </param>
+        <param name="viscousPos">           0.0030      0.0006      0.0007      0.0007  </param>
+        <param name="viscousNeg">           0.0030      0.0006      0.0007      0.0007  </param>
+        <param name="coulombPos">           0           0           0           0       </param>
+        <param name="coulombNeg">           0           0           0           0       </param>
         <param name="velocityThres">        0           0           0           0       </param>
         <param name="filterType">           0           0           0           0       </param>
         <param name="ktau">                 180         464         463         449     </param>

--- a/iCubGenova07/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
+++ b/iCubGenova07/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    0           0           0           0      </param>
         <param name="kff">             0           0           0           0      </param>
         <param name="kbemf">           0           0           0           0      </param>
+        <param name="velocityThres">   0           0           0           0      </param>
         <param name="filterType">      0           0           0           0      </param>
         <param name="ktau">            1           0           0           0      </param>
     </group>

--- a/iCubGenova07/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
+++ b/iCubGenova07/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0           0           0           0      </param>
         <param name="stictionDown">    0           0           0           0      </param>
         <param name="kff">             0           0           0           0      </param>
-        <param name="kbemf">           0           0           0           0      </param>
+        <param name="viscousPos">      0           0           0           0      </param>
+        <param name="viscousNeg">      0           0           0           0      </param>
+        <param name="coulombPos">      0           0           0           0      </param>
+        <param name="coulombNeg">      0           0           0           0      </param>
         <param name="velocityThres">   0           0           0           0      </param>
         <param name="filterType">      0           0           0           0      </param>
         <param name="ktau">            1           0           0           0      </param>

--- a/iCubGenova07/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
+++ b/iCubGenova07/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">     -2.0        2.0       -1.0       -1.0   </param>
         <param name="stictionDown">    1.4       -2.0        1.3        0.2   </param>
         <param name="kff">             1          1          1          1     </param>
-        <param name="kbemf">           0          0          0          0     </param>
+        <param name="viscousPos">      0          0          0          0     </param>
+        <param name="viscousNeg">      0          0          0          0     </param>
+        <param name="coulombPos">      0          0          0          0     </param>
+        <param name="coulombNeg">      0          0          0          0     </param>
         <param name="velocityThres">   0          0          0          0     </param>
         <param name="filterType">      0          0          0          0     </param>
         <param name="ktau">            -162        178       -197       -167  </param>

--- a/iCubGenova07/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
+++ b/iCubGenova07/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    1.4       -2.0        1.3        0.2   </param>
         <param name="kff">             1          1          1          1     </param>
         <param name="kbemf">           0          0          0          0     </param>
+        <param name="velocityThres">   0          0          0          0     </param>
         <param name="filterType">      0          0          0          0     </param>
         <param name="ktau">            -162        178       -197       -167  </param>
     </group>

--- a/iCubGenova07/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
+++ b/iCubGenova07/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
@@ -77,7 +77,10 @@
         <param name="stictionUp">   1.7	        0.8         </param>
         <param name="stictionDown"> -1.7        -1.8        </param>
         <param name="kff">          1           1           </param>
-        <param name="kbemf">        0           0           </param>
+        <param name="viscousPos">   0           0           </param>
+        <param name="viscousNeg">   0           0           </param>
+        <param name="coulombPos">   0           0           </param>
+        <param name="coulombNeg">   0           0           </param>
         <param name="velocityThres">0           0           </param>
         <param name="filterType">   0           0           </param>
         <param name="ktau">         209         160         </param>

--- a/iCubGenova07/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
+++ b/iCubGenova07/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
@@ -78,6 +78,7 @@
         <param name="stictionDown"> -1.7        -1.8        </param>
         <param name="kff">          1           1           </param>
         <param name="kbemf">        0           0           </param>
+        <param name="velocityThres">0           0           </param>
         <param name="filterType">   0           0           </param>
         <param name="ktau">         209         160         </param>
     </group>

--- a/iCubGenova07/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
+++ b/iCubGenova07/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0           0           0           0    </param>
         <param name="stictionDown">    0           0           0           0    </param>
         <param name="kff">             0           0           0           0    </param>
-        <param name="kbemf">           0           0           0           0    </param>
+        <param name="viscousPos">      0           0           0           0    </param>
+        <param name="viscousNeg">      0           0           0           0    </param>
+        <param name="coulombPos">      0           0           0           0    </param>
+        <param name="coulombNeg">      0           0           0           0    </param>
         <param name="velocityThres">   0           0           0           0    </param>
         <param name="filterType">      0           0           0           0    </param>
         <param name="ktau">            1           0           0           0    </param>

--- a/iCubGenova07/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
+++ b/iCubGenova07/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    0           0           0           0    </param>
         <param name="kff">             0           0           0           0    </param>
         <param name="kbemf">           0           0           0           0    </param>
+        <param name="velocityThres">   0           0           0           0    </param>
         <param name="filterType">      0           0           0           0    </param>
         <param name="ktau">            1           0           0           0    </param>
     </group>

--- a/iCubGenova07/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
+++ b/iCubGenova07/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">   0.7        0.7        0.8        1.2  </param>
         <param name="kff">             1          1          1          1   </param>
         <param name="kbemf">      -0.0030    -0.0006    -0.0007     0.0007  </param>
+        <param name="velocityThres">   0          0          0          0   </param>
         <param name="filterType">      0          0          0          0   </param>
         <param name="ktau">          -180       -464       -463       -449  </param>
     </group>

--- a/iCubGenova07/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
+++ b/iCubGenova07/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">    -0.5       -0.5       -1         -1.7  </param>
         <param name="stictionDown">   0.7        0.7        0.8        1.2  </param>
         <param name="kff">             1          1          1          1   </param>
-        <param name="kbemf">      -0.0030    -0.0006    -0.0007     0.0007  </param>
+        <param name="viscousPos">     -0.0030    -0.0006    -0.0007     0.0007   </param>
+        <param name="viscousNeg">     -0.0030    -0.0006    -0.0007     0.0007   </param>
+        <param name="coulombPos">      0          0          0          0   </param>
+        <param name="coulombNeg">      0          0          0          0   </param>
         <param name="velocityThres">   0          0          0          0   </param>
         <param name="filterType">      0          0          0          0   </param>
         <param name="ktau">          -180       -464       -463       -449  </param>

--- a/iCubGenova07/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
+++ b/iCubGenova07/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      2.3       -1.79       1.8        1.2     </param>
         <param name="stictionDown">   -3.3        1.76      -1.4       -1.7     </param>
         <param name="kff">             1          1          1          1       </param>
-        <param name="kbemf">           0          0          0          0       </param>
+        <param name="viscousPos">      0          0          0          0       </param>
+        <param name="viscousNeg">      0          0          0          0       </param>
+        <param name="coulombPos">      0          0          0          0       </param>
+        <param name="coulombNeg">      0          0          0          0       </param>
         <param name="velocityThres">   0          0          0          0       </param>
         <param name="filterType">      0          0          0          0       </param>
        <param name="ktau">             147        -180       217        282     </param>

--- a/iCubGenova07/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
+++ b/iCubGenova07/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">   -3.3        1.76      -1.4       -1.7     </param>
         <param name="kff">             1          1          1          1       </param>
         <param name="kbemf">           0          0          0          0       </param>
+        <param name="velocityThres">   0          0          0          0       </param>
         <param name="filterType">      0          0          0          0       </param>
        <param name="ktau">             147        -180       217        282     </param>
     </group>

--- a/iCubGenova07/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
+++ b/iCubGenova07/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">     -1.4        -1.5          </param>
         <param name="stictionDown">    2.4         1.6          </param>
         <param name="kff">             1          1             </param>
-        <param name="kbemf">           0          0             </param>
+        <param name="viscousPos">      0          0             </param>
+        <param name="viscousNeg">      0          0             </param>
+        <param name="coulombPos">      0          0             </param>
+        <param name="coulombNeg">      0          0             </param>
         <param name="velocityThres">   0          0             </param>
         <param name="filterType">      0          0             </param>
         <param name="ktau">            -231       -180          </param>

--- a/iCubGenova07/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
+++ b/iCubGenova07/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    2.4         1.6          </param>
         <param name="kff">             1          1             </param>
         <param name="kbemf">           0          0             </param>
+        <param name="velocityThres">   0          0             </param>
         <param name="filterType">      0          0             </param>
         <param name="ktau">            -231       -180          </param>
     </group>

--- a/iCubGenova07/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubGenova07/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0          0          0  </param>
         <param name="stictionDown">   -2         -2         -2  </param>
         <param name="kff">             1          1          1  </param>
-        <param name="kbemf">      -0.0016    -0.003     -0.003  </param>
+        <param name="viscousPos">      -0.0016   -0.003     -0.003  </param>
+        <param name="viscousNeg">      -0.0016   -0.003     -0.003  </param>
+        <param name="coulombPos">      0          0          0  </param>
+        <param name="coulombNeg">      0          0          0  </param>
         <param name="velocityThres">   0          0          0  </param>
         <param name="filterType">      0          0          0  </param>
         <param name="ktau">         -200       -200       -200  </param>

--- a/iCubGenova07/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubGenova07/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">   -2         -2         -2  </param>
         <param name="kff">             1          1          1  </param>
         <param name="kbemf">      -0.0016    -0.003     -0.003  </param>
+        <param name="velocityThres">   0          0          0  </param>
         <param name="filterType">      0          0          0  </param>
         <param name="ktau">         -200       -200       -200  </param>
     </group>

--- a/iCubGenova08/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
+++ b/iCubGenova08/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">         -0.7        -0.7       -0.8         -1.2    </param>
         <param name="kff">                  1           1           1           1       </param>
         <param name="kbemf">                0.0030      0.0006      0.0007      0.0007  </param>
+        <param name="velocityThres">        0           0           0           0       </param>
         <param name="filterType">           0           0           0           0       </param>
         <param name="ktau">                 180         464         463         449     </param>
     </group>

--- a/iCubGenova08/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
+++ b/iCubGenova08/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">           0.5         0.5         1           1.7     </param>
         <param name="stictionDown">         -0.7        -0.7       -0.8         -1.2    </param>
         <param name="kff">                  1           1           1           1       </param>
-        <param name="kbemf">                0.0030      0.0006      0.0007      0.0007  </param>
+        <param name="viscousPos">           0.0030      0.0006      0.0007      0.0007  </param>
+        <param name="viscousNeg">           0.0030      0.0006      0.0007      0.0007  </param>
+        <param name="coulombPos">           0           0           0           0       </param>
+        <param name="coulombNeg">           0           0           0           0       </param>
         <param name="velocityThres">        0           0           0           0       </param>
         <param name="filterType">           0           0           0           0       </param>
         <param name="ktau">                 180         464         463         449     </param>

--- a/iCubGenova08/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
+++ b/iCubGenova08/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    0           0           0           0      </param>
         <param name="kff">             0           0           0           0      </param>
         <param name="kbemf">           0           0           0           0      </param>
+        <param name="velocityThres">   0           0           0           0      </param>
         <param name="filterType">      0           0           0           0      </param>
         <param name="ktau">            1           0           0           0      </param>
     </group>

--- a/iCubGenova08/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
+++ b/iCubGenova08/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0           0           0           0      </param>
         <param name="stictionDown">    0           0           0           0      </param>
         <param name="kff">             0           0           0           0      </param>
-        <param name="kbemf">           0           0           0           0      </param>
+        <param name="viscousPos">      0           0           0           0      </param>
+        <param name="viscousNeg">      0           0           0           0      </param>
+        <param name="coulombPos">      0           0           0           0      </param>
+        <param name="coulombNeg">      0           0           0           0      </param>
         <param name="velocityThres">   0           0           0           0      </param>
         <param name="filterType">      0           0           0           0      </param>
         <param name="ktau">            1           0           0           0      </param>

--- a/iCubGenova08/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
+++ b/iCubGenova08/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">     -2.0        2.0       -1.0       -1.0   </param>
         <param name="stictionDown">    1.4       -2.0        1.3        0.2   </param>
         <param name="kff">             1          1          1          1     </param>
-        <param name="kbemf">           0          0          0          0     </param>
+        <param name="viscousPos">      0          0          0          0     </param>
+        <param name="viscousNeg">      0          0          0          0     </param>
+        <param name="coulombPos">      0          0          0          0     </param>
+        <param name="coulombNeg">      0          0          0          0     </param>
         <param name="velocityThres">   0          0          0          0     </param>
         <param name="filterType">      0          0          0          0     </param>
         <param name="ktau">            -162        178       -197       -167  </param>

--- a/iCubGenova08/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
+++ b/iCubGenova08/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    1.4       -2.0        1.3        0.2   </param>
         <param name="kff">             1          1          1          1     </param>
         <param name="kbemf">           0          0          0          0     </param>
+        <param name="velocityThres">   0          0          0          0     </param>
         <param name="filterType">      0          0          0          0     </param>
         <param name="ktau">            -162        178       -197       -167  </param>
     </group>

--- a/iCubGenova08/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
+++ b/iCubGenova08/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
@@ -77,7 +77,10 @@
         <param name="stictionUp">   1.7	        0.8         </param>
         <param name="stictionDown"> -1.7        -1.8        </param>
         <param name="kff">          1           1           </param>
-        <param name="kbemf">        0           0           </param>
+        <param name="viscousPos">   0           0           </param>
+        <param name="viscousNeg">   0           0           </param>
+        <param name="coulombPos">   0           0           </param>
+        <param name="coulombNeg">   0           0           </param>
         <param name="velocityThres">0           0           </param>
         <param name="filterType">   0           0           </param>
         <param name="ktau">         209         160         </param>

--- a/iCubGenova08/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
+++ b/iCubGenova08/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
@@ -78,6 +78,7 @@
         <param name="stictionDown"> -1.7        -1.8        </param>
         <param name="kff">          1           1           </param>
         <param name="kbemf">        0           0           </param>
+        <param name="velocityThres">0           0           </param>
         <param name="filterType">   0           0           </param>
         <param name="ktau">         209         160         </param>
     </group>

--- a/iCubGenova08/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
+++ b/iCubGenova08/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0           0           0           0    </param>
         <param name="stictionDown">    0           0           0           0    </param>
         <param name="kff">             0           0           0           0    </param>
-        <param name="kbemf">           0           0           0           0    </param>
+        <param name="viscousPos">      0           0           0           0    </param>
+        <param name="viscousNeg">      0           0           0           0    </param>
+        <param name="coulombPos">      0           0           0           0    </param>
+        <param name="coulombNeg">      0           0           0           0    </param>
         <param name="velocityThres">   0           0           0           0    </param>
         <param name="filterType">      0           0           0           0    </param>
         <param name="ktau">            1           0           0           0    </param>

--- a/iCubGenova08/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
+++ b/iCubGenova08/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    0           0           0           0    </param>
         <param name="kff">             0           0           0           0    </param>
         <param name="kbemf">           0           0           0           0    </param>
+        <param name="velocityThres">   0           0           0           0    </param>
         <param name="filterType">      0           0           0           0    </param>
         <param name="ktau">            1           0           0           0    </param>
     </group>

--- a/iCubGenova08/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
+++ b/iCubGenova08/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">   0.7        0.7        0.8        1.2  </param>
         <param name="kff">             1          1          1          1   </param>
         <param name="kbemf">      -0.0030    -0.0006    -0.0007     0.0007  </param>
+        <param name="velocityThres">   0          0          0          0   </param>
         <param name="filterType">      0          0          0          0   </param>
         <param name="ktau">          -180       -464       -463       -449  </param>
     </group>

--- a/iCubGenova08/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
+++ b/iCubGenova08/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">    -0.5       -0.5       -1         -1.7  </param>
         <param name="stictionDown">   0.7        0.7        0.8        1.2  </param>
         <param name="kff">             1          1          1          1   </param>
-        <param name="kbemf">      -0.0030    -0.0006    -0.0007     0.0007  </param>
+        <param name="viscousPos">     -0.0030    -0.0006    -0.0007     0.0007   </param>
+        <param name="viscousNeg">     -0.0030    -0.0006    -0.0007     0.0007   </param>
+        <param name="coulombPos">      0          0          0          0   </param>
+        <param name="coulombNeg">      0          0          0          0   </param>
         <param name="velocityThres">   0          0          0          0   </param>
         <param name="filterType">      0          0          0          0   </param>
         <param name="ktau">          -180       -464       -463       -449  </param>

--- a/iCubGenova08/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
+++ b/iCubGenova08/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      2.3       -1.79       1.8        1.2     </param>
         <param name="stictionDown">   -3.3        1.76      -1.4       -1.7     </param>
         <param name="kff">             1          1          1          1       </param>
-        <param name="kbemf">           0          0          0          0       </param>
+        <param name="viscousPos">      0          0          0          0       </param>
+        <param name="viscousNeg">      0          0          0          0       </param>
+        <param name="coulombPos">      0          0          0          0       </param>
+        <param name="coulombNeg">      0          0          0          0       </param>
         <param name="velocityThres">   0          0          0          0       </param>
         <param name="filterType">      0          0          0          0       </param>
        <param name="ktau">             147        -180       217        282     </param>

--- a/iCubGenova08/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
+++ b/iCubGenova08/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">   -3.3        1.76      -1.4       -1.7     </param>
         <param name="kff">             1          1          1          1       </param>
         <param name="kbemf">           0          0          0          0       </param>
+        <param name="velocityThres">   0          0          0          0       </param>
         <param name="filterType">      0          0          0          0       </param>
        <param name="ktau">             147        -180       217        282     </param>
     </group>

--- a/iCubGenova08/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
+++ b/iCubGenova08/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">     -1.4        -1.5          </param>
         <param name="stictionDown">    2.4         1.6          </param>
         <param name="kff">             1          1             </param>
-        <param name="kbemf">           0          0             </param>
+        <param name="viscousPos">      0          0             </param>
+        <param name="viscousNeg">      0          0             </param>
+        <param name="coulombPos">      0          0             </param>
+        <param name="coulombNeg">      0          0             </param>
         <param name="velocityThres">   0          0             </param>
         <param name="filterType">      0          0             </param>
         <param name="ktau">            -231       -180          </param>

--- a/iCubGenova08/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
+++ b/iCubGenova08/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    2.4         1.6          </param>
         <param name="kff">             1          1             </param>
         <param name="kbemf">           0          0             </param>
+        <param name="velocityThres">   0          0             </param>
         <param name="filterType">      0          0             </param>
         <param name="ktau">            -231       -180          </param>
     </group>

--- a/iCubGenova08/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubGenova08/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0          0          0  </param>
         <param name="stictionDown">   -2         -2         -2  </param>
         <param name="kff">             1          1          1  </param>
-        <param name="kbemf">      -0.0016    -0.003     -0.003  </param>
+        <param name="viscousPos">      -0.0016   -0.003     -0.003  </param>
+        <param name="viscousNeg">      -0.0016   -0.003     -0.003  </param>
+        <param name="coulombPos">      0          0          0  </param>
+        <param name="coulombNeg">      0          0          0  </param>
         <param name="velocityThres">   0          0          0  </param>
         <param name="filterType">      0          0          0  </param>
         <param name="ktau">         -200       -200       -200  </param>

--- a/iCubGenova08/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubGenova08/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">   -2         -2         -2  </param>
         <param name="kff">             1          1          1  </param>
         <param name="kbemf">      -0.0016    -0.003     -0.003  </param>
+        <param name="velocityThres">   0          0          0  </param>
         <param name="filterType">      0          0          0  </param>
         <param name="ktau">         -200       -200       -200  </param>
     </group>

--- a/iCubGenova10/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
+++ b/iCubGenova10/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">         -0.7        -0.7       -0.8         -1.2    </param>
         <param name="kff">                  1           1           1           1       </param>
         <param name="kbemf">                0.0030      0.0006      0.0007      0.0007  </param>
+        <param name="velocityThres">        0           0           0           0       </param>
         <param name="filterType">           0           0           0           0       </param>
         <param name="ktau">                 180         464         463         449     </param>
     </group>

--- a/iCubGenova10/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
+++ b/iCubGenova10/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">           0.5         0.5         1           1.7     </param>
         <param name="stictionDown">         -0.7        -0.7       -0.8         -1.2    </param>
         <param name="kff">                  1           1           1           1       </param>
-        <param name="kbemf">                0.0030      0.0006      0.0007      0.0007  </param>
+        <param name="viscousPos">           0.0030      0.0006      0.0007      0.0007  </param>
+        <param name="viscousNeg">           0.0030      0.0006      0.0007      0.0007  </param>
+        <param name="coulombPos">           0           0           0           0       </param>
+        <param name="coulombNeg">           0           0           0           0       </param>
         <param name="velocityThres">        0           0           0           0       </param>
         <param name="filterType">           0           0           0           0       </param>
         <param name="ktau">                 180         464         463         449     </param>

--- a/iCubGenova10/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
+++ b/iCubGenova10/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    0           0           0           0      </param>
         <param name="kff">             0           0           0           0      </param>
         <param name="kbemf">           0           0           0           0      </param>
+        <param name="velocityThres">   0           0           0           0      </param>
         <param name="filterType">      0           0           0           0      </param>
         <param name="ktau">            1           0           0           0      </param>
     </group>

--- a/iCubGenova10/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
+++ b/iCubGenova10/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0           0           0           0      </param>
         <param name="stictionDown">    0           0           0           0      </param>
         <param name="kff">             0           0           0           0      </param>
-        <param name="kbemf">           0           0           0           0      </param>
+        <param name="viscousPos">      0           0           0           0      </param>
+        <param name="viscousNeg">      0           0           0           0      </param>
+        <param name="coulombPos">      0           0           0           0      </param>
+        <param name="coulombNeg">      0           0           0           0      </param>
         <param name="velocityThres">   0           0           0           0      </param>
         <param name="filterType">      0           0           0           0      </param>
         <param name="ktau">            1           0           0           0      </param>

--- a/iCubGenova10/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
+++ b/iCubGenova10/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">     -2.0        2.0       -1.0       -1.0   </param>
         <param name="stictionDown">    1.4       -2.0        1.3        0.2   </param>
         <param name="kff">             1          1          1          1     </param>
-        <param name="kbemf">           0          0          0          0     </param>
+        <param name="viscousPos">      0          0          0          0     </param>
+        <param name="viscousNeg">      0          0          0          0     </param>
+        <param name="coulombPos">      0          0          0          0     </param>
+        <param name="coulombNeg">      0          0          0          0     </param>
         <param name="velocityThres">   0          0          0          0     </param>
         <param name="filterType">      0          0          0          0     </param>
         <param name="ktau">            -162        178       -197       -167  </param>

--- a/iCubGenova10/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
+++ b/iCubGenova10/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    1.4       -2.0        1.3        0.2   </param>
         <param name="kff">             1          1          1          1     </param>
         <param name="kbemf">           0          0          0          0     </param>
+        <param name="velocityThres">   0          0          0          0     </param>
         <param name="filterType">      0          0          0          0     </param>
         <param name="ktau">            -162        178       -197       -167  </param>
     </group>

--- a/iCubGenova10/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
+++ b/iCubGenova10/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
@@ -77,7 +77,10 @@
         <param name="stictionUp">   1.7	        0.8         </param>
         <param name="stictionDown"> -1.7        -1.8        </param>
         <param name="kff">          1           1           </param>
-        <param name="kbemf">        0           0           </param>
+        <param name="viscousPos">   0           0           </param>
+        <param name="viscousNeg">   0           0           </param>
+        <param name="coulombPos">   0           0           </param>
+        <param name="coulombNeg">   0           0           </param>
         <param name="velocityThres">0           0           </param>
         <param name="filterType">   0           0           </param>
         <param name="ktau">         209         160         </param>

--- a/iCubGenova10/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
+++ b/iCubGenova10/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
@@ -78,6 +78,7 @@
         <param name="stictionDown"> -1.7        -1.8        </param>
         <param name="kff">          1           1           </param>
         <param name="kbemf">        0           0           </param>
+        <param name="velocityThres">0           0           </param>
         <param name="filterType">   0           0           </param>
         <param name="ktau">         209         160         </param>
     </group>

--- a/iCubGenova10/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
+++ b/iCubGenova10/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0           0           0           0    </param>
         <param name="stictionDown">    0           0           0           0    </param>
         <param name="kff">             0           0           0           0    </param>
-        <param name="kbemf">           0           0           0           0    </param>
+        <param name="viscousPos">      0           0           0           0    </param>
+        <param name="viscousNeg">      0           0           0           0    </param>
+        <param name="coulombPos">      0           0           0           0    </param>
+        <param name="coulombNeg">      0           0           0           0    </param>
         <param name="velocityThres">   0          0            0           0    </param>
         <param name="filterType">      0           0           0           0    </param>
         <param name="ktau">            1           0           0           0    </param>

--- a/iCubGenova10/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
+++ b/iCubGenova10/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    0           0           0           0    </param>
         <param name="kff">             0           0           0           0    </param>
         <param name="kbemf">           0           0           0           0    </param>
+        <param name="velocityThres">   0          0            0           0    </param>
         <param name="filterType">      0           0           0           0    </param>
         <param name="ktau">            1           0           0           0    </param>
     </group>

--- a/iCubGenova10/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
+++ b/iCubGenova10/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">   0.7        0.7        0.8        1.2  </param>
         <param name="kff">             1          1          1          1   </param>
         <param name="kbemf">      -0.0030    -0.0006    -0.0007     0.0007  </param>
+        <param name="velocityThres">   0          0          0          0   </param>
         <param name="filterType">      0          0          0          0   </param>
         <param name="ktau">          -180       -464       -463       -449  </param>
     </group>

--- a/iCubGenova10/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
+++ b/iCubGenova10/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">    -0.5       -0.5       -1         -1.7  </param>
         <param name="stictionDown">   0.7        0.7        0.8        1.2  </param>
         <param name="kff">             1          1          1          1   </param>
-        <param name="kbemf">      -0.0030    -0.0006    -0.0007     0.0007  </param>
+        <param name="viscousPos">     -0.0030    -0.0006    -0.0007     0.0007   </param>
+        <param name="viscousNeg">     -0.0030    -0.0006    -0.0007     0.0007   </param>
+        <param name="coulombPos">      0          0          0          0   </param>
+        <param name="coulombNeg">      0          0          0          0   </param>
         <param name="velocityThres">   0          0          0          0   </param>
         <param name="filterType">      0          0          0          0   </param>
         <param name="ktau">          -180       -464       -463       -449  </param>

--- a/iCubGenova10/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
+++ b/iCubGenova10/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      2.3       -1.79       1.8        1.2     </param>
         <param name="stictionDown">   -3.3        1.76      -1.4       -1.7     </param>
         <param name="kff">             1          1          1          1       </param>
-        <param name="kbemf">           0          0          0          0       </param>
+        <param name="viscousPos">      0          0          0          0       </param>
+        <param name="viscousNeg">      0          0          0          0       </param>
+        <param name="coulombPos">      0          0          0          0       </param>
+        <param name="coulombNeg">      0          0          0          0       </param>
         <param name="velocityThres">   0          0          0          0       </param>
         <param name="filterType">      0          0          0          0       </param>
        <param name="ktau">             147        -180       217        282     </param>

--- a/iCubGenova10/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
+++ b/iCubGenova10/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">   -3.3        1.76      -1.4       -1.7     </param>
         <param name="kff">             1          1          1          1       </param>
         <param name="kbemf">           0          0          0          0       </param>
+        <param name="velocityThres">   0          0          0          0       </param>
         <param name="filterType">      0          0          0          0       </param>
        <param name="ktau">             147        -180       217        282     </param>
     </group>

--- a/iCubGenova10/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
+++ b/iCubGenova10/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">     -1.4        -1.5          </param>
         <param name="stictionDown">    2.4         1.6          </param>
         <param name="kff">             1          1             </param>
-        <param name="kbemf">           0          0             </param>
+        <param name="viscousPos">      0          0             </param>
+        <param name="viscousNeg">      0          0             </param>
+        <param name="coulombPos">      0          0             </param>
+        <param name="coulombNeg">      0          0             </param>
         <param name="velocityThres">   0          0             </param>
         <param name="filterType">      0          0             </param>
         <param name="ktau">            -231       -180          </param>

--- a/iCubGenova10/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
+++ b/iCubGenova10/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    2.4         1.6          </param>
         <param name="kff">             1          1             </param>
         <param name="kbemf">           0          0             </param>
+        <param name="velocityThres">   0          0             </param>
         <param name="filterType">      0          0             </param>
         <param name="ktau">            -231       -180          </param>
     </group>

--- a/iCubGenova10/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubGenova10/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0          0          0  </param>
         <param name="stictionDown">   -2         -2         -2  </param>
         <param name="kff">             1          1          1  </param>
-        <param name="kbemf">      -0.0016    -0.003     -0.003  </param>
+        <param name="viscousPos">      -0.0016   -0.003     -0.003  </param>
+        <param name="viscousNeg">      -0.0016   -0.003     -0.003  </param>
+        <param name="coulombPos">      0          0          0  </param>
+        <param name="coulombNeg">      0          0          0  </param>
         <param name="velocityThres">   0          0          0  </param>
         <param name="filterType">      0          0          0  </param>
         <param name="ktau">         -200       -200       -200  </param>

--- a/iCubGenova10/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubGenova10/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">   -2         -2         -2  </param>
         <param name="kff">             1          1          1  </param>
         <param name="kbemf">      -0.0016    -0.003     -0.003  </param>
+        <param name="velocityThres">   0          0          0  </param>
         <param name="filterType">      0          0          0  </param>
         <param name="ktau">         -200       -200       -200  </param>
     </group>

--- a/iCubGenova11/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
+++ b/iCubGenova11/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">         -0.7        -0.7       -0.8         -1.2    </param>
         <param name="kff">                  1           1           1           1       </param>
         <param name="kbemf">                0.0030      0.0006      0.0007      0.0007  </param>
+        <param name="velocityThres">        0           0           0           0       </param>
         <param name="filterType">           0           0           0           0       </param>
         <param name="ktau">                 180         464         463         449     </param>
     </group>

--- a/iCubGenova11/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
+++ b/iCubGenova11/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">           0.5         0.5         1           1.7     </param>
         <param name="stictionDown">         -0.7        -0.7       -0.8         -1.2    </param>
         <param name="kff">                  1           1           1           1       </param>
-        <param name="kbemf">                0.0030      0.0006      0.0007      0.0007  </param>
+        <param name="viscousPos">           0.0030      0.0006      0.0007      0.0007  </param>
+        <param name="viscousNeg">           0.0030      0.0006      0.0007      0.0007  </param>
+        <param name="coulombPos">           0           0           0           0       </param>
+        <param name="coulombNeg">           0           0           0           0       </param>
         <param name="velocityThres">        0           0           0           0       </param>
         <param name="filterType">           0           0           0           0       </param>
         <param name="ktau">                 180         464         463         449     </param>

--- a/iCubGenova11/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
+++ b/iCubGenova11/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    0           0           0           0      </param>
         <param name="kff">             0           0           0           0      </param>
         <param name="kbemf">           0           0           0           0      </param>
+        <param name="velocityThres">   0           0           0           0      </param>
         <param name="filterType">      0           0           0           0      </param>
         <param name="ktau">            1           0           0           0      </param>
     </group>

--- a/iCubGenova11/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
+++ b/iCubGenova11/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0           0           0           0      </param>
         <param name="stictionDown">    0           0           0           0      </param>
         <param name="kff">             0           0           0           0      </param>
-        <param name="kbemf">           0           0           0           0      </param>
+        <param name="viscousPos">      0           0           0           0      </param>
+        <param name="viscousNeg">      0           0           0           0      </param>
+        <param name="coulombPos">      0           0           0           0      </param>
+        <param name="coulombNeg">      0           0           0           0      </param>
         <param name="velocityThres">   0           0           0           0      </param>
         <param name="filterType">      0           0           0           0      </param>
         <param name="ktau">            1           0           0           0      </param>

--- a/iCubGenova11/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
+++ b/iCubGenova11/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">     -2.0        2.0       -1.0       -1.0   </param>
         <param name="stictionDown">    1.4       -2.0        1.3        0.2   </param>
         <param name="kff">             1          1          1          1     </param>
-        <param name="kbemf">           0          0          0          0     </param>
+        <param name="viscousPos">      0          0          0          0     </param>
+        <param name="viscousNeg">      0          0          0          0     </param>
+        <param name="coulombPos">      0          0          0          0     </param>
+        <param name="coulombNeg">      0          0          0          0     </param>
         <param name="velocityThres">   0          0          0          0     </param>
         <param name="filterType">      0          0          0          0     </param>
         <param name="ktau">            -162        178       -197       -167  </param>

--- a/iCubGenova11/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
+++ b/iCubGenova11/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    1.4       -2.0        1.3        0.2   </param>
         <param name="kff">             1          1          1          1     </param>
         <param name="kbemf">           0          0          0          0     </param>
+        <param name="velocityThres">   0          0          0          0     </param>
         <param name="filterType">      0          0          0          0     </param>
         <param name="ktau">            -162        178       -197       -167  </param>
     </group>

--- a/iCubGenova11/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
+++ b/iCubGenova11/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
@@ -77,7 +77,10 @@
         <param name="stictionUp">   1.7	        0.8         </param>
         <param name="stictionDown"> -1.7        -1.8        </param>
         <param name="kff">          1           1           </param>
-        <param name="kbemf">        0           0           </param>
+        <param name="viscousPos">   0           0           </param>
+        <param name="viscousNeg">   0           0           </param>
+        <param name="coulombPos">   0           0           </param>
+        <param name="coulombNeg">   0           0           </param>
         <param name="velocityThres">0           0           </param>
         <param name="filterType">   0           0           </param>
         <param name="ktau">         209         160         </param>

--- a/iCubGenova11/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
+++ b/iCubGenova11/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
@@ -78,6 +78,7 @@
         <param name="stictionDown"> -1.7        -1.8        </param>
         <param name="kff">          1           1           </param>
         <param name="kbemf">        0           0           </param>
+        <param name="velocityThres">0           0           </param>
         <param name="filterType">   0           0           </param>
         <param name="ktau">         209         160         </param>
     </group>

--- a/iCubGenova11/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
+++ b/iCubGenova11/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0           0           0           0    </param>
         <param name="stictionDown">    0           0           0           0    </param>
         <param name="kff">             0           0           0           0    </param>
-        <param name="kbemf">           0           0           0           0    </param>
+        <param name="viscousPos">      0           0           0           0    </param>
+        <param name="viscousNeg">      0           0           0           0    </param>
+        <param name="coulombPos">      0           0           0           0    </param>
+        <param name="coulombNeg">      0           0           0           0    </param>
         <param name="velocityThres">   0           0           0           0    </param>
         <param name="filterType">      0           0           0           0    </param>
         <param name="ktau">            1           0           0           0    </param>

--- a/iCubGenova11/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
+++ b/iCubGenova11/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    0           0           0           0    </param>
         <param name="kff">             0           0           0           0    </param>
         <param name="kbemf">           0           0           0           0    </param>
+        <param name="velocityThres">   0           0           0           0    </param>
         <param name="filterType">      0           0           0           0    </param>
         <param name="ktau">            1           0           0           0    </param>
     </group>

--- a/iCubGenova11/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
+++ b/iCubGenova11/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">   0.7        0.7        0.8        1.2  </param>
         <param name="kff">             1          1          1          1   </param>
         <param name="kbemf">      -0.0030    -0.0006    -0.0007     0.0007  </param>
+        <param name="velocityThres">   0          0          0          0   </param>
         <param name="filterType">      0          0          0          0   </param>
         <param name="ktau">          -180       -464       -463       -449  </param>
     </group>

--- a/iCubGenova11/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
+++ b/iCubGenova11/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">    -0.5       -0.5       -1         -1.7  </param>
         <param name="stictionDown">   0.7        0.7        0.8        1.2  </param>
         <param name="kff">             1          1          1          1   </param>
-        <param name="kbemf">      -0.0030    -0.0006    -0.0007     0.0007  </param>
+        <param name="viscousPos">     -0.0030    -0.0006    -0.0007     0.0007   </param>
+        <param name="viscousNeg">     -0.0030    -0.0006    -0.0007     0.0007   </param>
+        <param name="coulombPos">      0          0          0          0   </param>
+        <param name="coulombNeg">      0          0          0          0   </param>
         <param name="velocityThres">   0          0          0          0   </param>
         <param name="filterType">      0          0          0          0   </param>
         <param name="ktau">          -180       -464       -463       -449  </param>

--- a/iCubGenova11/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
+++ b/iCubGenova11/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      2.3       -1.79       1.8        1.2     </param>
         <param name="stictionDown">   -3.3        1.76      -1.4       -1.7     </param>
         <param name="kff">             1          1          1          1       </param>
-        <param name="kbemf">           0          0          0          0       </param>
+        <param name="viscousPos">      0          0          0          0       </param>
+        <param name="viscousNeg">      0          0          0          0       </param>
+        <param name="coulombPos">      0          0          0          0       </param>
+        <param name="coulombNeg">      0          0          0          0       </param>
         <param name="velocityThres">   0          0          0          0       </param>
         <param name="filterType">      0          0          0          0       </param>
        <param name="ktau">             147        -180       217        282     </param>

--- a/iCubGenova11/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
+++ b/iCubGenova11/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">   -3.3        1.76      -1.4       -1.7     </param>
         <param name="kff">             1          1          1          1       </param>
         <param name="kbemf">           0          0          0          0       </param>
+        <param name="velocityThres">   0          0          0          0       </param>
         <param name="filterType">      0          0          0          0       </param>
        <param name="ktau">             147        -180       217        282     </param>
     </group>

--- a/iCubGenova11/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
+++ b/iCubGenova11/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">     -1.4        -1.5          </param>
         <param name="stictionDown">    2.4         1.6          </param>
         <param name="kff">             1          1             </param>
-        <param name="kbemf">           0          0             </param>
+        <param name="viscousPos">      0          0             </param>
+        <param name="viscousNeg">      0          0             </param>
+        <param name="coulombPos">      0          0             </param>
+        <param name="coulombNeg">      0          0             </param>
         <param name="velocityThres">   0          0             </param>
         <param name="filterType">      0          0             </param>
         <param name="ktau">            -231       -180          </param>

--- a/iCubGenova11/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
+++ b/iCubGenova11/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    2.4         1.6          </param>
         <param name="kff">             1          1             </param>
         <param name="kbemf">           0          0             </param>
+        <param name="velocityThres">   0          0             </param>
         <param name="filterType">      0          0             </param>
         <param name="ktau">            -231       -180          </param>
     </group>

--- a/iCubGenova11/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubGenova11/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0          0          0  </param>
         <param name="stictionDown">   -2         -2         -2  </param>
         <param name="kff">             1          1          1  </param>
-        <param name="kbemf">      -0.0016    -0.003     -0.003  </param>
+        <param name="viscousPos">      -0.0016   -0.003     -0.003  </param>
+        <param name="viscousNeg">      -0.0016   -0.003     -0.003  </param>
+        <param name="coulombPos">      0          0          0  </param>
+        <param name="coulombNeg">      0          0          0  </param>
         <param name="velocityThres">   0          0          0  </param>
         <param name="filterType">      0          0          0  </param>
         <param name="ktau">         -200       -200       -200  </param>

--- a/iCubGenova11/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubGenova11/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">   -2         -2         -2  </param>
         <param name="kff">             1          1          1  </param>
         <param name="kbemf">      -0.0016    -0.003     -0.003  </param>
+        <param name="velocityThres">   0          0          0  </param>
         <param name="filterType">      0          0          0  </param>
         <param name="ktau">         -200       -200       -200  </param>
     </group>

--- a/iCubLisboa01/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
+++ b/iCubLisboa01/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">         -0.7        -0.7       -0.8         -1.2    </param>
         <param name="kff">                  1           1           1           1       </param>
         <param name="kbemf">                0.0030      0.0006      0.0007      0.0007  </param>
+        <param name="velocityThres">        0           0           0           0       </param>
         <param name="filterType">           0           0           0           0       </param>
         <param name="ktau">                 180         464         463         449     </param>
     </group>

--- a/iCubLisboa01/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
+++ b/iCubLisboa01/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">           0.5         0.5         1           1.7     </param>
         <param name="stictionDown">         -0.7        -0.7       -0.8         -1.2    </param>
         <param name="kff">                  1           1           1           1       </param>
-        <param name="kbemf">                0.0030      0.0006      0.0007      0.0007  </param>
+        <param name="viscousPos">           0.0030      0.0006      0.0007      0.0007  </param>
+        <param name="viscousNeg">           0.0030      0.0006      0.0007      0.0007  </param>
+        <param name="coulombPos">           0           0           0           0       </param>
+        <param name="coulombNeg">           0           0           0           0       </param>
         <param name="velocityThres">        0           0           0           0       </param>
         <param name="filterType">           0           0           0           0       </param>
         <param name="ktau">                 180         464         463         449     </param>

--- a/iCubLisboa01/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
+++ b/iCubLisboa01/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    0           0           0           0      </param>
         <param name="kff">             0           0           0           0      </param>
         <param name="kbemf">           0           0           0           0      </param>
+        <param name="velocityThres">   0           0           0           0      </param>
         <param name="filterType">      0           0           0           0      </param>
         <param name="ktau">            0.03        0           0           0      </param>
     </group>

--- a/iCubLisboa01/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
+++ b/iCubLisboa01/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0           0           0           0      </param>
         <param name="stictionDown">    0           0           0           0      </param>
         <param name="kff">             0           0           0           0      </param>
-        <param name="kbemf">           0           0           0           0      </param>
+        <param name="viscousPos">      0           0           0           0      </param>
+        <param name="viscousNeg">      0           0           0           0      </param>
+        <param name="coulombPos">      0           0           0           0      </param>
+        <param name="coulombNeg">      0           0           0           0      </param>
         <param name="velocityThres">   0           0           0           0      </param>
         <param name="filterType">      0           0           0           0      </param>
         <param name="ktau">            0.03        0           0           0      </param>

--- a/iCubLisboa01/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
+++ b/iCubLisboa01/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">     -2.0        2.0       -1.0       -1.0   </param>
         <param name="stictionDown">    1.4       -2.0        1.3        0.2   </param>
         <param name="kff">             1          1          1          1     </param>
-        <param name="kbemf">           0          0          0          0     </param>
+        <param name="viscousPos">      0          0          0          0     </param>
+        <param name="viscousNeg">      0          0          0          0     </param>
+        <param name="coulombPos">      0          0          0          0     </param>
+        <param name="coulombNeg">      0          0          0          0     </param>
         <param name="velocityThres">   0          0          0          0     </param>
         <param name="filterType">      0          0          0          0     </param>
         <param name="ktau">            -162        178       -197       -167  </param>

--- a/iCubLisboa01/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
+++ b/iCubLisboa01/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    1.4       -2.0        1.3        0.2   </param>
         <param name="kff">             1          1          1          1     </param>
         <param name="kbemf">           0          0          0          0     </param>
+        <param name="velocityThres">   0          0          0          0     </param>
         <param name="filterType">      0          0          0          0     </param>
         <param name="ktau">            -162        178       -197       -167  </param>
     </group>

--- a/iCubLisboa01/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
+++ b/iCubLisboa01/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
@@ -77,7 +77,10 @@
         <param name="stictionUp">   1.7	        0.8         </param>
         <param name="stictionDown"> -1.7        -1.8        </param>
         <param name="kff">          1           1           </param>
-        <param name="kbemf">        0           0           </param>
+        <param name="viscousPos">   0           0           </param>
+        <param name="viscousNeg">   0           0           </param>
+        <param name="coulombPos">   0           0           </param>
+        <param name="coulombNeg">   0           0           </param>
         <param name="velocityThres">0           0           </param>
         <param name="filterType">   0           0           </param>
         <param name="ktau">         209         160         </param>

--- a/iCubLisboa01/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
+++ b/iCubLisboa01/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
@@ -78,6 +78,7 @@
         <param name="stictionDown"> -1.7        -1.8        </param>
         <param name="kff">          1           1           </param>
         <param name="kbemf">        0           0           </param>
+        <param name="velocityThres">0           0           </param>
         <param name="filterType">   0           0           </param>
         <param name="ktau">         209         160         </param>
     </group>

--- a/iCubLisboa01/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
+++ b/iCubLisboa01/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    0           0           0           0    </param>
         <param name="kff">             0           0           0           0    </param>
         <param name="kbemf">           0           0           0           0    </param>
+        <param name="velocityThres">   0           0           0           0    </param>
         <param name="filterType">      0           0           0           0    </param>
         <param name="ktau">           0.03         0           0           0    </param>
     </group>

--- a/iCubLisboa01/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
+++ b/iCubLisboa01/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0           0           0           0    </param>
         <param name="stictionDown">    0           0           0           0    </param>
         <param name="kff">             0           0           0           0    </param>
-        <param name="kbemf">           0           0           0           0    </param>
+        <param name="viscousPos">      0           0           0           0    </param>
+        <param name="viscousNeg">      0           0           0           0    </param>
+        <param name="coulombPos">      0           0           0           0    </param>
+        <param name="coulombNeg">      0           0           0           0    </param>
         <param name="velocityThres">   0           0           0           0    </param>
         <param name="filterType">      0           0           0           0    </param>
         <param name="ktau">           0.03         0           0           0    </param>

--- a/iCubLisboa01/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
+++ b/iCubLisboa01/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">   0.7        0.7        0.8        1.2  </param>
         <param name="kff">             1          1          1          1   </param>
         <param name="kbemf">      -0.0030    -0.0006    -0.0007     0.0007  </param>
+        <param name="velocityThres">   0          0          0          0   </param>
         <param name="filterType">      0          0          0          0   </param>
         <param name="ktau">          -180       -464       -463       -449  </param>
     </group>

--- a/iCubLisboa01/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
+++ b/iCubLisboa01/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">    -0.5       -0.5       -1         -1.7  </param>
         <param name="stictionDown">   0.7        0.7        0.8        1.2  </param>
         <param name="kff">             1          1          1          1   </param>
-        <param name="kbemf">      -0.0030    -0.0006    -0.0007     0.0007  </param>
+        <param name="viscousPos">     -0.0030    -0.0006    -0.0007     0.0007   </param>
+        <param name="viscousNeg">     -0.0030    -0.0006    -0.0007     0.0007   </param>
+        <param name="coulombPos">      0          0          0          0   </param>
+        <param name="coulombNeg">      0          0          0          0   </param>
         <param name="velocityThres">   0          0          0          0   </param>
         <param name="filterType">      0          0          0          0   </param>
         <param name="ktau">          -180       -464       -463       -449  </param>

--- a/iCubLisboa01/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
+++ b/iCubLisboa01/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      2.3       -1.79       1.8        1.2     </param>
         <param name="stictionDown">   -3.3        1.76      -1.4       -1.7     </param>
         <param name="kff">             1          1          1          1       </param>
-        <param name="kbemf">           0          0          0          0       </param>
+        <param name="viscousPos">      0          0          0          0       </param>
+        <param name="viscousNeg">      0          0          0          0       </param>
+        <param name="coulombPos">      0          0          0          0       </param>
+        <param name="coulombNeg">      0          0          0          0       </param>
         <param name="velocityThres">   0          0          0          0       </param>
         <param name="filterType">      0          0          0          0       </param>
        <param name="ktau">             147        -180       217        282     </param>

--- a/iCubLisboa01/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
+++ b/iCubLisboa01/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">   -3.3        1.76      -1.4       -1.7     </param>
         <param name="kff">             1          1          1          1       </param>
         <param name="kbemf">           0          0          0          0       </param>
+        <param name="velocityThres">   0          0          0          0       </param>
         <param name="filterType">      0          0          0          0       </param>
        <param name="ktau">             147        -180       217        282     </param>
     </group>

--- a/iCubLisboa01/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
+++ b/iCubLisboa01/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">     -1.4        -1.5          </param>
         <param name="stictionDown">    2.4         1.6          </param>
         <param name="kff">             1          1             </param>
-        <param name="kbemf">           0          0             </param>
+        <param name="viscousPos">      0          0             </param>
+        <param name="viscousNeg">      0          0             </param>
+        <param name="coulombPos">      0          0             </param>
+        <param name="coulombNeg">      0          0             </param>
         <param name="velocityThres">   0          0             </param>
         <param name="filterType">      0          0             </param>
         <param name="ktau">            -231       -180          </param>

--- a/iCubLisboa01/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
+++ b/iCubLisboa01/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    2.4         1.6          </param>
         <param name="kff">             1          1             </param>
         <param name="kbemf">           0          0             </param>
+        <param name="velocityThres">   0          0             </param>
         <param name="filterType">      0          0             </param>
         <param name="ktau">            -231       -180          </param>
     </group>

--- a/iCubLisboa01/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubLisboa01/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0          0          0  </param>
         <param name="stictionDown">   -2         -2         -2  </param>
         <param name="kff">             1          1          1  </param>
-        <param name="kbemf">      -0.0016    -0.003     -0.003  </param>
+        <param name="viscousPos">      -0.0016   -0.003     -0.003  </param>
+        <param name="viscousNeg">      -0.0016   -0.003     -0.003  </param>
+        <param name="coulombPos">      0          0          0  </param>
+        <param name="coulombNeg">      0          0          0  </param>
         <param name="velocityThres">   0          0          0  </param>
         <param name="filterType">      0          0          0  </param>
         <param name="ktau">         -200       -200       -200  </param>

--- a/iCubLisboa01/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubLisboa01/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">   -2         -2         -2  </param>
         <param name="kff">             1          1          1  </param>
         <param name="kbemf">      -0.0016    -0.003     -0.003  </param>
+        <param name="velocityThres">   0          0          0  </param>
         <param name="filterType">      0          0          0  </param>
         <param name="ktau">         -200       -200       -200  </param>
     </group>

--- a/iCubNancy01/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
+++ b/iCubNancy01/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
@@ -66,6 +66,7 @@
         <param name="stictionDown">0 0 0 0</param>       
         <param name="kff">             1         1         1     1    </param>   
         <param name="kbemf">0 0 0 0</param>  
+        <param name="velocityThres">   0         0         0     0    </param>
         <param name="filterType">      0         0         0     0    </param>       
         <param name="ktau">0 0 0 0</param>             
     </group>

--- a/iCubNancy01/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
+++ b/iCubNancy01/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
@@ -65,7 +65,10 @@
         <param name="stictionUp">0 0 0 0</param>       
         <param name="stictionDown">0 0 0 0</param>       
         <param name="kff">             1         1         1     1    </param>   
-        <param name="kbemf">0 0 0 0</param>  
+        <param name="viscousPos">      0         0         0     0    </param>
+        <param name="viscousNeg">      0         0         0     0    </param>
+        <param name="coulombPos">      0         0         0     0    </param>
+        <param name="coulombNeg">      0         0         0     0    </param>
         <param name="velocityThres">   0         0         0     0    </param>
         <param name="filterType">      0         0         0     0    </param>       
         <param name="ktau">0 0 0 0</param>             

--- a/iCubNancy01/hardware/motorControl/left_arm-eb2-j4_15-mc.xml
+++ b/iCubNancy01/hardware/motorControl/left_arm-eb2-j4_15-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">         0       0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="kff">                  0       0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="kbemf">                0       0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="velocityThres">        0       0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="filterType">           0       0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="ktau">                 0       0      0      0      0      0      0      0      0      0      0      0    </param>
     </group>

--- a/iCubNancy01/hardware/motorControl/left_arm-eb2-j4_15-mc.xml
+++ b/iCubNancy01/hardware/motorControl/left_arm-eb2-j4_15-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">           0       0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="stictionDown">         0       0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="kff">                  0       0      0      0      0      0      0      0      0      0      0      0    </param>
-        <param name="kbemf">                0       0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="viscousPos">           0       0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="viscousNeg">           0       0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="coulombPos">           0       0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="coulombNeg">           0       0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="velocityThres">        0       0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="filterType">           0       0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="ktau">                 0       0      0      0      0      0      0      0      0      0      0      0    </param>

--- a/iCubNancy01/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
+++ b/iCubNancy01/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
@@ -67,6 +67,7 @@
         <param name="stictionDown">0 0 0 0</param>       
         <param name="kff">             1          1      1          1     </param>      
         <param name="kbemf">0 0 0 0</param>     
+        <param name="velocityThres">   0          0      0          0     </param>
         <param name="filterType">      0          0      0          0     </param>              
         <param name="ktau">0 0 0 0</param>      
     </group>

--- a/iCubNancy01/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
+++ b/iCubNancy01/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
@@ -66,7 +66,10 @@
         <param name="stictionUp">0 0 0 0</param>       
         <param name="stictionDown">0 0 0 0</param>       
         <param name="kff">             1          1      1          1     </param>      
-        <param name="kbemf">0 0 0 0</param>     
+        <param name="viscousPos">      0          0      0          0     </param>
+        <param name="viscousNeg">      0          0      0          0     </param>
+        <param name="coulombPos">      0          0      0          0     </param>
+        <param name="coulombNeg">      0          0      0          0     </param>
         <param name="velocityThres">   0          0      0          0     </param>
         <param name="filterType">      0          0      0          0     </param>              
         <param name="ktau">0 0 0 0</param>      

--- a/iCubNancy01/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
+++ b/iCubNancy01/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
@@ -67,7 +67,10 @@
         <param name="stictionUp">   0           0           </param>
         <param name="stictionDown"> 0           0           </param>
         <param name="kff">          1           1           </param>
-        <param name="kbemf">        0           0           </param>
+        <param name="viscousPos">   0           0           </param>
+        <param name="viscousNeg">   0           0           </param>
+        <param name="coulombPos">   0           0           </param>
+        <param name="coulombNeg">   0           0           </param>
         <param name="velocityThres">0           0           </param>
         <param name="filterType">   0           0           </param>
         <param name="ktau">         0           0           </param>

--- a/iCubNancy01/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
+++ b/iCubNancy01/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
@@ -68,6 +68,7 @@
         <param name="stictionDown"> 0           0           </param>
         <param name="kff">          1           1           </param>
         <param name="kbemf">        0           0           </param>
+        <param name="velocityThres">0           0           </param>
         <param name="filterType">   0           0           </param>
         <param name="ktau">         0           0           </param>
     </group>

--- a/iCubNancy01/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
+++ b/iCubNancy01/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
@@ -67,7 +67,10 @@
         <param name="stictionUp">      0          0          0          0   </param>
         <param name="stictionDown">    0          0          0          0   </param>
         <param name="kff">             1          1          1          1   </param>
-        <param name="kbemf">           0          0          0          0   </param>
+        <param name="viscousPos">      0          0          0          0   </param>
+        <param name="viscousNeg">      0          0          0          0   </param>
+        <param name="coulombPos">      0          0          0          0   </param>
+        <param name="coulombNeg">      0          0          0          0   </param>
         <param name="velocityThres">   0          0          0          0   </param>
         <param name="filterType">      0          0          0          0   </param>
         <param name="ktau">            0          0          0          0   </param>

--- a/iCubNancy01/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
+++ b/iCubNancy01/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
@@ -68,6 +68,7 @@
         <param name="stictionDown">    0          0          0          0   </param>
         <param name="kff">             1          1          1          1   </param>
         <param name="kbemf">           0          0          0          0   </param>
+        <param name="velocityThres">   0          0          0          0   </param>
         <param name="filterType">      0          0          0          0   </param>
         <param name="ktau">            0          0          0          0   </param>
     </group>

--- a/iCubNancy01/hardware/motorControl/right_arm-eb4-j4_15-mc.xml
+++ b/iCubNancy01/hardware/motorControl/right_arm-eb4-j4_15-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">        0      0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="stictionDown">      0      0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="kff">               0      0      0      0      0      0      0      0      0      0      0      0    </param>
-        <param name="kbemf">             0      0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="viscousPos">        0      0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="viscousNeg">        0      0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="coulombPos">        0      0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="coulombNeg">        0      0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="velocityThres">     0      0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="filterType">        0      0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="ktau">              0      0      0      0      0      0      0      0      0      0      0      0    </param>

--- a/iCubNancy01/hardware/motorControl/right_arm-eb4-j4_15-mc.xml
+++ b/iCubNancy01/hardware/motorControl/right_arm-eb4-j4_15-mc.xml
@@ -77,8 +77,9 @@
         <param name="stictionDown">      0      0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="kff">               0      0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="kbemf">             0      0      0      0      0      0      0      0      0      0      0      0    </param>
+        <param name="velocityThres">     0      0      0      0      0      0      0      0      0      0      0      0    </param>
         <param name="filterType">        0      0      0      0      0      0      0      0      0      0      0      0    </param>
-        <param name="ktau">              0      0      0      0      0      0      0      0      0      0      0      0     </param>
+        <param name="ktau">              0      0      0      0      0      0      0      0      0      0      0      0    </param>
     </group>
 
     <!-- other default PIDs: end -->

--- a/iCubNancy01/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
+++ b/iCubNancy01/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
@@ -67,7 +67,10 @@
         <param name="stictionUp">0 0 0 0</param>       
         <param name="stictionDown">0 0 0 0</param>       
         <param name="kff">             1          1          1          1     </param>  
-        <param name="kbemf">0 0 0 0</param>            
+        <param name="viscousPos">      0          0          0          0      </param>
+        <param name="viscousNeg">      0          0          0          0      </param>
+        <param name="coulombPos">      0          0          0          0      </param>
+        <param name="coulombNeg">      0          0          0          0      </param>
         <param name="velocityThres">   0          0          0          0     </param>
         <param name="filterType">      0          0          0          0     </param>     
         <param name="ktau">0 0 0 0</param>          

--- a/iCubNancy01/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
+++ b/iCubNancy01/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
@@ -68,6 +68,7 @@
         <param name="stictionDown">0 0 0 0</param>       
         <param name="kff">             1          1          1          1     </param>  
         <param name="kbemf">0 0 0 0</param>            
+        <param name="velocityThres">   0          0          0          0     </param>
         <param name="filterType">      0          0          0          0     </param>     
         <param name="ktau">0 0 0 0</param>          
     </group>

--- a/iCubNancy01/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
+++ b/iCubNancy01/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
@@ -66,7 +66,10 @@
         <param name="stictionUp">0 0</param>       
         <param name="stictionDown">0 0</param>       
         <param name="kff">           1           1              </param>      
-        <param name="kbemf">0 0</param>
+        <param name="viscousPos">    0           0              </param>
+        <param name="viscousNeg">    0           0              </param>
+        <param name="coulombPos">    0           0              </param>
+        <param name="coulombNeg">    0           0              </param>
         <param name="velocityThres"> 0           0              </param>
         <param name="filterType">    0           0              </param>  
         <param name="ktau">0 0</param>        

--- a/iCubNancy01/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
+++ b/iCubNancy01/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
@@ -66,7 +66,8 @@
         <param name="stictionUp">0 0</param>       
         <param name="stictionDown">0 0</param>       
         <param name="kff">           1           1              </param>      
-        <param name="kbemf">0 0</param>  
+        <param name="kbemf">0 0</param>
+        <param name="velocityThres"> 0           0              </param>
         <param name="filterType">    0           0              </param>  
         <param name="ktau">0 0</param>        
     </group>

--- a/iCubNancy01/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubNancy01/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -58,9 +58,10 @@
         <param name="ko">              0       0       0 </param>       
         <param name="stictionUp">0 0 0</param>       
         <param name="stictionDown">0 0 0</param>      
-        <param name="kff">             1       1       1 </param>      
-        <param name="kbemf">0 0 0</param>           
-        <param name="filterType">      0       0       0 </param>   
+        <param name="kff">             1       1       1 </param>
+        <param name="kbemf">           0       0       0 </param>
+        <param name="velocityThres">   0       0       0 </param>
+        <param name="filterType">      0       0       0 </param>
         <param name="ktau">0 0 0</param>  
     </group>
     

--- a/iCubNancy01/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubNancy01/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -59,7 +59,10 @@
         <param name="stictionUp">0 0 0</param>       
         <param name="stictionDown">0 0 0</param>      
         <param name="kff">             1       1       1 </param>
-        <param name="kbemf">           0       0       0 </param>
+        <param name="viscousPos">      0       0       0 </param>
+        <param name="viscousNeg">      0       0       0 </param>
+        <param name="coulombPos">      0       0       0 </param>
+        <param name="coulombNeg">      0       0       0 </param>
         <param name="velocityThres">   0       0       0 </param>
         <param name="filterType">      0       0       0 </param>
         <param name="ktau">0 0 0</param>  

--- a/iCubPrague01/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
+++ b/iCubPrague01/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">         -0.7        -0.7       -0.8         -1.2    </param>
         <param name="kff">                  1           1           1           1       </param>
         <param name="kbemf">                0.0030      0.0006      0.0007      0.0007  </param>
+        <param name="velocityThres">        0           0           0           0       </param>
         <param name="filterType">           0           0           0           0       </param>
         <param name="ktau">                 180         464         463         449     </param>
     </group>

--- a/iCubPrague01/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
+++ b/iCubPrague01/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">           0.5         0.5         1           1.7     </param>
         <param name="stictionDown">         -0.7        -0.7       -0.8         -1.2    </param>
         <param name="kff">                  1           1           1           1       </param>
-        <param name="kbemf">                0.0030      0.0006      0.0007      0.0007  </param>
+        <param name="viscousPos">           0.0030      0.0006      0.0007      0.0007  </param>
+        <param name="viscousNeg">           0.0030      0.0006      0.0007      0.0007  </param>
+        <param name="coulombPos">           0           0           0           0       </param>
+        <param name="coulombNeg">           0           0           0           0       </param>
         <param name="velocityThres">        0           0           0           0       </param>
         <param name="filterType">           0           0           0           0       </param>
         <param name="ktau">                 180         464         463         449     </param>

--- a/iCubPrague01/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
+++ b/iCubPrague01/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    0           0           0           0      </param>
         <param name="kff">             0           0           0           0      </param>
         <param name="kbemf">           0           0           0           0      </param>
+        <param name="velocityThres">   0           0           0           0      </param>
         <param name="filterType">      0           0           0           0      </param>
         <param name="ktau">            1           0           0           0      </param>
     </group>

--- a/iCubPrague01/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
+++ b/iCubPrague01/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0           0           0           0      </param>
         <param name="stictionDown">    0           0           0           0      </param>
         <param name="kff">             0           0           0           0      </param>
-        <param name="kbemf">           0           0           0           0      </param>
+        <param name="viscousPos">      0           0           0           0      </param>
+        <param name="viscousNeg">      0           0           0           0      </param>
+        <param name="coulombPos">      0           0           0           0      </param>
+        <param name="coulombNeg">      0           0           0           0      </param>
         <param name="velocityThres">   0           0           0           0      </param>
         <param name="filterType">      0           0           0           0      </param>
         <param name="ktau">            1           0           0           0      </param>

--- a/iCubPrague01/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
+++ b/iCubPrague01/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">     -2.0        2.0       -1.0       -1.0   </param>
         <param name="stictionDown">    1.4       -2.0        1.3        0.2   </param>
         <param name="kff">             1          1          1          1     </param>
-        <param name="kbemf">           0          0          0          0     </param>
+        <param name="viscousPos">      0          0          0          0     </param>
+        <param name="viscousNeg">      0          0          0          0     </param>
+        <param name="coulombPos">      0          0          0          0     </param>
+        <param name="coulombNeg">      0          0          0          0     </param>
         <param name="velocityThres">   0          0          0          0     </param>
         <param name="filterType">      0          0          0          0     </param>
         <param name="ktau">            -162        178       -197       -167  </param>

--- a/iCubPrague01/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
+++ b/iCubPrague01/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    1.4       -2.0        1.3        0.2   </param>
         <param name="kff">             1          1          1          1     </param>
         <param name="kbemf">           0          0          0          0     </param>
+        <param name="velocityThres">   0          0          0          0     </param>
         <param name="filterType">      0          0          0          0     </param>
         <param name="ktau">            -162        178       -197       -167  </param>
     </group>

--- a/iCubPrague01/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
+++ b/iCubPrague01/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
@@ -77,7 +77,10 @@
         <param name="stictionUp">   1.7	        0.8         </param>
         <param name="stictionDown"> -1.7        -1.8        </param>
         <param name="kff">          1           1           </param>
-        <param name="kbemf">        0           0           </param>
+        <param name="viscousPos">   0           0           </param>
+        <param name="viscousNeg">   0           0           </param>
+        <param name="coulombPos">   0           0           </param>
+        <param name="coulombNeg">   0           0           </param>
         <param name="velocityThres">0           0           </param>
         <param name="filterType">   0           0           </param>
         <param name="ktau">         209         160         </param>

--- a/iCubPrague01/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
+++ b/iCubPrague01/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
@@ -78,6 +78,7 @@
         <param name="stictionDown"> -1.7        -1.8        </param>
         <param name="kff">          1           1           </param>
         <param name="kbemf">        0           0           </param>
+        <param name="velocityThres">0           0           </param>
         <param name="filterType">   0           0           </param>
         <param name="ktau">         209         160         </param>
     </group>

--- a/iCubPrague01/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
+++ b/iCubPrague01/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0           0           0           0    </param>
         <param name="stictionDown">    0           0           0           0    </param>
         <param name="kff">             0           0           0           0    </param>
-        <param name="kbemf">           0           0           0           0    </param>
+        <param name="viscousPos">      0           0           0           0    </param>
+        <param name="viscousNeg">      0           0           0           0    </param>
+        <param name="coulombPos">      0           0           0           0    </param>
+        <param name="coulombNeg">      0           0           0           0    </param>
         <param name="velocityThres">   0           0           0           0    </param>
         <param name="filterType">      0           0           0           0    </param>
         <param name="ktau">            1           0           0           0    </param>

--- a/iCubPrague01/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
+++ b/iCubPrague01/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    0           0           0           0    </param>
         <param name="kff">             0           0           0           0    </param>
         <param name="kbemf">           0           0           0           0    </param>
+        <param name="velocityThres">   0           0           0           0    </param>
         <param name="filterType">      0           0           0           0    </param>
         <param name="ktau">            1           0           0           0    </param>
     </group>

--- a/iCubPrague01/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
+++ b/iCubPrague01/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">   0.7        0.7        0.8        1.2  </param>
         <param name="kff">             1          1          1          1   </param>
         <param name="kbemf">      -0.0030    -0.0006    -0.0007     0.0007  </param>
+        <param name="velocityThres">   0          0          0          0   </param>
         <param name="filterType">      0          0          0          0   </param>
         <param name="ktau">          -180       -464       -463       -449  </param>
     </group>

--- a/iCubPrague01/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
+++ b/iCubPrague01/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">    -0.5       -0.5       -1         -1.7  </param>
         <param name="stictionDown">   0.7        0.7        0.8        1.2  </param>
         <param name="kff">             1          1          1          1   </param>
-        <param name="kbemf">      -0.0030    -0.0006    -0.0007     0.0007  </param>
+        <param name="viscousPos">     -0.0030    -0.0006    -0.0007     0.0007   </param>
+        <param name="viscousNeg">     -0.0030    -0.0006    -0.0007     0.0007   </param>
+        <param name="coulombPos">      0          0          0          0   </param>
+        <param name="coulombNeg">      0          0          0          0   </param>
         <param name="velocityThres">   0          0          0          0   </param>
         <param name="filterType">      0          0          0          0   </param>
         <param name="ktau">          -180       -464       -463       -449  </param>

--- a/iCubPrague01/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
+++ b/iCubPrague01/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      2.3       -1.79       1.8        1.2     </param>
         <param name="stictionDown">   -3.3        1.76      -1.4       -1.7     </param>
         <param name="kff">             1          1          1          1       </param>
-        <param name="kbemf">           0          0          0          0       </param>
+        <param name="viscousPos">      0          0          0          0       </param>
+        <param name="viscousNeg">      0          0          0          0       </param>
+        <param name="coulombPos">      0          0          0          0       </param>
+        <param name="coulombNeg">      0          0          0          0       </param>
         <param name="velocityThres">   0          0          0          0       </param>
         <param name="filterType">      0          0          0          0       </param>
        <param name="ktau">             147        -180       217        282     </param>

--- a/iCubPrague01/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
+++ b/iCubPrague01/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">   -3.3        1.76      -1.4       -1.7     </param>
         <param name="kff">             1          1          1          1       </param>
         <param name="kbemf">           0          0          0          0       </param>
+        <param name="velocityThres">   0          0          0          0       </param>
         <param name="filterType">      0          0          0          0       </param>
        <param name="ktau">             147        -180       217        282     </param>
     </group>

--- a/iCubPrague01/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
+++ b/iCubPrague01/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">     -1.4        -1.5          </param>
         <param name="stictionDown">    2.4         1.6          </param>
         <param name="kff">             1          1             </param>
-        <param name="kbemf">           0          0             </param>
+        <param name="viscousPos">      0          0             </param>
+        <param name="viscousNeg">      0          0             </param>
+        <param name="coulombPos">      0          0             </param>
+        <param name="coulombNeg">      0          0             </param>
         <param name="velocityThres">   0          0             </param>
         <param name="filterType">      0          0             </param>
         <param name="ktau">            -231       -180          </param>

--- a/iCubPrague01/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
+++ b/iCubPrague01/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    2.4         1.6          </param>
         <param name="kff">             1          1             </param>
         <param name="kbemf">           0          0             </param>
+        <param name="velocityThres">   0          0             </param>
         <param name="filterType">      0          0             </param>
         <param name="ktau">            -231       -180          </param>
     </group>

--- a/iCubPrague01/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubPrague01/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0          0          0  </param>
         <param name="stictionDown">   -2         -2         -2  </param>
         <param name="kff">             1          1          1  </param>
-        <param name="kbemf">      -0.0016    -0.003     -0.003  </param>
+        <param name="viscousPos">      -0.0016   -0.003     -0.003  </param>
+        <param name="viscousNeg">      -0.0016   -0.003     -0.003  </param>
+        <param name="coulombPos">      0          0          0  </param>
+        <param name="coulombNeg">      0          0          0  </param>
         <param name="velocityThres">   0          0          0  </param>
         <param name="filterType">      0          0          0  </param>
         <param name="ktau">         -200       -200       -200  </param>

--- a/iCubPrague01/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubPrague01/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">   -2         -2         -2  </param>
         <param name="kff">             1          1          1  </param>
         <param name="kbemf">      -0.0016    -0.003     -0.003  </param>
+        <param name="velocityThres">   0          0          0  </param>
         <param name="filterType">      0          0          0  </param>
         <param name="ktau">         -200       -200       -200  </param>
     </group>

--- a/iCubShanghai01/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
+++ b/iCubShanghai01/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">         -0.7        -0.7       -0.8         -1.2    </param>
         <param name="kff">                  1           1           1           1       </param>
         <param name="kbemf">                0.0030      0.0006      0.0007      0.0007  </param>
+        <param name="velocityThres">        0           0           0           0       </param>
         <param name="filterType">           0           0           0           0       </param>
         <param name="ktau">                 180         464         463         449     </param>
     </group>

--- a/iCubShanghai01/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
+++ b/iCubShanghai01/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">           0.5         0.5         1           1.7     </param>
         <param name="stictionDown">         -0.7        -0.7       -0.8         -1.2    </param>
         <param name="kff">                  1           1           1           1       </param>
-        <param name="kbemf">                0.0030      0.0006      0.0007      0.0007  </param>
+        <param name="viscousPos">           0.0030      0.0006      0.0007      0.0007  </param>
+        <param name="viscousNeg">           0.0030      0.0006      0.0007      0.0007  </param>
+        <param name="coulombPos">           0           0           0           0       </param>
+        <param name="coulombNeg">           0           0           0           0       </param>
         <param name="velocityThres">        0           0           0           0       </param>
         <param name="filterType">           0           0           0           0       </param>
         <param name="ktau">                 180         464         463         449     </param>

--- a/iCubShanghai01/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
+++ b/iCubShanghai01/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    0           0           0           0      </param>
         <param name="kff">             0           0           0           0      </param>
         <param name="kbemf">           0           0           0           0      </param>
+        <param name="velocityThres">   0           0           0           0      </param>
         <param name="filterType">      0           0           0           0      </param>
         <param name="ktau">            1           0           0           0      </param>
     </group>

--- a/iCubShanghai01/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
+++ b/iCubShanghai01/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0           0           0           0      </param>
         <param name="stictionDown">    0           0           0           0      </param>
         <param name="kff">             0           0           0           0      </param>
-        <param name="kbemf">           0           0           0           0      </param>
+        <param name="viscousPos">      0           0           0           0      </param>
+        <param name="viscousNeg">      0           0           0           0      </param>
+        <param name="coulombPos">      0           0           0           0      </param>
+        <param name="coulombNeg">      0           0           0           0      </param>
         <param name="velocityThres">   0           0           0           0      </param>
         <param name="filterType">      0           0           0           0      </param>
         <param name="ktau">            1           0           0           0      </param>

--- a/iCubShanghai01/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
+++ b/iCubShanghai01/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">     -2.0        2.0       -1.0       -1.0   </param>
         <param name="stictionDown">    1.4       -2.0        1.3        0.2   </param>
         <param name="kff">             1          1          1          1     </param>
-        <param name="kbemf">           0          0          0          0     </param>
+        <param name="viscousPos">      0          0          0          0     </param>
+        <param name="viscousNeg">      0          0          0          0     </param>
+        <param name="coulombPos">      0          0          0          0     </param>
+        <param name="coulombNeg">      0          0          0          0     </param>
         <param name="velocityThres">   0          0          0          0     </param>
         <param name="filterType">      0          0          0          0     </param>
         <param name="ktau">            -162        178       -197       -167  </param>

--- a/iCubShanghai01/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
+++ b/iCubShanghai01/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    1.4       -2.0        1.3        0.2   </param>
         <param name="kff">             1          1          1          1     </param>
         <param name="kbemf">           0          0          0          0     </param>
+        <param name="velocityThres">   0          0          0          0     </param>
         <param name="filterType">      0          0          0          0     </param>
         <param name="ktau">            -162        178       -197       -167  </param>
     </group>

--- a/iCubShanghai01/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
+++ b/iCubShanghai01/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
@@ -77,7 +77,10 @@
         <param name="stictionUp">   1.7	        0.8         </param>
         <param name="stictionDown"> -1.7        -1.8        </param>
         <param name="kff">          1           1           </param>
-        <param name="kbemf">        0           0           </param>
+        <param name="viscousPos">   0           0           </param>
+        <param name="viscousNeg">   0           0           </param>
+        <param name="coulombPos">   0           0           </param>
+        <param name="coulombNeg">   0           0           </param>
         <param name="velocityThres">0           0           </param>
         <param name="filterType">   0           0           </param>
         <param name="ktau">         209         160         </param>

--- a/iCubShanghai01/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
+++ b/iCubShanghai01/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
@@ -78,6 +78,7 @@
         <param name="stictionDown"> -1.7        -1.8        </param>
         <param name="kff">          1           1           </param>
         <param name="kbemf">        0           0           </param>
+        <param name="velocityThres">0           0           </param>
         <param name="filterType">   0           0           </param>
         <param name="ktau">         209         160         </param>
     </group>

--- a/iCubShanghai01/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
+++ b/iCubShanghai01/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0           0           0           0    </param>
         <param name="stictionDown">    0           0           0           0    </param>
         <param name="kff">             0           0           0           0    </param>
-        <param name="kbemf">           0           0           0           0    </param>
+        <param name="viscousPos">      0           0           0           0    </param>
+        <param name="viscousNeg">      0           0           0           0    </param>
+        <param name="coulombPos">      0           0           0           0    </param>
+        <param name="coulombNeg">      0           0           0           0    </param>
         <param name="velocityThres">   0           0           0           0    </param>
         <param name="filterType">      0           0           0           0    </param>
         <param name="ktau">            1           0           0           0    </param>

--- a/iCubShanghai01/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
+++ b/iCubShanghai01/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    0           0           0           0    </param>
         <param name="kff">             0           0           0           0    </param>
         <param name="kbemf">           0           0           0           0    </param>
+        <param name="velocityThres">   0           0           0           0    </param>
         <param name="filterType">      0           0           0           0    </param>
         <param name="ktau">            1           0           0           0    </param>
     </group>

--- a/iCubShanghai01/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
+++ b/iCubShanghai01/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">   0.7        0.7        0.8        1.2  </param>
         <param name="kff">             1          1          1          1   </param>
         <param name="kbemf">      -0.0030    -0.0006    -0.0007     0.0007  </param>
+        <param name="velocityThres">   0          0          0          0   </param>
         <param name="filterType">      0          0          0          0   </param>
         <param name="ktau">          -180       -464       -463       -449  </param>
     </group>

--- a/iCubShanghai01/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
+++ b/iCubShanghai01/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">    -0.5       -0.5       -1         -1.7  </param>
         <param name="stictionDown">   0.7        0.7        0.8        1.2  </param>
         <param name="kff">             1          1          1          1   </param>
-        <param name="kbemf">      -0.0030    -0.0006    -0.0007     0.0007  </param>
+        <param name="viscousPos">     -0.0030    -0.0006    -0.0007     0.0007   </param>
+        <param name="viscousNeg">     -0.0030    -0.0006    -0.0007     0.0007   </param>
+        <param name="coulombPos">      0          0          0          0   </param>
+        <param name="coulombNeg">      0          0          0          0   </param>
         <param name="velocityThres">   0          0          0          0   </param>
         <param name="filterType">      0          0          0          0   </param>
         <param name="ktau">          -180       -464       -463       -449  </param>

--- a/iCubShanghai01/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
+++ b/iCubShanghai01/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      2.3       -1.79       1.8        1.2     </param>
         <param name="stictionDown">   -3.3        1.76      -1.4       -1.7     </param>
         <param name="kff">             1          1          1          1       </param>
-        <param name="kbemf">           0          0          0          0       </param>
+        <param name="viscousPos">      0          0          0          0       </param>
+        <param name="viscousNeg">      0          0          0          0       </param>
+        <param name="coulombPos">      0          0          0          0       </param>
+        <param name="coulombNeg">      0          0          0          0       </param>
         <param name="velocityThres">   0          0          0          0       </param>
         <param name="filterType">      0          0          0          0       </param>
        <param name="ktau">             147        -180       217        282     </param>

--- a/iCubShanghai01/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
+++ b/iCubShanghai01/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">   -3.3        1.76      -1.4       -1.7     </param>
         <param name="kff">             1          1          1          1       </param>
         <param name="kbemf">           0          0          0          0       </param>
+        <param name="velocityThres">   0          0          0          0       </param>
         <param name="filterType">      0          0          0          0       </param>
        <param name="ktau">             147        -180       217        282     </param>
     </group>

--- a/iCubShanghai01/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
+++ b/iCubShanghai01/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">     -1.4        -1.5          </param>
         <param name="stictionDown">    2.4         1.6          </param>
         <param name="kff">             1          1             </param>
-        <param name="kbemf">           0          0             </param>
+        <param name="viscousPos">      0          0             </param>
+        <param name="viscousNeg">      0          0             </param>
+        <param name="coulombPos">      0          0             </param>
+        <param name="coulombNeg">      0          0             </param>
         <param name="velocityThres">   0          0             </param>
         <param name="filterType">      0          0             </param>
         <param name="ktau">            -231       -180          </param>

--- a/iCubShanghai01/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
+++ b/iCubShanghai01/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    2.4         1.6          </param>
         <param name="kff">             1          1             </param>
         <param name="kbemf">           0          0             </param>
+        <param name="velocityThres">   0          0             </param>
         <param name="filterType">      0          0             </param>
         <param name="ktau">            -231       -180          </param>
     </group>

--- a/iCubShanghai01/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubShanghai01/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0          0          0  </param>
         <param name="stictionDown">   -2         -2         -2  </param>
         <param name="kff">             1          1          1  </param>
-        <param name="kbemf">      -0.0016    -0.003     -0.003  </param>
+        <param name="viscousPos">      -0.0016   -0.003     -0.003  </param>
+        <param name="viscousNeg">      -0.0016   -0.003     -0.003  </param>
+        <param name="coulombPos">      0          0          0  </param>
+        <param name="coulombNeg">      0          0          0  </param>
         <param name="velocityThres">   0          0          0  </param>
         <param name="filterType">      0          0          0  </param>
         <param name="ktau">         -200       -200       -200  </param>

--- a/iCubShanghai01/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubShanghai01/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">   -2         -2         -2  </param>
         <param name="kff">             1          1          1  </param>
         <param name="kbemf">      -0.0016    -0.003     -0.003  </param>
+        <param name="velocityThres">   0          0          0  </param>
         <param name="filterType">      0          0          0  </param>
         <param name="ktau">         -200       -200       -200  </param>
     </group>

--- a/iCubShenzhen01/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
+++ b/iCubShenzhen01/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">         -0.7        -0.7       -0.8         -1.2    </param>
         <param name="kff">                  1           1           1           1       </param>
         <param name="kbemf">                0.0030      0.0006      0.0007      0.0007  </param>
+        <param name="velocityThres">        0           0           0           0       </param>
         <param name="filterType">           0           0           0           0       </param>
         <param name="ktau">                 180         464         463         449     </param>
     </group>

--- a/iCubShenzhen01/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
+++ b/iCubShenzhen01/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">           0.5         0.5         1           1.7     </param>
         <param name="stictionDown">         -0.7        -0.7       -0.8         -1.2    </param>
         <param name="kff">                  1           1           1           1       </param>
-        <param name="kbemf">                0.0030      0.0006      0.0007      0.0007  </param>
+        <param name="viscousPos">           0.0030      0.0006      0.0007      0.0007  </param>
+        <param name="viscousNeg">           0.0030      0.0006      0.0007      0.0007  </param>
+        <param name="coulombPos">           0           0           0           0       </param>
+        <param name="coulombNeg">           0           0           0           0       </param>
         <param name="velocityThres">        0           0           0           0       </param>
         <param name="filterType">           0           0           0           0       </param>
         <param name="ktau">                 180         464         463         449     </param>

--- a/iCubShenzhen01/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
+++ b/iCubShenzhen01/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    0           0           0           0      </param>
         <param name="kff">             0           0           0           0      </param>
         <param name="kbemf">           0           0           0           0      </param>
+        <param name="velocityThres">   0           0           0           0      </param>
         <param name="filterType">      0           0           0           0      </param>
         <param name="ktau">            1           0           0           0      </param>
     </group>

--- a/iCubShenzhen01/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
+++ b/iCubShenzhen01/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0           0           0           0      </param>
         <param name="stictionDown">    0           0           0           0      </param>
         <param name="kff">             0           0           0           0      </param>
-        <param name="kbemf">           0           0           0           0      </param>
+        <param name="viscousPos">      0           0           0           0      </param>
+        <param name="viscousNeg">      0           0           0           0      </param>
+        <param name="coulombPos">      0           0           0           0      </param>
+        <param name="coulombNeg">      0           0           0           0      </param>
         <param name="velocityThres">   0           0           0           0      </param>
         <param name="filterType">      0           0           0           0      </param>
         <param name="ktau">            1           0           0           0      </param>

--- a/iCubShenzhen01/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
+++ b/iCubShenzhen01/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">     -2.0        2.0       -1.0       -1.0   </param>
         <param name="stictionDown">    1.4       -2.0        1.3        0.2   </param>
         <param name="kff">             1          1          1          1     </param>
-        <param name="kbemf">           0          0          0          0     </param>
+        <param name="viscousPos">      0          0          0          0     </param>
+        <param name="viscousNeg">      0          0          0          0     </param>
+        <param name="coulombPos">      0          0          0          0     </param>
+        <param name="coulombNeg">      0          0          0          0     </param>
         <param name="velocityThres">   0          0          0          0     </param>
         <param name="filterType">      0          0          0          0     </param>
         <param name="ktau">            -162        178       -197       -167  </param>

--- a/iCubShenzhen01/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
+++ b/iCubShenzhen01/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    1.4       -2.0        1.3        0.2   </param>
         <param name="kff">             1          1          1          1     </param>
         <param name="kbemf">           0          0          0          0     </param>
+        <param name="velocityThres">   0          0          0          0     </param>
         <param name="filterType">      0          0          0          0     </param>
         <param name="ktau">            -162        178       -197       -167  </param>
     </group>

--- a/iCubShenzhen01/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
+++ b/iCubShenzhen01/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
@@ -77,7 +77,10 @@
         <param name="stictionUp">   1.7	        0.8         </param>
         <param name="stictionDown"> -1.7        -1.8        </param>
         <param name="kff">          1           1           </param>
-        <param name="kbemf">        0           0           </param>
+        <param name="viscousPos">   0           0           </param>
+        <param name="viscousNeg">   0           0           </param>
+        <param name="coulombPos">   0           0           </param>
+        <param name="coulombNeg">   0           0           </param>
         <param name="velocityThres">0           0           </param>
         <param name="filterType">   0           0           </param>
         <param name="ktau">         209         160         </param>

--- a/iCubShenzhen01/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
+++ b/iCubShenzhen01/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
@@ -78,6 +78,7 @@
         <param name="stictionDown"> -1.7        -1.8        </param>
         <param name="kff">          1           1           </param>
         <param name="kbemf">        0           0           </param>
+        <param name="velocityThres">0           0           </param>
         <param name="filterType">   0           0           </param>
         <param name="ktau">         209         160         </param>
     </group>

--- a/iCubShenzhen01/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
+++ b/iCubShenzhen01/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0           0           0           0    </param>
         <param name="stictionDown">    0           0           0           0    </param>
         <param name="kff">             0           0           0           0    </param>
-        <param name="kbemf">           0           0           0           0    </param>
+        <param name="viscousPos">      0           0           0           0    </param>
+        <param name="viscousNeg">      0           0           0           0    </param>
+        <param name="coulombPos">      0           0           0           0    </param>
+        <param name="coulombNeg">      0           0           0           0    </param>
         <param name="velocityThres">   0           0           0           0    </param>
         <param name="filterType">      0           0           0           0    </param>
         <param name="ktau">            1           0           0           0    </param>

--- a/iCubShenzhen01/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
+++ b/iCubShenzhen01/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    0           0           0           0    </param>
         <param name="kff">             0           0           0           0    </param>
         <param name="kbemf">           0           0           0           0    </param>
+        <param name="velocityThres">   0           0           0           0    </param>
         <param name="filterType">      0           0           0           0    </param>
         <param name="ktau">            1           0           0           0    </param>
     </group>

--- a/iCubShenzhen01/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
+++ b/iCubShenzhen01/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">   0.7        0.7        0.8        1.2  </param>
         <param name="kff">             1          1          1          1   </param>
         <param name="kbemf">      -0.0030    -0.0006    -0.0007     0.0007  </param>
+        <param name="velocityThres">   0          0          0          0   </param>
         <param name="filterType">      0          0          0          0   </param>
         <param name="ktau">          -180       -464       -463       -449  </param>
     </group>

--- a/iCubShenzhen01/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
+++ b/iCubShenzhen01/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">    -0.5       -0.5       -1         -1.7  </param>
         <param name="stictionDown">   0.7        0.7        0.8        1.2  </param>
         <param name="kff">             1          1          1          1   </param>
-        <param name="kbemf">      -0.0030    -0.0006    -0.0007     0.0007  </param>
+        <param name="viscousPos">     -0.0030    -0.0006    -0.0007     0.0007   </param>
+        <param name="viscousNeg">     -0.0030    -0.0006    -0.0007     0.0007   </param>
+        <param name="coulombPos">      0          0          0          0   </param>
+        <param name="coulombNeg">      0          0          0          0   </param>
         <param name="velocityThres">   0          0          0          0   </param>
         <param name="filterType">      0          0          0          0   </param>
         <param name="ktau">          -180       -464       -463       -449  </param>

--- a/iCubShenzhen01/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
+++ b/iCubShenzhen01/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      2.3       -1.79       1.8        1.2     </param>
         <param name="stictionDown">   -3.3        1.76      -1.4       -1.7     </param>
         <param name="kff">             1          1          1          1       </param>
-        <param name="kbemf">           0          0          0          0       </param>
+        <param name="viscousPos">      0          0          0          0       </param>
+        <param name="viscousNeg">      0          0          0          0       </param>
+        <param name="coulombPos">      0          0          0          0       </param>
+        <param name="coulombNeg">      0          0          0          0       </param>
         <param name="velocityThres">   0          0          0          0       </param>
         <param name="filterType">      0          0          0          0       </param>
        <param name="ktau">             147        -180       217        282     </param>

--- a/iCubShenzhen01/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
+++ b/iCubShenzhen01/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">   -3.3        1.76      -1.4       -1.7     </param>
         <param name="kff">             1          1          1          1       </param>
         <param name="kbemf">           0          0          0          0       </param>
+        <param name="velocityThres">   0          0          0          0       </param>
         <param name="filterType">      0          0          0          0       </param>
        <param name="ktau">             147        -180       217        282     </param>
     </group>

--- a/iCubShenzhen01/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
+++ b/iCubShenzhen01/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">     -1.4        -1.5          </param>
         <param name="stictionDown">    2.4         1.6          </param>
         <param name="kff">             1          1             </param>
-        <param name="kbemf">           0          0             </param>
+        <param name="viscousPos">      0          0             </param>
+        <param name="viscousNeg">      0          0             </param>
+        <param name="coulombPos">      0          0             </param>
+        <param name="coulombNeg">      0          0             </param>
         <param name="velocityThres">   0          0             </param>
         <param name="filterType">      0          0             </param>
         <param name="ktau">            -231       -180          </param>

--- a/iCubShenzhen01/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
+++ b/iCubShenzhen01/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    2.4         1.6          </param>
         <param name="kff">             1          1             </param>
         <param name="kbemf">           0          0             </param>
+        <param name="velocityThres">   0          0             </param>
         <param name="filterType">      0          0             </param>
         <param name="ktau">            -231       -180          </param>
     </group>

--- a/iCubShenzhen01/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubShenzhen01/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0          0          0  </param>
         <param name="stictionDown">   -2         -2         -2  </param>
         <param name="kff">             1          1          1  </param>
-        <param name="kbemf">      -0.0016    -0.003     -0.003  </param>
+        <param name="viscousPos">      -0.0016   -0.003     -0.003  </param>
+        <param name="viscousNeg">      -0.0016   -0.003     -0.003  </param>
+        <param name="coulombPos">      0          0          0  </param>
+        <param name="coulombNeg">      0          0          0  </param>
         <param name="velocityThres">   0          0          0  </param>
         <param name="filterType">      0          0          0  </param>
         <param name="ktau">         -200       -200       -200  </param>

--- a/iCubShenzhen01/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubShenzhen01/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">   -2         -2         -2  </param>
         <param name="kff">             1          1          1  </param>
         <param name="kbemf">      -0.0016    -0.003     -0.003  </param>
+        <param name="velocityThres">   0          0          0  </param>
         <param name="filterType">      0          0          0  </param>
         <param name="ktau">         -200       -200       -200  </param>
     </group>

--- a/iCubSingapore01/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
+++ b/iCubSingapore01/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">         0           0           0           0       </param>
         <param name="kff">                  1           1           1           1       </param>
         <param name="kbemf">                0           0           0           0       </param>
+        <param name="velocityThres">        0           0           0           0       </param>
         <param name="filterType">           0           0           0           0       </param>
         <param name="ktau">                 0           0           0           0       </param>
     </group>

--- a/iCubSingapore01/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
+++ b/iCubSingapore01/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">           0           0           0           0       </param>
         <param name="stictionDown">         0           0           0           0       </param>
         <param name="kff">                  1           1           1           1       </param>
-        <param name="kbemf">                0           0           0           0       </param>
+        <param name="viscousPos">           0           0           0           0       </param>
+        <param name="viscousNeg">           0           0           0           0       </param>
+        <param name="coulombPos">           0           0           0           0       </param>
+        <param name="coulombNeg">           0           0           0           0       </param>
         <param name="velocityThres">        0           0           0           0       </param>
         <param name="filterType">           0           0           0           0       </param>
         <param name="ktau">                 0           0           0           0       </param>

--- a/iCubSingapore01/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
+++ b/iCubSingapore01/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0           0           0           0      </param>
         <param name="stictionDown">    0           0           0           0      </param>
         <param name="kff">             0           0           0           0      </param>
-        <param name="kbemf">           0           0           0           0      </param>
+        <param name="viscousPos">      0           0           0           0      </param>
+        <param name="viscousNeg">      0           0           0           0      </param>
+        <param name="coulombPos">      0           0           0           0      </param>
+        <param name="coulombNeg">      0           0           0           0      </param>
         <param name="velocityThres">   0           0           0           0      </param>
         <param name="filterType">      0           0           0           0      </param>
         <param name="ktau">            0           0           0           0      </param>

--- a/iCubSingapore01/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
+++ b/iCubSingapore01/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    0           0           0           0      </param>
         <param name="kff">             0           0           0           0      </param>
         <param name="kbemf">           0           0           0           0      </param>
+        <param name="velocityThres">   0           0           0           0      </param>
         <param name="filterType">      0           0           0           0      </param>
         <param name="ktau">            0           0           0           0      </param>
     </group>

--- a/iCubSingapore01/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
+++ b/iCubSingapore01/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    0          0          0          0     </param>
         <param name="kff">             1          1          1          1     </param>
         <param name="kbemf">           0          0          0          0     </param>
+        <param name="velocityThres">   0          0          0          0     </param>
         <param name="filterType">      0          0          0          0     </param>
         <param name="ktau">            0          0          0          0     </param>
     </group>

--- a/iCubSingapore01/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
+++ b/iCubSingapore01/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0          0          0          0     </param>
         <param name="stictionDown">    0          0          0          0     </param>
         <param name="kff">             1          1          1          1     </param>
-        <param name="kbemf">           0          0          0          0     </param>
+        <param name="viscousPos">      0          0          0          0     </param>
+        <param name="viscousNeg">      0          0          0          0     </param>
+        <param name="coulombPos">      0          0          0          0     </param>
+        <param name="coulombNeg">      0          0          0          0     </param>
         <param name="velocityThres">   0          0          0          0     </param>
         <param name="filterType">      0          0          0          0     </param>
         <param name="ktau">            0          0          0          0     </param>

--- a/iCubSingapore01/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
+++ b/iCubSingapore01/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown"> 0           0           </param>
         <param name="kff">          1           1           </param>
         <param name="kbemf">        0           0           </param>
+        <param name="velocityThres">0           0           </param>
         <param name="filterType">   0           0           </param>
         <param name="ktau">         0           0           </param>
     </group>

--- a/iCubSingapore01/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
+++ b/iCubSingapore01/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">   0           0           </param>
         <param name="stictionDown"> 0           0           </param>
         <param name="kff">          1           1           </param>
-        <param name="kbemf">        0           0           </param>
+        <param name="viscousPos">   0           0           </param>
+        <param name="viscousNeg">   0           0           </param>
+        <param name="coulombPos">   0           0           </param>
+        <param name="coulombNeg">   0           0           </param>
         <param name="velocityThres">0           0           </param>
         <param name="filterType">   0           0           </param>
         <param name="ktau">         0           0           </param>

--- a/iCubSingapore01/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
+++ b/iCubSingapore01/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0           0           0           0    </param>
         <param name="stictionDown">    0           0           0           0    </param>
         <param name="kff">             0           0           0           0    </param>
-        <param name="kbemf">           0           0           0           0    </param>
+        <param name="viscousPos">      0           0           0           0    </param>
+        <param name="viscousNeg">      0           0           0           0    </param>
+        <param name="coulombPos">      0           0           0           0    </param>
+        <param name="coulombNeg">      0           0           0           0    </param>
         <param name="velocityThres">   0           0           0           0    </param>
         <param name="filterType">      0           0           0           0    </param>
         <param name="ktau">            0           0           0           0    </param>

--- a/iCubSingapore01/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
+++ b/iCubSingapore01/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    0           0           0           0    </param>
         <param name="kff">             0           0           0           0    </param>
         <param name="kbemf">           0           0           0           0    </param>
+        <param name="velocityThres">   0           0           0           0    </param>
         <param name="filterType">      0           0           0           0    </param>
         <param name="ktau">            0           0           0           0    </param>
     </group>

--- a/iCubSingapore01/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
+++ b/iCubSingapore01/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    0          0          0          0   </param>
         <param name="kff">             1          1          1          1   </param>
         <param name="kbemf">           0          0          0          0   </param>
+        <param name="velocityThres">   0          0          0          0   </param>
         <param name="filterType">      0          0          0          0   </param>
         <param name="ktau">            0          0          0          0   </param>
     </group>

--- a/iCubSingapore01/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
+++ b/iCubSingapore01/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0          0          0          0   </param>
         <param name="stictionDown">    0          0          0          0   </param>
         <param name="kff">             1          1          1          1   </param>
-        <param name="kbemf">           0          0          0          0   </param>
+        <param name="viscousPos">      0          0          0          0   </param>
+        <param name="viscousNeg">      0          0          0          0   </param>
+        <param name="coulombPos">      0          0          0          0   </param>
+        <param name="coulombNeg">      0          0          0          0   </param>
         <param name="velocityThres">   0          0          0          0   </param>
         <param name="filterType">      0          0          0          0   </param>
         <param name="ktau">            0          0          0          0   </param>

--- a/iCubSingapore01/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
+++ b/iCubSingapore01/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0          0          0          0       </param>
         <param name="stictionDown">    0          0          0          0       </param>
         <param name="kff">             1          1          1          1       </param>
-        <param name="kbemf">           0          0          0          0       </param>
+        <param name="viscousPos">      0          0          0          0       </param>
+        <param name="viscousNeg">      0          0          0          0       </param>
+        <param name="coulombPos">      0          0          0          0       </param>
+        <param name="coulombNeg">      0          0          0          0       </param>
         <param name="velocityThres">   0          0          0          0       </param>
         <param name="filterType">      0          0          0          0       </param>
         <param name="ktau">            0          0          0          0       </param>

--- a/iCubSingapore01/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
+++ b/iCubSingapore01/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    0          0          0          0       </param>
         <param name="kff">             1          1          1          1       </param>
         <param name="kbemf">           0          0          0          0       </param>
+        <param name="velocityThres">   0          0          0          0       </param>
         <param name="filterType">      0          0          0          0       </param>
         <param name="ktau">            0          0          0          0       </param>
     </group>

--- a/iCubSingapore01/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
+++ b/iCubSingapore01/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    0          0             </param>
         <param name="kff">             1          1             </param>
         <param name="kbemf">           0          0             </param>
+        <param name="velocityThres">   0          0             </param>
         <param name="filterType">      0          0             </param>
         <param name="ktau">            0          0             </param>
     </group>

--- a/iCubSingapore01/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
+++ b/iCubSingapore01/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0          0             </param>
         <param name="stictionDown">    0          0             </param>
         <param name="kff">             1          1             </param>
-        <param name="kbemf">           0          0             </param>
+        <param name="viscousPos">      0          0             </param>
+        <param name="viscousNeg">      0          0             </param>
+        <param name="coulombPos">      0          0             </param>
+        <param name="coulombNeg">      0          0             </param>
         <param name="velocityThres">   0          0             </param>
         <param name="filterType">      0          0             </param>
         <param name="ktau">            0          0             </param>

--- a/iCubSingapore01/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubSingapore01/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0          0          0  </param>
         <param name="stictionDown">    0          0          0  </param>
         <param name="kff">             1          1          1  </param>
-        <param name="kbemf">           0          0          0  </param>
+        <param name="viscousPos">      0          0          0  </param>
+        <param name="viscousNeg">      0          0          0  </param>
+        <param name="coulombPos">      0          0          0  </param>
+        <param name="coulombNeg">      0          0          0  </param>
         <param name="velocityThres">   0          0          0  </param>
         <param name="filterType">      0          0          0  </param>
         <param name="ktau">            0          0          0  </param>

--- a/iCubSingapore01/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubSingapore01/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    0          0          0  </param>
         <param name="kff">             1          1          1  </param>
         <param name="kbemf">           0          0          0  </param>
+        <param name="velocityThres">   0          0          0  </param>
         <param name="filterType">      0          0          0  </param>
         <param name="ktau">            0          0          0  </param>
     </group>

--- a/iCubTemplates/iCubTemplateV3_0/hardware/motorControl/body_part--ebX-jA_B-mc.xml
+++ b/iCubTemplates/iCubTemplateV3_0/hardware/motorControl/body_part--ebX-jA_B-mc.xml
@@ -101,10 +101,14 @@
         <param name="trq_ko">            Openloop output [expressed in PWM raw units] </param>       
         <param name="trq_stictionUp">    Not used at present.                      </param>       
         <param name="trq_stictionDwn">   Not used at present.                      </param>    
-        <param name="trq_kff">           Feed forward torque part [expressed in pwm_raw/Nm]</param>  
-        <param name="trq_kbemf">         Friction compensation [expressed in pwm_raw/(degrees/sec)]    </param>    
+        <param name="trq_kff">           Feed forward torque part [expressed in pwm_raw/Nm]</param>
+        <param name="velocityThres">0   </param>   <!-- Velocity threshold for friction compensation [expressed in icubdegrees/sec] -->
+        <param name="viscousPos">   0   </param>   <!-- Viscous constant used for friction (positive direction )                    -->
+        <param name="viscousNeg">   0   </param>   <!-- Viscous constant used for friction (negative direction )                    -->
+        <param name="coulombPos">   0   </param>   <!-- Coulomb constant used for friction (positive direction )                    -->
+        <param name="coulombNeg">   0   </param>   <!-- Coulomb constant used for friction (negative direction )                    -->
         <param name="trq_filterType">    Low pass filter on output 0=no filter 1=3 HZ 2=1.1 Hz 3=0.8 Hz 4=0.5 Hz </param>    
-        <param name="trq_ktau">          Gain on Kff and Kbemf parts (usually 1) [adimensional] </param>             
+        <param name="trq_ktau">          Gain on Kff part [adimensional] </param>             
     </group>
     
     
@@ -122,8 +126,11 @@
         <param name="trq_stictionUp">    Not used.      </param>       
         <param name="trq_stictionDwn">   Not used.      </param>    
         <param name="trq_kff">           Not used.      </param>  
-        <param name="trq_kbemf">         Not used.      </param>    
-        <param name="trq_filterType">    Not used.      </param>    
+        <param name="velocityThres">0   </param>   <!-- Velocity threshold for friction compensation [expressed in icubdegrees/sec] -->
+        <param name="viscousPos">   0   </param>   <!-- Viscous constant used for friction (positive direction )                    -->
+        <param name="viscousNeg">   0   </param>   <!-- Viscous constant used for friction (negative direction )                    -->
+        <param name="coulombPos">   0   </param>   <!-- Coulomb constant used for friction (positive direction )                    -->
+        <param name="coulombNeg">   0   </param>   <!-- Coulomb constant used for friction (negative direction )                    -->        <param name="trq_filterType">    Not used.      </param>    
         <param name="trq_ktau">          Not used.      </param>  
         <param name="vel_kp">            Velocity inner loop proportional part constant [expressed in pwm_raw/(icubdegrees/msec)]   </param>       
         <param name="vel_kd">            Velocity inner loop derivative part constant [expressed in pwm_raw/(icubdegrees/msec^2)]   </param>       

--- a/iCubTemplates/iCubTemplateV4_0/hardware/motorControl/body_part--ebX-jA_B-mc.xml
+++ b/iCubTemplates/iCubTemplateV4_0/hardware/motorControl/body_part--ebX-jA_B-mc.xml
@@ -102,9 +102,13 @@
         <param name="trq_stictionUp">    Not used at present.                      </param>       
         <param name="trq_stictionDwn">   Not used at present.                      </param>    
         <param name="trq_kff">           Feed forward torque part [expressed in pwm_raw/Nm]</param>  
-        <param name="trq_kbemf">         Friction compensation [expressed in pwm_raw/(degrees/sec)]    </param>    
+        <param name="velocityThres">0   </param>   <!-- Velocity threshold for friction compensation [expressed in icubdegrees/sec] -->
+        <param name="viscousPos">   0   </param>   <!-- Viscous constant used for friction (positive direction )                    -->
+        <param name="viscousNeg">   0   </param>   <!-- Viscous constant used for friction (negative direction )                    -->
+        <param name="coulombPos">   0   </param>   <!-- Coulomb constant used for friction (positive direction )                    -->
+        <param name="coulombNeg">   0   </param>   <!-- Coulomb constant used for friction (negative direction )                    -->
         <param name="trq_filterType">    Low pass filter on output 0=no filter 1=3 HZ 2=1.1 Hz 3=0.8 Hz 4=0.5 Hz </param>    
-        <param name="trq_ktau">          Gain on Kff and Kbemf parts (usually 1) [adimensional] </param>             
+        <param name="trq_ktau">          Gain on Kff part [adimensional] </param>             
     </group>
     
     
@@ -122,7 +126,11 @@
         <param name="trq_stictionUp">    Not used.      </param>       
         <param name="trq_stictionDwn">   Not used.      </param>    
         <param name="trq_kff">           Not used.      </param>  
-        <param name="trq_kbemf">         Not used.      </param>    
+        <param name="velocityThres">0   </param>   <!-- Velocity threshold for friction compensation [expressed in icubdegrees/sec] -->
+        <param name="viscousPos">   0   </param>   <!-- Viscous constant used for friction (positive direction )                    -->
+        <param name="viscousNeg">   0   </param>   <!-- Viscous constant used for friction (negative direction )                    -->
+        <param name="coulombPos">   0   </param>   <!-- Coulomb constant used for friction (positive direction )                    -->
+        <param name="coulombNeg">   0   </param>   <!-- Coulomb constant used for friction (negative direction )                    -->
         <param name="trq_filterType">    Not used.      </param>    
         <param name="trq_ktau">          Not used.      </param>  
         <param name="vel_kp">            Velocity inner loop proportional part constant [expressed in pwm_raw/(icubdegrees/msec)]   </param>       

--- a/iCubTemplates/iCubTemplateV5_0/hardware/motorControl/body_part--ebX-jA_B-mc.xml
+++ b/iCubTemplates/iCubTemplateV5_0/hardware/motorControl/body_part--ebX-jA_B-mc.xml
@@ -90,9 +90,13 @@
         <param name="trq_stictionUp">      0      </param> <!-- Not used at present.                                                    -->
         <param name="trq_stictionDwn">     0      </param> <!-- Not used at present.                                                    -->
         <param name="trq_kff">             0      </param> <!-- Feed forward torque part [expressed in pwm_raw/Nm]                      -->
-        <param name="trq_kbemf">           0      </param> <!-- Friction compensation [expressed in pwm_raw/(degrees/sec)]              -->
+        <param name="velocityThres">0   </param>   <!-- Velocity threshold for friction compensation [expressed in icubdegrees/sec] -->
+        <param name="viscousPos">   0   </param>   <!-- Viscous constant used for friction (positive direction )                    -->
+        <param name="viscousNeg">   0   </param>   <!-- Viscous constant used for friction (negative direction )                    -->
+        <param name="coulombPos">   0   </param>   <!-- Coulomb constant used for friction (positive direction )                    -->
+        <param name="coulombNeg">   0   </param>   <!-- Coulomb constant used for friction (negative direction )                    -->
         <param name="trq_filterType">      0      </param> <!-- Low pass filter on output 0=no filter 1=3 HZ 2=1.1 Hz 3=0.8 Hz 4=0.5 Hz -->
-        <param name="trq_ktau">            0      </param> <!-- Gain on Kff and Kbemf parts (usually 1) [adimensional]                  -->
+        <param name="trq_ktau">            0      </param> <!-- Gain on Kff [adimensional]                  -->
     </group>
 
     <group name="MY_TRQ_VEL_CTRL">
@@ -109,7 +113,11 @@
         <param name="trq_stictionUp">      0      </param> <!-- Not used. -->
         <param name="trq_stictionDwn">     0      </param> <!-- Not used. -->
         <param name="trq_kff">             0      </param> <!-- Not used. -->
-        <param name="trq_kbemf">           0      </param> <!-- Not used. -->
+        <param name="velocityThres">0   </param>   <!-- Velocity threshold for friction compensation [expressed in icubdegrees/sec] -->
+        <param name="viscousPos">   0   </param>   <!-- Viscous constant used for friction (positive direction )                    -->
+        <param name="viscousNeg">   0   </param>   <!-- Viscous constant used for friction (negative direction )                    -->
+        <param name="coulombPos">   0   </param>   <!-- Coulomb constant used for friction (positive direction )                    -->
+        <param name="coulombNeg">   0   </param>   <!-- Coulomb constant used for friction (negative direction )                    -->
         <param name="trq_filterType">      0      </param> <!-- Not used. -->
         <param name="trq_ktau">            0      </param> <!-- Not used. -->
         <param name="vel_kp">              0      </param> <!-- Velocity inner loop proportional part constant [expressed in pwm_raw/(icubdegrees/msec)] -->

--- a/iCubTemplates/iCubTemplateV6_0/hardware/motorControl/body_part--ebX-jA_B-mc.xml
+++ b/iCubTemplates/iCubTemplateV6_0/hardware/motorControl/body_part--ebX-jA_B-mc.xml
@@ -116,13 +116,14 @@
         <param name="ki">           0   </param>   <!-- Integral part of the PID control loop [expressed in pwm_raw/(Nm*sec)]                                -->
         <param name="maxOutput">    0   </param>   <!-- Limit on PID output [expressed in PWM raw units]                                                     -->
         <param name="maxInt">       0   </param>   <!-- Anti-windup limit on PID integral part [expressed in PWM raw units]                                  -->
-        <param name="ko">           0   </param>   <!-- Openloop output [expressed in PWM raw units]                            -->
-        <param name="stictionUp">   0   </param>   <!-- Not used at present.                                                    -->
-        <param name="stictionDown"> 0   </param>   <!-- Not used at present.                                                    -->
-        <param name="kff">          0   </param>   <!-- Feed forward torque part [expressed in pwm_raw/Nm]                      -->
-        <param name="kbemf">        0   </param>   <!-- Friction compensation [expressed in pwm_raw/(degrees/sec)]              -->
-        <param name="filterType">   0   </param>   <!-- Low pass filter on output 0=no filter 1=3 HZ 2=1.1 Hz 3=0.8 Hz 4=0.5 Hz -->
-        <param name="ktau">         0   </param>   <!-- Gain on Kff and Kbemf parts (usually 1) [adimensional]                  -->
+        <param name="ko">           0   </param>   <!-- Openloop output [expressed in PWM raw units]                                -->
+        <param name="stictionUp">   0   </param>   <!-- Not used at present.                                                        -->
+        <param name="stictionDown"> 0   </param>   <!-- Not used at present.                                                        -->
+        <param name="kff">          0   </param>   <!-- Feed forward torque part [expressed in pwm_raw/Nm]                          -->
+        <param name="kbemf">        0   </param>   <!-- Friction compensation [expressed in pwm_raw/(degrees/sec)]                  -->
+        <param name="velocityThres">0   </param>   <!-- Velocity threshold for friction compensation [expressed in icubdegrees/sec] -->
+        <param name="filterType">   0   </param>   <!-- Low pass filter on output 0=no filter 1=3 HZ 2=1.1 Hz 3=0.8 Hz 4=0.5 Hz     -->
+        <param name="ktau">         0   </param>   <!-- Gain on Kff and Kbemf parts (usually 1) [adimensional]                      -->
      </group>                                      
 
     <group name="IMPEDANCE">

--- a/iCubTemplates/iCubTemplateV6_0/hardware/motorControl/body_part--ebX-jA_B-mc.xml
+++ b/iCubTemplates/iCubTemplateV6_0/hardware/motorControl/body_part--ebX-jA_B-mc.xml
@@ -120,10 +120,13 @@
         <param name="stictionUp">   0   </param>   <!-- Not used at present.                                                        -->
         <param name="stictionDown"> 0   </param>   <!-- Not used at present.                                                        -->
         <param name="kff">          0   </param>   <!-- Feed forward torque part [expressed in pwm_raw/Nm]                          -->
-        <param name="kbemf">        0   </param>   <!-- Friction compensation [expressed in pwm_raw/(degrees/sec)]                  -->
         <param name="velocityThres">0   </param>   <!-- Velocity threshold for friction compensation [expressed in icubdegrees/sec] -->
+        <param name="viscousPos">   0   </param>   <!-- Viscous constant used for friction (positive direction )                    -->
+        <param name="viscousNeg">   0   </param>   <!-- Viscous constant used for friction (negative direction )                    -->
+        <param name="coulombPos">   0   </param>   <!-- Coulomb constant used for friction (positive direction )                    -->
+        <param name="coulombNeg">   0   </param>   <!-- Coulomb constant used for friction (negative direction )                    -->
         <param name="filterType">   0   </param>   <!-- Low pass filter on output 0=no filter 1=3 HZ 2=1.1 Hz 3=0.8 Hz 4=0.5 Hz     -->
-        <param name="ktau">         0   </param>   <!-- Gain on Kff and Kbemf parts (usually 1) [adimensional]                      -->
+        <param name="ktau">         0   </param>   <!-- Gain on Kff part [adimensional]                      -->
      </group>                                      
 
     <group name="IMPEDANCE">

--- a/iCubValparaiso01/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
+++ b/iCubValparaiso01/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">         -0.7        -0.7       -0.8         -1.2    </param>
         <param name="kff">                  1           1           1           1       </param>
         <param name="kbemf">                0.0030      0.0006      0.0007      0.0007  </param>
+        <param name="velocityThres">        0           0           0           0       </param>
         <param name="filterType">           0           0           0           0       </param>
         <param name="ktau">                 180         464         463         449     </param>
     </group>

--- a/iCubValparaiso01/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
+++ b/iCubValparaiso01/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">           0.5         0.5         1           1.7     </param>
         <param name="stictionDown">         -0.7        -0.7       -0.8         -1.2    </param>
         <param name="kff">                  1           1           1           1       </param>
-        <param name="kbemf">                0.0030      0.0006      0.0007      0.0007  </param>
+        <param name="viscousPos">           0.0030      0.0006      0.0007      0.0007  </param>
+        <param name="viscousNeg">           0.0030      0.0006      0.0007      0.0007  </param>
+        <param name="coulombPos">           0           0           0           0       </param>
+        <param name="coulombNeg">           0           0           0           0       </param>
         <param name="velocityThres">        0           0           0           0       </param>
         <param name="filterType">           0           0           0           0       </param>
         <param name="ktau">                 180         464         463         449     </param>

--- a/iCubValparaiso01/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
+++ b/iCubValparaiso01/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    0           0           0           0      </param>
         <param name="kff">             0           0           0           0      </param>
         <param name="kbemf">           0           0           0           0      </param>
+        <param name="velocityThres">   0           0           0           0      </param>
         <param name="filterType">      0           0           0           0      </param>
         <param name="ktau">            1           0           0           0      </param>
     </group>

--- a/iCubValparaiso01/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
+++ b/iCubValparaiso01/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0           0           0           0      </param>
         <param name="stictionDown">    0           0           0           0      </param>
         <param name="kff">             0           0           0           0      </param>
-        <param name="kbemf">           0           0           0           0      </param>
+        <param name="viscousPos">      0           0           0           0      </param>
+        <param name="viscousNeg">      0           0           0           0      </param>
+        <param name="coulombPos">      0           0           0           0      </param>
+        <param name="coulombNeg">      0           0           0           0      </param>
         <param name="velocityThres">   0           0           0           0      </param>
         <param name="filterType">      0           0           0           0      </param>
         <param name="ktau">            1           0           0           0      </param>

--- a/iCubValparaiso01/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
+++ b/iCubValparaiso01/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">     -2.0        2.0       -1.0       -1.0   </param>
         <param name="stictionDown">    1.4       -2.0        1.3        0.2   </param>
         <param name="kff">             1          1          1          1     </param>
-        <param name="kbemf">           0          0          0          0     </param>
+        <param name="viscousPos">      0          0          0          0     </param>
+        <param name="viscousNeg">      0          0          0          0     </param>
+        <param name="coulombPos">      0          0          0          0     </param>
+        <param name="coulombNeg">      0          0          0          0     </param>
         <param name="velocityThres">   0          0          0          0     </param>
         <param name="filterType">      0          0          0          0     </param>
         <param name="ktau">            -162        178       -197       -167  </param>

--- a/iCubValparaiso01/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
+++ b/iCubValparaiso01/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    1.4       -2.0        1.3        0.2   </param>
         <param name="kff">             1          1          1          1     </param>
         <param name="kbemf">           0          0          0          0     </param>
+        <param name="velocityThres">   0          0          0          0     </param>
         <param name="filterType">      0          0          0          0     </param>
         <param name="ktau">            -162        178       -197       -167  </param>
     </group>

--- a/iCubValparaiso01/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
+++ b/iCubValparaiso01/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
@@ -77,7 +77,10 @@
         <param name="stictionUp">   1.7	        0.8         </param>
         <param name="stictionDown"> -1.7        -1.8        </param>
         <param name="kff">          1           1           </param>
-        <param name="kbemf">        0           0           </param>
+        <param name="viscousPos">   0           0           </param>
+        <param name="viscousNeg">   0           0           </param>
+        <param name="coulombPos">   0           0           </param>
+        <param name="coulombNeg">   0           0           </param>
         <param name="velocityThres">0           0           </param>
         <param name="filterType">   0           0           </param>
         <param name="ktau">         209         160         </param>

--- a/iCubValparaiso01/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
+++ b/iCubValparaiso01/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
@@ -78,6 +78,7 @@
         <param name="stictionDown"> -1.7        -1.8        </param>
         <param name="kff">          1           1           </param>
         <param name="kbemf">        0           0           </param>
+        <param name="velocityThres">0           0           </param>
         <param name="filterType">   0           0           </param>
         <param name="ktau">         209         160         </param>
     </group>

--- a/iCubValparaiso01/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
+++ b/iCubValparaiso01/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0           0           0           0    </param>
         <param name="stictionDown">    0           0           0           0    </param>
         <param name="kff">             0           0           0           0    </param>
-        <param name="kbemf">           0           0           0           0    </param>
+        <param name="viscousPos">      0           0           0           0    </param>
+        <param name="viscousNeg">      0           0           0           0    </param>
+        <param name="coulombPos">      0           0           0           0    </param>
+        <param name="coulombNeg">      0           0           0           0    </param>
         <param name="velocityThres">   0           0           0           0    </param>
         <param name="filterType">      0           0           0           0    </param>
         <param name="ktau">            1           0           0           0    </param>

--- a/iCubValparaiso01/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
+++ b/iCubValparaiso01/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    0           0           0           0    </param>
         <param name="kff">             0           0           0           0    </param>
         <param name="kbemf">           0           0           0           0    </param>
+        <param name="velocityThres">   0           0           0           0    </param>
         <param name="filterType">      0           0           0           0    </param>
         <param name="ktau">            1           0           0           0    </param>
     </group>

--- a/iCubValparaiso01/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
+++ b/iCubValparaiso01/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">   0.7        0.7        0.8        1.2  </param>
         <param name="kff">             1          1          1          1   </param>
         <param name="kbemf">      -0.0030    -0.0006    -0.0007     0.0007  </param>
+        <param name="velocityThres">   0          0          0          0   </param>
         <param name="filterType">      0          0          0          0   </param>
         <param name="ktau">          -180       -464       -463       -449  </param>
     </group>

--- a/iCubValparaiso01/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
+++ b/iCubValparaiso01/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">    -0.5       -0.5       -1         -1.7  </param>
         <param name="stictionDown">   0.7        0.7        0.8        1.2  </param>
         <param name="kff">             1          1          1          1   </param>
-        <param name="kbemf">      -0.0030    -0.0006    -0.0007     0.0007  </param>
+        <param name="viscousPos">     -0.0030    -0.0006    -0.0007     0.0007   </param>
+        <param name="viscousNeg">     -0.0030    -0.0006    -0.0007     0.0007   </param>
+        <param name="coulombPos">      0          0          0          0   </param>
+        <param name="coulombNeg">      0          0          0          0   </param>
         <param name="velocityThres">   0          0          0          0   </param>
         <param name="filterType">      0          0          0          0   </param>
         <param name="ktau">          -180       -464       -463       -449  </param>

--- a/iCubValparaiso01/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
+++ b/iCubValparaiso01/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      2.3       -1.79       1.8        1.2     </param>
         <param name="stictionDown">   -3.3        1.76      -1.4       -1.7     </param>
         <param name="kff">             1          1          1          1       </param>
-        <param name="kbemf">           0          0          0          0       </param>
+        <param name="viscousPos">      0          0          0          0       </param>
+        <param name="viscousNeg">      0          0          0          0       </param>
+        <param name="coulombPos">      0          0          0          0       </param>
+        <param name="coulombNeg">      0          0          0          0       </param>
         <param name="velocityThres">   0          0          0          0       </param>
         <param name="filterType">      0          0          0          0       </param>
        <param name="ktau">             147        -180       217        282     </param>

--- a/iCubValparaiso01/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
+++ b/iCubValparaiso01/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">   -3.3        1.76      -1.4       -1.7     </param>
         <param name="kff">             1          1          1          1       </param>
         <param name="kbemf">           0          0          0          0       </param>
+        <param name="velocityThres">   0          0          0          0       </param>
         <param name="filterType">      0          0          0          0       </param>
        <param name="ktau">             147        -180       217        282     </param>
     </group>

--- a/iCubValparaiso01/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
+++ b/iCubValparaiso01/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">     -1.4        -1.5          </param>
         <param name="stictionDown">    2.4         1.6          </param>
         <param name="kff">             1          1             </param>
-        <param name="kbemf">           0          0             </param>
+        <param name="viscousPos">      0          0             </param>
+        <param name="viscousNeg">      0          0             </param>
+        <param name="coulombPos">      0          0             </param>
+        <param name="coulombNeg">      0          0             </param>
         <param name="velocityThres">   0          0             </param>
         <param name="filterType">      0          0             </param>
         <param name="ktau">            -231       -180          </param>

--- a/iCubValparaiso01/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
+++ b/iCubValparaiso01/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    2.4         1.6          </param>
         <param name="kff">             1          1             </param>
         <param name="kbemf">           0          0             </param>
+        <param name="velocityThres">   0          0             </param>
         <param name="filterType">      0          0             </param>
         <param name="ktau">            -231       -180          </param>
     </group>

--- a/iCubValparaiso01/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubValparaiso01/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0          0          0  </param>
         <param name="stictionDown">   -2         -2         -2  </param>
         <param name="kff">             1          1          1  </param>
-        <param name="kbemf">      -0.0016    -0.003     -0.003  </param>
+        <param name="viscousPos">      -0.0016   -0.003     -0.003  </param>
+        <param name="viscousNeg">      -0.0016   -0.003     -0.003  </param>
+        <param name="coulombPos">      0          0          0  </param>
+        <param name="coulombNeg">      0          0          0  </param>
         <param name="velocityThres">   0          0          0  </param>
         <param name="filterType">      0          0          0  </param>
         <param name="ktau">         -200       -200       -200  </param>

--- a/iCubValparaiso01/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubValparaiso01/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">   -2         -2         -2  </param>
         <param name="kff">             1          1          1  </param>
         <param name="kbemf">      -0.0016    -0.003     -0.003  </param>
+        <param name="velocityThres">   0          0          0  </param>
         <param name="filterType">      0          0          0  </param>
         <param name="ktau">         -200       -200       -200  </param>
     </group>

--- a/iCubWaterloo01/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
+++ b/iCubWaterloo01/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">         -0.7        -0.7       -0.8         -1.2    </param>
         <param name="kff">                  1           1           1           1       </param>
         <param name="kbemf">                0.0030      0.0006      0.0007      0.0007  </param>
+        <param name="velocityThres">        0           0           0           0       </param>
         <param name="filterType">           0           0           0           0       </param>
         <param name="ktau">                 180         464         463         449     </param>
     </group>

--- a/iCubWaterloo01/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
+++ b/iCubWaterloo01/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">           0.5         0.5         1           1.7     </param>
         <param name="stictionDown">         -0.7        -0.7       -0.8         -1.2    </param>
         <param name="kff">                  1           1           1           1       </param>
-        <param name="kbemf">                0.0030      0.0006      0.0007      0.0007  </param>
+        <param name="viscousPos">           0.0030      0.0006      0.0007      0.0007  </param>
+        <param name="viscousNeg">           0.0030      0.0006      0.0007      0.0007  </param>
+        <param name="coulombPos">           0           0           0           0       </param>
+        <param name="coulombNeg">           0           0           0           0       </param>
         <param name="velocityThres">        0           0           0           0       </param>
         <param name="filterType">           0           0           0           0       </param>
         <param name="ktau">                 180         464         463         449     </param>

--- a/iCubWaterloo01/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
+++ b/iCubWaterloo01/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    0           0           0           0      </param>
         <param name="kff">             0           0           0           0      </param>
         <param name="kbemf">           0           0           0           0      </param>
+        <param name="velocityThres">   0           0           0           0      </param>
         <param name="filterType">      0           0           0           0      </param>
         <param name="ktau">            1           0           0           0      </param>
     </group>

--- a/iCubWaterloo01/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
+++ b/iCubWaterloo01/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0           0           0           0      </param>
         <param name="stictionDown">    0           0           0           0      </param>
         <param name="kff">             0           0           0           0      </param>
-        <param name="kbemf">           0           0           0           0      </param>
+        <param name="viscousPos">      0           0           0           0      </param>
+        <param name="viscousNeg">      0           0           0           0      </param>
+        <param name="coulombPos">      0           0           0           0      </param>
+        <param name="coulombNeg">      0           0           0           0      </param>
         <param name="velocityThres">   0           0           0           0      </param>
         <param name="filterType">      0           0           0           0      </param>
         <param name="ktau">            1           0           0           0      </param>

--- a/iCubWaterloo01/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
+++ b/iCubWaterloo01/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">     -2.0        2.0       -1.0       -1.0   </param>
         <param name="stictionDown">    1.4       -2.0        1.3        0.2   </param>
         <param name="kff">             1          1          1          1     </param>
-        <param name="kbemf">           0          0          0          0     </param>
+        <param name="viscousPos">      0          0          0          0     </param>
+        <param name="viscousNeg">      0          0          0          0     </param>
+        <param name="coulombPos">      0          0          0          0     </param>
+        <param name="coulombNeg">      0          0          0          0     </param>
         <param name="velocityThres">   0          0          0          0     </param>
         <param name="filterType">      0          0          0          0     </param>
         <param name="ktau">            -162        178       -197       -167  </param>

--- a/iCubWaterloo01/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
+++ b/iCubWaterloo01/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    1.4       -2.0        1.3        0.2   </param>
         <param name="kff">             1          1          1          1     </param>
         <param name="kbemf">           0          0          0          0     </param>
+        <param name="velocityThres">   0          0          0          0     </param>
         <param name="filterType">      0          0          0          0     </param>
         <param name="ktau">            -162        178       -197       -167  </param>
     </group>

--- a/iCubWaterloo01/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
+++ b/iCubWaterloo01/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
@@ -77,7 +77,10 @@
         <param name="stictionUp">   1.7	        0.8         </param>
         <param name="stictionDown"> -1.7        -1.8        </param>
         <param name="kff">          1           1           </param>
-        <param name="kbemf">        0           0           </param>
+        <param name="viscousPos">   0           0           </param>
+        <param name="viscousNeg">   0           0           </param>
+        <param name="coulombPos">   0           0           </param>
+        <param name="coulombNeg">   0           0           </param>
         <param name="velocityThres">0           0           </param>
         <param name="filterType">   0           0           </param>
         <param name="ktau">         209         160         </param>

--- a/iCubWaterloo01/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
+++ b/iCubWaterloo01/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
@@ -78,6 +78,7 @@
         <param name="stictionDown"> -1.7        -1.8        </param>
         <param name="kff">          1           1           </param>
         <param name="kbemf">        0           0           </param>
+        <param name="velocityThres">0           0           </param>
         <param name="filterType">   0           0           </param>
         <param name="ktau">         209         160         </param>
     </group>

--- a/iCubWaterloo01/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
+++ b/iCubWaterloo01/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0           0           0           0    </param>
         <param name="stictionDown">    0           0           0           0    </param>
         <param name="kff">             0           0           0           0    </param>
-        <param name="kbemf">           0           0           0           0    </param>
+        <param name="viscousPos">      0           0           0           0    </param>
+        <param name="viscousNeg">      0           0           0           0    </param>
+        <param name="coulombPos">      0           0           0           0    </param>
+        <param name="coulombNeg">      0           0           0           0    </param>
         <param name="velocityThres">   0           0           0           0    </param>
         <param name="filterType">      0           0           0           0    </param>
         <param name="ktau">            1           0           0           0    </param>

--- a/iCubWaterloo01/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
+++ b/iCubWaterloo01/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    0           0           0           0    </param>
         <param name="kff">             0           0           0           0    </param>
         <param name="kbemf">           0           0           0           0    </param>
+        <param name="velocityThres">   0           0           0           0    </param>
         <param name="filterType">      0           0           0           0    </param>
         <param name="ktau">            1           0           0           0    </param>
     </group>

--- a/iCubWaterloo01/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
+++ b/iCubWaterloo01/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">   0.7        0.7        0.8        1.2  </param>
         <param name="kff">             1          1          1          1   </param>
         <param name="kbemf">      -0.0030    -0.0006    -0.0007     0.0007  </param>
+        <param name="velocityThres">   0          0          0          0   </param>
         <param name="filterType">      0          0          0          0   </param>
         <param name="ktau">          -180       -464       -463       -449  </param>
     </group>

--- a/iCubWaterloo01/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
+++ b/iCubWaterloo01/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">    -0.5       -0.5       -1         -1.7  </param>
         <param name="stictionDown">   0.7        0.7        0.8        1.2  </param>
         <param name="kff">             1          1          1          1   </param>
-        <param name="kbemf">      -0.0030    -0.0006    -0.0007     0.0007  </param>
+        <param name="viscousPos">     -0.0030    -0.0006    -0.0007     0.0007   </param>
+        <param name="viscousNeg">     -0.0030    -0.0006    -0.0007     0.0007   </param>
+        <param name="coulombPos">      0          0          0          0   </param>
+        <param name="coulombNeg">      0          0          0          0   </param>
         <param name="velocityThres">   0          0          0          0   </param>
         <param name="filterType">      0          0          0          0   </param>
         <param name="ktau">          -180       -464       -463       -449  </param>

--- a/iCubWaterloo01/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
+++ b/iCubWaterloo01/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      2.3       -1.79       1.8        1.2     </param>
         <param name="stictionDown">   -3.3        1.76      -1.4       -1.7     </param>
         <param name="kff">             1          1          1          1       </param>
-        <param name="kbemf">           0          0          0          0       </param>
+        <param name="viscousPos">      0          0          0          0       </param>
+        <param name="viscousNeg">      0          0          0          0       </param>
+        <param name="coulombPos">      0          0          0          0       </param>
+        <param name="coulombNeg">      0          0          0          0       </param>
         <param name="velocityThres">   0          0          0          0       </param>
         <param name="filterType">      0          0          0          0       </param>
        <param name="ktau">             147        -180       217        282     </param>

--- a/iCubWaterloo01/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
+++ b/iCubWaterloo01/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">   -3.3        1.76      -1.4       -1.7     </param>
         <param name="kff">             1          1          1          1       </param>
         <param name="kbemf">           0          0          0          0       </param>
+        <param name="velocityThres">   0          0          0          0       </param>
         <param name="filterType">      0          0          0          0       </param>
        <param name="ktau">             147        -180       217        282     </param>
     </group>

--- a/iCubWaterloo01/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
+++ b/iCubWaterloo01/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">     -1.4        -1.5          </param>
         <param name="stictionDown">    2.4         1.6          </param>
         <param name="kff">             1          1             </param>
-        <param name="kbemf">           0          0             </param>
+        <param name="viscousPos">      0          0             </param>
+        <param name="viscousNeg">      0          0             </param>
+        <param name="coulombPos">      0          0             </param>
+        <param name="coulombNeg">      0          0             </param>
         <param name="velocityThres">   0          0             </param>
         <param name="filterType">      0          0             </param>
         <param name="ktau">            -231       -180          </param>

--- a/iCubWaterloo01/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
+++ b/iCubWaterloo01/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    2.4         1.6          </param>
         <param name="kff">             1          1             </param>
         <param name="kbemf">           0          0             </param>
+        <param name="velocityThres">   0          0             </param>
         <param name="filterType">      0          0             </param>
         <param name="ktau">            -231       -180          </param>
     </group>

--- a/iCubWaterloo01/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubWaterloo01/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0          0          0  </param>
         <param name="stictionDown">   -2         -2         -2  </param>
         <param name="kff">             1          1          1  </param>
-        <param name="kbemf">      -0.0016    -0.003     -0.003  </param>
+        <param name="viscousPos">      -0.0016   -0.003     -0.003  </param>
+        <param name="viscousNeg">      -0.0016   -0.003     -0.003  </param>
+        <param name="coulombPos">      0          0          0  </param>
+        <param name="coulombNeg">      0          0          0  </param>
         <param name="velocityThres">   0          0          0  </param>
         <param name="filterType">      0          0          0  </param>
         <param name="ktau">         -200       -200       -200  </param>

--- a/iCubWaterloo01/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubWaterloo01/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">   -2         -2         -2  </param>
         <param name="kff">             1          1          1  </param>
         <param name="kbemf">      -0.0016    -0.003     -0.003  </param>
+        <param name="velocityThres">   0          0          0  </param>
         <param name="filterType">      0          0          0  </param>
         <param name="ktau">         -200       -200       -200  </param>
     </group>

--- a/iCubZagreb01/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
+++ b/iCubZagreb01/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">         -0.7        -0.7       -0.8         -1.2    </param>
         <param name="kff">                  1           1           1           1       </param>
         <param name="kbemf">                0.0030      0.0006      0.0007      0.0007  </param>
+        <param name="velocityThres">        0           0           0           0       </param>
         <param name="filterType">           0           0           0           0       </param>
         <param name="ktau">                 180         464         463         449     </param>
     </group>

--- a/iCubZagreb01/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
+++ b/iCubZagreb01/hardware/motorControl/left_arm-eb1-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">           0.5         0.5         1           1.7     </param>
         <param name="stictionDown">         -0.7        -0.7       -0.8         -1.2    </param>
         <param name="kff">                  1           1           1           1       </param>
-        <param name="kbemf">                0.0030      0.0006      0.0007      0.0007  </param>
+        <param name="viscousPos">           0.0030      0.0006      0.0007      0.0007  </param>
+        <param name="viscousNeg">           0.0030      0.0006      0.0007      0.0007  </param>
+        <param name="coulombPos">           0           0           0           0       </param>
+        <param name="coulombNeg">           0           0           0           0       </param>
         <param name="velocityThres">        0           0           0           0       </param>
         <param name="filterType">           0           0           0           0       </param>
         <param name="ktau">                 180         464         463         449     </param>

--- a/iCubZagreb01/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
+++ b/iCubZagreb01/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    0           0           0           0      </param>
         <param name="kff">             0           0           0           0      </param>
         <param name="kbemf">           0           0           0           0      </param>
+        <param name="velocityThres">   0           0           0           0      </param>
         <param name="filterType">      0           0           0           0      </param>
         <param name="ktau">            1           0           0           0      </param>
     </group>

--- a/iCubZagreb01/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
+++ b/iCubZagreb01/hardware/motorControl/left_arm-eb24-j4_7-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0           0           0           0      </param>
         <param name="stictionDown">    0           0           0           0      </param>
         <param name="kff">             0           0           0           0      </param>
-        <param name="kbemf">           0           0           0           0      </param>
+        <param name="viscousPos">      0           0           0           0      </param>
+        <param name="viscousNeg">      0           0           0           0      </param>
+        <param name="coulombPos">      0           0           0           0      </param>
+        <param name="coulombNeg">      0           0           0           0      </param>
         <param name="velocityThres">   0           0           0           0      </param>
         <param name="filterType">      0           0           0           0      </param>
         <param name="ktau">            1           0           0           0      </param>

--- a/iCubZagreb01/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
+++ b/iCubZagreb01/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">     -2.0        2.0       -1.0       -1.0   </param>
         <param name="stictionDown">    1.4       -2.0        1.3        0.2   </param>
         <param name="kff">             1          1          1          1     </param>
-        <param name="kbemf">           0          0          0          0     </param>
+        <param name="viscousPos">      0          0          0          0     </param>
+        <param name="viscousNeg">      0          0          0          0     </param>
+        <param name="coulombPos">      0          0          0          0     </param>
+        <param name="coulombNeg">      0          0          0          0     </param>
         <param name="velocityThres">   0          0          0          0     </param>
         <param name="filterType">      0          0          0          0     </param>
         <param name="ktau">            -162        178       -197       -167  </param>

--- a/iCubZagreb01/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
+++ b/iCubZagreb01/hardware/motorControl/left_leg-eb6-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    1.4       -2.0        1.3        0.2   </param>
         <param name="kff">             1          1          1          1     </param>
         <param name="kbemf">           0          0          0          0     </param>
+        <param name="velocityThres">   0          0          0          0     </param>
         <param name="filterType">      0          0          0          0     </param>
         <param name="ktau">            -162        178       -197       -167  </param>
     </group>

--- a/iCubZagreb01/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
+++ b/iCubZagreb01/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
@@ -77,7 +77,10 @@
         <param name="stictionUp">   1.7	        0.8         </param>
         <param name="stictionDown"> -1.7        -1.8        </param>
         <param name="kff">          1           1           </param>
-        <param name="kbemf">        0           0           </param>
+        <param name="viscousPos">   0           0           </param>
+        <param name="viscousNeg">   0           0           </param>
+        <param name="coulombPos">   0           0           </param>
+        <param name="coulombNeg">   0           0           </param>
         <param name="velocityThres">0           0           </param>
         <param name="filterType">   0           0           </param>
         <param name="ktau">         209         160         </param>

--- a/iCubZagreb01/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
+++ b/iCubZagreb01/hardware/motorControl/left_leg-eb7-j4_5-mc.xml
@@ -78,6 +78,7 @@
         <param name="stictionDown"> -1.7        -1.8        </param>
         <param name="kff">          1           1           </param>
         <param name="kbemf">        0           0           </param>
+        <param name="velocityThres">0           0           </param>
         <param name="filterType">   0           0           </param>
         <param name="ktau">         209         160         </param>
     </group>

--- a/iCubZagreb01/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
+++ b/iCubZagreb01/hardware/motorControl/right_arm-eb27-j4_7-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0           0           0           0    </param>
         <param name="stictionDown">    0           0           0           0    </param>
         <param name="kff">             0           0           0           0    </param>
-        <param name="kbemf">           0           0           0           0    </param>
+        <param name="viscousPos">      0           0           0           0    </param>
+        <param name="viscousNeg">      0           0           0           0    </param>
+        <param name="coulombPos">      0           0           0           0    </param>
+        <param name="coulombNeg">      0           0           0           0    </param>
         <param name="filterType">      0           0           0           0    </param>
         <param name="ktau">            1           0           0           0    </param>
     </group>

--- a/iCubZagreb01/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
+++ b/iCubZagreb01/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">   0.7        0.7        0.8        1.2  </param>
         <param name="kff">             1          1          1          1   </param>
         <param name="kbemf">      -0.0030    -0.0006    -0.0007     0.0007  </param>
+        <param name="velocityThres">   0          0          0          0   </param>
         <param name="filterType">      0          0          0          0   </param>
         <param name="ktau">          -180       -464       -463       -449  </param>
     </group>

--- a/iCubZagreb01/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
+++ b/iCubZagreb01/hardware/motorControl/right_arm-eb3-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">    -0.5       -0.5       -1         -1.7  </param>
         <param name="stictionDown">   0.7        0.7        0.8        1.2  </param>
         <param name="kff">             1          1          1          1   </param>
-        <param name="kbemf">      -0.0030    -0.0006    -0.0007     0.0007  </param>
+        <param name="viscousPos">     -0.0030    -0.0006    -0.0007     0.0007   </param>
+        <param name="viscousNeg">     -0.0030    -0.0006    -0.0007     0.0007   </param>
+        <param name="coulombPos">      0          0          0          0   </param>
+        <param name="coulombNeg">      0          0          0          0   </param>
         <param name="velocityThres">   0          0          0          0   </param>
         <param name="filterType">      0          0          0          0   </param>
         <param name="ktau">          -180       -464       -463       -449  </param>

--- a/iCubZagreb01/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
+++ b/iCubZagreb01/hardware/motorControl/right_leg-eb8-j0_3-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      2.3       -1.79       1.8        1.2     </param>
         <param name="stictionDown">   -3.3        1.76      -1.4       -1.7     </param>
         <param name="kff">             1          1          1          1       </param>
-        <param name="kbemf">           0          0          0          0       </param>
+        <param name="viscousPos">      0          0          0          0       </param>
+        <param name="viscousNeg">      0          0          0          0       </param>
+        <param name="coulombPos">      0          0          0          0       </param>
+        <param name="coulombNeg">      0          0          0          0       </param>
         <param name="filterType">      0          0          0          0       </param>
        <param name="ktau">             147        -180       217        282     </param>
     </group>

--- a/iCubZagreb01/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
+++ b/iCubZagreb01/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">     -1.4        -1.5          </param>
         <param name="stictionDown">    2.4         1.6          </param>
         <param name="kff">             1          1             </param>
-        <param name="kbemf">           0          0             </param>
+        <param name="viscousPos">      0          0             </param>
+        <param name="viscousNeg">      0          0             </param>
+        <param name="coulombPos">      0          0             </param>
+        <param name="coulombNeg">      0          0             </param>
         <param name="velocityThres">   0          0             </param>
         <param name="filterType">      0          0             </param>
         <param name="ktau">            -231       -180          </param>

--- a/iCubZagreb01/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
+++ b/iCubZagreb01/hardware/motorControl/right_leg-eb9-j4_5-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">    2.4         1.6          </param>
         <param name="kff">             1          1             </param>
         <param name="kbemf">           0          0             </param>
+        <param name="velocityThres">   0          0             </param>
         <param name="filterType">      0          0             </param>
         <param name="ktau">            -231       -180          </param>
     </group>

--- a/iCubZagreb01/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubZagreb01/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -76,7 +76,10 @@
         <param name="stictionUp">      0          0          0  </param>
         <param name="stictionDown">   -2         -2         -2  </param>
         <param name="kff">             1          1          1  </param>
-        <param name="kbemf">      -0.0016    -0.003     -0.003  </param>
+        <param name="viscousPos">      -0.0016   -0.003     -0.003  </param>
+        <param name="viscousNeg">      -0.0016   -0.003     -0.003  </param>
+        <param name="coulombPos">      0          0          0  </param>
+        <param name="coulombNeg">      0          0          0  </param>
         <param name="velocityThres">   0          0          0  </param>
         <param name="filterType">      0          0          0  </param>
         <param name="ktau">         -200       -200       -200  </param>

--- a/iCubZagreb01/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/iCubZagreb01/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -77,6 +77,7 @@
         <param name="stictionDown">   -2         -2         -2  </param>
         <param name="kff">             1          1          1  </param>
         <param name="kbemf">      -0.0016    -0.003     -0.003  </param>
+        <param name="velocityThres">   0          0          0  </param>
         <param name="filterType">      0          0          0  </param>
         <param name="ktau">         -200       -200       -200  </param>
     </group>


### PR DESCRIPTION
**What's new:**
- As per https://github.com/robotology/icub-firmware/issues/396 removes the old `kbemf` torque parameter in favor of the new torque control parameters:
  - `viscousPos`
  - `viscousNeg`
  - `coulombPos`
  - `coulombNeg`
  - `verlocityThres`

The new friction compensation law is the following one (see also the [source code][1]):

```cpp
float PID_do_friction_comp(PID *o, float32_t vel_fbk, float32_t trq_ref)
{
    const float32_t MICRO { 1000000.0 }; // conversion from Nm into microNm
    const float32_t coulomb_pos_converted = o->coulomb_pos_val * MICRO;
    const float32_t coulomb_neg_converted = o->coulomb_neg_val * MICRO;
    
    const float32_t viscous_neg = o->viscous_neg_val * vel_fbk;
    const float32_t viscous_pos = o->viscous_pos_val * vel_fbk;
    
    if (vel_fbk <= -o->velocityThres_val)
    {
        return o->Ktau*(-coulomb_neg_converted + viscous_neg + o->Kff*trq_ref);
    }
    else if (vel_fbk > o->velocityThres_val)
    {
        return o->Ktau*(coulomb_pos_converted + viscous_pos + o->Kff*trq_ref);
    }
    else
    {
        return o->Ktau*(o->Kff*trq_ref);
    }
}
```

**Note:**
- The following robots will be affected by this changes:

| # | robot                          |
| :--: | :---------------------- |
| 1 | ergoCubSN000           | 
| 2 | ergoCubSN001            |
| 3 | iCubEdinburg01           | 
| 4 | iCubErzelli01                | 
| 5 | iCubErzelli02                | 
| 6 | iCubGenova02             |
| 7 | iCubGenova07             |      
| 8 | iCubGenova08             |
| 9 | iCubGenova10             |
| 10 | iCubGenova11             | 
| 11 | iCubLisboa01               | 
| 12 | iCubNancy01               | 
| 13 | iCubPargue01              |
| 14 | iCubShanghai01          | 
| 15 | iCubShenzhen01         |
| 16 | iCubSingapore01        | 
| 17 | iCubTemplates            |
| 18 | iCubValparaiso01        | 
| 19 | iCubWaterloo01          |
| 20 | iCubZagreb01             |




cc @isorrentino @marcoaccame @Nicogene 

[1]: https://github.com/robotology/icub-firmware/blob/89299e156937c709f0381d9578cfbca7e0244a5a/emBODY/eBcode/arch-arm/embobj/plus/mc/Pid.c#L206C1-L234C2


