### PR TITLE
configured skin on right and left arm - ergocub SN0001

### DIFF
--- a/ergoCubSN001/hardware/skin/left_arm-eb24-j4_7-skin.xml
+++ b/ergoCubSN001/hardware/skin/left_arm-eb24-j4_7-skin.xml
@@ -7,7 +7,7 @@
  
         <xi:include href="../../hardware/electronics/left_arm-eb24-j4_7-eln.xml" />
         <group name="patches">
-            <param name="skinCanAddrsPatch1"> 14 13 12 11 10 9 8 </param> 
+            <param name="skinCanAddrsPatch1"> 14 </param> 
         </group>
         <xi:include href="./left_arm-eb24-j4_7-skinSpec.xml" />
     </device>

--- a/ergoCubSN001/hardware/skin/left_arm-eb24-j4_7-skinSpec.xml
+++ b/ergoCubSN001/hardware/skin/left_arm-eb24-j4_7-skinSpec.xml
@@ -19,23 +19,23 @@
 	      -->
 	    <param name="numOfSets"> 1 </param> 
 	    <!--                            patch       adr start   adr end     period      type    no_load     -->            
-	    <param name="boardSetCfg1">     1           14          14          50          1       0xf0        </param> 
+	    <param name="boardSetCfg1">     1           14          14          50          1       0xc8        </param> 
 		                  
 	</group>
         
         
        <group name="defaultCfgTriangle">
             <param name="enabled">         false  </param> 
-            <param name="shift">           2  </param>
-            <param name="cdcOffset">       0x2200  </param>
+            <param name="shift">           1  </param>
+            <param name="cdcOffset">       0x0000  </param>
         </group>
  
         <group name="specialCfgTriangles">
-            <param name="numOfSets">         2  </param>
-            <param name="triangleSetCfg1">     1            14        0             6             1              0            0x2000      </param>
-           <param name="triangleSetCfg2">      1            14        8             11             1              2           0x2200       </param>
-           
-
+            <param name="numOfSets">         4  </param>
+            <param name="triangleSetCfgThumb">     1            14        0             0              1              1           0x0000      </param>
+            <param name="triangleSetCfgIndex">     1            14        4             4              1              1           0x0000      </param>
+            <param name="triangleSetCfgMiddle">    1            14        8             8              1              1           0x0000      </param>
+            <param name="triangleSetCfgRing">      1            14        12            12             1              1           0x0000      </param>
         </group>
 
         

--- a/ergoCubSN001/hardware/skin/right_arm-eb27-j4_7-skin.xml
+++ b/ergoCubSN001/hardware/skin/right_arm-eb27-j4_7-skin.xml
@@ -7,7 +7,7 @@
  
         <xi:include href="../../hardware/electronics/right_arm-eb27-j4_7-eln.xml" />
         <group name="patches">
-            <param name="skinCanAddrsPatch1"> 14 13 12 11 10 9 8</param> 
+            <param name="skinCanAddrsPatch1"> 14 </param> 
         </group>
         <xi:include href="./right_arm-eb27-j4_7-skinSpec.xml" /> 
     </device>  

--- a/ergoCubSN001/hardware/skin/right_arm-eb27-j4_7-skinSpec.xml
+++ b/ergoCubSN001/hardware/skin/right_arm-eb27-j4_7-skinSpec.xml
@@ -19,23 +19,23 @@
 	      -->
 	    <param name="numOfSets"> 1 </param> 
 	    <!--                            patch       adr start   adr end     period      type    no_load     -->            
-	    <param name="boardSetCfg1">     1           14          14          50          1       0xf0        </param> 
+	    <param name="boardSetCfg1">     1           14          14          50          1       0xc8        </param> 
 		                  
 	</group>
         
         
        <group name="defaultCfgTriangle">
             <param name="enabled">         false  </param> 
-            <param name="shift">           2  </param>
-            <param name="cdcOffset">       0x2200  </param>
+            <param name="shift">           1  </param>
+            <param name="cdcOffset">       0x0000  </param>
         </group>
  
         <group name="specialCfgTriangles">
-            <param name="numOfSets">         2  </param>
-            <param name="triangleSetCfg1">     1            14        0             6             1              0            0x2000      </param>
-           <param name="triangleSetCfg2">      1            14        8             11             1              2           0x2200       </param>
-           
-
+            <param name="numOfSets">         4  </param>
+            <param name="triangleSetCfgThumb">     1            14        0             0              1              1           0x0000      </param>
+            <param name="triangleSetCfgIndex">     1            14        4             4              1              1           0x0000      </param>
+            <param name="triangleSetCfgMiddle">    1            14        8             8              1              1           0x0000      </param>
+            <param name="triangleSetCfgRing">      1            14        12            12             1              1           0x0000      </param>
         </group>
 
         

--- a/ergoCubSN001/wrappers/skin/left_arm-skin_wrapper.xml
+++ b/ergoCubSN001/wrappers/skin/left_arm-skin_wrapper.xml
@@ -4,13 +4,13 @@
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-skin_wrapper" type="skinWrapper">
         <param name="period">       20                  </param>
-        <param name="total_taxels"> 1344                </param>
+        <param name="total_taxels"> 192                </param>
         <param name="device">       skinWrapper             </param>
         
         <paramlist name="ports">
           <elem name="left_hand">   0   191  0 191</elem>
-          <elem name="left_forearm">    192 575  0 383</elem>
-          <elem name="left_arm">    576 1343 0 767</elem>
+          <!-- elem name="left_forearm">    192 575  0 383</elem>
+          <elem name="left_arm">    576 1343 0 767</elem-->
         </paramlist>
         
         <action phase="startup" level="5" type="attach">

--- a/ergoCubSN001/wrappers/skin/right_arm-skin_wrapper.xml
+++ b/ergoCubSN001/wrappers/skin/right_arm-skin_wrapper.xml
@@ -4,13 +4,13 @@
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-skin_wrapper" type="skinWrapper">
         <param name="period">       20                  </param>
-        <param name="total_taxels"> 1344                </param>
+        <param name="total_taxels"> 192                </param>
         <param name="device">       skinWrapper             </param>
         
         <paramlist name="ports">
           <elem name="right_hand">  0   191  0 191</elem>
-          <elem name="right_forearm">   192 575  0 383</elem>
-          <elem name="right_arm">   576 1343 0 767</elem>
+          <!--elem name="right_forearm">   192 575  0 383</elem>
+          <elem name="right_arm">   576 1343 0 767</elem-->
         </paramlist>
         
         <action phase="startup" level="5" type="attach">


### PR DESCRIPTION
files to configure and stream over yarp ports the fingertip skins  in ergocubSN0001 (and following) 
wrappers and elecronics are configured according to [documentation](https://icub-tech-iit.github.io/documentation/hands/fingertip_and_mma_mk5/)
both hands are configured. 