### PR TITLE
Feature/fw updater bat

### DIFF
--- a/ergoCubSN001/hardware/battery/battery_bat.xml
+++ b/ergoCubSN001/hardware/battery/battery_bat.xml
@@ -29,7 +29,7 @@
             <group name="SENSORS">
                 <param name="id">                   battery1        </param>
                 <param name="board">                bat             </param>
-                <param name="location">             CAN2:1          </param>
+                <param name="location">             CAN2:2          </param>
             </group>
 
         </group>

--- a/ergoCubSN001/hardware/battery/battery_bms.xml
+++ b/ergoCubSN001/hardware/battery/battery_bms.xml
@@ -29,7 +29,7 @@
             <group name="SENSORS">
                 <param name="id">                   battery1        </param>
                 <param name="board">                bms             </param>
-                <param name="location">             CAN2:1          </param>
+                <param name="location">             CAN2:2          </param>
             </group>
 
         </group>

--- a/experimentalSetups/battery/hardware/battery/ergocubbattery.xml
+++ b/experimentalSetups/battery/hardware/battery/ergocubbattery.xml
@@ -29,7 +29,7 @@
             <group name="SENSORS">
                 <param name="id">                   battery1        </param>
                 <param name="board">                bat             </param>
-                <param name="location">             CAN1:1          </param>
+                <param name="location">             CAN2:2          </param>
             </group>
 
         </group>

--- a/iCubTemplates/iCubTemplateV6_0/hardware/battery/battery_part.xml
+++ b/iCubTemplates/iCubTemplateV6_0/hardware/battery/battery_part.xml
@@ -34,7 +34,7 @@
                 <param name="id">                   battery1        </param>
                 <!-- same as the type above-->
                 <param name="board">                bat             </param>
-                <param name="location">             CAN2:1          </param> <!-- this is the CAN location. It should be on CAN2 since on CAN1 we have the FT sensors-->
+                <param name="location">             CAN2:2          </param> <!-- this is the CAN location. It should be on CAN2 since on CAN1 we have the FT sensors-->
             </group>
 
         </group>


### PR DESCRIPTION
This PR brings the following changes:
setting the configuration of the BAT CAN Address to CANId ==> 2 since we are using specific messages that are of class 6 and the sending address is specifically 2, such as 620 and 628.

So user must always set the CANId for the BAT to 2.