### PR TITLE
[ergoCubSN001] FTs and AMOs enabling

### DIFF
--- a/ergoCubSN001/ergocub_all.xml
+++ b/ergoCubSN001/ergocub_all.xml
@@ -70,9 +70,9 @@
     <xi:include href="hardware/motorControl/right_leg-eb6-j0_3-mc.xml" />
     <xi:include href="hardware/motorControl/right_leg-eb7-j4_5-mc.xml" />
 
-    <!-- FT SENSORS 
+    <!-- FT SENSORS -->
     <xi:include href="hardware/FT/left_arm-eb2-j0_1-strain.xml" />
-    <xi:include href="hardware/FT/right_arm-eb1-j0_1-strain.xml" /> -->
+    <xi:include href="hardware/FT/right_arm-eb1-j0_1-strain.xml" /> 
     <xi:include href="hardware/FT/left_leg-eb9-j4_5-strain.xml" />
     <xi:include href="hardware/FT/right_leg-eb7-j4_5-strain.xml" />
     <xi:include href="hardware/FT/left_leg-eb8-j0_3-strain.xml" />
@@ -82,9 +82,9 @@
     <xi:include href="wrappers/FT/left_leg-FT_remapper.xml" />
     <xi:include href="wrappers/FT/right_leg-FT_remapper.xml" />
 
-    <!-- FT SENSORS - MULTIPLE ANALOG SENSOR SERVERS 
+    <!-- FT SENSORS - MULTIPLE ANALOG SENSOR SERVERS -->
     <xi:include href="wrappers/FT/left_arm-FT_wrapper.xml" />
-    <xi:include href="wrappers/FT/right_arm-FT_wrapper.xml" /> -->
+    <xi:include href="wrappers/FT/right_arm-FT_wrapper.xml" /> 
     <xi:include href="wrappers/FT/left_leg-FT_wrapper.xml" />
     <xi:include href="wrappers/FT/right_leg-FT_wrapper.xml" />
 
@@ -103,17 +103,17 @@
     <xi:include href="hardware/inertials/right_arm-eb3-j2_3-inertial.xml" />
     <xi:include href="wrappers/inertials/right_arm-inertials_wrapper.xml" /> -->
 
-    <!-- FT SENSORS - IMU 
+    <!-- FT SENSORS - IMU -->
     <xi:include href="hardware/inertials/left_arm-eb2-j0_1-inertial.xml" />
-    <xi:include href="hardware/inertials/right_arm-eb1-j0_1-inertial.xml" /> -->
+    <xi:include href="hardware/inertials/right_arm-eb1-j0_1-inertial.xml" /> 
     <xi:include href="hardware/inertials/left_leg-eb8-j0_3-inertial.xml" />
     <xi:include href="hardware/inertials/right_leg-eb6-j0_3-inertial.xml" />
     <xi:include href="hardware/inertials/left_leg-eb9-j4_5-inertial.xml" />
     <xi:include href="hardware/inertials/right_leg-eb7-j4_5-inertial.xml" />
 
-    <!-- FT SENSORS - IMU - MULTIPLE ANALOG SENSOR SERVERS 
+    <!-- FT SENSORS - IMU - MULTIPLE ANALOG SENSOR SERVERS -->
     <xi:include href="wrappers/inertials/left_arm-imu_wrapper.xml" />
-    <xi:include href="wrappers/inertials/right_arm-imu_wrapper.xml" /> -->
+    <xi:include href="wrappers/inertials/right_arm-imu_wrapper.xml" /> 
     <xi:include href="wrappers/inertials/left_leg-imu_wrapper.xml" />
     <xi:include href="wrappers/inertials/right_leg-imu_wrapper.xml" />
     <xi:include href="wrappers/inertials/left_foot-imu_wrapper.xml" />

--- a/ergoCubSN001/ergocub_wbd.xml
+++ b/ergoCubSN001/ergocub_wbd.xml
@@ -71,8 +71,8 @@
     <xi:include href="hardware/motorControl/right_leg-eb7-j4_5-mc.xml" />
 
     <!-- FT SENSORS -->
-    <!--xi:include href="hardware/FT/left_arm-eb2-j0_1-strain.xml" />
-    <xi:include href="hardware/FT/right_arm-eb1-j0_1-strain.xml" /-->
+    <xi:include href="hardware/FT/left_arm-eb2-j0_1-strain.xml" />
+    <xi:include href="hardware/FT/right_arm-eb1-j0_1-strain.xml" />
     <xi:include href="hardware/FT/left_leg-eb9-j4_5-strain.xml" />
     <xi:include href="hardware/FT/right_leg-eb7-j4_5-strain.xml" />
     <xi:include href="hardware/FT/left_leg-eb8-j0_3-strain.xml" />
@@ -83,8 +83,8 @@
     <xi:include href="wrappers/FT/right_leg-FT_remapper.xml" />
 
     <!-- FT SENSORS - MULTIPLE ANALOG SENSOR SERVERS -->
-    <!--xi:include href="wrappers/FT/left_arm-FT_wrapper.xml" />
-    <xi:include href="wrappers/FT/right_arm-FT_wrapper.xml" /-->
+    <xi:include href="wrappers/FT/left_arm-FT_wrapper.xml" />
+    <xi:include href="wrappers/FT/right_arm-FT_wrapper.xml" />
     <xi:include href="wrappers/FT/left_leg-FT_wrapper.xml" />
     <xi:include href="wrappers/FT/right_leg-FT_wrapper.xml" />
 
@@ -104,16 +104,16 @@
     <xi:include href="wrappers/inertials/right_arm-inertials_wrapper.xml" /> -->
 
     <!-- FT SENSORS - IMU -->
-    <!--xi:include href="hardware/inertials/left_arm-eb2-j0_1-inertial.xml" />
-    <xi:include href="hardware/inertials/right_arm-eb1-j0_1-inertial.xml" /-->
+    <xi:include href="hardware/inertials/left_arm-eb2-j0_1-inertial.xml" />
+    <xi:include href="hardware/inertials/right_arm-eb1-j0_1-inertial.xml" />
     <xi:include href="hardware/inertials/left_leg-eb8-j0_3-inertial.xml" />
     <xi:include href="hardware/inertials/right_leg-eb6-j0_3-inertial.xml" />
     <xi:include href="hardware/inertials/left_leg-eb9-j4_5-inertial.xml" />
     <xi:include href="hardware/inertials/right_leg-eb7-j4_5-inertial.xml" />
 
     <!-- FT SENSORS - IMU - MULTIPLE ANALOG SENSOR SERVERS -->
-    <!--xi:include href="wrappers/inertials/left_arm-imu_wrapper.xml" />
-    <xi:include href="wrappers/inertials/right_arm-imu_wrapper.xml" /-->
+    <xi:include href="wrappers/inertials/left_arm-imu_wrapper.xml" />
+    <xi:include href="wrappers/inertials/right_arm-imu_wrapper.xml" />
     <xi:include href="wrappers/inertials/left_leg-imu_wrapper.xml" />
     <xi:include href="wrappers/inertials/right_leg-imu_wrapper.xml" />
     <xi:include href="wrappers/inertials/left_foot-imu_wrapper.xml" />

--- a/ergoCubSN001/hardware/mechanicals/left_arm-eb31-j4_6-mec.xml
+++ b/ergoCubSN001/hardware/mechanicals/left_arm-eb31-j4_6-mec.xml
@@ -65,7 +65,7 @@
         <group name="JOINTSET_0">
             <param name="listofjoints">  0 1 2         </param>
             <param name="constraint">    ergocubwrist  </param> <!-- none for calibration -->
-            <param name="param1">        20            </param>
+            <param name="param1">        21            </param>
             <param name="param2">        0             </param>
         </group>
     </group>

--- a/ergoCubSN001/hardware/mechanicals/right_arm-eb30-j4_6-mec.xml
+++ b/ergoCubSN001/hardware/mechanicals/right_arm-eb30-j4_6-mec.xml
@@ -65,7 +65,7 @@
         <group name="JOINTSET_0">
             <param name="listofjoints">  0 1 2         </param>
             <param name="constraint">    ergocubwrist  </param> <!-- none for calibration -->
-            <param name="param1">        20             </param>
+            <param name="param1">        21             </param>
             <param name="param2">        1             </param>
         </group>
     </group>

--- a/ergoCubSN001/hardware/motorControl/left_arm-eb2-j0_1-mc_service.xml
+++ b/ergoCubSN001/hardware/motorControl/left_arm-eb2-j0_1-mc_service.xml
@@ -36,7 +36,7 @@
                 </group>
                 
                 <group name="ENCODER1">  
-                    <param name="type">             none                none                </param>  
+                    <param name="type">             amo                 amo                 </param>  
                     <param name="port">             CONN:P6             CONN:P8             </param>
                     <param name="position">         atjoint             atjoint             </param> 
                     <param name="resolution">      -16384               16384               </param>

--- a/ergoCubSN001/hardware/motorControl/left_leg-eb8-j0_3-mc_service.xml
+++ b/ergoCubSN001/hardware/motorControl/left_leg-eb8-j0_3-mc_service.xml
@@ -36,7 +36,7 @@
                 </group>
                 
                 <group name="ENCODER1">  
-                    <param name="type">             none                amo         amo        amo       </param>  
+                    <param name="type">             amo                amo         amo        amo       </param>  
                     <param name="port">             CONN:P6             CONN:P8     CONN:P7    CONN:P9   </param>
                     <param name="position">         atjoint             atjoint     atjoint    atjoint   </param>
                     <param name="resolution">       16384               16384       16384      -16384    </param> 

--- a/ergoCubSN001/hardware/motorControl/right_arm-eb1-j0_1-mc_service.xml
+++ b/ergoCubSN001/hardware/motorControl/right_arm-eb1-j0_1-mc_service.xml
@@ -36,7 +36,7 @@
                 </group>
                 
                 <group name="ENCODER1">  
-                    <param name="type">             none                none                </param>  
+                    <param name="type">             amo                 amo                </param>  
                     <param name="port">             CONN:P6             CONN:P8             </param>
                     <param name="position">         atjoint             atjoint             </param> 
                     <param name="resolution">       16384              -16384               </param>  

--- a/ergoCubSN001/hardware/motorControl/right_arm-eb3-j2_3-mc_service.xml
+++ b/ergoCubSN001/hardware/motorControl/right_arm-eb3-j2_3-mc_service.xml
@@ -36,7 +36,7 @@
                 </group>
                 
                 <group name="ENCODER1">  
-                    <param name="type">             none                none                </param>  
+                    <param name="type">             none                amo                 </param>  
                     <param name="port">             CONN:P6             CONN:P8             </param>
                     <param name="position">         atjoint             atjoint             </param> 
                     <param name="resolution">      -16384              -16384               </param>


### PR DESCRIPTION
## What changes:
This PR enable some AMO sensors (roll and pitch shoulders and right elbow) after the maintenance service.

In addiction, this PR enable the FT on the shoulders after the maintenance service.

I have also included the correct version for the wrist.

## Note

Stress tests have been performed on all these enabled sensors and they seem to work correctly.


cc @GiulioRomualdi @Nicogene 