### PR TITLE
update lego-setup-amc2c config files

### DIFF
--- a/experimentalSetups/lego_setup_amc2c/hardware/motorControl/setup-eb2-j0_2-mc_service.xml
+++ b/experimentalSetups/lego_setup_amc2c/hardware/motorControl/setup-eb2-j0_2-mc_service.xml
@@ -22,7 +22,7 @@
                 <group name="FIRMWARE">
                     <param name="major">            2           </param>
                     <param name="minor">            0           </param>
-                    <param name="build">            4           </param>
+                    <param name="build">            7           </param>
                 </group>
             </group>
 
@@ -34,10 +34,10 @@
                 </group>
 
                 <group name="ENCODER1">
-                    <param name="type">             eomc_enc_aea      </param>
+                    <param name="type">             aea3      </param>
                     <param name="port">             CONN:J5_X1        </param>
                     <param name="position">         eomc_pos_atjoint  </param>
-                    <param name="resolution">       4096              </param>
+                    <param name="resolution">       16384              </param>
                     <param name="tolerance">        0.4               </param>
                 </group>
 


### PR DESCRIPTION
Config files for `lego-setup` aligned with the latest `icub-firmware` changes v2.0.7 (https://github.com/robotology/icub-firmware/pull/457)