### PR TITLE
[ergoCubSN00x] Change CAN communication time

### DIFF
--- a/ergoCubSN000/hardware/electronics/left_leg-eb8-j0_3-eln.xml
+++ b/ergoCubSN000/hardware/electronics/left_leg-eb8-j0_3-eln.xml
@@ -19,9 +19,9 @@
             <param name="Name">                     "left_leg-eb8-j0_3"     </param> 
             <group name="RUNNINGMODE">
                 <param name="period">                   1000                </param>
-                <param name="maxTimeOfRXactivity">      400                 </param>
-                <param name="maxTimeOfDOactivity">      300                 </param>   
-                <param name="maxTimeOfTXactivity">      300                 </param>                
+                <param name="maxTimeOfRXactivity">      300                 </param>
+                <param name="maxTimeOfDOactivity">      350                 </param>   
+                <param name="maxTimeOfTXactivity">      350                 </param>                
                 <param name="TXrateOfRegularROPs">      2                   </param> 
             </group>              
         </group>                 

--- a/ergoCubSN000/hardware/electronics/right_leg-eb6-j0_3-eln.xml
+++ b/ergoCubSN000/hardware/electronics/right_leg-eb6-j0_3-eln.xml
@@ -19,9 +19,9 @@
             <param name="Name">                     "right_leg-eb6-j0_3"     </param> 
             <group name="RUNNINGMODE">
                 <param name="period">                   1000                </param>
-                <param name="maxTimeOfRXactivity">      400                 </param>
-                <param name="maxTimeOfDOactivity">      300                 </param>   
-                <param name="maxTimeOfTXactivity">      300                 </param>                
+                <param name="maxTimeOfRXactivity">      300                 </param>
+                <param name="maxTimeOfDOactivity">      350                 </param>   
+                <param name="maxTimeOfTXactivity">      350                 </param>                
                 <param name="TXrateOfRegularROPs">      2                   </param> 
             </group>              
         </group>                 

--- a/ergoCubSN001/hardware/electronics/left_leg-eb8-j0_3-eln.xml
+++ b/ergoCubSN001/hardware/electronics/left_leg-eb8-j0_3-eln.xml
@@ -19,9 +19,9 @@
             <param name="Name">                     "left_leg-eb8-j0_3"     </param> 
             <group name="RUNNINGMODE">
                 <param name="period">                   1000                </param>
-                <param name="maxTimeOfRXactivity">      400                 </param>
-                <param name="maxTimeOfDOactivity">      300                 </param>   
-                <param name="maxTimeOfTXactivity">      300                 </param>                
+                <param name="maxTimeOfRXactivity">      300                 </param>
+                <param name="maxTimeOfDOactivity">      350                 </param>   
+                <param name="maxTimeOfTXactivity">      350                 </param>                
                 <param name="TXrateOfRegularROPs">      2                   </param> 
             </group>              
         </group>                 

--- a/ergoCubSN001/hardware/electronics/right_leg-eb6-j0_3-eln.xml
+++ b/ergoCubSN001/hardware/electronics/right_leg-eb6-j0_3-eln.xml
@@ -19,9 +19,9 @@
             <param name="Name">                     "right_leg-eb6-j0_3"     </param> 
             <group name="RUNNINGMODE">
                 <param name="period">                   1000                </param>
-                <param name="maxTimeOfRXactivity">      400                 </param>
-                <param name="maxTimeOfDOactivity">      300                 </param>   
-                <param name="maxTimeOfTXactivity">      300                 </param>                
+                <param name="maxTimeOfRXactivity">      300                 </param>
+                <param name="maxTimeOfDOactivity">      350                 </param>   
+                <param name="maxTimeOfTXactivity">      350                 </param>                
                 <param name="TXrateOfRegularROPs">      2                   </param> 
             </group>              
         </group>                 


### PR DESCRIPTION
## What Changes:

This PR change the CAN communication time between CAN boards and EMS boards EB6 and EB8.

This change was necessary as the `yarprobotinterface` log is being clogged by this warning message:

`[WARNING] from BOARD 10.0.1.8 (left_leg-eb8-j0_3), src LOCAL, adr 0, time 60s 885m 977u: (code 0x00000c, par16 0x0181 par64 0x003d018000ce0040) -> SYS: the DO phase of the control loop has lasted more than wanted. In par16: DO execution time [usec]. In par64: latest previous execution times of RX, DO, TX, RX [usec] + .`

## Note
The robot has been tested and it is working properly, and the warning messages have significantly decreased.
