### PR TITLE
[iCubGenova11] Add config files for FT IMUs of the arms

### DIFF
--- a/iCubGenova11/hardware/inertials/left_arm-eb1-IMU.xml
+++ b/iCubGenova11/hardware/inertials/left_arm-eb1-IMU.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-eb1-imu" type="embObjIMU">
+
+        <xi:include href="../../general.xml" />
+
+        <xi:include href="../../hardware/electronics/left_arm-eb1-j0_3-eln.xml" />
+
+        <group name="SERVICE">
+
+            <param name="type"> eomn_serv_AS_inertials3 </param>
+
+            <group name="PROPERTIES">
+
+                <group name="CANBOARDS">
+                    <param name="type">                 eobrd_strain2           </param>
+
+                    <group name="PROTOCOL">
+                        <param name="major">            2                   </param>
+                        <param name="minor">            0                   </param>
+                    </group>
+                    <group name="FIRMWARE">
+                        <param name="major">            0                   </param>
+                        <param name="minor">            0                   </param>
+                        <param name="build">            0                   </param>
+                    </group>
+                </group>
+
+                <group name="SENSORS">
+                    <param name="id">         l_arm_ft_acc      l_arm_ft_gyro      l_arm_ft_eul      l_arm_ft_mag      l_arm_ft_stat </param>
+
+                    <param name="sensorName"> l_arm_ft          l_arm_ft           l_arm_ft          l_arm_ft          l_arm_ft </param>
+
+                    <param name="type">       eoas_imu_acc      eoas_imu_gyr       eoas_imu_mag      eoas_imu_eul      eoas_imu_status </param>
+
+                    <param name="boardType">  strain2           strain2            strain2           strain2           strain2 </param>
+
+                    <param name="location">   CAN2:13           CAN2:13            CAN2:13           CAN2:13           CAN2:13 </param>
+                </group>
+
+            </group>
+
+            <group name="SETTINGS">
+                <param name="acquisitionRate">      10      </param>
+                <param name="enabledSensors">       l_arm_ft_acc    l_arm_ft_gyro    l_arm_ft_eul    l_arm_ft_mag    l_arm_ft_stat </param>
+            </group>
+
+        </group>
+
+    </device>

--- a/iCubGenova11/hardware/inertials/right_arm-eb3-IMU.xml
+++ b/iCubGenova11/hardware/inertials/right_arm-eb3-IMU.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-eb3-imu" type="embObjIMU">
+
+        <xi:include href="../../general.xml" />
+
+        <xi:include href="../../hardware/electronics/right_arm-eb3-j0_3-eln.xml" />
+
+        <group name="SERVICE">
+
+            <param name="type"> eomn_serv_AS_inertials3 </param>
+
+            <group name="PROPERTIES">
+
+                <group name="CANBOARDS">
+                    <param name="type">                 eobrd_strain2           </param>
+
+                    <group name="PROTOCOL">
+                        <param name="major">            2                   </param>
+                        <param name="minor">            0                   </param>
+                    </group>
+                    <group name="FIRMWARE">
+                        <param name="major">            0                   </param>
+                        <param name="minor">            0                   </param>
+                        <param name="build">            0                   </param>
+                    </group>
+                </group>
+
+                <group name="SENSORS">
+                    <param name="id">          r_arm_ft_acc    r_arm_ft_gyro   r_arm_ft_eul    r_arm_ft_mag    r_arm_ft_stat </param>
+
+                    <param name="sensorName">  r_arm_ft        r_arm_ft        r_arm_ft        r_arm_ft        r_arm_ft </param>
+
+                    <param name="type">        eoas_imu_acc    eoas_imu_gyr    eoas_imu_mag    eoas_imu_eul    eoas_imu_status </param>
+
+                    <param name="boardType">   strain2         strain2         strain2         strain2         strain2  </param>
+
+                    <param name="location">    CAN2:13         CAN2:13         CAN2:13         CAN2:13         CAN2:13 </param>
+                </group>
+
+            </group>
+
+            <group name="SETTINGS">
+                <param name="acquisitionRate">      10      </param>
+                <param name="enabledSensors">       r_arm_ft_acc    r_arm_ft_gyro    r_arm_ft_eul    r_arm_ft_mag    r_arm_ft_stat </param>
+            </group>
+
+        </group>
+
+    </device>

--- a/iCubGenova11/wrappers/inertials/alljoints-inertials_remapper.xml
+++ b/iCubGenova11/wrappers/inertials/alljoints-inertials_remapper.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_remapper" type="multipleanalogsensorsremapper">
+        <param name="OrientationSensorsNames">
+            (l_arm_ft r_arm_ft head_imu_0)
+        </param>
+        <action phase="startup" level="10" type="attach">
+            <paramlist name="networks">
+                <elem name="head_imu">  head-inertial </elem>
+                <elem name="left_arm_imu">  left_arm-eb1-imu </elem>
+                <elem name="right_arm_imu">  right_arm-eb3-imu </elem>
+            </paramlist>
+        </action>
+
+        <action phase="shutdown" level="20" type="detach" />
+    </device>

--- a/iCubGenova11/wrappers/inertials/alljoints-inertials_wrapper.xml
+++ b/iCubGenova11/wrappers/inertials/alljoints-inertials_wrapper.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_wrapper" type="multipleanalogsensorsserver">
+    <param name="period">      10                           </param>
+    <param name="name"> /${portprefix}/alljoints/inertials   </param>
+
+    <action phase="startup" level="15" type="attach">
+        <paramlist name="networks">
+            <elem name="FirstStrain"> alljoints-inertials_remapper </elem>
+        </paramlist>
+       </action>
+
+    <action phase="shutdown" level="20" type="detach" />
+</device>


### PR DESCRIPTION
This PR aims to add the configuration files for reading from the IMU of the FT sensors mounted on the left and right arms. Moreover, I added also an `alljoints-inertials_wrapper.xml` and `alljoints-inertials_remapper.xml` to wrap up the inertials with a `multipleanalogsensorsremapper`. 

I didn't add those files in the `icub_all_no_legs.xml` which is the startup xml of the robot since I don't know if someone is interested in that information. 

cc @Nicogene @traversaro @pattacini 