### PR TITLE
[ergoCubSN001] New Hip Rolls calibration values

### DIFF
--- a/ergoCubSN001/calibrators/left_leg-calib.xml
+++ b/ergoCubSN001/calibrators/left_leg-calib.xml
@@ -20,11 +20,11 @@
     <param name="calibration3">                       0.0            0.0          0             0          0       0        </param> 
     <param name="calibration4">                       0.0            0.0          0             0          0       0        </param>
     <param name="calibration5">                       0.0            0.0          0             0          0       0        </param>
-    <param name="calibrationZero">                    110.15         111.776      81.65         7.75       -46.624 25.313     </param>
+    <param name="calibrationZero">                    110.15         111.776      81.65         7.75       -46.624 25.313   </param>
     <param name="calibrationDelta">                   0              0            0             0          0       0        </param>
     <param name="startupPosition">                    90             80           0             -95        0       0        </param>
     <param name="startupVelocity">                    10.0           10.0         10.0          10         10      10       </param>
-    <param name="startupMaxPwm">                      8000           8000         8000          8000       8000    8000      </param>
+    <param name="startupMaxPwm">                      8000           8000         8000          8000       12000   8000     </param>
     <param name="startupPosThreshold">                2              2            2             2          2       2        </param>
   </group>
 <!-- <param name="CALIB_ORDER"> (2) (4) (5) (3) (0) (1)  </param> --> <!-- Don't remove this line -->

--- a/ergoCubSN001/calibrators/right_leg-calib.xml
+++ b/ergoCubSN001/calibrators/right_leg-calib.xml
@@ -22,12 +22,12 @@
     <param name="calibration3">                       0.0            0.0          0             0          0       0        </param> 
     <param name="calibration4">                       0.0            0.0          0             0          0       0        </param>
     <param name="calibration5">                       0.0            0.0          0             0          0       0        </param>
-   <param name="calibrationZero">                     110.15         111.463      81.078        7.75       -45.942 25.786    </param>
+   <param name="calibrationZero">                     110.15         111.463      81.078        7.75       -45.942 25.786   </param>
     <param name="calibrationDelta">                   0              0            0             0          0       0        </param>
     
     <param name="startupPosition">                    90             80           0             -95        0       0        </param>
     <param name="startupVelocity">                    10.0           10.0         10.0          10         10      10       </param>
-    <param name="startupMaxPwm">                      8000           8000         8000          8000       8000    8000     </param>
+    <param name="startupMaxPwm">                      8000           8000         8000          8000       12000   8000     </param>
     <param name="startupPosThreshold">                2              2            2             2          2       2        </param>
   </group>
 

--- a/ergoCubSN001/hardware/mechanicals/left_leg-eb8-j0_3-mec.xml
+++ b/ergoCubSN001/hardware/mechanicals/left_leg-eb8-j0_3-mec.xml
@@ -33,7 +33,7 @@
         <param name="HasRotorEncoder">            1             1     1     1     </param>
         <param name="HasRotorEncoderIndex">       1             1     1     1     </param>
         <param name="HasSpeedEncoder">            0             0     0     0     </param>
-        <param name="RotorIndexOffset">           337           153   112   113   </param>
+        <param name="RotorIndexOffset">           337           181   112   113   </param>
         <param name="MotorPoles">                 12            8     8     12    </param>
    </group>
 

--- a/ergoCubSN001/hardware/mechanicals/right_leg-eb6-j0_3-mec.xml
+++ b/ergoCubSN001/hardware/mechanicals/right_leg-eb6-j0_3-mec.xml
@@ -36,7 +36,7 @@
         <param name="HasRotorEncoder">       1             1        1   1  </param>
         <param name="HasRotorEncoderIndex">  1             1        1   1  </param>
         <param name="HasSpeedEncoder">       0             0        0   0  </param>
-        <param name="RotorIndexOffset">      170           350      62  89 </param>
+        <param name="RotorIndexOffset">      170           345      62  89 </param>
         <param name="MotorPoles">            12            8        8   12 </param>
    </group>
 


### PR DESCRIPTION
## What Changes

This PR updates the calibration values after the maintenance service.

We disassembled and assembled the rotor of the right hip roll and replaced the stator of the left hip roll.

In addiction, I increased the pwm limit in calibration of both ankle pitch to prevent the joint from getting stuck in the hardware limit, during the calibration, without reaching the start-up position.