### PR TITLE
The `amc` board uses `ICC` and `CAN` to move the wrist of `ergoCub`

### DIFF
--- a/ergoCubSN001/hardware/mechanicals/left_arm-eb31-j4_6-mec.xml
+++ b/ergoCubSN001/hardware/mechanicals/left_arm-eb31-j4_6-mec.xml
@@ -25,7 +25,7 @@
         <param name="rotorPosMax">           0             0             0           </param>
     </group>
 
-    <group name="AMCBLDC">
+    <group name="ADVFOC">
         <param name="HasHallSensor">         1             1             1           </param>
         <param name="HasTempSensor">         0             0             0           </param>
         <param name="HasRotorEncoder">       0             0             0           </param>

--- a/ergoCubSN001/hardware/mechanicals/right_arm-eb30-j4_6-mec.xml
+++ b/ergoCubSN001/hardware/mechanicals/right_arm-eb30-j4_6-mec.xml
@@ -25,7 +25,7 @@
         <param name="rotorPosMax">           0             0             0           </param>
     </group>
 
-    <group name="AMCBLDC">
+    <group name="ADVFOC">
         <param name="HasHallSensor">         1             1             1           </param>
         <param name="HasTempSensor">         0             0             0           </param>
         <param name="HasRotorEncoder">       0             0             0           </param>

--- a/ergoCubSN001/hardware/motorControl/left_arm-eb31-j4_6-mc_service.xml
+++ b/ergoCubSN001/hardware/motorControl/left_arm-eb31-j4_6-mc_service.xml
@@ -5,7 +5,7 @@
 
     <group name="SERVICE">
 
-        <param name="type"> eomn_serv_MC_foc </param>
+        <param name="type"> eomn_serv_MC_advfoc </param>
 
         <group name="PROPERTIES">
 
@@ -14,23 +14,24 @@
             </group>
 
             <group name="CANBOARDS">
-                <param name="type">                 amcbldc     </param>
+                <param name="type">                 amcbldc     amc2c   </param>
                 <group name="PROTOCOL">
-                    <param name="major">            2           </param>
-                    <param name="minor">            0           </param>
+                    <param name="major">            2           2       </param>
+                    <param name="minor">            0           0       </param>
                 </group>
                 <group name="FIRMWARE">
-                    <param name="major">            2           </param>
-                    <param name="minor">            0           </param>
-                    <param name="build">            4           </param>
+                    <param name="major">            2           3       </param>
+                    <param name="minor">            0           0       </param>
+                    <param name="build">            10          0       </param>
                 </group>
             </group>
 
             <group name="JOINTMAPPING">
 
                 <group name="ACTUATOR">
-                    <param name="type">             foc                 foc                 foc         </param>
-                    <param name="port">             CAN1:1:0            CAN1:2:0            CAN1:3:0    </param>
+                    <param name="type">             advfoc              advfoc              advfoc      </param>
+                    <param name="onboard">          amcbldc             amcbldc             amc2c       </param>
+                    <param name="port">             CAN1:1              CAN1:2              ICC1:3      </param>
                 </group>
 
                 <group name="ENCODER1">
@@ -43,10 +44,10 @@
 
                 <group name="ENCODER2">
                     <param name="type">             none                none                none       </param>
-                    <param name="port">             CAN1:1:0            CAN1:2:0            CAN1:3:0   </param>
+                    <param name="port">             CAN1:1              CAN1:2              ICC1:3     </param>
                     <param name="position">         atmotor             atmotor             atmotor    </param>
-                    <param name="resolution">        0                   0                   0         </param>
-                    <param name="tolerance">         0                   0                   0         </param>
+                    <param name="resolution">       0                   0                   0          </param>
+                    <param name="tolerance">        0                   0                   0          </param>
                 </group>
 
             </group>

--- a/ergoCubSN001/hardware/motorControl/right_arm-eb30-j4_6-mc_service.xml
+++ b/ergoCubSN001/hardware/motorControl/right_arm-eb30-j4_6-mc_service.xml
@@ -5,7 +5,7 @@
 
     <group name="SERVICE">
 
-        <param name="type"> eomn_serv_MC_foc </param>
+        <param name="type"> eomn_serv_MC_advfoc </param>
 
         <group name="PROPERTIES">
 
@@ -14,23 +14,24 @@
             </group>
 
             <group name="CANBOARDS">
-                <param name="type">                 amcbldc     </param>
+                <param name="type">                 amcbldc     amc2c   </param>
                 <group name="PROTOCOL">
-                    <param name="major">            2           </param>
-                    <param name="minor">            0           </param>
+                    <param name="major">            2           2       </param>
+                    <param name="minor">            0           0       </param>
                 </group>
                 <group name="FIRMWARE">
-                    <param name="major">            2           </param>
-                    <param name="minor">            0           </param>
-                    <param name="build">            4           </param>
+                    <param name="major">            2           3       </param>
+                    <param name="minor">            0           0       </param>
+                    <param name="build">            10          0       </param>
                 </group>
             </group>
 
             <group name="JOINTMAPPING">
 
                 <group name="ACTUATOR">
-                    <param name="type">             foc                 foc                 foc         </param>
-                    <param name="port">             CAN1:1:0            CAN1:2:0            CAN1:3:0    </param>
+                    <param name="type">             advfoc              advfoc              advfoc      </param>
+                    <param name="onboard">          amcbldc             amcbldc             amc2c       </param>
+                    <param name="port">             CAN1:1              CAN1:2              ICC1:3      </param>
                 </group>
 
                 <group name="ENCODER1">
@@ -42,11 +43,11 @@
                 </group>
 
                 <group name="ENCODER2">
-                    <param name="type">             none                none                none        </param>
-                    <param name="port">             CAN1:1:0            CAN1:2:0            CAN1:3:0    </param>
-                    <param name="position">         atmotor             atmotor             atmotor     </param>
-                    <param name="resolution">       0                   0                   0           </param>
-                    <param name="tolerance">        0                   0                   0           </param>
+                    <param name="type">             none                none                none       </param>
+                    <param name="port">             CAN1:1              CAN1:2              ICC1:3     </param>
+                    <param name="position">         atmotor             atmotor             atmotor    </param>
+                    <param name="resolution">       0                   0                   0          </param>
+                    <param name="tolerance">        0                   0                   0          </param>
                 </group>
 
             </group>

--- a/ergoCubSN002/hardware/mechanicals/left_arm-eb31-j4_6-mec.xml
+++ b/ergoCubSN002/hardware/mechanicals/left_arm-eb31-j4_6-mec.xml
@@ -25,7 +25,7 @@
         <param name="rotorPosMax">           0             0             0           </param>
     </group>
 
-    <group name="AMCBLDC">
+    <group name="ADVFOC">
         <param name="HasHallSensor">         1             1             1           </param>
         <param name="HasTempSensor">         0             0             0           </param>
         <param name="HasRotorEncoder">       0             0             0           </param>

--- a/ergoCubSN002/hardware/mechanicals/right_arm-eb30-j4_6-mec.xml
+++ b/ergoCubSN002/hardware/mechanicals/right_arm-eb30-j4_6-mec.xml
@@ -25,7 +25,7 @@
         <param name="rotorPosMax">           0             0             0           </param>
     </group>
 
-    <group name="AMCBLDC">
+    <group name="ADVFOC">
         <param name="HasHallSensor">         1             1             1           </param>
         <param name="HasTempSensor">         0             0             0           </param>
         <param name="HasRotorEncoder">       0             0             0           </param>

--- a/ergoCubSN002/hardware/motorControl/left_arm-eb31-j4_6-mc_service.xml
+++ b/ergoCubSN002/hardware/motorControl/left_arm-eb31-j4_6-mc_service.xml
@@ -5,7 +5,7 @@
 
     <group name="SERVICE">
 
-        <param name="type"> eomn_serv_MC_foc </param>
+        <param name="type"> eomn_serv_MC_advfoc </param>
 
         <group name="PROPERTIES">
 
@@ -14,23 +14,24 @@
             </group>
 
             <group name="CANBOARDS">
-                <param name="type">                 amcbldc     </param>
+                <param name="type">                 amcbldc     amc2c   </param>
                 <group name="PROTOCOL">
-                    <param name="major">            2           </param>
-                    <param name="minor">            0           </param>
+                    <param name="major">            2           2       </param>
+                    <param name="minor">            0           0       </param>
                 </group>
                 <group name="FIRMWARE">
-                    <param name="major">            2           </param>
-                    <param name="minor">            0           </param>
-                    <param name="build">            4           </param>
+                    <param name="major">            2           3       </param>
+                    <param name="minor">            0           0       </param>
+                    <param name="build">            10          0       </param>
                 </group>
             </group>
 
             <group name="JOINTMAPPING">
 
                 <group name="ACTUATOR">
-                    <param name="type">             foc                 foc                 foc         </param>
-                    <param name="port">             CAN1:1:0            CAN1:2:0            CAN1:3:0    </param>
+                    <param name="type">             advfoc              advfoc              advfoc      </param>
+                    <param name="onboard">          amcbldc             amcbldc             amc2c       </param>
+                    <param name="port">             CAN1:1              CAN1:2              ICC1:3      </param>
                 </group>
 
                 <group name="ENCODER1">
@@ -43,10 +44,10 @@
 
                 <group name="ENCODER2">
                     <param name="type">             none                none                none       </param>
-                    <param name="port">             CAN1:1:0            CAN1:2:0            CAN1:3:0   </param>
+                    <param name="port">             CAN1:1              CAN1:2              ICC1:3     </param>
                     <param name="position">         atmotor             atmotor             atmotor    </param>
-                    <param name="resolution">        0                   0                   0         </param>
-                    <param name="tolerance">         0                   0                   0         </param>
+                    <param name="resolution">       0                   0                   0          </param>
+                    <param name="tolerance">        0                   0                   0          </param>
                 </group>
 
             </group>

--- a/ergoCubSN002/hardware/motorControl/right_arm-eb30-j4_6-mc_service.xml
+++ b/ergoCubSN002/hardware/motorControl/right_arm-eb30-j4_6-mc_service.xml
@@ -5,7 +5,7 @@
 
     <group name="SERVICE">
 
-        <param name="type"> eomn_serv_MC_foc </param>
+        <param name="type"> eomn_serv_MC_advfoc </param>
 
         <group name="PROPERTIES">
 
@@ -14,23 +14,24 @@
             </group>
 
             <group name="CANBOARDS">
-                <param name="type">                 amcbldc     </param>
+                <param name="type">                 amcbldc     amc2c   </param>
                 <group name="PROTOCOL">
-                    <param name="major">            2           </param>
-                    <param name="minor">            0           </param>
+                    <param name="major">            2           2       </param>
+                    <param name="minor">            0           0       </param>
                 </group>
                 <group name="FIRMWARE">
-                    <param name="major">            2           </param>
-                    <param name="minor">            0           </param>
-                    <param name="build">            4           </param>
+                    <param name="major">            2           3       </param>
+                    <param name="minor">            0           0       </param>
+                    <param name="build">            10          0       </param>
                 </group>
             </group>
 
             <group name="JOINTMAPPING">
 
                 <group name="ACTUATOR">
-                    <param name="type">             foc                 foc                 foc         </param>
-                    <param name="port">             CAN1:1:0            CAN1:2:0            CAN1:3:0    </param>
+                    <param name="type">             advfoc              advfoc              advfoc      </param>
+                    <param name="onboard">          amcbldc             amcbldc             amc2c       </param>
+                    <param name="port">             CAN1:1              CAN1:2              ICC1:3      </param>
                 </group>
 
                 <group name="ENCODER1">
@@ -42,11 +43,11 @@
                 </group>
 
                 <group name="ENCODER2">
-                    <param name="type">             none                none                none        </param>
-                    <param name="port">             CAN1:1:0            CAN1:2:0            CAN1:3:0    </param>
-                    <param name="position">         atmotor             atmotor             atmotor     </param>
-                    <param name="resolution">       0                   0                   0           </param>
-                    <param name="tolerance">        0                   0                   0           </param>
+                    <param name="type">             none                none                none       </param>
+                    <param name="port">             CAN1:1              CAN1:2              ICC1:3     </param>
+                    <param name="position">         atmotor             atmotor             atmotor    </param>
+                    <param name="resolution">       0                   0                   0          </param>
+                    <param name="tolerance">        0                   0                   0          </param>
                 </group>
 
             </group>

--- a/experimentalSetups/lego_setup_amc_advfoc/calibrators/setup-calib.xml
+++ b/experimentalSetups/lego_setup_amc_advfoc/calibrators/setup-calib.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="setup-calibrator" type="parametricCalibratorEth">
+
+    <xi:include href="../general.xml" />
+
+    <group name="GENERAL">
+        <param name="joints"> 1 </param> <!-- the number of joints of the robot part -->
+        <param name="deviceName"> Setup_Calibrator </param>
+    </group>
+
+    <group name="HOME">
+        <param name="positionHome">                     0       </param>
+        <param name="velocityHome">                     10      </param>
+    </group>
+
+    <group name="CALIBRATION">
+        <param name="calibrationType">                  12      </param>
+
+        <param name="calibration1">                     6865    </param>
+        <param name="calibration2">                     0       </param>
+        <param name="calibration3">                     0       </param>
+        <param name="calibration4">                     0       </param>
+        <param name="calibration5">                     0       </param>
+        <param name="calibrationZero">                  0       </param>
+        <param name="calibrationDelta">                 0       </param>
+
+        <param name="startupPosition">                  0.0     </param>
+        <param name="startupVelocity">                  30.0    </param>
+        <param name="startupMaxPwm">                    16000   </param>
+        <param name="startupPosThreshold">              2       </param>
+    </group>
+
+    <param name="CALIB_ORDER"> (0) </param>
+
+    <action phase="startup" level="10" type="calibrate">
+        <param name="target">setup-mc_remapper</param>
+    </action>
+
+    <action phase="interrupt1" level="1" type="park">
+        <param name="target">setup-mc_remapper</param>
+    </action>
+
+    <action phase="interrupt3" level="1" type="abort" />
+
+</device>

--- a/experimentalSetups/lego_setup_amc_advfoc/firmwareupdater.ini
+++ b/experimentalSetups/lego_setup_amc_advfoc/firmwareupdater.ini
@@ -1,0 +1,2 @@
+[DRIVERS]
+ETH "eth"

--- a/experimentalSetups/lego_setup_amc_advfoc/general.xml
+++ b/experimentalSetups/lego_setup_amc_advfoc/general.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="setup" build="1">
+  
+  <group name="GENERAL">
+      <param name="skipCalibration">    false  </param>
+      <param name="useRawEncoderData">  false  </param>
+      <param name="useLimitedPWM">      false  </param>
+      <param name="verbose">            false  </param>
+  </group>
+</params>

--- a/experimentalSetups/lego_setup_amc_advfoc/hardware/electronics/pc104.xml
+++ b/experimentalSetups/lego_setup_amc_advfoc/hardware/electronics/pc104.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="setup" build="1">
+
+    <group name="PC104">
+        <param name="PC104IpAddress">           10.0.1.104      </param>
+        <param name="PC104IpPort">              12345           </param>
+        <param name="PC104TXrate">              1               </param> 
+        <param name="PC104RXrate">              5               </param>
+    </group>
+
+</params>
+

--- a/experimentalSetups/lego_setup_amc_advfoc/hardware/electronics/setup-eb2-j0_2-eln.xml
+++ b/experimentalSetups/lego_setup_amc_advfoc/hardware/electronics/setup-eb2-j0_2-eln.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="setup" build="1">
+
+    <xi:include href="./pc104.xml" />
+
+    <group name="ETH_BOARD">
+
+        <group name="ETH_BOARD_PROPERTIES">
+            <param name="IpAddress">                10.0.1.1                </param>
+            <param name="IpPort">                   12345                   </param>
+            <param name="Type">                     amc                    </param>
+            <param name="maxSizeRXpacket">          768                     </param>
+            <param name="maxSizeROP">               384                     </param>
+        </group>
+
+        <group name="ETH_BOARD_SETTINGS">
+            <param name="Name">                     "setup-eb2-j0_2"        </param>
+            <group name="RUNNINGMODE">
+                <param name="period">                   1000                </param>
+                <param name="maxTimeOfRXactivity">      400                 </param>
+                <param name="maxTimeOfDOactivity">      300                 </param>
+                <param name="maxTimeOfTXactivity">      300                 </param>
+                <param name="TXrateOfRegularROPs">      5                   </param>
+            </group>
+        </group>
+
+        <group name="ETH_BOARD_ACTIONS">
+            <group name="MONITOR_ITS_PRESENCE">
+                <param name="enabled">                  true                </param>
+                <param name="timeout">                  0.020               </param>
+                <param name="periodOfMissingReport">    60.0                </param>
+            </group>
+        </group>
+
+    </group>
+
+</params>
+

--- a/experimentalSetups/lego_setup_amc_advfoc/hardware/electronics/setup-eb2-j0_2-eln.xml.bak
+++ b/experimentalSetups/lego_setup_amc_advfoc/hardware/electronics/setup-eb2-j0_2-eln.xml.bak
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="setup" build="1">
+
+    <xi:include href="./pc104.xml" />
+
+    <group name="ETH_BOARD">
+
+        <group name="ETH_BOARD_PROPERTIES">
+            <param name="IpAddress">                10.0.1.1                </param>
+            <param name="IpPort">                   12345                   </param>
+            <param name="Type">                     amc                    </param>
+            <param name="maxSizeRXpacket">          768                     </param>
+            <param name="maxSizeROP">               400                     </param>
+        </group>
+
+        <group name="ETH_BOARD_SETTINGS">
+            <param name="Name">                     "setup-eb2-j0_2"        </param>
+            <group name="RUNNINGMODE">
+                <param name="period">                   1000                </param>
+                <param name="maxTimeOfRXactivity">      400                 </param>
+                <param name="maxTimeOfDOactivity">      300                 </param>
+                <param name="maxTimeOfTXactivity">      300                 </param>
+                <param name="TXrateOfRegularROPs">      5                   </param>
+            </group>
+        </group>
+
+        <group name="ETH_BOARD_ACTIONS">
+            <group name="MONITOR_ITS_PRESENCE">
+                <param name="enabled">                  true                </param>
+                <param name="timeout">                  0.020               </param>
+                <param name="periodOfMissingReport">    60.0                </param>
+            </group>
+        </group>
+
+    </group>
+
+</params>
+

--- a/experimentalSetups/lego_setup_amc_advfoc/hardware/mechanicals/setup-eb2-j0_2-mec.xml
+++ b/experimentalSetups/lego_setup_amc_advfoc/hardware/mechanicals/setup-eb2-j0_2-mec.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="setup" build="1">
+    <group name="GENERAL">
+        <param name="MotioncontrolVersion"> 6 </param>
+        <param name="Joints"> 1 </param>
+        <param name="AxisMap">               0          </param>
+        <param name="AxisName">         "setup_yaw"     </param>
+        <param name="AxisType">         "revolute"      </param>
+        <param name="Encoder">          182.044         </param>
+        <param name="fullscalePWM">     32000           </param>
+        <param name="ampsToSensor">     1000.0          </param>
+        <param name="Gearbox_M2J">     -384.44          </param>
+        <param name="Gearbox_E2J">      1.778           </param>
+        <param name="useMotorSpeedFbk"> 0               </param>
+        <param name="MotorType">        "BLL_MOOG"      </param>
+        <param name="Verbose">          0               </param>
+    </group>
+
+    <group name="LIMITS">
+        <param name="hardwareJntPosMax">     180        </param>
+        <param name="hardwareJntPosMin">     -180       </param>
+        <param name="rotorPosMin">           0          </param>
+        <param name="rotorPosMax">           0          </param>
+    </group>
+
+    <group name="AMCBLDC">
+        <param name="HasHallSensor">         1          </param>
+        <param name="HasTempSensor">         0          </param>
+        <param name="HasRotorEncoder">       0          </param>
+        <param name="HasRotorEncoderIndex">  0          </param>
+        <param name="HasSpeedEncoder">       0          </param>
+        <param name="RotorIndexOffset">      0          </param>
+        <param name="MotorPoles">            14         </param>
+   </group>
+   
+    <group name="ADVFOC">
+        <param name="HasHallSensor">         1          </param>
+        <param name="HasTempSensor">         0          </param>
+        <param name="HasRotorEncoder">       0          </param>
+        <param name="HasRotorEncoderIndex">  0          </param>
+        <param name="HasSpeedEncoder">       0          </param>
+        <param name="RotorIndexOffset">      0          </param>
+        <param name="MotorPoles">            14         </param>
+   </group>   
+
+    <group name="COUPLINGS">
+
+        <param name ="matrixJ2M">
+            1.0 0.0 0.0 0.0
+            0.0 1.0 0.0 0.0
+            0.0 0.0 1.0 0.0
+            0.0 0.0 0.0 1.0
+        </param>
+
+        <param name ="matrixM2J">
+            1.0 0.0 0.0 0.0
+            0.0 1.0 0.0 0.0
+            0.0 0.0 1.0 0.0
+            0.0 0.0 0.0 1.0
+        </param>
+
+        <param name ="matrixE2J">
+            1.00    0.00    0.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00    0.00    0.00
+            0.00    0.00    1.00    0.00    0.00    0.00
+            0.00    0.00    0.00    1.00    0.00    0.00
+        </param>
+
+    </group>
+
+    <group name="JOINTSET_CFG">
+        <param name= "numberofsets"> 1 </param>
+        <group name="JOINTSET_0">
+            <param name="listofjoints">  0         </param>
+            <param name="constraint">    none      </param>
+            <param name="param1">        0         </param>
+            <param name="param2">        0         </param>
+        </group>
+    </group>
+
+</params>

--- a/experimentalSetups/lego_setup_amc_advfoc/hardware/motorControl/setup-eb2-j0_2-mc.xml
+++ b/experimentalSetups/lego_setup_amc_advfoc/hardware/motorControl/setup-eb2-j0_2-mc.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="setup-eb2-j0_2-mc" type="embObjMotionControl">
+
+    <xi:include href="../../general.xml" />
+    <xi:include href="../../hardware/electronics/setup-eb2-j0_2-eln.xml" />
+    <xi:include href="../../hardware/mechanicals/setup-eb2-j0_2-mec.xml" />
+    <xi:include href="./setup-eb2-j0_2-mc_service.xml" />
+
+    <!-- joint number                           0                   -->
+    <!-- joint name -->
+    <group name="LIMITS">
+        <param name="jntPosMax">                180                 </param>
+        <param name="jntPosMin">                -180                 </param>
+        <param name="jntVelMax">                90                 </param>
+        <param name="motorNominalCurrents">     1000               </param>
+        <param name="motorPeakCurrents">        1500               </param>
+        <param name="motorOverloadCurrents">    2000               </param>
+        <param name="motorPwmLimit">            16000              </param>
+    </group>
+
+    <group name="TIMEOUTS">
+        <param name="velocity">                 100                </param>
+    </group>
+
+    <group name="IMPEDANCE">
+        <param name="stiffness">                0                  </param>
+        <param name="damping">                  0                  </param>
+    </group>
+
+    <group name="CONTROLS">
+        <param name="positionControl">          POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     </param>
+        <param name="mixedControl">             POS_PID_DEFAULT     </param>
+        <param name="torqueControl">            none                </param>
+        <param name="currentPid">               2FOC_CUR_CONTROL    </param>
+        <param name="speedPid">                 2FOC_VEL_CONTROL    </param>
+    </group>
+
+
+    <!-- default position PID: begin -->
+
+    <group name="POS_PID_DEFAULT">
+        <param name="controlLaw">             minjerk                </param>
+        <param name="outputType">             current                </param>
+        <param name="fbkControlUnits">        metric_units           </param>
+        <param name="outputControlUnits">     machine_units          </param>
+        <param name="kp">                    -30                     </param>
+        <param name="kd">                    -10                     </param>
+        <param name="ki">                    -100                    </param>
+        <param name="maxOutput">              500                    </param>
+        <param name="maxInt">                 200                    </param>
+        <param name="stictionUp">             0                      </param>
+        <param name="stictionDown">           0                      </param>
+        <param name="kff">                    0                      </param>
+    </group>
+
+    <!-- default position PID: end -->
+
+
+    <!-- other default PIDs: begin -->
+
+    <group name="2FOC_CUR_CONTROL">
+        <param name="controlLaw">           low_lev_current          </param>
+        <param name="fbkControlUnits">      machine_units            </param>
+        <param name="outputControlUnits">   machine_units            </param>
+        <param name="kp">                   2                        </param>
+        <param name="kd">                   0                        </param>
+        <param name="ki">                   500                      </param>
+        <param name="shift">                0                        </param>
+        <param name="maxOutput">            32000                    </param>
+        <param name="maxInt">               32000                    </param>
+        <param name="kff">                  0                        </param>
+    </group>
+
+    <group name="2FOC_VEL_CONTROL">
+        <param name="controlLaw">           low_lev_speed            </param>
+        <param name="fbkControlUnits">      machine_units            </param>
+        <param name="outputControlUnits">   machine_units            </param>
+        <param name="kff">                  0                        </param>
+        <param name="kp">                   12                       </param>
+        <param name="kd">                   0                        </param>
+        <param name="ki">                   16                       </param>
+        <param name="shift">                10                       </param>
+        <param name="maxOutput">            32000                    </param>
+        <param name="maxInt">               32000                    </param>
+    </group>
+
+    <!-- other default PIDs: end -->
+
+    <!-- custom PIDs: begin -->
+
+    <!-- custom PIDs: end -->
+
+</device>

--- a/experimentalSetups/lego_setup_amc_advfoc/hardware/motorControl/setup-eb2-j0_2-mc_service.xml
+++ b/experimentalSetups/lego_setup_amc_advfoc/hardware/motorControl/setup-eb2-j0_2-mc_service.xml
@@ -105,7 +105,7 @@
                 <group name="FIRMWARE">
                     <param name="major">            3       2           </param>
                     <param name="minor">            0       0           </param>
-                    <param name="build">            0       9           </param>
+                    <param name="build">            0       10          </param>
                 </group>
             </group>
            

--- a/experimentalSetups/lego_setup_amc_advfoc/hardware/motorControl/setup-eb2-j0_2-mc_service.xml
+++ b/experimentalSetups/lego_setup_amc_advfoc/hardware/motorControl/setup-eb2-j0_2-mc_service.xml
@@ -4,6 +4,67 @@
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="setup" build="1">
 
     <group name="SERVICE">
+    
+        <group name="templates">
+        
+        <!--
+            the group templates is not parsed by icub-main and contains xml snapshots that help to compose the MC service
+            
+            we can test two MC service types (advfoc and foc) with a number of actuator boards (amcbldc and amc2c). 
+            the controlling ETH board shall be:
+            - amc for both the advfoc and foc MC service types;
+            - ems for the single case of foc MC service type
+           
+            so, you need to:
+            1. pick up a type (either eomn_serv_MC_advfoc or eomn_serv_MC_foc)
+            2. for the given type pick up the wanted ACTUATOR:
+               - advfoc.ACTUATOR-01-amc2c-icc: the amc uses ICC to communicate w/ its second core
+               - advfoc.ACTUATOR-02-amc2c-can: the amc uses CAN to communicate w/ its second core
+               - advfoc.ACTUATOR-03-amcbldc-can: the amc uses CAN to communicate w/ an amcbldc
+               - foc.ACTUATOR-01-amcbldc: the amc uses CAN to communicate w/ an amcbldc w/ legacy foc mode
+                 note: this mode is also available if we use an ems instead of the amc                      
+        
+         -->
+        
+            <group name="advfoc">
+            
+                <param name="type"> eomn_serv_MC_advfoc </param>
+
+                <group name="ACTUATOR-01-amc2c-icc">
+                    <param name="type">             eomc_act_advfoc     </param>
+                    <param name="onboard">          amc2c               </param>
+                    <param name="port">             ICC1:3              </param>                               
+                </group>    
+
+                <group name="ACTUATOR-02-amc2c-can">
+                    <param name="type">             eomc_act_advfoc     </param>
+                    <param name="onboard">          amc2c               </param>
+                    <param name="port">             CAN1:3              </param>                               
+                </group>                    
+
+                <group name="ACTUATOR-03-amcbldc-can">
+                    <param name="type">             eomc_act_advfoc     </param>
+                    <param name="onboard">          amcbldc             </param>
+                    <param name="port">             CAN1:1              </param>                               
+                </group> 
+                
+            </group>
+        
+
+            <group name="foc">
+            
+                <param name="type"> eomn_serv_MC_foc </param>  
+                
+                <group name="ACTUATOR-01-amcbldc">
+                    <param name="type">             eomc_act_foc        </param>
+                    <param name="onboard">          amcbldc             </param>
+                    <param name="port">             CAN1:1              </param>                               
+                </group>  
+                
+            </group>
+            
+        </group>
+        
 
         <param name="type"> eomn_serv_MC_advfoc </param>
 
@@ -25,25 +86,7 @@
                     <param name="build">            0       9           </param>
                 </group>
             </group>
-
-            <group name="actuator-can-amcbldc">
-                    <param name="type">             eomc_act_advfoc     </param>
-                    <param name="onboardcan">       amcbldc             </param>
-                    <param name="portcan">          CAN1:3              </param>                               
-            </group>
-
-            <group name="actuator-can-amc2c">
-                    <param name="type">             eomc_act_advfoc     </param>
-                    <param name="onboardcan">       amc2c             </param>
-                    <param name="portcan">          CAN1:3              </param>                               
-            </group>
-            
-            <group name="actuator-icc-amc2c">
-                    <param name="type">             eomc_act_advfoc     </param>
-                    <param name="onboardcan">       amc2c             </param>
-                    <param name="portcan">          ICC1:3              </param>                               
-            </group>
-            
+           
                         
             <group name="JOINTMAPPING">
 

--- a/experimentalSetups/lego_setup_amc_advfoc/hardware/motorControl/setup-eb2-j0_2-mc_service.xml
+++ b/experimentalSetups/lego_setup_amc_advfoc/hardware/motorControl/setup-eb2-j0_2-mc_service.xml
@@ -4,10 +4,11 @@
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="setup" build="1">
 
     <group name="SERVICE">
-    
-        <group name="templates">
+
         
         <!--
+            templates: description
+
             the group templates is not parsed by icub-main and contains xml snapshots that help to compose the MC service
             
             we can test two MC service types (advfoc and foc) with a number of actuator boards (amcbldc and amc2c). 
@@ -22,10 +23,29 @@
                - advfoc.ACTUATOR-02-amc2c-can: the amc uses CAN to communicate w/ its second core
                - advfoc.ACTUATOR-03-amcbldc-can: the amc uses CAN to communicate w/ an amcbldc
                - foc.ACTUATOR-01-amcbldc: the amc uses CAN to communicate w/ an amcbldc w/ legacy foc mode
-                 note: this mode is also available if we use an ems instead of the amc                      
+                 note: this mode is also available if we use an ems instead of the amc
+            3. for the eomn_serv_MC_foc w/ amcbldc also put the amcbldc in first position as in the following
+            
+                <group name="CANBOARDS">
+                    <param name="type">                 amcbldc amc2c       </param> 
+                    <group name="PROTOCOL">
+                        <param name="major">            2       2           </param>
+                        <param name="minor">            0       0           </param>
+                    </group>
+                    <group name="FIRMWARE">
+                        <param name="major">            2       3           </param>
+                        <param name="minor">            0       0           </param>
+                        <param name="build">            9       0           </param>
+                    </group>
+                </group>                   
         
          -->
-        
+ 
+        <!-- 
+            templates: code snippets
+
+        <group name="templates">
+      
             <group name="advfoc">
             
                 <param name="type"> eomn_serv_MC_advfoc </param>
@@ -64,7 +84,9 @@
             </group>
             
         </group>
-        
+
+         -->    
+    
 
         <param name="type"> eomn_serv_MC_advfoc </param>
 

--- a/experimentalSetups/lego_setup_amc_advfoc/hardware/motorControl/setup-eb2-j0_2-mc_service.xml
+++ b/experimentalSetups/lego_setup_amc_advfoc/hardware/motorControl/setup-eb2-j0_2-mc_service.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="setup" build="1">
+
+    <group name="SERVICE">
+
+        <param name="type"> eomn_serv_MC_advfoc </param>
+
+        <group name="PROPERTIES">
+
+            <group name="ETHBOARD">
+                <param name="type">                 amc        </param>
+            </group>
+
+            <group name="CANBOARDS">
+                <param name="type">                 amc2c   amcbldc     </param> 
+                <group name="PROTOCOL">
+                    <param name="major">            2       2           </param>
+                    <param name="minor">            0       0           </param>
+                </group>
+                <group name="FIRMWARE">
+                    <param name="major">            3       2           </param>
+                    <param name="minor">            0       0           </param>
+                    <param name="build">            0       9           </param>
+                </group>
+            </group>
+
+            <group name="actuator-can-amcbldc">
+                    <param name="type">             eomc_act_advfoc     </param>
+                    <param name="onboardcan">       amcbldc             </param>
+                    <param name="portcan">          CAN1:3              </param>                               
+            </group>
+
+            <group name="actuator-can-amc2c">
+                    <param name="type">             eomc_act_advfoc     </param>
+                    <param name="onboardcan">       amc2c             </param>
+                    <param name="portcan">          CAN1:3              </param>                               
+            </group>
+            
+            <group name="actuator-icc-amc2c">
+                    <param name="type">             eomc_act_advfoc     </param>
+                    <param name="onboardcan">       amc2c             </param>
+                    <param name="portcan">          ICC1:3              </param>                               
+            </group>
+            
+                        
+            <group name="JOINTMAPPING">
+
+                <group name="ACTUATOR">
+                    <param name="type">             eomc_act_advfoc     </param>
+                    <param name="onboard">          amc2c               </param>
+                    <param name="port">             ICC1:3              </param>
+                </group>
+
+                <group name="ENCODER1">
+                    <param name="type">             aea3                </param>
+                    <param name="port">             CONN:J5_X1          </param>
+                    <param name="position">         eomc_pos_atjoint    </param>
+                    <param name="resolution">       16384               </param>
+                    <param name="tolerance">        0.4                 </param>
+                </group>
+
+                <group name="ENCODER2">
+                    <param name="type">             none                </param>
+                    <param name="port">             CAN2:3:0            </param>
+                    <param name="position">         atmotor             </param>
+                    <param name="resolution">       0                   </param>
+                    <param name="tolerance">        0                   </param>
+                </group>
+
+            </group>
+
+        </group>
+
+    </group>
+
+</params>

--- a/experimentalSetups/lego_setup_amc_advfoc/lego_setup_amc_advfoc.xml
+++ b/experimentalSetups/lego_setup_amc_advfoc/lego_setup_amc_advfoc.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+    <robot name="setup" build="1" portprefix="/lego" xmlns:xi="http://www.w3.org/2001/XInclude">
+        <params>
+            <xi:include href="hardware/electronics/pc104.xml" />
+        </params>
+
+        <devices>
+    
+            <!-- LEGO SETUP MC -->
+            <xi:include href="hardware/motorControl/setup-eb2-j0_2-mc.xml" />
+            <xi:include href="wrappers/motorControl/setup-mc_wrapper.xml"  />
+            <xi:include href="wrappers/motorControl/setup-mc_remapper.xml" />
+    
+            <!--  CALIBRATORS -->
+            <xi:include href="calibrators/setup-calib.xml" />
+        
+    </devices>
+</robot>

--- a/experimentalSetups/lego_setup_amc_advfoc/wrappers/motorControl/setup-mc_remapper.xml
+++ b/experimentalSetups/lego_setup_amc_advfoc/wrappers/motorControl/setup-mc_remapper.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="setup-mc_remapper" type="controlboardremapper">
+    <paramlist name="networks">
+        <elem name="FirstSetOfJoints">  0  0  0  0 </elem>
+    </paramlist>
+    <param name="joints"> 1 </param>
+    <action phase="startup" level="5" type="attach">
+        <paramlist name="networks">
+            <elem name="FirstSetOfJoints">  setup-eb2-j0_2-mc    </elem>
+        </paramlist>
+    </action>
+    <action phase="shutdown" level="20" type="detach" />
+</device>

--- a/experimentalSetups/lego_setup_amc_advfoc/wrappers/motorControl/setup-mc_wrapper.xml
+++ b/experimentalSetups/lego_setup_amc_advfoc/wrappers/motorControl/setup-mc_wrapper.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="setup-mc_wrapper" type="controlBoard_nws_yarp">
+    <param name="period"> 0.01  </param>
+        <param name="name"> /lego/setup_mc </param>
+        <action phase="startup" level="10" type="attach">
+            <param name="device"> setup-mc_remapper </param>
+        </action>
+        <action phase="shutdown" level="15" type="detach" />
+    </device>

--- a/experimentalSetups/lego_setup_amc_advfoc/yarpmotorgui.ini
+++ b/experimentalSetups/lego_setup_amc_advfoc/yarpmotorgui.ini
@@ -1,0 +1,3 @@
+robot lego
+
+parts (setup_mc)

--- a/experimentalSetups/lego_setup_amc_advfoc/yarprobotinterface.ini
+++ b/experimentalSetups/lego_setup_amc_advfoc/yarprobotinterface.ini
@@ -1,0 +1,2 @@
+config ./lego_setup_amc_advfoc.xml
+

--- a/experimentalSetups/wristMK2.1_SN002F/calibrators/wrist-calib.xml
+++ b/experimentalSetups/wristMK2.1_SN002F/calibrators/wrist-calib.xml
@@ -19,7 +19,7 @@
         <param name="calibrationType">                  12      12      12      </param>
 
         <!--param name="calibration1">                     729     15429   11211   </param-->
-        <param name="calibration1">               11443.0 11188.0 23850.0   </param>
+        <param name="calibration1">                     4653    12480   8225    </param>
         <!--param name="calibration1">               -21434.0 -21264.0 -8858.0   </param-->
         <param name="calibration2">                     0       0       0       </param>
         <param name="calibration3">                     0       0       0       </param>

--- a/experimentalSetups/wristMK2.1_SN002F/hardware/mechanicals/wrist-eb2-j0_2-mec.xml
+++ b/experimentalSetups/wristMK2.1_SN002F/hardware/mechanicals/wrist-eb2-j0_2-mec.xml
@@ -25,6 +25,7 @@
         <param name="rotorPosMax">           0             0             0           </param>
     </group>
 
+
     <group name="AMCBLDC">
         <param name="HasHallSensor">         1             1             1           </param>
         <param name="HasTempSensor">         0             0             0           </param>
@@ -35,6 +36,17 @@
         <param name="MotorPoles">            14            14            14          </param>
    </group>
 
+ 
+    <group name="ADVFOC">
+        <param name="HasHallSensor">         1             1             1           </param>
+        <param name="HasTempSensor">         0             0             0           </param>
+        <param name="HasRotorEncoder">       0             0             0           </param>
+        <param name="HasRotorEncoderIndex">  0             0             0           </param>
+        <param name="HasSpeedEncoder">       0             0             0           </param>
+        <param name="RotorIndexOffset">      0             0             0           </param>
+        <param name="MotorPoles">            14            14            14          </param>
+    </group>
+   
     <group name="COUPLINGS">
 
         <param name ="matrixJ2M">

--- a/experimentalSetups/wristMK2.1_SN002F/hardware/motorControl/wrist-eb2-j0_2-mc_service.xml
+++ b/experimentalSetups/wristMK2.1_SN002F/hardware/motorControl/wrist-eb2-j0_2-mc_service.xml
@@ -4,6 +4,33 @@
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="nfa" build="1">
 
     <group name="SERVICE">
+    
+    <!--
+    
+        the legacy foc MC service type with CAN communciation uses the following
+        - SERVICE.type = eomn_serv_MC_foc
+        - SERVICE.PROPERTIES.JOINTMAPPING.ACTUATOR:
+          - .type =     foc         foc         foc
+          - .onboard =  any-string  any-string  any-string -> it uses the first board on PROPERTIES.CANBOARDS
+          - .port =     CAN1:1      CAN1:2      CAN1:3   
+          
+        to enable the advfoc MC service type and inter-core-communication vs amc2c, do the following
+        - change the SERVICE.type to be: 
+          - SERVICE.type = eomn_serv_MC_advfoc
+        - change the SERVICE.PROPERTIES.JOINTMAPPING.ACTUATOR to be:
+          - .type =     advfoc      advfoc      advfoc
+          - .onboard =  amcbldc     amcbldc     amc2c
+          - .port =     CAN1:1      CAN1:2      ICC1:3          
+          
+        to enable the advfoc MC service type and CAN communciation vs amc2c, do the following
+        - change the SERVICE.type to be: 
+          - SERVICE.type = eomn_serv_MC_advfoc
+        - change the SERVICE.PROPERTIES.JOINTMAPPING.ACTUATOR to be:
+          - .type =     advfoc      advfoc      advfoc
+          - .onboard =  amcbldc     amcbldc     amc2c
+          - .port =     CAN1:1      CAN1:2      CAN1:3                  
+    
+     -->
 
         <param name="type"> eomn_serv_MC_foc </param>
 
@@ -13,16 +40,19 @@
                 <param name="type">                 amc        </param>
             </group>
 
+            <!-- NOTE: 
+                 keep amcbldc fist if you use the eomn_serv_MC_foc, because the service gets the board from here 
+             -->
             <group name="CANBOARDS">
-                <param name="type">                 amcbldc     </param>
+                <param name="type">                 amcbldc amc2c       </param> 
                 <group name="PROTOCOL">
-                    <param name="major">            2           </param>
-                    <param name="minor">            0           </param>
+                    <param name="major">            2       2           </param>
+                    <param name="minor">            0       0           </param>
                 </group>
                 <group name="FIRMWARE">
-                    <param name="major">            2           </param>
-                    <param name="minor">            0           </param>
-                    <param name="build">            4          </param>
+                    <param name="major">            2       3           </param>
+                    <param name="minor">            0       0           </param>
+                    <param name="build">            9       0           </param>
                 </group>
             </group>
 
@@ -30,14 +60,15 @@
 
                 <group name="ACTUATOR">
                     <param name="type">             foc                 foc                 foc         </param>
-                    <param name="port">             CAN1:1:0            CAN1:2:0            CAN1:3:0    </param>
+                    <param name="onboard">          amcbldc             amcbldc             amcbldc     </param>
+                    <param name="port">             CAN1:1              CAN1:2              CAN1:3      </param>
                 </group>
 
                 <group name="ENCODER1">
-                    <param name="type">             aea3                aea3                aea3         </param>
+                    <param name="type">             aea3                aea3                aea3        </param>
                     <param name="port">             CONN:J5_X1          CONN:J5_X2          CONN:J5_X3  </param>
                     <param name="position">         atjoint             atjoint             atjoint     </param>
-                    <param name="resolution">       16384               16384               16384        </param>
+                    <param name="resolution">       16384               16384               16384       </param>
                     <param name="tolerance">        0.4                 0.4                 0.4         </param>
                 </group>
 

--- a/experimentalSetups/wristMK2.1_SN002F/hardware/motorControl/wrist-eb2-j0_2-mc_service.xml
+++ b/experimentalSetups/wristMK2.1_SN002F/hardware/motorControl/wrist-eb2-j0_2-mc_service.xml
@@ -6,6 +6,7 @@
     <group name="SERVICE">
     
     <!--
+        migration to inter-core-communication (ICC) 
     
         the legacy foc MC service type with CAN communciation uses the following
         - SERVICE.type = eomn_serv_MC_foc
@@ -22,7 +23,7 @@
           - .onboard =  amcbldc     amcbldc     amc2c
           - .port =     CAN1:1      CAN1:2      ICC1:3          
           
-        to enable the advfoc MC service type and CAN communciation vs amc2c, do the following
+        to enable the advfoc MC service type and CAN communication vs amc2c, do the following
         - change the SERVICE.type to be: 
           - SERVICE.type = eomn_serv_MC_advfoc
         - change the SERVICE.PROPERTIES.JOINTMAPPING.ACTUATOR to be:
@@ -33,15 +34,18 @@
      -->
 
         <param name="type"> eomn_serv_MC_foc </param>
+        <!-- icc: use this one
+        <param name="type"> eomn_serv_MC_advfoc </param>
+         -->
 
         <group name="PROPERTIES">
 
             <group name="ETHBOARD">
-                <param name="type">                 amc        </param>
+                <param name="type"> amc </param>
             </group>
 
             <!-- NOTE: 
-                 keep amcbldc fist if you use the eomn_serv_MC_foc, because the service gets the board from here 
+                 keep amcbldc first in the column if you use the eomn_serv_MC_foc, because the service gets first board the boar
              -->
             <group name="CANBOARDS">
                 <param name="type">                 amcbldc amc2c       </param> 
@@ -63,7 +67,14 @@
                     <param name="onboard">          amcbldc             amcbldc             amcbldc     </param>
                     <param name="port">             CAN1:1              CAN1:2              CAN1:3      </param>
                 </group>
-
+                
+                <!-- icc: use this one
+                <group name="ACTUATOR">
+                    <param name="type">             advfoc              advfoc              advfoc      </param>
+                    <param name="onboard">          amcbldc             amcbldc             amc2c       </param>
+                    <param name="port">             CAN1:1              CAN1:2              ICC1:3      </param>
+                </group>
+                -->
                 <group name="ENCODER1">
                     <param name="type">             aea3                aea3                aea3        </param>
                     <param name="port">             CONN:J5_X1          CONN:J5_X2          CONN:J5_X3  </param>

--- a/experimentalSetups/wristMK2.1_SN002F/hardware/motorControl/wrist-eb2-j0_2-mc_service.xml
+++ b/experimentalSetups/wristMK2.1_SN002F/hardware/motorControl/wrist-eb2-j0_2-mc_service.xml
@@ -33,10 +33,7 @@
     
      -->
 
-        <param name="type"> eomn_serv_MC_foc </param>
-        <!-- icc: use this one
         <param name="type"> eomn_serv_MC_advfoc </param>
-         -->
 
         <group name="PROPERTIES">
 
@@ -56,25 +53,18 @@
                 <group name="FIRMWARE">
                     <param name="major">            2       3           </param>
                     <param name="minor">            0       0           </param>
-                    <param name="build">            9       0           </param>
+                    <param name="build">            10      0           </param>
                 </group>
             </group>
 
             <group name="JOINTMAPPING">
 
                 <group name="ACTUATOR">
-                    <param name="type">             foc                 foc                 foc         </param>
-                    <param name="onboard">          amcbldc             amcbldc             amcbldc     </param>
-                    <param name="port">             CAN1:1              CAN1:2              CAN1:3      </param>
-                </group>
-                
-                <!-- icc: use this one
-                <group name="ACTUATOR">
                     <param name="type">             advfoc              advfoc              advfoc      </param>
                     <param name="onboard">          amcbldc             amcbldc             amc2c       </param>
                     <param name="port">             CAN1:1              CAN1:2              ICC1:3      </param>
                 </group>
-                -->
+
                 <group name="ENCODER1">
                     <param name="type">             aea3                aea3                aea3        </param>
                     <param name="port">             CONN:J5_X1          CONN:J5_X2          CONN:J5_X3  </param>

--- a/iCubTemplates/iCubTemplateV6_0/hardware/mechanicals/body_part-ebX-jA_B-mec.xml
+++ b/iCubTemplates/iCubTemplateV6_0/hardware/mechanicals/body_part-ebX-jA_B-mec.xml
@@ -45,6 +45,23 @@
         <param name="MotorPoles">            1    </param> <!--  Number of poles of motor -->
     </group>
 
+    <group name="ADVFOC"> <!-- this group is used only if SERVICE.type is eomn_serv_MC_advfoc. Its syntax at date of march 2024 is the same as the group 2FOC-->
+        <param name="Verbose">               0    </param> <!-- If 1, it enables debug prints of actuator boards. It is optional and its default value is 1. -->
+        <param name="AutoCalibration">       0    </param> <!-- If 1, it enables AutoCalibration procedure of optical encoder. It is optional and its default value is 0. -->
+        <param name="HasHallSensor">         0    </param> <!-- Indicates if hall sensors are connected to actuator board -->
+        <param name="HasTempSensor">         0    </param> <!-- Indicates if the temperature sensors are connected to actuator board.
+                                                                It will be soon DEPRECATED in favour of TemperatureSensorType. 
+                                                                If you want to configure the temperature sensor you have to use the TemperatureSensorType instead of set this to 1. -->
+        <param name="TemperatureSensorType"> NONE </param> <!-- Indicates the type of temperature sensor mounted on this motor.
+                                                                It is going to SUBSTITUTE the param HasTempSensor, which is going to be deprecated.
+                                                                Currently the availbale values are PT100, PT1000, NONE (used if motor is equipped with no sensors)
+                                                                If set, the user MUST also set the hardwareTemperatureLimit and the warningTemperatureLimit in motorControl configuration file.-->
+        <param name="HasRotorEncoder">       0    </param> <!-- Indicates if rotor has encoder   -->
+        <param name="HasRotorEncoderIndex">  0    </param> <!-- Indicates if the rotor encoder has index -->
+        <param name="HasSpeedEncoder">       0    </param> <!-- It is as an alternative to rotorEncoder. It is not used for FOC controller. -->
+        <param name="RotorIndexOffset">      0    </param> <!-- Rotor index offset between first electric sector and encoder index [degree] -->
+        <param name="MotorPoles">            1    </param> <!--  Number of poles of motor -->
+    </group>
 
     <group name="COUPLINGS"> 
 

--- a/iCubTemplates/iCubTemplateV6_0/hardware/motorControl/body_part--ebX-jA_B-mc-service.xml
+++ b/iCubTemplates/iCubTemplateV6_0/hardware/motorControl/body_part--ebX-jA_B-mc-service.xml
@@ -7,16 +7,17 @@
         
         <param name="type"> eomn_serv_MC_foc </param> <!-- This param describe the type of motion control service. Possible values are:
                                                           * eomn_serv_MC_foc : ems with 2foc
+                                                          * eomn_serv_MC_advfoc : as eomn_serv_MC_foc but also with mixed actuator boards. See ADVFOC tag for description.
                                                           * eomn_serv_MC_mc4: ems with mc4 can boards.
                                                           * eomn_serv_MC_mc4plus : mc4plus
                                                           * eomn_serv_MC_mc4plusmais : mc4plus board connected to mais board (used for hands) -->
         <group name="PROPERTIES">
             <group name="ETHBOARD">
-                <param name="type">  ems4    </param> <!-- specifies type of ethernet board: it ca be  ems4  or mc4plus or mc2plus -->
+                <param name="type">  ems4    </param> <!-- specifies type of ethernet board: it ca be  ems4  or mc4plus or mc2plus or amc -->
             </group>          
 
-            <group name="CANBOARDS"> <!-- This group is present only if there is at least one can board (both motor control board or sensor board) -->
-                <param name="type">        foc       </param> <!-- tyepe of can board:   foc, mc4 and mais-->
+            <group name="CANBOARDS"> <!-- This group contains the properties of the used CAN boards. For ADVFOC we can have more than one type, e.g., amcbldc and amc2c -->
+                <param name="type">        foc       </param> <!-- type of can board: foc, mc4, amcbldc, amc2c -->
                 <group name="PROTOCOL"> <!-- can protol version of : if its values are 0.0 then no check on can protocol compatibility is performed -->
                     <param name="major">   1          </param>  <!--  allowed values are in range[0, 255] -->
                     <param name="minor">   1          </param>  <!--  allowed values are in range[0, 255] -->
@@ -33,27 +34,33 @@
                 <group name="ACTUATOR">                
                     <param name="type"> foc      </param> <!-- Its values are: 
                                                            * foc: if the motor is connected to the foc
+                                                           * advfoc: if the type is eomn_serv_MC_advfoc 
                                                            * mc4: if the motor is connected to the mc4 (can board)  
-                                                           * pwm: if the motor is directly connected to the ethernet board, like in case on mc4plus and mc2plus -->
+                                                           * pwm: if the motor is directly connected to the ethernet board, like in case on mc4plus and mc2plus 
+                                                           -->
                                          
-                                         
+                    <param name="onboard">  amc2c </param> <!-- It is used only if the type is eomn_serv_MC_advfoc and tells on which board type is the actuator       
+                                                            -->                    
                                          
                     <param name="port">  1:1:1  </param>   <!-- The value of this param depend on type (previous parameter):
-                                                            *if type=foc than port is a can port, where the syntax is : CANX:ADDR:INDEX, 
+                                                            * if type=foc the port is a can port, where the syntax is : CANX:ADDR:INDEX, 
                                                                                                                             * CANX is the can port of ethernet board (CAN1 or CAN2)
                                                                                                                             * ADDR: the address of can board [1, 14]
                                                                                                                             * index: indicates if the motor is the first or second for the can board [0, 1]
-                                                                                                                            
-                                                            * if type=mc4  than port is a can port, where the syntax is : CANX:ADDR:INDEX, 
+                                                            * if type=advfoc the port can be either a can or an icc port, where the syntax is  CANX:ADDR or ICCx:ADDR, where: 
+                                                                                                                            * CANX is the can port of ethernet board (CAN1 or CAN2)
+                                                                                                                            * ICCx is the ICC channel of dual core ETH boards (amc, amcfoc, etc.) and can be ICC1 or ICC2
+                                                                                                                            * ADDR: the address of can board [1, 14]                                                           
+                                                            * if type=mc4 the port is a can port, where the syntax is : CANX:ADDR:INDEX, 
                                                                                                                             * CANX is the can port of ethernet board (CAN1 or CAN2)
                                                                                                                             * ADDR: the address of can board [1, 14]
                                                                                                                             * index: indicates if the motor is the first or second for the can board [0, 1]
-                                                            * if type=pwm than port is CONN:Px, wherre Px in the conector on ethernet board. -->
+                                                            * if type=pwm the port is CONN:Px, wherre Px in the conector on ethernet board. -->
                 </group>
                 
                 <!-- the ENCODER1 and ENCODER2 are equivalent, so their parameter are the same meaning -->
                 <group name="ENCODER1">
-                    <param name="type">   aea     </param>  <!-- type of encoder. It can be: aea, roie, absanalog, mais, qenc, hallmotor, spichainof2, spichainof3, none (if no encoder is present) -->
+                    <param name="type">   aea     </param>  <!-- type of encoder. It can be: aea3, aea, roie, absanalog, mais, qenc, hallmotor, spichainof2, spichainof3, none (if no encoder is present) -->
                     <param name="port">   </param>          <!-- This param has the same meaning of ACTUATOR.port.
                                                                  The value of this param depend where the encoder is connected, if to ethenert board or can board
                                                                   *if it is connected to a can board than port is a can port, where the syntax is : CANX:ADDR:INDEX, 
@@ -61,7 +68,7 @@
                                                                                                                                   * ADDR: the address of can board [1, 14]
                                                                                                                                   * index: indicates if the motor is the first or second for the can board [0, 1]
                                                                                                                                   
-                                                                  * if it is connected to ethernet board than port is CONN:Px, wherre Px in the conector on ethernet board.  (SPI port or PWM port)
+                                                                  * if it is connected to ethernet board then port is CONN:Px, wherre Px in the connector on ethernet board.  (SPI port or PWM port)
                                                                   
                                                                   * if the enoder type is a mais, the possible values of port param is: MAIS:thumbproximal  MAIS:thumbdistal MAIS:indexproximal   MAIS:indexdistal    MAIS:mediumproximal MAIS:mediumdistal   MAIS:littlefingers -->
                     <param name="position">   0 </param> <!-- it can value  atjoint, at motor or none. -->


### PR DESCRIPTION
This PR belongs to a set of five PRs on `icub-firmware`, `icub-firmware-shared`, `icub-firmware-build`, `icub-main` and `robots-configuration`.

They introduce a new MC service  that supports  actuators located on the second core of the new dual core ETH boards that run the outer control loop at 1 ms.  So far the only dual core board we use is the `amc` which runs on the first CM7 core and uses an actuator board on its CM4 core: the `amc2c`. 

See https://github.com/robotology/icub-firmware/pull/474 for details

## Linked PRs
- https://github.com/robotology/icub-firmware/pull/474
- https://github.com/robotology/icub-firmware-shared/pull/93
- https://github.com/robotology/icub-firmware-build/pull/141
- https://github.com/robotology/icub-main/pull/948