### PR TITLE
[iCubGenova11] Fix IMU config and new right thumb oppose calib

### DIFF
--- a/iCubGenova11/calibrators/right_arm-calib.xml
+++ b/iCubGenova11/calibrators/right_arm-calib.xml
@@ -21,8 +21,8 @@
 	<param name="calibration1">          35535     33135    24960    25983  1500   11700  55950  0     0     0     0     0     0      0      0     0     </param>
 	<param name="calibration2">	      	 0         0        0         0     16384   0      0     0     0     9102  9102  9102  9102   9102   9102  10000 </param>
 	<param name="calibration3">	      	 0         0        0	   	  0		 0	    0      0     0     0    -1     1    -1     1     -1      1     1     </param>
-	<param name="calibration4">          0         0        0         0      0      0      0    1720  2600   241   510   255   510    255    510   785   </param>
-	<param name="calibration5">          0         0        0         0      0      0      0    1945  3600   40    0     0    23      0      0     210   </param>
+	<param name="calibration4">          0         0        0         0      0      0      0    1720  2180   241   510   255   510    255    510   785   </param>
+	<param name="calibration5">          0         0        0         0      0      0      0    1945  3420   40    0     0    23      0      0     210   </param>
 	<param name="calibrationZero">       0         0        0         0      0      0      0     0     0     0     0     0     0      0      0     0     </param>
 	<param name="calibrationDelta">      1.0       -9.2     -14.2     0      0      0      0     0     0     0     0     0     0      0      0     0     </param>
 

--- a/iCubGenova11/icub_all.xml
+++ b/iCubGenova11/icub_all.xml
@@ -67,10 +67,7 @@
     <xi:include href="wrappers/inertials/head-inertials_wrapper.xml" />
     <xi:include href="hardware/inertials/head-inertial.xml" />
 
-    <xi:include href="wrappers/inertials/waist-inertials_remapper.xml" />
-    <xi:include href="wrappers/inertials/waist-inertials_wrapper.xml" />
     <xi:include href="hardware/inertials/waist-inertial.xml" />
-    <xi:include href="hardware/inertials/waist-eb5-inertials.xml" />
 
 
     <!-- ANALOG SENSOR MAIS -->

--- a/iCubGenova11/icub_all_no_legs.xml
+++ b/iCubGenova11/icub_all_no_legs.xml
@@ -54,10 +54,7 @@
     <xi:include href="wrappers/inertials/head-inertials_wrapper.xml" />
     <xi:include href="hardware/inertials/head-inertial.xml" />
 
-    <xi:include href="wrappers/inertials/waist-inertials_remapper.xml" />
-    <xi:include href="wrappers/inertials/waist-inertials_wrapper.xml" />
     <xi:include href="hardware/inertials/waist-inertial.xml" />
-    <xi:include href="hardware/inertials/waist-eb5-inertials.xml" />
 
 
     <!-- ANALOG SENSOR MAIS -->

--- a/iCubGenova11/icub_all_no_legs_ros2.xml
+++ b/iCubGenova11/icub_all_no_legs_ros2.xml
@@ -54,11 +54,7 @@
     <xi:include href="wrappers/inertials/head-inertials_wrapper.xml" />
     <xi:include href="hardware/inertials/head-inertial.xml" />
 
-    <xi:include href="wrappers/inertials/waist-inertials_remapper.xml" />
-    <xi:include href="wrappers/inertials/waist-inertials_wrapper.xml" />
-    <xi:include href="wrappers/inertials/waist-inertials_wrapper-deprecated.xml" />
     <xi:include href="hardware/inertials/waist-inertial.xml" />
-    <xi:include href="hardware/inertials/waist-eb5-inertials.xml" />
 
 
     <!-- ANALOG SENSOR MAIS -->

--- a/iCubGenova11/icub_all_ros2.xml
+++ b/iCubGenova11/icub_all_ros2.xml
@@ -74,10 +74,7 @@
     <xi:include href="wrappers/inertials/head-inertials_wrapper.xml" />
     <xi:include href="hardware/inertials/head-inertial.xml" />
 
-    <xi:include href="wrappers/inertials/waist-inertials_remapper.xml" />
-    <xi:include href="wrappers/inertials/waist-inertials_wrapper.xml" />
     <xi:include href="hardware/inertials/waist-inertial.xml" />
-    <xi:include href="hardware/inertials/waist-eb5-inertials.xml" />
 
 
     <!-- ANALOG SENSOR MAIS -->


### PR DESCRIPTION
## What changes:

This PR fixes two things:

- New calibration for the right thumb oppose

- Fixed the configuration files for the waist IMU.

## Note

With the previous configuration files the robot would no longer start. 

In fact, the deleted lines enabled IMUs for MTBs connected to the eb5 board, the problem is that the robot has no MTBs connected to the eb5 and so the `yarprobotinterface` crashed.

With these changes, the robot starts and the waist IMU can be read on the `/icub/xsens_inertial` port.

cc @sgiraz @martinaxgloria