### PR TITLE
[iCubGenova11] Fix strain2 firmware version after update

### DIFF
--- a/iCubGenova11/hardware/FT/left_arm-eb1-j0_3-strain.xml
+++ b/iCubGenova11/hardware/FT/left_arm-eb1-j0_3-strain.xml
@@ -24,7 +24,7 @@
                     </group>
                     <group name="FIRMWARE">
                         <param name="major">            2                       </param>
-                        <param name="minor">            2                       </param>
+                        <param name="minor">            3                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
@@ -51,7 +51,3 @@
         </group>
 
   </device>
-
-
-
-

--- a/iCubGenova11/hardware/FT/right_arm-eb3-j0_3-strain.xml
+++ b/iCubGenova11/hardware/FT/right_arm-eb3-j0_3-strain.xml
@@ -24,7 +24,7 @@
                     </group>
                     <group name="FIRMWARE">
                         <param name="major">            2                       </param>
-                        <param name="minor">            2                       </param>
+                        <param name="minor">            3                       </param>
                         <param name="build">            0                       </param>
                     </group>
                 </group>
@@ -51,9 +51,3 @@
         </group>
 
   </device>
-
-
-
-
-
-


### PR DESCRIPTION
Yesterday I updated the `iCubGenova11 icub-head` firmware and software to be aligned with the last robotology-superbuild distro release (v2024.02.0). In this sense, I updated the firmware version of the `strain2` boards for both the left and the right arm from v2.2.0 to `v2.3.0` so as to be consistence with [firmware.info.xml](https://github.com/robotology/icub-firmware-build/blob/a48eab5c9f8702fef165b50e4ce5a4a219247a1b/info/firmware.info.xml#L145-L150).

With this PR, I added the same change also in the configuration files.

cc @Nicogene @pattacini 