### PR TITLE
Add alljoints-inertials_wrapper/remapper to expose IMU orientation measurements

### DIFF
--- a/ergoCubSN000/wrappers/inertials/alljoints-inertials_remapper.xml
+++ b/ergoCubSN000/wrappers/inertials/alljoints-inertials_remapper.xml
@@ -6,7 +6,7 @@
         <param name="OrientationSensorsNames">
             (head_imu_0 l_arm_ft l_leg_ft l_foot_ft r_arm_ft r_leg_ft r_foot_ft)
         </param>
-        <action phase="startup" level="10" type="attach">
+        <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
                 <elem name="head_imu">  head-inertial </elem>
                 <elem name="l_arm_imu"> left_arm-eb2-j0_1-inertial </elem>

--- a/ergoCubSN000/wrappers/inertials/alljoints-inertials_remapper.xml
+++ b/ergoCubSN000/wrappers/inertials/alljoints-inertials_remapper.xml
@@ -13,7 +13,7 @@
                 <elem name="l_leg_imu"> left_leg-eb8-j0_3-inertial </elem>
                 <elem name="l_foot_imu"> left_leg-eb9-j4_5-inertial </elem>
                 <elem name="r_arm_imu"> right_arm-eb1-j0_1-inertial </elem>
-                <elem name="r_leg_imu"> right_leg-eb6-j0_3-inertia </elem>
+                <elem name="r_leg_imu"> right_leg-eb6-j0_3-inertial </elem>
                 <elem name="r_foot_imu"> right_leg-eb7-j4_5-inertial </elem>
             </paramlist>
         </action>

--- a/ergoCubSN000/wrappers/inertials/alljoints-inertials_remapper.xml
+++ b/ergoCubSN000/wrappers/inertials/alljoints-inertials_remapper.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_remapper" type="multipleanalogsensorsremapper">
+        <param name="OrientationSensorsNames">
+            (head_imu_0 l_arm_ft l_leg_ft l_foot_ft r_arm_ft r_leg_ft r_foot_ft)
+        </param>
+        <action phase="startup" level="10" type="attach">
+            <paramlist name="networks">
+                <elem name="head_imu">  head-inertial </elem>
+                <elem name="l_arm_imu"> left_arm-eb2-j0_1-inertial </elem>
+                <elem name="l_leg_imu"> left_leg-eb8-j0_3-inertial </elem>
+                <elem name="l_foot_imu"> left_leg-eb9-j4_5-inertial </elem>
+                <elem name="r_arm_imu"> right_arm-eb1-j0_1-inertial </elem>
+                <elem name="r_leg_imu"> right_leg-eb6-j0_3-inertia </elem>
+                <elem name="r_foot_imu"> right_leg-eb7-j4_5-inertial </elem>
+            </paramlist>
+        </action>
+
+        <action phase="shutdown" level="20" type="detach" />
+    </device>

--- a/ergoCubSN000/wrappers/inertials/alljoints-inertials_remapper.xml
+++ b/ergoCubSN000/wrappers/inertials/alljoints-inertials_remapper.xml
@@ -4,7 +4,7 @@
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_remapper" type="multipleanalogsensorsremapper">
         <param name="OrientationSensorsNames">
-            (head_imu_0 l_arm_ft l_leg_ft l_foot_ft r_arm_ft r_leg_ft r_foot_ft)
+            (head_imu_0 l_arm_ft l_leg_ft l_foot_rear_ft l_foot_front_ft r_arm_ft r_leg_ft r_foot_rear_ft r_foot_front_ft waist_imu_0)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
@@ -15,6 +15,7 @@
                 <elem name="r_arm_imu"> right_arm-eb1-j0_1-inertial </elem>
                 <elem name="r_leg_imu"> right_leg-eb6-j0_3-inertial </elem>
                 <elem name="r_foot_imu"> right_leg-eb7-j4_5-inertial </elem>
+                <elem name="waist_imu"> waist_inertial </elem>
             </paramlist>
         </action>
 

--- a/ergoCubSN000/wrappers/inertials/alljoints-inertials_wrapper.xml
+++ b/ergoCubSN000/wrappers/inertials/alljoints-inertials_wrapper.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_wrapper" type="multipleanalogsensorsserver">
+    <param name="period">      10                           </param>
+    <param name="name"> /${portprefix}/alljoints/inertials   </param>
+
+    <action phase="startup" level="15" type="attach">
+        <paramlist name="networks">
+            <elem name="FirstStrain"> alljoints-inertials_remapper </elem>
+        </paramlist>
+       </action>
+
+    <action phase="shutdown" level="20" type="detach" />
+</device>

--- a/ergoCubSN000/wrappers/inertials/alljoints-inertials_wrapper.xml
+++ b/ergoCubSN000/wrappers/inertials/alljoints-inertials_wrapper.xml
@@ -11,5 +11,5 @@
         </paramlist>
        </action>
 
-    <action phase="shutdown" level="20" type="detach" />
+    <action phase="shutdown" level="15" type="detach" />
 </device>

--- a/ergoCubSN001/wrappers/inertials/alljoints-inertials_remapper.xml
+++ b/ergoCubSN001/wrappers/inertials/alljoints-inertials_remapper.xml
@@ -6,7 +6,7 @@
         <param name="OrientationSensorsNames">
             (head_imu_0 l_arm_ft l_leg_ft l_foot_ft r_arm_ft r_leg_ft r_foot_ft)
         </param>
-        <action phase="startup" level="10" type="attach">
+        <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
                 <elem name="head_imu">  head-inertial </elem>
                 <elem name="l_arm_imu"> left_arm-eb2-j0_1-inertial </elem>

--- a/ergoCubSN001/wrappers/inertials/alljoints-inertials_remapper.xml
+++ b/ergoCubSN001/wrappers/inertials/alljoints-inertials_remapper.xml
@@ -13,7 +13,7 @@
                 <elem name="l_leg_imu"> left_leg-eb8-j0_3-inertial </elem>
                 <elem name="l_foot_imu"> left_leg-eb9-j4_5-inertial </elem>
                 <elem name="r_arm_imu"> right_arm-eb1-j0_1-inertial </elem>
-                <elem name="r_leg_imu"> right_leg-eb6-j0_3-inertia </elem>
+                <elem name="r_leg_imu"> right_leg-eb6-j0_3-inertial </elem>
                 <elem name="r_foot_imu"> right_leg-eb7-j4_5-inertial </elem>
             </paramlist>
         </action>

--- a/ergoCubSN001/wrappers/inertials/alljoints-inertials_remapper.xml
+++ b/ergoCubSN001/wrappers/inertials/alljoints-inertials_remapper.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_remapper" type="multipleanalogsensorsremapper">
+        <param name="OrientationSensorsNames">
+            (head_imu_0 l_arm_ft l_leg_ft l_foot_ft r_arm_ft r_leg_ft r_foot_ft)
+        </param>
+        <action phase="startup" level="10" type="attach">
+            <paramlist name="networks">
+                <elem name="head_imu">  head-inertial </elem>
+                <elem name="l_arm_imu"> left_arm-eb2-j0_1-inertial </elem>
+                <elem name="l_leg_imu"> left_leg-eb8-j0_3-inertial </elem>
+                <elem name="l_foot_imu"> left_leg-eb9-j4_5-inertial </elem>
+                <elem name="r_arm_imu"> right_arm-eb1-j0_1-inertial </elem>
+                <elem name="r_leg_imu"> right_leg-eb6-j0_3-inertia </elem>
+                <elem name="r_foot_imu"> right_leg-eb7-j4_5-inertial </elem>
+            </paramlist>
+        </action>
+
+        <action phase="shutdown" level="20" type="detach" />
+    </device>

--- a/ergoCubSN001/wrappers/inertials/alljoints-inertials_remapper.xml
+++ b/ergoCubSN001/wrappers/inertials/alljoints-inertials_remapper.xml
@@ -4,7 +4,7 @@
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_remapper" type="multipleanalogsensorsremapper">
         <param name="OrientationSensorsNames">
-            (head_imu_0 l_arm_ft l_leg_ft l_foot_ft r_arm_ft r_leg_ft r_foot_ft)
+            (head_imu_0 l_arm_ft l_leg_ft l_foot_rear_ft l_foot_front_ft r_arm_ft r_leg_ft r_foot_rear_ft r_foot_front_ft waist_imu_0)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
@@ -15,6 +15,7 @@
                 <elem name="r_arm_imu"> right_arm-eb1-j0_1-inertial </elem>
                 <elem name="r_leg_imu"> right_leg-eb6-j0_3-inertial </elem>
                 <elem name="r_foot_imu"> right_leg-eb7-j4_5-inertial </elem>
+                <elem name="waist_imu"> waist_inertial </elem>
             </paramlist>
         </action>
 

--- a/ergoCubSN001/wrappers/inertials/alljoints-inertials_wrapper.xml
+++ b/ergoCubSN001/wrappers/inertials/alljoints-inertials_wrapper.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_wrapper" type="multipleanalogsensorsserver">
+    <param name="period">      10                           </param>
+    <param name="name"> /${portprefix}/alljoints/inertials   </param>
+
+    <action phase="startup" level="15" type="attach">
+        <paramlist name="networks">
+            <elem name="FirstStrain"> alljoints-inertials_remapper </elem>
+        </paramlist>
+       </action>
+
+    <action phase="shutdown" level="20" type="detach" />
+</device>

--- a/ergoCubSN001/wrappers/inertials/alljoints-inertials_wrapper.xml
+++ b/ergoCubSN001/wrappers/inertials/alljoints-inertials_wrapper.xml
@@ -11,5 +11,5 @@
         </paramlist>
        </action>
 
-    <action phase="shutdown" level="20" type="detach" />
+    <action phase="shutdown" level="15" type="detach" />
 </device>

--- a/ergoCubSN002/wrappers/inertials/alljoints-inertials_remapper.xml
+++ b/ergoCubSN002/wrappers/inertials/alljoints-inertials_remapper.xml
@@ -6,7 +6,7 @@
         <param name="OrientationSensorsNames">
             (head_imu_0 l_arm_ft l_leg_ft l_foot_ft r_arm_ft r_leg_ft r_foot_ft)
         </param>
-        <action phase="startup" level="10" type="attach">
+        <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
                 <elem name="head_imu">  head-inertial </elem>
                 <elem name="l_arm_imu"> left_arm-eb2-j0_1-inertial </elem>

--- a/ergoCubSN002/wrappers/inertials/alljoints-inertials_remapper.xml
+++ b/ergoCubSN002/wrappers/inertials/alljoints-inertials_remapper.xml
@@ -13,7 +13,7 @@
                 <elem name="l_leg_imu"> left_leg-eb8-j0_3-inertial </elem>
                 <elem name="l_foot_imu"> left_leg-eb9-j4_5-inertial </elem>
                 <elem name="r_arm_imu"> right_arm-eb1-j0_1-inertial </elem>
-                <elem name="r_leg_imu"> right_leg-eb6-j0_3-inertia </elem>
+                <elem name="r_leg_imu"> right_leg-eb6-j0_3-inertial </elem>
                 <elem name="r_foot_imu"> right_leg-eb7-j4_5-inertial </elem>
             </paramlist>
         </action>

--- a/ergoCubSN002/wrappers/inertials/alljoints-inertials_remapper.xml
+++ b/ergoCubSN002/wrappers/inertials/alljoints-inertials_remapper.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_remapper" type="multipleanalogsensorsremapper">
+        <param name="OrientationSensorsNames">
+            (head_imu_0 l_arm_ft l_leg_ft l_foot_ft r_arm_ft r_leg_ft r_foot_ft)
+        </param>
+        <action phase="startup" level="10" type="attach">
+            <paramlist name="networks">
+                <elem name="head_imu">  head-inertial </elem>
+                <elem name="l_arm_imu"> left_arm-eb2-j0_1-inertial </elem>
+                <elem name="l_leg_imu"> left_leg-eb8-j0_3-inertial </elem>
+                <elem name="l_foot_imu"> left_leg-eb9-j4_5-inertial </elem>
+                <elem name="r_arm_imu"> right_arm-eb1-j0_1-inertial </elem>
+                <elem name="r_leg_imu"> right_leg-eb6-j0_3-inertia </elem>
+                <elem name="r_foot_imu"> right_leg-eb7-j4_5-inertial </elem>
+            </paramlist>
+        </action>
+
+        <action phase="shutdown" level="20" type="detach" />
+    </device>

--- a/ergoCubSN002/wrappers/inertials/alljoints-inertials_remapper.xml
+++ b/ergoCubSN002/wrappers/inertials/alljoints-inertials_remapper.xml
@@ -4,7 +4,7 @@
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_remapper" type="multipleanalogsensorsremapper">
         <param name="OrientationSensorsNames">
-            (head_imu_0 l_arm_ft l_leg_ft l_foot_ft r_arm_ft r_leg_ft r_foot_ft)
+            (head_imu_0 l_arm_ft l_leg_ft l_foot_rear_ft l_foot_front_ft r_arm_ft r_leg_ft r_foot_rear_ft r_foot_front_ft waist_imu_0)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
@@ -15,6 +15,7 @@
                 <elem name="r_arm_imu"> right_arm-eb1-j0_1-inertial </elem>
                 <elem name="r_leg_imu"> right_leg-eb6-j0_3-inertial </elem>
                 <elem name="r_foot_imu"> right_leg-eb7-j4_5-inertial </elem>
+                <elem name="waist_imu"> waist_inertial </elem>
             </paramlist>
         </action>
 

--- a/ergoCubSN002/wrappers/inertials/alljoints-inertials_wrapper.xml
+++ b/ergoCubSN002/wrappers/inertials/alljoints-inertials_wrapper.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_wrapper" type="multipleanalogsensorsserver">
+    <param name="period">      10                           </param>
+    <param name="name"> /${portprefix}/alljoints/inertials   </param>
+
+    <action phase="startup" level="15" type="attach">
+        <paramlist name="networks">
+            <elem name="FirstStrain"> alljoints-inertials_remapper </elem>
+        </paramlist>
+       </action>
+
+    <action phase="shutdown" level="20" type="detach" />
+</device>

--- a/ergoCubSN002/wrappers/inertials/alljoints-inertials_wrapper.xml
+++ b/ergoCubSN002/wrappers/inertials/alljoints-inertials_wrapper.xml
@@ -11,5 +11,5 @@
         </paramlist>
        </action>
 
-    <action phase="shutdown" level="20" type="detach" />
+    <action phase="shutdown" level="15" type="detach" />
 </device>

--- a/iCubGenova07/wrappers/inertials/alljoints-inertials_remapper.xml
+++ b/iCubGenova07/wrappers/inertials/alljoints-inertials_remapper.xml
@@ -6,7 +6,7 @@
         <param name="OrientationSensorsNames">
             (head_imu_0 l_leg_ft l_foot_ft r_leg_ft r_foot_ft)
         </param>
-        <action phase="startup" level="10" type="attach">
+        <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
                 <elem name="head_imu">  head-inertial </elem>
                 <elem name="l_upper_leg_imu"> left_leg-eb6-imu </elem>

--- a/iCubGenova07/wrappers/inertials/alljoints-inertials_remapper.xml
+++ b/iCubGenova07/wrappers/inertials/alljoints-inertials_remapper.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_remapper" type="multipleanalogsensorsremapper">
+        <param name="OrientationSensorsNames">
+            (head_imu_0 l_leg_ft l_foot_ft r_leg_ft r_foot_ft)
+        </param>
+        <action phase="startup" level="10" type="attach">
+            <paramlist name="networks">
+                <elem name="head_imu">  head-inertial </elem>
+                <elem name="l_upper_leg_imu"> left_leg-eb6-imu </elem>
+                <elem name="l_lower_leg_imu"> left_leg-eb7-imu </elem>
+                <elem name="r_upper_leg_imu"> right_leg-eb8-imu </elem>
+                <elem name="r_lower_leg_imu"> right_leg-eb9-imu </elem>
+            </paramlist>
+        </action>
+
+        <action phase="shutdown" level="20" type="detach" />
+    </device>

--- a/iCubGenova07/wrappers/inertials/alljoints-inertials_wrapper.xml
+++ b/iCubGenova07/wrappers/inertials/alljoints-inertials_wrapper.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_wrapper" type="multipleanalogsensorsserver">
+    <param name="period">      10                           </param>
+    <param name="name"> /${portprefix}/alljoints/inertials   </param>
+
+    <action phase="startup" level="15" type="attach">
+        <paramlist name="networks">
+            <elem name="FirstStrain"> alljoints-inertials_remapper </elem>
+        </paramlist>
+       </action>
+
+    <action phase="shutdown" level="20" type="detach" />
+</device>

--- a/iCubGenova07/wrappers/inertials/alljoints-inertials_wrapper.xml
+++ b/iCubGenova07/wrappers/inertials/alljoints-inertials_wrapper.xml
@@ -11,5 +11,5 @@
         </paramlist>
        </action>
 
-    <action phase="shutdown" level="20" type="detach" />
+    <action phase="shutdown" level="15" type="detach" />
 </device>

--- a/iCubGenova11/wrappers/inertials/alljoints-inertials_remapper.xml
+++ b/iCubGenova11/wrappers/inertials/alljoints-inertials_remapper.xml
@@ -6,7 +6,7 @@
         <param name="OrientationSensorsNames">
             (l_arm_ft r_arm_ft head_imu_0)
         </param>
-        <action phase="startup" level="10" type="attach">
+        <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
                 <elem name="head_imu">  head-inertial </elem>
                 <elem name="left_arm_imu">  left_arm-eb1-imu </elem>

--- a/iCubGenova11/wrappers/inertials/alljoints-inertials_wrapper.xml
+++ b/iCubGenova11/wrappers/inertials/alljoints-inertials_wrapper.xml
@@ -11,5 +11,5 @@
         </paramlist>
        </action>
 
-    <action phase="shutdown" level="20" type="detach" />
+    <action phase="shutdown" level="15" type="detach" />
 </device>

--- a/iCubLisboa01/wrappers/inertials/alljoints-inertials_remapper.xml
+++ b/iCubLisboa01/wrappers/inertials/alljoints-inertials_remapper.xml
@@ -6,7 +6,7 @@
         <param name="OrientationSensorsNames">
             (head_imu_0 l_leg_ft l_foot_ft r_leg_ft r_foot_ft)
         </param>
-        <action phase="startup" level="10" type="attach">
+        <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
                 <elem name="head_imu">  head-inertial </elem>
                 <elem name="l_upper_leg_imu"> left_leg-eb6-imu </elem>

--- a/iCubLisboa01/wrappers/inertials/alljoints-inertials_remapper.xml
+++ b/iCubLisboa01/wrappers/inertials/alljoints-inertials_remapper.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_remapper" type="multipleanalogsensorsremapper">
+        <param name="OrientationSensorsNames">
+            (head_imu_0 l_leg_ft l_foot_ft r_leg_ft r_foot_ft)
+        </param>
+        <action phase="startup" level="10" type="attach">
+            <paramlist name="networks">
+                <elem name="head_imu">  head-inertial </elem>
+                <elem name="l_upper_leg_imu"> left_leg-eb6-imu </elem>
+                <elem name="l_lower_leg_imu"> left_leg-eb7-imu </elem>
+                <elem name="r_upper_leg_imu"> right_leg-eb8-imu </elem>
+                <elem name="r_lower_leg_imu"> right_leg-eb9-imu </elem>
+            </paramlist>
+        </action>
+
+        <action phase="shutdown" level="20" type="detach" />
+    </device>

--- a/iCubLisboa01/wrappers/inertials/alljoints-inertials_wrapper.xml
+++ b/iCubLisboa01/wrappers/inertials/alljoints-inertials_wrapper.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_wrapper" type="multipleanalogsensorsserver">
+    <param name="period">      10                           </param>
+    <param name="name"> /${portprefix}/alljoints/inertials   </param>
+
+    <action phase="startup" level="15" type="attach">
+        <paramlist name="networks">
+            <elem name="FirstStrain"> alljoints-inertials_remapper </elem>
+        </paramlist>
+       </action>
+
+    <action phase="shutdown" level="20" type="detach" />
+</device>

--- a/iCubLisboa01/wrappers/inertials/alljoints-inertials_wrapper.xml
+++ b/iCubLisboa01/wrappers/inertials/alljoints-inertials_wrapper.xml
@@ -11,5 +11,5 @@
         </paramlist>
        </action>
 
-    <action phase="shutdown" level="20" type="detach" />
+    <action phase="shutdown" level="15" type="detach" />
 </device>

--- a/iCubPrague01/wrappers/inertials/alljoints-inertials_remapper.xml
+++ b/iCubPrague01/wrappers/inertials/alljoints-inertials_remapper.xml
@@ -6,7 +6,7 @@
         <param name="OrientationSensorsNames">
             (head_imu_0 l_leg_ft l_foot_ft r_leg_ft r_foot_ft)
         </param>
-        <action phase="startup" level="10" type="attach">
+        <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
                 <elem name="head_imu">  head-inertial </elem>
                 <elem name="l_upper_leg_imu"> left_leg-eb6-imu </elem>

--- a/iCubPrague01/wrappers/inertials/alljoints-inertials_remapper.xml
+++ b/iCubPrague01/wrappers/inertials/alljoints-inertials_remapper.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_remapper" type="multipleanalogsensorsremapper">
+        <param name="OrientationSensorsNames">
+            (head_imu_0 l_leg_ft l_foot_ft r_leg_ft r_foot_ft)
+        </param>
+        <action phase="startup" level="10" type="attach">
+            <paramlist name="networks">
+                <elem name="head_imu">  head-inertial </elem>
+                <elem name="l_upper_leg_imu"> left_leg-eb6-imu </elem>
+                <elem name="l_lower_leg_imu"> left_leg-eb7-imu </elem>
+                <elem name="r_upper_leg_imu"> right_leg-eb8-imu </elem>
+                <elem name="r_lower_leg_imu"> right_leg-eb9-imu </elem>
+            </paramlist>
+        </action>
+
+        <action phase="shutdown" level="20" type="detach" />
+    </device>

--- a/iCubPrague01/wrappers/inertials/alljoints-inertials_wrapper.xml
+++ b/iCubPrague01/wrappers/inertials/alljoints-inertials_wrapper.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_wrapper" type="multipleanalogsensorsserver">
+    <param name="period">      10                           </param>
+    <param name="name"> /${portprefix}/alljoints/inertials   </param>
+
+    <action phase="startup" level="15" type="attach">
+        <paramlist name="networks">
+            <elem name="FirstStrain"> alljoints-inertials_remapper </elem>
+        </paramlist>
+       </action>
+
+    <action phase="shutdown" level="20" type="detach" />
+</device>

--- a/iCubPrague01/wrappers/inertials/alljoints-inertials_wrapper.xml
+++ b/iCubPrague01/wrappers/inertials/alljoints-inertials_wrapper.xml
@@ -11,5 +11,5 @@
         </paramlist>
        </action>
 
-    <action phase="shutdown" level="20" type="detach" />
+    <action phase="shutdown" level="15" type="detach" />
 </device>

--- a/iCubShanghai01/wrappers/inertials/alljoints-inertials_remapper.xml
+++ b/iCubShanghai01/wrappers/inertials/alljoints-inertials_remapper.xml
@@ -6,7 +6,7 @@
         <param name="OrientationSensorsNames">
             (head_imu_0 l_leg_ft l_foot_ft r_leg_ft r_foot_ft)
         </param>
-        <action phase="startup" level="10" type="attach">
+        <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
                 <elem name="head_imu">  head-inertial </elem>
                 <elem name="l_upper_leg_imu"> left_leg-eb6-imu </elem>

--- a/iCubShanghai01/wrappers/inertials/alljoints-inertials_remapper.xml
+++ b/iCubShanghai01/wrappers/inertials/alljoints-inertials_remapper.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_remapper" type="multipleanalogsensorsremapper">
+        <param name="OrientationSensorsNames">
+            (head_imu_0 l_leg_ft l_foot_ft r_leg_ft r_foot_ft)
+        </param>
+        <action phase="startup" level="10" type="attach">
+            <paramlist name="networks">
+                <elem name="head_imu">  head-inertial </elem>
+                <elem name="l_upper_leg_imu"> left_leg-eb6-imu </elem>
+                <elem name="l_lower_leg_imu"> left_leg-eb7-imu </elem>
+                <elem name="r_upper_leg_imu"> right_leg-eb8-imu </elem>
+                <elem name="r_lower_leg_imu"> right_leg-eb9-imu </elem>
+            </paramlist>
+        </action>
+
+        <action phase="shutdown" level="20" type="detach" />
+    </device>

--- a/iCubShanghai01/wrappers/inertials/alljoints-inertials_wrapper.xml
+++ b/iCubShanghai01/wrappers/inertials/alljoints-inertials_wrapper.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_wrapper" type="multipleanalogsensorsserver">
+    <param name="period">      10                           </param>
+    <param name="name"> /${portprefix}/alljoints/inertials   </param>
+
+    <action phase="startup" level="15" type="attach">
+        <paramlist name="networks">
+            <elem name="FirstStrain"> alljoints-inertials_remapper </elem>
+        </paramlist>
+       </action>
+
+    <action phase="shutdown" level="20" type="detach" />
+</device>

--- a/iCubShanghai01/wrappers/inertials/alljoints-inertials_wrapper.xml
+++ b/iCubShanghai01/wrappers/inertials/alljoints-inertials_wrapper.xml
@@ -11,5 +11,5 @@
         </paramlist>
        </action>
 
-    <action phase="shutdown" level="20" type="detach" />
+    <action phase="shutdown" level="15" type="detach" />
 </device>

--- a/iCubShenzhen01/wrappers/inertials/alljoints-inertials_remapper.xml
+++ b/iCubShenzhen01/wrappers/inertials/alljoints-inertials_remapper.xml
@@ -6,7 +6,7 @@
         <param name="OrientationSensorsNames">
             (head_imu_0 l_leg_ft l_foot_ft r_leg_ft r_foot_ft)
         </param>
-        <action phase="startup" level="10" type="attach">
+        <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
                 <elem name="head_imu">  head-inertial </elem>
                 <elem name="l_upper_leg_imu"> left_leg-eb6-imu </elem>

--- a/iCubShenzhen01/wrappers/inertials/alljoints-inertials_remapper.xml
+++ b/iCubShenzhen01/wrappers/inertials/alljoints-inertials_remapper.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_remapper" type="multipleanalogsensorsremapper">
+        <param name="OrientationSensorsNames">
+            (head_imu_0 l_leg_ft l_foot_ft r_leg_ft r_foot_ft)
+        </param>
+        <action phase="startup" level="10" type="attach">
+            <paramlist name="networks">
+                <elem name="head_imu">  head-inertial </elem>
+                <elem name="l_upper_leg_imu"> left_leg-eb6-imu </elem>
+                <elem name="l_lower_leg_imu"> left_leg-eb7-imu </elem>
+                <elem name="r_upper_leg_imu"> right_leg-eb8-imu </elem>
+                <elem name="r_lower_leg_imu"> right_leg-eb9-imu </elem>
+            </paramlist>
+        </action>
+
+        <action phase="shutdown" level="20" type="detach" />
+    </device>

--- a/iCubShenzhen01/wrappers/inertials/alljoints-inertials_wrapper.xml
+++ b/iCubShenzhen01/wrappers/inertials/alljoints-inertials_wrapper.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_wrapper" type="multipleanalogsensorsserver">
+    <param name="period">      10                           </param>
+    <param name="name"> /${portprefix}/alljoints/inertials   </param>
+
+    <action phase="startup" level="15" type="attach">
+        <paramlist name="networks">
+            <elem name="FirstStrain"> alljoints-inertials_remapper </elem>
+        </paramlist>
+       </action>
+
+    <action phase="shutdown" level="20" type="detach" />
+</device>

--- a/iCubShenzhen01/wrappers/inertials/alljoints-inertials_wrapper.xml
+++ b/iCubShenzhen01/wrappers/inertials/alljoints-inertials_wrapper.xml
@@ -11,5 +11,5 @@
         </paramlist>
        </action>
 
-    <action phase="shutdown" level="20" type="detach" />
+    <action phase="shutdown" level="15" type="detach" />
 </device>

--- a/iCubValparaiso01/wrappers/inertials/alljoints-inertials_remapper.xml
+++ b/iCubValparaiso01/wrappers/inertials/alljoints-inertials_remapper.xml
@@ -6,7 +6,7 @@
         <param name="OrientationSensorsNames">
             (head_imu_0 l_leg_ft l_foot_ft r_leg_ft r_foot_ft)
         </param>
-        <action phase="startup" level="10" type="attach">
+        <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
                 <elem name="head_imu">  head-inertial </elem>
                 <elem name="l_upper_leg_imu"> left_leg-eb6-imu </elem>

--- a/iCubValparaiso01/wrappers/inertials/alljoints-inertials_remapper.xml
+++ b/iCubValparaiso01/wrappers/inertials/alljoints-inertials_remapper.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_remapper" type="multipleanalogsensorsremapper">
+        <param name="OrientationSensorsNames">
+            (head_imu_0 l_leg_ft l_foot_ft r_leg_ft r_foot_ft)
+        </param>
+        <action phase="startup" level="10" type="attach">
+            <paramlist name="networks">
+                <elem name="head_imu">  head-inertial </elem>
+                <elem name="l_upper_leg_imu"> left_leg-eb6-imu </elem>
+                <elem name="l_lower_leg_imu"> left_leg-eb7-imu </elem>
+                <elem name="r_upper_leg_imu"> right_leg-eb8-imu </elem>
+                <elem name="r_lower_leg_imu"> right_leg-eb9-imu </elem>
+            </paramlist>
+        </action>
+
+        <action phase="shutdown" level="20" type="detach" />
+    </device>

--- a/iCubValparaiso01/wrappers/inertials/alljoints-inertials_wrapper.xml
+++ b/iCubValparaiso01/wrappers/inertials/alljoints-inertials_wrapper.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_wrapper" type="multipleanalogsensorsserver">
+    <param name="period">      10                           </param>
+    <param name="name"> /${portprefix}/alljoints/inertials   </param>
+
+    <action phase="startup" level="15" type="attach">
+        <paramlist name="networks">
+            <elem name="FirstStrain"> alljoints-inertials_remapper </elem>
+        </paramlist>
+       </action>
+
+    <action phase="shutdown" level="20" type="detach" />
+</device>

--- a/iCubValparaiso01/wrappers/inertials/alljoints-inertials_wrapper.xml
+++ b/iCubValparaiso01/wrappers/inertials/alljoints-inertials_wrapper.xml
@@ -11,5 +11,5 @@
         </paramlist>
        </action>
 
-    <action phase="shutdown" level="20" type="detach" />
+    <action phase="shutdown" level="15" type="detach" />
 </device>

--- a/iCubWaterloo01/wrappers/inertials/alljoints-inertials_remapper.xml
+++ b/iCubWaterloo01/wrappers/inertials/alljoints-inertials_remapper.xml
@@ -6,7 +6,7 @@
         <param name="OrientationSensorsNames">
             (head_imu_0 l_leg_ft l_foot_ft r_leg_ft r_foot_ft)
         </param>
-        <action phase="startup" level="10" type="attach">
+        <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
                 <elem name="head_imu">  head-inertial </elem>
                 <elem name="l_upper_leg_imu"> left_leg-eb6-imu </elem>

--- a/iCubWaterloo01/wrappers/inertials/alljoints-inertials_remapper.xml
+++ b/iCubWaterloo01/wrappers/inertials/alljoints-inertials_remapper.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_remapper" type="multipleanalogsensorsremapper">
+        <param name="OrientationSensorsNames">
+            (head_imu_0 l_leg_ft l_foot_ft r_leg_ft r_foot_ft)
+        </param>
+        <action phase="startup" level="10" type="attach">
+            <paramlist name="networks">
+                <elem name="head_imu">  head-inertial </elem>
+                <elem name="l_upper_leg_imu"> left_leg-eb6-imu </elem>
+                <elem name="l_lower_leg_imu"> left_leg-eb7-imu </elem>
+                <elem name="r_upper_leg_imu"> right_leg-eb8-imu </elem>
+                <elem name="r_lower_leg_imu"> right_leg-eb9-imu </elem>
+            </paramlist>
+        </action>
+
+        <action phase="shutdown" level="20" type="detach" />
+    </device>

--- a/iCubWaterloo01/wrappers/inertials/alljoints-inertials_wrapper.xml
+++ b/iCubWaterloo01/wrappers/inertials/alljoints-inertials_wrapper.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_wrapper" type="multipleanalogsensorsserver">
+    <param name="period">      10                           </param>
+    <param name="name"> /${portprefix}/alljoints/inertials   </param>
+
+    <action phase="startup" level="15" type="attach">
+        <paramlist name="networks">
+            <elem name="FirstStrain"> alljoints-inertials_remapper </elem>
+        </paramlist>
+       </action>
+
+    <action phase="shutdown" level="20" type="detach" />
+</device>

--- a/iCubWaterloo01/wrappers/inertials/alljoints-inertials_wrapper.xml
+++ b/iCubWaterloo01/wrappers/inertials/alljoints-inertials_wrapper.xml
@@ -11,5 +11,5 @@
         </paramlist>
        </action>
 
-    <action phase="shutdown" level="20" type="detach" />
+    <action phase="shutdown" level="15" type="detach" />
 </device>

--- a/iCubZagreb01/wrappers/inertials/alljoints-inertials_remapper.xml
+++ b/iCubZagreb01/wrappers/inertials/alljoints-inertials_remapper.xml
@@ -6,7 +6,7 @@
         <param name="OrientationSensorsNames">
             (head_imu_0 l_leg_ft l_foot_ft r_leg_ft r_foot_ft)
         </param>
-        <action phase="startup" level="10" type="attach">
+        <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
                 <elem name="head_imu">  head-inertial </elem>
                 <elem name="l_upper_leg_imu"> left_leg-eb6-imu </elem>

--- a/iCubZagreb01/wrappers/inertials/alljoints-inertials_remapper.xml
+++ b/iCubZagreb01/wrappers/inertials/alljoints-inertials_remapper.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_remapper" type="multipleanalogsensorsremapper">
+        <param name="OrientationSensorsNames">
+            (head_imu_0 l_leg_ft l_foot_ft r_leg_ft r_foot_ft)
+        </param>
+        <action phase="startup" level="10" type="attach">
+            <paramlist name="networks">
+                <elem name="head_imu">  head-inertial </elem>
+                <elem name="l_upper_leg_imu"> left_leg-eb6-imu </elem>
+                <elem name="l_lower_leg_imu"> left_leg-eb7-imu </elem>
+                <elem name="r_upper_leg_imu"> right_leg-eb8-imu </elem>
+                <elem name="r_lower_leg_imu"> right_leg-eb9-imu </elem>
+            </paramlist>
+        </action>
+
+        <action phase="shutdown" level="20" type="detach" />
+    </device>

--- a/iCubZagreb01/wrappers/inertials/alljoints-inertials_wrapper.xml
+++ b/iCubZagreb01/wrappers/inertials/alljoints-inertials_wrapper.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_wrapper" type="multipleanalogsensorsserver">
+    <param name="period">      10                           </param>
+    <param name="name"> /${portprefix}/alljoints/inertials   </param>
+
+    <action phase="startup" level="15" type="attach">
+        <paramlist name="networks">
+            <elem name="FirstStrain"> alljoints-inertials_remapper </elem>
+        </paramlist>
+       </action>
+
+    <action phase="shutdown" level="20" type="detach" />
+</device>

--- a/iCubZagreb01/wrappers/inertials/alljoints-inertials_wrapper.xml
+++ b/iCubZagreb01/wrappers/inertials/alljoints-inertials_wrapper.xml
@@ -11,5 +11,5 @@
         </paramlist>
        </action>
 
-    <action phase="shutdown" level="20" type="detach" />
+    <action phase="shutdown" level="15" type="detach" />
 </device>


### PR DESCRIPTION
This is the twin of https://github.com/robotology/icub-models-generator/pull/264. The aim of this PR is to expose via multipleanalogsensorsremapper the orientation measurements of the available IMUs and wrap them in one channel. 

The robots involved in these changes are the ergoCubs + the iCubs similar to iCubGenova11, so V2_7. Moreover, I included in the remapper only the IMUs that already have a specific configuration file under `/hardware/inertials/`. 

Unfortunately, it's difficult to test these changes, but I took https://github.com/robotology/robots-configuration/pull/615 as reference that works on iCubGenova11

cc @Nicogene @pattacini @traversaro 