### PR TITLE
[ergoCubSN00*]  Fix attach and detach level in rgbdSensor_nws_yarp

### DIFF
--- a/ergoCubSN000/sensors/realsense.xml
+++ b/ergoCubSN000/sensors/realsense.xml
@@ -25,13 +25,12 @@
   <device xmlns:xi="http://www.w3.org/2001/XInclude" name="RGBDWrapperyarp" type="rgbdSensor_nws_yarp">
     <param name="period"> 0.03 </param>
     <param name="name">    /depthCamera </param>
-    <action phase="startup" level="5" type="attach">
+    <action phase="startup" level="10" type="attach">
       <paramlist name="networks">
         <elem name="subdevicergbd"> realsenseD450 </elem>
       </paramlist>
     </action>
-    <action phase="shutdown" level="5" type="detach" />
+    <action phase="shutdown" level="15" type="detach" />
   </device>
 
 </devices>
-

--- a/ergoCubSN001/sensors/realsense.xml
+++ b/ergoCubSN001/sensors/realsense.xml
@@ -23,13 +23,12 @@
   <device xmlns:xi="http://www.w3.org/2001/XInclude" name="RGBDWrapperyarp" type="rgbdSensor_nws_yarp">
     <param name="period"> 0.03 </param>
     <param name="name">    /depthCamera </param>
-    <action phase="startup" level="5" type="attach">
+    <action phase="startup" level="10" type="attach">
       <paramlist name="networks">
         <elem name="subdevicergbd"> realsenseD450 </elem>
       </paramlist>
     </action>
-    <action phase="shutdown" level="5" type="detach" />
+    <action phase="shutdown" level="15" type="detach" />
   </device>
 
 </devices>
-

--- a/ergoCubSN002/sensors/realsense.xml
+++ b/ergoCubSN002/sensors/realsense.xml
@@ -23,13 +23,12 @@
   <device xmlns:xi="http://www.w3.org/2001/XInclude" name="RGBDWrapperyarp" type="rgbdSensor_nws_yarp">
     <param name="period"> 0.03 </param>
     <param name="name">    /depthCamera </param>
-    <action phase="startup" level="5" type="attach">
+    <action phase="startup" level="10" type="attach">
       <paramlist name="networks">
         <elem name="subdevicergbd"> realsenseD450 </elem>
       </paramlist>
     </action>
-    <action phase="shutdown" level="5" type="detach" />
+    <action phase="shutdown" level="15" type="detach" />
   </device>
 
 </devices>
-


### PR DESCRIPTION
The configuration files for launching the `realsense` device on ergoCubs had the wrong attach and detach levels (both set to level 5). This PR fixes this error as documented [here](https://github.com/robotology/robots-configuration/issues/377)
