### PR TITLE
 IMU sensors: add sensorName tag in FT IMU xml 

### DIFF
--- a/ergoCubSN000/hardware/inertials/head-inertial.xml
+++ b/ergoCubSN000/hardware/inertials/head-inertial.xml
@@ -30,14 +30,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">           rfeimu_acc      rfeimu_gyro     rfeimu_mag     rfeimu_eul      rfeimu_status
-                    </param>
-                    <param name="type">         eoas_imu_acc    eoas_imu_gyr    eoas_imu_mag    eoas_imu_eul    eoas_imu_status
-                    </param>
-                    <param name="boardType">    rfe             rfe             rfe             rfe             rfe
-                    </param>
-                    <param name="location">     CAN1:1          CAN1:1          CAN1:1          CAN1:1          CAN1:1
-                    </param>
+                    <param name="id">           rfeimu_acc      rfeimu_gyro     rfeimu_mag      rfeimu_eul      rfeimu_status    </param>
+                    <param name="sensorName">   head_imu_0      head_imu_0      head_imu_0      head_imu_0      head_imu_0       </param>
+                    <param name="type">         eoas_imu_acc    eoas_imu_gyr    eoas_imu_mag    eoas_imu_eul    eoas_imu_status  </param>
+                    <param name="boardType">    rfe             rfe             rfe             rfe             rfe              </param>
+                    <param name="location">     CAN1:1          CAN1:1          CAN1:1          CAN1:1          CAN1:1           </param>
                 </group>
 
             </group>

--- a/ergoCubSN000/hardware/inertials/left_arm-eb2-j0_1-inertial.xml
+++ b/ergoCubSN000/hardware/inertials/left_arm-eb2-j0_1-inertial.xml
@@ -29,10 +29,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">       l_arm_ft_acc    l_arm_ft_gyro    l_arm_ft_eul    l_arm_ft_mag    l_arm_ft_stat    </param>
-                    <param name="type">     eoas_imu_acc    eoas_imu_gyr     eoas_imu_eul    eoas_imu_mag    eoas_imu_status  </param>
-                    <param name="boardType">  strain2       strain2      strain2       strain2        strain2  </param>
-                    <param name="location">  CAN2:13       CAN2:13      CAN2:13       CAN2:13        CAN2:13   </param>
+                    <param name="id">         l_arm_ft_acc   l_arm_ft_gyro   l_arm_ft_eul   l_arm_ft_mag   l_arm_ft_stat    </param>
+                    <param name="sensorName"> l_arm_ft_imu   l_arm_ft_imu    l_arm_ft_imu   l_arm_ft_imu   l_arm_ft_imu     </param>
+                    <param name="type">       eoas_imu_acc   eoas_imu_gyr    eoas_imu_eul   eoas_imu_mag   eoas_imu_status  </param>
+                    <param name="boardType">  strain2        strain2         strain2        strain2        strain2          </param>
+                    <param name="location">   CAN2:13        CAN2:13         CAN2:13        CAN2:13        CAN2:13          </param>
                 </group>
 
             </group>

--- a/ergoCubSN000/hardware/inertials/left_leg-eb8-j0_3-inertial.xml
+++ b/ergoCubSN000/hardware/inertials/left_leg-eb8-j0_3-inertial.xml
@@ -29,10 +29,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">       l_leg_ft_acc    l_leg_ft_gyro    l_leg_ft_eul    l_leg_ft_mag    l_leg_ft_stat</param>
-                    <param name="type">     eoas_imu_acc    eoas_imu_gyr     eoas_imu_eul    eoas_imu_mag    eoas_imu_status</param>
-                    <param name="boardType">  strain2       strain2      strain2            strain2           strain2</param>
-                    <param name="location">  CAN2:13       CAN2:13      CAN2:13       CAN2:13        CAN2:13    </param>
+                    <param name="id">         l_leg_ft_acc   l_leg_ft_gyro   l_leg_ft_eul   l_leg_ft_mag   l_leg_ft_stat    </param>
+                    <param name="sensorName"> l_leg_ft_imu   l_leg_ft_imu    l_leg_ft_imu   l_leg_ft_imu   l_leg_ft_imu     </param>
+                    <param name="type">       eoas_imu_acc   eoas_imu_gyr    eoas_imu_eul   eoas_imu_mag   eoas_imu_status  </param>
+                    <param name="boardType">  strain2        strain2         strain2        strain2        strain2          </param>
+                    <param name="location">   CAN2:13        CAN2:13         CAN2:13        CAN2:13        CAN2:13          </param>
                 </group>
 
             </group>

--- a/ergoCubSN000/hardware/inertials/left_leg-eb9-j4_5-inertial.xml
+++ b/ergoCubSN000/hardware/inertials/left_leg-eb9-j4_5-inertial.xml
@@ -29,10 +29,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">       l_foot_rear_ft_acc    l_foot_rear_ft_gyro    l_foot_rear_ft_eul    l_foot_rear_ft_mag    l_foot_rear_ft_stat   l_foot_front_ft_acc    l_foot_front_ft_gyro    l_foot_front_ft_eul    l_foot_front_ft_mag    l_foot_front_ft_stat</param>
-                    <param name="type">     eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status   eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status</param>
-                    <param name="boardType">  strain2       strain2      strain2       strain2        strain2   strain2       strain2      strain2       strain2        strain2</param>
-                    <param name="location">  CAN2:13       CAN2:13      CAN2:13       CAN2:13        CAN2:13    CAN2:14       CAN2:14      CAN2:14       CAN2:14        CAN2:14</param>
+                    <param name="id">         l_foot_rear_ft_acc    l_foot_rear_ft_gyro    l_foot_rear_ft_eul    l_foot_rear_ft_mag    l_foot_rear_ft_stat   l_foot_front_ft_acc    l_foot_front_ft_gyro    l_foot_front_ft_eul    l_foot_front_ft_mag    l_foot_front_ft_stat  </param>
+                    <param name="sensorName"> l_foot_rear_ft_imu    l_foot_rear_ft_imu     l_foot_rear_ft_imu    l_foot_rear_ft_imu    l_foot_rear_ft_imu    l_foot_front_ft_imu    l_foot_front_ft_imu     l_foot_front_ft_imu    l_foot_front_ft_imu    l_foot_front_ft_imu   </param>
+                    <param name="type">       eoas_imu_acc          eoas_imu_gyr           eoas_imu_eul          eoas_imu_mag          eoas_imu_status       eoas_imu_acc           eoas_imu_gyr            eoas_imu_eul           eoas_imu_mag           eoas_imu_status       </param>
+                    <param name="boardType">  strain2               strain2                strain2               strain2               strain2               strain2                strain2                 strain2                strain2                strain2               </param>
+                    <param name="location">   CAN2:13               CAN2:13                CAN2:13               CAN2:13               CAN2:13               CAN2:14                CAN2:14                 CAN2:14                CAN2:14                CAN2:14               </param>
                 </group>
 
             </group>

--- a/ergoCubSN000/hardware/inertials/right_arm-eb1-j0_1-inertial.xml
+++ b/ergoCubSN000/hardware/inertials/right_arm-eb1-j0_1-inertial.xml
@@ -29,10 +29,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">       r_arm_ft_acc    r_arm_ft_gyro    r_arm_ft_eul    r_arm_ft_mag    r_arm_ft_stat    </param>
-                    <param name="type">     eoas_imu_acc    eoas_imu_gyr     eoas_imu_eul    eoas_imu_mag    eoas_imu_status  </param>
-                    <param name="boardType">  strain2       strain2      strain2       strain2        strain2  </param>
-                    <param name="location">  CAN2:13       CAN2:13      CAN2:13       CAN2:13        CAN2:13   </param>
+                    <param name="id">         r_arm_ft_acc   r_arm_ft_gyro   r_arm_ft_eul   r_arm_ft_mag   r_arm_ft_stat    </param>
+                    <param name="sensorName"> r_arm_ft_imu   r_arm_ft_imu    r_arm_ft_imu   r_arm_ft_imu   r_arm_ft_imu     </param>
+                    <param name="type">       eoas_imu_acc   eoas_imu_gyr    eoas_imu_eul   eoas_imu_mag   eoas_imu_status  </param>
+                    <param name="boardType">  strain2        strain2         strain2        strain2        strain2          </param>
+                    <param name="location">   CAN2:13        CAN2:13         CAN2:13        CAN2:13        CAN2:13          </param>
                 </group>
 
             </group>

--- a/ergoCubSN000/hardware/inertials/right_leg-eb6-j0_3-inertial.xml
+++ b/ergoCubSN000/hardware/inertials/right_leg-eb6-j0_3-inertial.xml
@@ -29,10 +29,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">       r_leg_ft_acc    r_leg_ft_gyro    r_leg_ft_eul    r_leg_ft_mag    r_leg_ft_stat </param>
-                    <param name="type">     eoas_imu_acc   eoas_imu_gyr      eoas_imu_eul    eoas_imu_mag   eoas_imu_status</param>
-                    <param name="boardType">  strain2       strain2           strain2         strain2        strain2  </param>
-                    <param name="location">  CAN2:13       CAN2:13      CAN2:13       CAN2:13        CAN2:13    </param>
+                    <param name="id">         r_leg_ft_acc   r_leg_ft_gyro   r_leg_ft_eul   r_leg_ft_mag   r_leg_ft_stat    </param>
+                    <param name="sensorName"> r_leg_ft_imu   r_leg_ft_imu    r_leg_ft_imu   r_leg_ft_imu   r_leg_ft_imu     </param>
+                    <param name="type">       eoas_imu_acc   eoas_imu_gyr    eoas_imu_eul   eoas_imu_mag   eoas_imu_status  </param>
+                    <param name="boardType">  strain2        strain2         strain2        strain2        strain2          </param>
+                    <param name="location">   CAN2:13        CAN2:13         CAN2:13        CAN2:13        CAN2:13          </param>
                 </group>
 
             </group>

--- a/ergoCubSN000/hardware/inertials/right_leg-eb7-j4_5-inertial.xml
+++ b/ergoCubSN000/hardware/inertials/right_leg-eb7-j4_5-inertial.xml
@@ -29,10 +29,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">       r_foot_rear_ft_acc    r_foot_rear_ft_gyro    r_foot_rear_ft_eul    r_foot_rear_ft_mag    r_foot_rear_ft_stat   r_foot_front_ft_acc    r_foot_front_ft_gyro    r_foot_front_ft_eul    r_foot_front_ft_mag    r_foot_front_ft_stat</param>
-                    <param name="type">     eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status   eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status</param>
-                    <param name="boardType">  strain2       strain2      strain2       strain2        strain2   strain2       strain2      strain2       strain2        strain2</param>
-                    <param name="location">  CAN2:13       CAN2:13      CAN2:13       CAN2:13        CAN2:13    CAN2:14       CAN2:14      CAN2:14       CAN2:14        CAN2:14</param>
+                    <param name="id">         r_foot_rear_ft_acc    r_foot_rear_ft_gyro    r_foot_rear_ft_eul    r_foot_rear_ft_mag    r_foot_rear_ft_stat   r_foot_front_ft_acc    r_foot_front_ft_gyro    r_foot_front_ft_eul    r_foot_front_ft_mag    r_foot_front_ft_stat  </param>
+                    <param name="sensorName"> r_foot_rear_ft_imu    r_foot_rear_ft_imu     r_foot_rear_ft_imu    r_foot_rear_ft_imu    r_foot_rear_ft_imu    r_foot_front_ft_imu    r_foot_front_ft_imu     r_foot_front_ft_imu    r_foot_front_ft_imu    r_foot_front_ft_imu   </param>
+                    <param name="type">       eoas_imu_acc          eoas_imu_gyr           eoas_imu_eul          eoas_imu_mag          eoas_imu_status       eoas_imu_acc           eoas_imu_gyr            eoas_imu_eul           eoas_imu_mag           eoas_imu_status       </param>
+                    <param name="boardType">  strain2               strain2                strain2               strain2               strain2               strain2                strain2                 strain2                strain2                strain2               </param>
+                    <param name="location">   CAN2:13               CAN2:13                CAN2:13               CAN2:13               CAN2:13               CAN2:14                CAN2:14                 CAN2:14                CAN2:14                CAN2:14               </param>
                 </group>
 
             </group>

--- a/ergoCubSN000/wrappers/inertials/alljoints-inertials_remapper.xml
+++ b/ergoCubSN000/wrappers/inertials/alljoints-inertials_remapper.xml
@@ -4,7 +4,7 @@
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_remapper" type="multipleanalogsensorsremapper">
         <param name="OrientationSensorsNames">
-            (head_imu_0 l_arm_ft l_leg_ft l_foot_rear_ft l_foot_front_ft r_arm_ft r_leg_ft r_foot_rear_ft r_foot_front_ft waist_imu_0)
+            (head_imu_0 l_arm_ft_imu l_leg_ft_imu l_foot_rear_ft_imu l_foot_front_ft_imu r_arm_ft_imu r_leg_ft_imu r_foot_rear_ft_imu r_foot_front_ft_imu waist_imu_0)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/ergoCubSN000/wrappers/inertials/alljoints-inertials_remapper.xml
+++ b/ergoCubSN000/wrappers/inertials/alljoints-inertials_remapper.xml
@@ -15,7 +15,7 @@
                 <elem name="r_arm_imu"> right_arm-eb1-j0_1-inertial </elem>
                 <elem name="r_leg_imu"> right_leg-eb6-j0_3-inertial </elem>
                 <elem name="r_foot_imu"> right_leg-eb7-j4_5-inertial </elem>
-                <elem name="waist_imu"> waist_inertial </elem>
+                <elem name="waist_imu"> waist-inertial </elem>
             </paramlist>
         </action>
 

--- a/ergoCubSN000/wrappers/inertials/alljoints-inertials_wrapper.xml
+++ b/ergoCubSN000/wrappers/inertials/alljoints-inertials_wrapper.xml
@@ -5,7 +5,7 @@
     <param name="period">      10                           </param>
     <param name="name"> /${portprefix}/alljoints/inertials   </param>
 
-    <action phase="startup" level="15" type="attach">
+    <action phase="startup" level="10" type="attach">
         <paramlist name="networks">
             <elem name="FirstStrain"> alljoints-inertials_remapper </elem>
         </paramlist>

--- a/ergoCubSN001/hardware/inertials/head-inertial.xml
+++ b/ergoCubSN001/hardware/inertials/head-inertial.xml
@@ -30,14 +30,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">           rfeimu_acc      rfeimu_gyro     rfeimu_mag     rfeimu_eul      rfeimu_status
-                    </param>
-                    <param name="type">         eoas_imu_acc    eoas_imu_gyr    eoas_imu_mag    eoas_imu_eul    eoas_imu_status
-                    </param>
-                    <param name="boardType">    rfe             rfe             rfe             rfe             rfe
-                    </param>
-                    <param name="location">     CAN1:1          CAN1:1          CAN1:1          CAN1:1          CAN1:1
-                    </param>
+                    <param name="id">           rfeimu_acc      rfeimu_gyro     rfeimu_mag      rfeimu_eul      rfeimu_status    </param>
+                    <param name="sensorName">   head_imu_0      head_imu_0      head_imu_0      head_imu_0      head_imu_0       </param>
+                    <param name="type">         eoas_imu_acc    eoas_imu_gyr    eoas_imu_mag    eoas_imu_eul    eoas_imu_status  </param>
+                    <param name="boardType">    rfe             rfe             rfe             rfe             rfe              </param>
+                    <param name="location">     CAN1:1          CAN1:1          CAN1:1          CAN1:1          CAN1:1           </param>
                 </group>
 
             </group>

--- a/ergoCubSN001/hardware/inertials/left_arm-eb2-j0_1-inertial.xml
+++ b/ergoCubSN001/hardware/inertials/left_arm-eb2-j0_1-inertial.xml
@@ -30,7 +30,7 @@
 
                 <group name="SENSORS">
                     <param name="id">          l_arm_ft_acc   l_arm_ft_gyro   l_arm_ft_eul    l_arm_ft_mag    l_arm_ft_stat    </param>
-                    <param mame="sensorName">  l_arm_ft_imu   l_arm_ft_imu    l_arm_ft_imu    l_arm_ft_imu    l_arm_ft_imu     </param>
+                    <param name="sensorName">  l_arm_ft_imu   l_arm_ft_imu    l_arm_ft_imu    l_arm_ft_imu    l_arm_ft_imu     </param>
                     <param name="type">        eoas_imu_acc   eoas_imu_gyr    eoas_imu_eul    eoas_imu_mag    eoas_imu_status  </param>
                     <param name="boardType">   strain2        strain2         strain2         strain2         strain2          </param>
                     <param name="location">    CAN2:13        CAN2:13         CAN2:13         CAN2:13         CAN2:13          </param>

--- a/ergoCubSN001/hardware/inertials/left_arm-eb2-j0_1-inertial.xml
+++ b/ergoCubSN001/hardware/inertials/left_arm-eb2-j0_1-inertial.xml
@@ -29,10 +29,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">       l_arm_ft_acc    l_arm_ft_gyro    l_arm_ft_eul    l_arm_ft_mag    l_arm_ft_stat    </param>
-                    <param name="type">     eoas_imu_acc    eoas_imu_gyr     eoas_imu_eul    eoas_imu_mag    eoas_imu_status  </param>
-                    <param name="boardType">  strain2       strain2      strain2       strain2        strain2  </param>
-                    <param name="location">  CAN2:13       CAN2:13      CAN2:13       CAN2:13        CAN2:13   </param>
+                    <param name="id">          l_arm_ft_acc   l_arm_ft_gyro   l_arm_ft_eul    l_arm_ft_mag    l_arm_ft_stat    </param>
+                    <param mame="sensorName">  l_arm_ft_imu   l_arm_ft_imu    l_arm_ft_imu    l_arm_ft_imu    l_arm_ft_imu     </param>
+                    <param name="type">        eoas_imu_acc   eoas_imu_gyr    eoas_imu_eul    eoas_imu_mag    eoas_imu_status  </param>
+                    <param name="boardType">   strain2        strain2         strain2         strain2         strain2          </param>
+                    <param name="location">    CAN2:13        CAN2:13         CAN2:13         CAN2:13         CAN2:13          </param>
                 </group>
 
             </group>

--- a/ergoCubSN001/hardware/inertials/left_leg-eb8-j0_3-inertial.xml
+++ b/ergoCubSN001/hardware/inertials/left_leg-eb8-j0_3-inertial.xml
@@ -29,10 +29,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">       l_leg_ft_acc    l_leg_ft_gyro    l_leg_ft_eul    l_leg_ft_mag    l_leg_ft_stat</param>
-                    <param name="type">     eoas_imu_acc    eoas_imu_gyr     eoas_imu_eul    eoas_imu_mag    eoas_imu_status</param>
-                    <param name="boardType">  strain2       strain2      strain2            strain2           strain2</param>
-                    <param name="location">  CAN2:13       CAN2:13      CAN2:13       CAN2:13        CAN2:13    </param>
+                    <param name="id">         l_leg_ft_acc   l_leg_ft_gyro   l_leg_ft_eul   l_leg_ft_mag   l_leg_ft_stat    </param>
+                    <param name="sensorName"> l_leg_ft_imu   l_leg_ft_imu    l_leg_ft_imu   l_leg_ft_imu   l_leg_ft_imu     </param>
+                    <param name="type">       eoas_imu_acc   eoas_imu_gyr    eoas_imu_eul   eoas_imu_mag   eoas_imu_status  </param>
+                    <param name="boardType">  strain2        strain2         strain2        strain2        strain2          </param>
+                    <param name="location">   CAN2:13        CAN2:13         CAN2:13        CAN2:13        CAN2:13          </param>
                 </group>
 
             </group>

--- a/ergoCubSN001/hardware/inertials/left_leg-eb9-j4_5-inertial.xml
+++ b/ergoCubSN001/hardware/inertials/left_leg-eb9-j4_5-inertial.xml
@@ -29,10 +29,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">       l_foot_rear_ft_acc    l_foot_rear_ft_gyro    l_foot_rear_ft_eul    l_foot_rear_ft_mag    l_foot_rear_ft_stat   l_foot_front_ft_acc    l_foot_front_ft_gyro    l_foot_front_ft_eul    l_foot_front_ft_mag    l_foot_front_ft_stat</param>
-                    <param name="type">     eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status   eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status</param>
-                    <param name="boardType">  strain2       strain2      strain2       strain2        strain2   strain2       strain2      strain2       strain2        strain2</param>
-                    <param name="location">  CAN2:13       CAN2:13      CAN2:13       CAN2:13        CAN2:13    CAN2:14       CAN2:14      CAN2:14       CAN2:14        CAN2:14</param>
+                    <param name="id">         l_foot_rear_ft_acc    l_foot_rear_ft_gyro    l_foot_rear_ft_eul    l_foot_rear_ft_mag    l_foot_rear_ft_stat   l_foot_front_ft_acc    l_foot_front_ft_gyro    l_foot_front_ft_eul    l_foot_front_ft_mag    l_foot_front_ft_stat  </param>
+                    <param name="sensorName"> l_foot_rear_ft_imu    l_foot_rear_ft_imu     l_foot_rear_ft_imu    l_foot_rear_ft_imu    l_foot_rear_ft_imu    l_foot_front_ft_imu    l_foot_front_ft_imu     l_foot_front_ft_imu    l_foot_front_ft_imu    l_foot_front_ft_imu   </param>
+                    <param name="type">       eoas_imu_acc          eoas_imu_gyr           eoas_imu_eul          eoas_imu_mag          eoas_imu_status       eoas_imu_acc           eoas_imu_gyr            eoas_imu_eul           eoas_imu_mag           eoas_imu_status       </param>
+                    <param name="boardType">  strain2               strain2                strain2               strain2               strain2               strain2                strain2                 strain2                strain2                strain2               </param>
+                    <param name="location">   CAN2:13               CAN2:13                CAN2:13               CAN2:13               CAN2:13               CAN2:14                CAN2:14                 CAN2:14                CAN2:14                CAN2:14               </param>
                 </group>
 
             </group>

--- a/ergoCubSN001/hardware/inertials/right_arm-eb1-j0_1-inertial.xml
+++ b/ergoCubSN001/hardware/inertials/right_arm-eb1-j0_1-inertial.xml
@@ -29,10 +29,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">       r_arm_ft_acc    r_arm_ft_gyro    r_arm_ft_eul    r_arm_ft_mag    r_arm_ft_stat    </param>
-                    <param name="type">     eoas_imu_acc    eoas_imu_gyr     eoas_imu_eul    eoas_imu_mag    eoas_imu_status  </param>
-                    <param name="boardType">  strain2       strain2      strain2       strain2        strain2  </param>
-                    <param name="location">  CAN2:13       CAN2:13      CAN2:13       CAN2:13        CAN2:13   </param>
+                    <param name="id">         r_arm_ft_acc   r_arm_ft_gyro   r_arm_ft_eul   r_arm_ft_mag   r_arm_ft_stat    </param>
+                    <param name="sensorName"> r_arm_ft_imu   r_arm_ft_imu    r_arm_ft_imu   r_arm_ft_imu   r_arm_ft_imu     </param>
+                    <param name="type">       eoas_imu_acc   eoas_imu_gyr    eoas_imu_eul   eoas_imu_mag   eoas_imu_status  </param>
+                    <param name="boardType">  strain2        strain2         strain2        strain2        strain2          </param>
+                    <param name="location">   CAN2:13        CAN2:13         CAN2:13        CAN2:13        CAN2:13          </param>
                 </group>
 
             </group>

--- a/ergoCubSN001/hardware/inertials/right_leg-eb6-j0_3-inertial.xml
+++ b/ergoCubSN001/hardware/inertials/right_leg-eb6-j0_3-inertial.xml
@@ -29,10 +29,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">       r_leg_ft_acc    r_leg_ft_gyro    r_leg_ft_eul    r_leg_ft_mag    r_leg_ft_stat </param>
-                    <param name="type">     eoas_imu_acc   eoas_imu_gyr      eoas_imu_eul    eoas_imu_mag   eoas_imu_status</param>
-                    <param name="boardType">  strain2       strain2           strain2         strain2        strain2  </param>
-                    <param name="location">  CAN2:13       CAN2:13      CAN2:13       CAN2:13        CAN2:13    </param>
+                    <param name="id">         r_leg_ft_acc   r_leg_ft_gyro   r_leg_ft_eul   r_leg_ft_mag   r_leg_ft_stat    </param>
+                    <param name="sensorName"> r_leg_ft_imu   r_leg_ft_imu    r_leg_ft_imu   r_leg_ft_imu   r_leg_ft_imu     </param>
+                    <param name="type">       eoas_imu_acc   eoas_imu_gyr    eoas_imu_eul   eoas_imu_mag   eoas_imu_status  </param>
+                    <param name="boardType">  strain2        strain2         strain2        strain2        strain2          </param>
+                    <param name="location">   CAN2:13        CAN2:13         CAN2:13        CAN2:13        CAN2:13          </param>
                 </group>
 
             </group>

--- a/ergoCubSN001/hardware/inertials/right_leg-eb7-j4_5-inertial.xml
+++ b/ergoCubSN001/hardware/inertials/right_leg-eb7-j4_5-inertial.xml
@@ -29,10 +29,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">       r_foot_rear_ft_acc    r_foot_rear_ft_gyro    r_foot_rear_ft_eul    r_foot_rear_ft_mag    r_foot_rear_ft_stat   r_foot_front_ft_acc    r_foot_front_ft_gyro    r_foot_front_ft_eul    r_foot_front_ft_mag    r_foot_front_ft_stat</param>
-                    <param name="type">     eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status   eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status</param>
-                    <param name="boardType">  strain2       strain2      strain2       strain2        strain2   strain2       strain2      strain2       strain2        strain2</param>
-                    <param name="location">  CAN2:13       CAN2:13      CAN2:13       CAN2:13        CAN2:13    CAN2:14       CAN2:14      CAN2:14       CAN2:14        CAN2:14</param>
+                    <param name="id">         r_foot_rear_ft_acc    r_foot_rear_ft_gyro    r_foot_rear_ft_eul    r_foot_rear_ft_mag    r_foot_rear_ft_stat   r_foot_front_ft_acc    r_foot_front_ft_gyro    r_foot_front_ft_eul    r_foot_front_ft_mag    r_foot_front_ft_stat  </param>
+                    <param name="sensorName"> r_foot_rear_ft_imu    r_foot_rear_ft_imu     r_foot_rear_ft_imu    r_foot_rear_ft_imu    r_foot_rear_ft_imu    r_foot_front_ft_imu    r_foot_front_ft_imu     r_foot_front_ft_imu    r_foot_front_ft_imu    r_foot_front_ft_imu   </param>
+                    <param name="type">       eoas_imu_acc          eoas_imu_gyr           eoas_imu_eul          eoas_imu_mag          eoas_imu_status       eoas_imu_acc           eoas_imu_gyr            eoas_imu_eul           eoas_imu_mag           eoas_imu_status       </param>
+                    <param name="boardType">  strain2               strain2                strain2               strain2               strain2               strain2                strain2                 strain2                strain2                strain2               </param>
+                    <param name="location">   CAN2:13               CAN2:13                CAN2:13               CAN2:13               CAN2:13               CAN2:14                CAN2:14                 CAN2:14                CAN2:14                CAN2:14               </param>
                 </group>
 
             </group>

--- a/ergoCubSN001/wrappers/inertials/alljoints-inertials_remapper.xml
+++ b/ergoCubSN001/wrappers/inertials/alljoints-inertials_remapper.xml
@@ -4,7 +4,7 @@
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_remapper" type="multipleanalogsensorsremapper">
         <param name="OrientationSensorsNames">
-            (head_imu_0 l_arm_ft l_leg_ft l_foot_rear_ft l_foot_front_ft r_arm_ft r_leg_ft r_foot_rear_ft r_foot_front_ft waist_imu_0)
+            (head_imu_0 l_arm_ft_imu l_leg_ft_imu l_foot_rear_ft_imu l_foot_front_ft_imu r_arm_ft_imu r_leg_ft_imu r_foot_rear_ft_imu r_foot_front_ft_imu waist_imu_0)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/ergoCubSN001/wrappers/inertials/alljoints-inertials_remapper.xml
+++ b/ergoCubSN001/wrappers/inertials/alljoints-inertials_remapper.xml
@@ -15,7 +15,7 @@
                 <elem name="r_arm_imu"> right_arm-eb1-j0_1-inertial </elem>
                 <elem name="r_leg_imu"> right_leg-eb6-j0_3-inertial </elem>
                 <elem name="r_foot_imu"> right_leg-eb7-j4_5-inertial </elem>
-                <elem name="waist_imu"> waist_inertial </elem>
+                <elem name="waist_imu"> waist-inertial </elem>
             </paramlist>
         </action>
 

--- a/ergoCubSN001/wrappers/inertials/alljoints-inertials_wrapper.xml
+++ b/ergoCubSN001/wrappers/inertials/alljoints-inertials_wrapper.xml
@@ -5,7 +5,7 @@
     <param name="period">      10                           </param>
     <param name="name"> /${portprefix}/alljoints/inertials   </param>
 
-    <action phase="startup" level="15" type="attach">
+    <action phase="startup" level="10" type="attach">
         <paramlist name="networks">
             <elem name="FirstStrain"> alljoints-inertials_remapper </elem>
         </paramlist>

--- a/ergoCubSN002/hardware/inertials/head-inertial.xml
+++ b/ergoCubSN002/hardware/inertials/head-inertial.xml
@@ -30,14 +30,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">           rfeimu_acc      rfeimu_gyro     rfeimu_mag     rfeimu_eul      rfeimu_status
-                    </param>
-                    <param name="type">         eoas_imu_acc    eoas_imu_gyr    eoas_imu_mag    eoas_imu_eul    eoas_imu_status
-                    </param>
-                    <param name="boardType">    rfe             rfe             rfe             rfe             rfe
-                    </param>
-                    <param name="location">     CAN1:1          CAN1:1          CAN1:1          CAN1:1          CAN1:1
-                    </param>
+                    <param name="id">           rfeimu_acc      rfeimu_gyro     rfeimu_mag      rfeimu_eul      rfeimu_status    </param>
+                    <param name="sensorName">   head_imu_0      head_imu_0      head_imu_0      head_imu_0      head_imu_0       </param>
+                    <param name="type">         eoas_imu_acc    eoas_imu_gyr    eoas_imu_mag    eoas_imu_eul    eoas_imu_status  </param>
+                    <param name="boardType">    rfe             rfe             rfe             rfe             rfe              </param>
+                    <param name="location">     CAN1:1          CAN1:1          CAN1:1          CAN1:1          CAN1:1           </param>
                 </group>
 
             </group>

--- a/ergoCubSN002/hardware/inertials/left_arm-eb2-j0_1-inertial.xml
+++ b/ergoCubSN002/hardware/inertials/left_arm-eb2-j0_1-inertial.xml
@@ -29,10 +29,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">       l_arm_ft_acc    l_arm_ft_gyro    l_arm_ft_eul    l_arm_ft_mag    l_arm_ft_stat    </param>
-                    <param name="type">     eoas_imu_acc    eoas_imu_gyr     eoas_imu_eul    eoas_imu_mag    eoas_imu_status  </param>
-                    <param name="boardType">  strain2       strain2      strain2       strain2        strain2  </param>
-                    <param name="location">  CAN2:13       CAN2:13      CAN2:13       CAN2:13        CAN2:13   </param>
+                    <param name="id">         l_arm_ft_acc   l_arm_ft_gyro   l_arm_ft_eul   l_arm_ft_mag   l_arm_ft_stat    </param>
+                    <param name="sensorName"> l_arm_ft_imu   l_arm_ft_imu    l_arm_ft_imu   l_arm_ft_imu   l_arm_ft_imu     </param>
+                    <param name="type">       eoas_imu_acc   eoas_imu_gyr    eoas_imu_eul   eoas_imu_mag   eoas_imu_status  </param>
+                    <param name="boardType">  strain2        strain2         strain2        strain2        strain2          </param>
+                    <param name="location">   CAN2:13        CAN2:13         CAN2:13        CAN2:13        CAN2:13          </param>
                 </group>
 
             </group>

--- a/ergoCubSN002/hardware/inertials/left_leg-eb8-j0_3-inertial.xml
+++ b/ergoCubSN002/hardware/inertials/left_leg-eb8-j0_3-inertial.xml
@@ -29,10 +29,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">       l_leg_ft_acc    l_leg_ft_gyro    l_leg_ft_eul    l_leg_ft_mag    l_leg_ft_stat</param>
-                    <param name="type">     eoas_imu_acc    eoas_imu_gyr     eoas_imu_eul    eoas_imu_mag    eoas_imu_status</param>
-                    <param name="boardType">  strain2       strain2      strain2            strain2           strain2</param>
-                    <param name="location">  CAN2:13       CAN2:13      CAN2:13       CAN2:13        CAN2:13    </param>
+                    <param name="id">         l_leg_ft_acc   l_leg_ft_gyro   l_leg_ft_eul   l_leg_ft_mag   l_leg_ft_stat    </param>
+                    <param name="sensorName"> l_leg_ft_imu   l_leg_ft_imu    l_leg_ft_imu   l_leg_ft_imu   l_leg_ft_imu     </param>
+                    <param name="type">       eoas_imu_acc   eoas_imu_gyr    eoas_imu_eul   eoas_imu_mag   eoas_imu_status  </param>
+                    <param name="boardType">  strain2        strain2         strain2        strain2        strain2          </param>
+                    <param name="location">   CAN2:13        CAN2:13         CAN2:13        CAN2:13        CAN2:13          </param>
                 </group>
 
             </group>

--- a/ergoCubSN002/hardware/inertials/left_leg-eb9-j4_5-inertial.xml
+++ b/ergoCubSN002/hardware/inertials/left_leg-eb9-j4_5-inertial.xml
@@ -29,10 +29,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">       l_foot_rear_ft_acc    l_foot_rear_ft_gyro    l_foot_rear_ft_eul    l_foot_rear_ft_mag    l_foot_rear_ft_stat   l_foot_front_ft_acc    l_foot_front_ft_gyro    l_foot_front_ft_eul    l_foot_front_ft_mag    l_foot_front_ft_stat</param>
-                    <param name="type">     eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status   eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status</param>
-                    <param name="boardType">  strain2       strain2      strain2       strain2        strain2   strain2       strain2      strain2       strain2        strain2</param>
-                    <param name="location">  CAN2:13       CAN2:13      CAN2:13       CAN2:13        CAN2:13    CAN2:14       CAN2:14      CAN2:14       CAN2:14        CAN2:14</param>
+                    <param name="id">         l_foot_rear_ft_acc    l_foot_rear_ft_gyro    l_foot_rear_ft_eul    l_foot_rear_ft_mag    l_foot_rear_ft_stat   l_foot_front_ft_acc    l_foot_front_ft_gyro    l_foot_front_ft_eul    l_foot_front_ft_mag    l_foot_front_ft_stat  </param>
+                    <param name="sensorName"> l_foot_rear_ft_imu    l_foot_rear_ft_imu     l_foot_rear_ft_imu    l_foot_rear_ft_imu    l_foot_rear_ft_imu    l_foot_front_ft_imu    l_foot_front_ft_imu     l_foot_front_ft_imu    l_foot_front_ft_imu    l_foot_front_ft_imu   </param>
+                    <param name="type">       eoas_imu_acc          eoas_imu_gyr           eoas_imu_eul          eoas_imu_mag          eoas_imu_status       eoas_imu_acc           eoas_imu_gyr            eoas_imu_eul           eoas_imu_mag           eoas_imu_status       </param>
+                    <param name="boardType">  strain2               strain2                strain2               strain2               strain2               strain2                strain2                 strain2                strain2                strain2               </param>
+                    <param name="location">   CAN2:13               CAN2:13                CAN2:13               CAN2:13               CAN2:13               CAN2:14                CAN2:14                 CAN2:14                CAN2:14                CAN2:14               </param>
                 </group>
 
             </group>

--- a/ergoCubSN002/hardware/inertials/right_arm-eb1-j0_1-inertial.xml
+++ b/ergoCubSN002/hardware/inertials/right_arm-eb1-j0_1-inertial.xml
@@ -29,10 +29,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">       r_arm_ft_acc    r_arm_ft_gyro    r_arm_ft_eul    r_arm_ft_mag    r_arm_ft_stat    </param>
-                    <param name="type">     eoas_imu_acc    eoas_imu_gyr     eoas_imu_eul    eoas_imu_mag    eoas_imu_status  </param>
-                    <param name="boardType">  strain2       strain2      strain2       strain2        strain2  </param>
-                    <param name="location">  CAN2:13       CAN2:13      CAN2:13       CAN2:13        CAN2:13   </param>
+                    <param name="id">         r_arm_ft_acc   r_arm_ft_gyro   r_arm_ft_eul   r_arm_ft_mag   r_arm_ft_stat    </param>
+                    <param name="sensorName"> r_arm_ft_imu   r_arm_ft_imu    r_arm_ft_imu   r_arm_ft_imu   r_arm_ft_imu     </param>
+                    <param name="type">       eoas_imu_acc   eoas_imu_gyr    eoas_imu_eul   eoas_imu_mag   eoas_imu_status  </param>
+                    <param name="boardType">  strain2        strain2         strain2        strain2        strain2          </param>
+                    <param name="location">   CAN2:13        CAN2:13         CAN2:13        CAN2:13        CAN2:13          </param>
                 </group>
 
             </group>

--- a/ergoCubSN002/hardware/inertials/right_leg-eb6-j0_3-inertial.xml
+++ b/ergoCubSN002/hardware/inertials/right_leg-eb6-j0_3-inertial.xml
@@ -29,10 +29,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">       r_leg_ft_acc    r_leg_ft_gyro    r_leg_ft_eul    r_leg_ft_mag    r_leg_ft_stat </param>
-                    <param name="type">     eoas_imu_acc   eoas_imu_gyr      eoas_imu_eul    eoas_imu_mag   eoas_imu_status</param>
-                    <param name="boardType">  strain2       strain2           strain2         strain2        strain2  </param>
-                    <param name="location">  CAN2:13       CAN2:13      CAN2:13       CAN2:13        CAN2:13    </param>
+                    <param name="id">         r_leg_ft_acc   r_leg_ft_gyro   r_leg_ft_eul   r_leg_ft_mag   r_leg_ft_stat    </param>
+                    <param name="sensorName"> r_leg_ft_imu   r_leg_ft_imu    r_leg_ft_imu   r_leg_ft_imu   r_leg_ft_imu     </param>
+                    <param name="type">       eoas_imu_acc   eoas_imu_gyr    eoas_imu_eul   eoas_imu_mag   eoas_imu_status  </param>
+                    <param name="boardType">  strain2        strain2         strain2        strain2        strain2          </param>
+                    <param name="location">   CAN2:13        CAN2:13         CAN2:13        CAN2:13        CAN2:13          </param>
                 </group>
 
             </group>

--- a/ergoCubSN002/hardware/inertials/right_leg-eb7-j4_5-inertial.xml
+++ b/ergoCubSN002/hardware/inertials/right_leg-eb7-j4_5-inertial.xml
@@ -29,10 +29,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">       r_foot_rear_ft_acc    r_foot_rear_ft_gyro    r_foot_rear_ft_eul    r_foot_rear_ft_mag    r_foot_rear_ft_stat   r_foot_front_ft_acc    r_foot_front_ft_gyro    r_foot_front_ft_eul    r_foot_front_ft_mag    r_foot_front_ft_stat</param>
-                    <param name="type">     eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status   eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status</param>
-                    <param name="boardType">  strain2       strain2      strain2       strain2        strain2   strain2       strain2      strain2       strain2        strain2</param>
-                    <param name="location">  CAN2:13       CAN2:13      CAN2:13       CAN2:13        CAN2:13    CAN2:14       CAN2:14      CAN2:14       CAN2:14        CAN2:14</param>
+                    <param name="id">         r_foot_rear_ft_acc    r_foot_rear_ft_gyro    r_foot_rear_ft_eul    r_foot_rear_ft_mag    r_foot_rear_ft_stat   r_foot_front_ft_acc    r_foot_front_ft_gyro    r_foot_front_ft_eul    r_foot_front_ft_mag    r_foot_front_ft_stat  </param>
+                    <param name="sensorName"> r_foot_rear_ft_imu    r_foot_rear_ft_imu     r_foot_rear_ft_imu    r_foot_rear_ft_imu    r_foot_rear_ft_imu    r_foot_front_ft_imu    r_foot_front_ft_imu     r_foot_front_ft_imu    r_foot_front_ft_imu    r_foot_front_ft_imu   </param>
+                    <param name="type">       eoas_imu_acc          eoas_imu_gyr           eoas_imu_eul          eoas_imu_mag          eoas_imu_status       eoas_imu_acc           eoas_imu_gyr            eoas_imu_eul           eoas_imu_mag           eoas_imu_status       </param>
+                    <param name="boardType">  strain2               strain2                strain2               strain2               strain2               strain2                strain2                 strain2                strain2                strain2               </param>
+                    <param name="location">   CAN2:13               CAN2:13                CAN2:13               CAN2:13               CAN2:13               CAN2:14                CAN2:14                 CAN2:14                CAN2:14                CAN2:14               </param>
                 </group>
 
             </group>

--- a/ergoCubSN002/wrappers/inertials/alljoints-inertials_remapper.xml
+++ b/ergoCubSN002/wrappers/inertials/alljoints-inertials_remapper.xml
@@ -4,7 +4,7 @@
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_remapper" type="multipleanalogsensorsremapper">
         <param name="OrientationSensorsNames">
-            (head_imu_0 l_arm_ft l_leg_ft l_foot_rear_ft l_foot_front_ft r_arm_ft r_leg_ft r_foot_rear_ft r_foot_front_ft waist_imu_0)
+            (head_imu_0 l_arm_ft_imu l_leg_ft_imu l_foot_rear_ft_imu l_foot_front_ft_imu r_arm_ft_imu r_leg_ft_imu r_foot_rear_ft_imu r_foot_front_ft_imu waist_imu_0)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/ergoCubSN002/wrappers/inertials/alljoints-inertials_remapper.xml
+++ b/ergoCubSN002/wrappers/inertials/alljoints-inertials_remapper.xml
@@ -15,7 +15,7 @@
                 <elem name="r_arm_imu"> right_arm-eb1-j0_1-inertial </elem>
                 <elem name="r_leg_imu"> right_leg-eb6-j0_3-inertial </elem>
                 <elem name="r_foot_imu"> right_leg-eb7-j4_5-inertial </elem>
-                <elem name="waist_imu"> waist_inertial </elem>
+                <elem name="waist_imu"> waist-inertial </elem>
             </paramlist>
         </action>
 

--- a/ergoCubSN002/wrappers/inertials/alljoints-inertials_wrapper.xml
+++ b/ergoCubSN002/wrappers/inertials/alljoints-inertials_wrapper.xml
@@ -5,7 +5,7 @@
     <param name="period">      10                           </param>
     <param name="name"> /${portprefix}/alljoints/inertials   </param>
 
-    <action phase="startup" level="15" type="attach">
+    <action phase="startup" level="10" type="attach">
         <paramlist name="networks">
             <elem name="FirstStrain"> alljoints-inertials_remapper </elem>
         </paramlist>

--- a/iCubGenova07/hardware/inertials/head-inertial.xml
+++ b/iCubGenova07/hardware/inertials/head-inertial.xml
@@ -30,15 +30,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">           rfeimu_acc      rfeimu_gyro     rfeimu_mag      rfeimu_status
-                    </param>
-                    <param name="sensorName">   head_imu_0          head_imu_0          head_imu_0          head_imu_0 </param>
-                    <param name="type">         eoas_imu_acc    eoas_imu_gyr    eoas_imu_mag    eoas_imu_status
-                    </param>
-                    <param name="boardType">    rfe             rfe             rfe             rfe
-                    </param>
-                    <param name="location">     CAN1:1          CAN1:1          CAN1:1          CAN1:1
-                    </param>
+                    <param name="id">           rfeimu_acc      rfeimu_gyro     rfeimu_mag      rfeimu_status    </param>
+                    <param name="sensorName">   head_imu_0      head_imu_0      head_imu_0      head_imu_0       </param>
+                    <param name="type">         eoas_imu_acc    eoas_imu_gyr    eoas_imu_mag    eoas_imu_status  </param>
+                    <param name="boardType">    rfe             rfe             rfe             rfe              </param>
+                    <param name="location">     CAN1:1          CAN1:1          CAN1:1          CAN1:1           </param>
                 </group>
 
             </group>

--- a/iCubGenova07/hardware/inertials/left_leg-eb6-IMU.xml
+++ b/iCubGenova07/hardware/inertials/left_leg-eb6-IMU.xml
@@ -30,17 +30,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">       l_upper_leg_imu_acc_1    l_upper_leg_imu_gyro_1    l_upper_leg_imu_eul_1    l_upper_leg_imu_mag_1    l_upper_leg_imu_stat_1
-                    </param>
-
-                    <param name="type">     eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status
-                    </param>
-
-                    <param name="boardType"> strain2       strain2      strain2       strain2        strain2
-                    </param>
-
-                    <param name="location">  CAN2:13       CAN2:13      CAN2:13       CAN2:13        CAN2:13
-                    </param>
+                    <param name="id">         l_upper_leg_imu_acc_1    l_upper_leg_imu_gyro_1    l_upper_leg_imu_eul_1    l_upper_leg_imu_mag_1    l_upper_leg_imu_stat_1  </param>
+                    <param name="sensorName"> l_leg_ft_imu             l_leg_ft_imu              l_leg_ft_imu             l_leg_ft_imu             l_leg_ft_imu            </param>
+                    <param name="type">       eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_statu          </param>
+                    <param name="boardType">  strain2                  strain2                   strain2                  strain2                  strain2                 </param>
+                    <param name="location">   CAN2:13                  CAN2:13                   CAN2:13                  CAN2:13                  CAN2:13                 </param>
                 </group>
 
             </group>

--- a/iCubGenova07/hardware/inertials/left_leg-eb7-IMU.xml
+++ b/iCubGenova07/hardware/inertials/left_leg-eb7-IMU.xml
@@ -30,17 +30,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">       l_lower_leg_imu_acc_2    l_lower_leg_imu_gyro_2    l_lower_leg_imu_eul_2    l_lower_leg_imu_mag_2    l_lower_leg_imu_stat_2
-                    </param>
-
-                    <param name="type">     eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status
-                    </param>
-
-                    <param name="boardType"> strain2       strain2      strain2       strain2        strain2
-                    </param>
-
-                    <param name="location">  CAN2:13       CAN2:13      CAN2:13       CAN2:13        CAN2:13
-                    </param>
+                    <param name="id">        l_lower_leg_imu_acc_2    l_lower_leg_imu_gyro_2    l_lower_leg_imu_eul_2    l_lower_leg_imu_mag_2    l_lower_leg_imu_stat_2  </param>
+                    <param name="type">      l_foot_ft_imu            l_foot_ft_imu             l_foot_ft_imu            l_foot_ft_imu            l_foot_ft_imu           </param>
+                    <param name="type">      eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status         </param>
+                    <param name="boardType"> strain2                  strain2                   strain2                  strain2                  strain2                 </param>
+                    <param name="location">  CAN2:13                  CAN2:13                   CAN2:13                  CAN2:13                  CAN2:13                 </param>
                 </group>
 
             </group>

--- a/iCubGenova07/hardware/inertials/right_leg-eb8-IMU.xml
+++ b/iCubGenova07/hardware/inertials/right_leg-eb8-IMU.xml
@@ -30,17 +30,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">       r_upper_leg_imu_acc_1    r_upper_leg_imu_gyro_1    r_upper_leg_imu_eul_1    r_upper_leg_imu_mag_1    r_upper_leg_imu_stat_1
-                    </param>
-
-                    <param name="type">     eoas_imu_acc  eoas_imu_gyr  eoas_imu_eul  eoas_imu_mag   eoas_imu_status
-                    </param>
-                    <param name="boardType"> strain2       strain2      strain2       strain2        strain2
-                    </param>
-
-
-                    <param name="location">  CAN2:13       CAN2:13      CAN2:13       CAN2:13        CAN2:13
-                    </param>
+                    <param name="id">         r_upper_leg_imu_acc_1    r_upper_leg_imu_gyro_1    r_upper_leg_imu_eul_1    r_upper_leg_imu_mag_1    r_upper_leg_imu_stat_1  </param>
+                    <param name="sensorName"> r_leg_ft_imu             r_leg_ft_imu              r_leg_ft_imu             r_leg_ft_imu             r_leg_ft_imu            </param>
+                    <param name="type">       eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status         </param>
+                    <param name="boardType">  strain2                  strain2                   strain2                  strain2                  strain2                 </param>
+                    <param name="location">   CAN2:13                  CAN2:13                   CAN2:13                  CAN2:13                  CAN2:13                 </param>
                 </group>
 
             </group>

--- a/iCubGenova07/hardware/inertials/right_leg-eb9-IMU.xml
+++ b/iCubGenova07/hardware/inertials/right_leg-eb9-IMU.xml
@@ -30,17 +30,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">       r_lower_leg_imu_acc_2    r_lower_leg_imu_gyro_2    r_lower_leg_imu_eul_2    r_lower_leg_imu_mag_2    r_lower_leg_imu_stat_2
-                    </param>
-
-                    <param name="type">     eoas_imu_acc  eoas_imu_gyr  eoas_imu_eul  eoas_imu_mag   eoas_imu_status
-                    </param>
-                    <param name="boardType"> strain2       strain2      strain2       strain2        strain2
-                    </param>
-
-
-                    <param name="location">  CAN2:13       CAN2:13      CAN2:13       CAN2:13        CAN2:13
-                    </param>
+                    <param name="id">         r_lower_leg_imu_acc_2    r_lower_leg_imu_gyro_2    r_lower_leg_imu_eul_2    r_lower_leg_imu_mag_2    r_lower_leg_imu_stat_2  </param>
+                    <param name="sensorName"> r_foot_ft_imu            r_foot_ft_imu             r_foot_ft_imu            r_foot_ft_imu            r_foot_ft_imu           </param>
+                    <param name="type">       eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status         </param>
+                    <param name="boardType">  strain2                  strain2                   strain2                  strain2                  strain2                 </param>
+                    <param name="location">   CAN2:13                  CAN2:13                   CAN2:13                  CAN2:13                  CAN2:13                 </param>
                 </group>
 
             </group>

--- a/iCubGenova07/wrappers/inertials/alljoints-inertials_remapper.xml
+++ b/iCubGenova07/wrappers/inertials/alljoints-inertials_remapper.xml
@@ -4,7 +4,7 @@
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_remapper" type="multipleanalogsensorsremapper">
         <param name="OrientationSensorsNames">
-            (head_imu_0 l_leg_ft l_foot_ft r_leg_ft r_foot_ft)
+            (head_imu_0 l_leg_ft_imu l_foot_ft_imu r_leg_ft_imu r_foot_ft_imu)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubGenova07/wrappers/inertials/alljoints-inertials_wrapper.xml
+++ b/iCubGenova07/wrappers/inertials/alljoints-inertials_wrapper.xml
@@ -5,7 +5,7 @@
     <param name="period">      10                           </param>
     <param name="name"> /${portprefix}/alljoints/inertials   </param>
 
-    <action phase="startup" level="15" type="attach">
+    <action phase="startup" level="10" type="attach">
         <paramlist name="networks">
             <elem name="FirstStrain"> alljoints-inertials_remapper </elem>
         </paramlist>

--- a/iCubGenova11/hardware/inertials/head-inertial.xml
+++ b/iCubGenova11/hardware/inertials/head-inertial.xml
@@ -30,15 +30,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">           rfeimu_acc      rfeimu_gyro     rfeimu_mag      rfeimu_eul      rfeimu_status
-                    </param>
-                    <param name="sensorName">   head_imu_0      head_imu_0      head_imu_0      head_imu_0      head_imu_0</param>
-                    <param name="type">         eoas_imu_acc    eoas_imu_gyr    eoas_imu_mag    eoas_imu_eul     eoas_imu_status
-                    </param>
-                    <param name="boardType">    rfe             rfe             rfe             rfe             rfe
-                    </param>
-                    <param name="location">     CAN1:1          CAN1:1          CAN1:1          CAN1:1          CAN1:1
-                    </param>
+                    <param name="id">           rfeimu_acc      rfeimu_gyro     rfeimu_mag      rfeimu_eul      rfeimu_status    </param>
+                    <param name="sensorName">   head_imu_0      head_imu_0      head_imu_0      head_imu_0      head_imu_0       </param>
+                    <param name="type">         eoas_imu_acc    eoas_imu_gyr    eoas_imu_mag    eoas_imu_eul    eoas_imu_status  </param>
+                    <param name="boardType">    rfe             rfe             rfe             rfe             rfe              </param>
+                    <param name="location">     CAN1:1          CAN1:1          CAN1:1          CAN1:1          CAN1:1           </param>
                 </group>
 
             </group>

--- a/iCubGenova11/hardware/inertials/left_arm-eb1-IMU.xml
+++ b/iCubGenova11/hardware/inertials/left_arm-eb1-IMU.xml
@@ -30,15 +30,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">         l_arm_ft_acc      l_arm_ft_gyro      l_arm_ft_eul      l_arm_ft_mag      l_arm_ft_stat </param>
-
-                    <param name="sensorName"> l_arm_ft          l_arm_ft           l_arm_ft          l_arm_ft          l_arm_ft </param>
-
+                    <param name="id">         l_arm_ft_acc      l_arm_ft_gyro      l_arm_ft_eul      l_arm_ft_mag      l_arm_ft_stat   </param>
+                    <param name="sensorName"> l_arm_ft_imu      l_arm_ft_imu       l_arm_ft_imu      l_arm_ft_imu      l_arm_ft_imu    </param>
                     <param name="type">       eoas_imu_acc      eoas_imu_gyr       eoas_imu_mag      eoas_imu_eul      eoas_imu_status </param>
-
-                    <param name="boardType">  strain2           strain2            strain2           strain2           strain2 </param>
-
-                    <param name="location">   CAN2:13           CAN2:13            CAN2:13           CAN2:13           CAN2:13 </param>
+                    <param name="boardType">  strain2           strain2            strain2           strain2           strain2         </param>
+                    <param name="location">   CAN2:13           CAN2:13            CAN2:13           CAN2:13           CAN2:13         </param>
                 </group>
 
             </group>

--- a/iCubGenova11/hardware/inertials/right_arm-eb3-IMU.xml
+++ b/iCubGenova11/hardware/inertials/right_arm-eb3-IMU.xml
@@ -30,15 +30,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">          r_arm_ft_acc    r_arm_ft_gyro   r_arm_ft_eul    r_arm_ft_mag    r_arm_ft_stat </param>
-
-                    <param name="sensorName">  r_arm_ft        r_arm_ft        r_arm_ft        r_arm_ft        r_arm_ft </param>
-
+                    <param name="id">          r_arm_ft_acc    r_arm_ft_gyro   r_arm_ft_eul    r_arm_ft_mag    r_arm_ft_stat   </param>
+                    <param name="sensorName">  r_arm_ft_imu    r_arm_ft_imu    r_arm_ft_imu    r_arm_ft_imu    r_arm_ft_imu    </param>
                     <param name="type">        eoas_imu_acc    eoas_imu_gyr    eoas_imu_mag    eoas_imu_eul    eoas_imu_status </param>
-
-                    <param name="boardType">   strain2         strain2         strain2         strain2         strain2  </param>
-
-                    <param name="location">    CAN2:13         CAN2:13         CAN2:13         CAN2:13         CAN2:13 </param>
+                    <param name="boardType">   strain2         strain2         strain2         strain2         strain2         </param>
+                    <param name="location">    CAN2:13         CAN2:13         CAN2:13         CAN2:13         CAN2:13         </param>
                 </group>
 
             </group>

--- a/iCubGenova11/wrappers/inertials/alljoints-inertials_remapper.xml
+++ b/iCubGenova11/wrappers/inertials/alljoints-inertials_remapper.xml
@@ -4,7 +4,7 @@
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_remapper" type="multipleanalogsensorsremapper">
         <param name="OrientationSensorsNames">
-            (l_arm_ft r_arm_ft head_imu_0)
+            (head_imu_0 l_arm_ft_imu r_arm_ft_imu)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubGenova11/wrappers/inertials/alljoints-inertials_wrapper.xml
+++ b/iCubGenova11/wrappers/inertials/alljoints-inertials_wrapper.xml
@@ -5,7 +5,7 @@
     <param name="period">      10                           </param>
     <param name="name"> /${portprefix}/alljoints/inertials   </param>
 
-    <action phase="startup" level="15" type="attach">
+    <action phase="startup" level="10" type="attach">
         <paramlist name="networks">
             <elem name="FirstStrain"> alljoints-inertials_remapper </elem>
         </paramlist>

--- a/iCubLisboa01/hardware/inertials/head-inertial.xml
+++ b/iCubLisboa01/hardware/inertials/head-inertial.xml
@@ -30,15 +30,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">           rfeimu_acc      rfeimu_gyro     rfeimu_mag      rfeimu_status
-                    </param>
-                    <param name="sensorName">   head_imu_0          head_imu_0          head_imu_0          head_imu_0 </param>
-                    <param name="type">         eoas_imu_acc    eoas_imu_gyr    eoas_imu_mag    eoas_imu_status
-                    </param>
-                    <param name="boardType">    rfe             rfe             rfe             rfe
-                    </param>
-                    <param name="location">     CAN1:1          CAN1:1          CAN1:1          CAN1:1
-                    </param>
+                    <param name="id">           rfeimu_acc      rfeimu_gyro     rfeimu_mag      rfeimu_status    </param>
+                    <param name="sensorName">   head_imu_0      head_imu_0      head_imu_0      head_imu_0       </param>
+                    <param name="type">         eoas_imu_acc    eoas_imu_gyr    eoas_imu_mag    eoas_imu_status  </param>
+                    <param name="boardType">    rfe             rfe             rfe             rfe              </param>
+                    <param name="location">     CAN1:1          CAN1:1          CAN1:1          CAN1:1           </param>
                 </group>
 
             </group>

--- a/iCubLisboa01/hardware/inertials/left_leg-eb6-IMU.xml
+++ b/iCubLisboa01/hardware/inertials/left_leg-eb6-IMU.xml
@@ -30,17 +30,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">       l_upper_leg_imu_acc_1    l_upper_leg_imu_gyro_1    l_upper_leg_imu_eul_1    l_upper_leg_imu_mag_1    l_upper_leg_imu_stat_1
-                    </param>
-
-                    <param name="type">     eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status
-                    </param>
-
-                    <param name="boardType"> strain2       strain2      strain2       strain2        strain2
-                    </param>
-
-                    <param name="location">  CAN2:13       CAN2:13      CAN2:13       CAN2:13        CAN2:13
-                    </param>
+                    <param name="id">         l_upper_leg_imu_acc_1    l_upper_leg_imu_gyro_1    l_upper_leg_imu_eul_1    l_upper_leg_imu_mag_1    l_upper_leg_imu_stat_1 </param>
+                    <param name="sensorName"> l_leg_ft_imu             l_leg_ft_imu              l_leg_ft_imu             l_leg_ft_imu             l_leg_ft_imu           </param>
+                    <param name="type">       eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status        </param>
+                    <param name="boardType">  strain2                  strain2                   strain2                  strain2                  strain2                </param>
+                    <param name="location">   CAN2:13                  CAN2:13                   CAN2:13                  CAN2:13                  CAN2:13                </param>
                 </group>
 
             </group>

--- a/iCubLisboa01/hardware/inertials/left_leg-eb7-IMU.xml
+++ b/iCubLisboa01/hardware/inertials/left_leg-eb7-IMU.xml
@@ -30,17 +30,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">       l_lower_leg_imu_acc_2    l_lower_leg_imu_gyro_2    l_lower_leg_imu_eul_2    l_lower_leg_imu_mag_2    l_lower_leg_imu_stat_2
-                    </param>
-
-                    <param name="type">     eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status
-                    </param>
-
-                    <param name="boardType"> strain2       strain2      strain2       strain2        strain2
-                    </param>
-
-                    <param name="location">  CAN2:13       CAN2:13      CAN2:13       CAN2:13        CAN2:13
-                    </param>
+                    <param name="id">         l_lower_leg_imu_acc_2    l_lower_leg_imu_gyro_2    l_lower_leg_imu_eul_2    l_lower_leg_imu_mag_2    l_lower_leg_imu_stat_2  </param>
+                    <param name="sensorName"> l_foot_ft_imu            l_foot_ft_imu             l_foot_ft_imu            l_foot_ft_imu            l_foot_ft_imu           </param>
+                    <param name="type">       eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status         </param>
+                    <param name="boardType">  strain2                  strain2                   strain2                  strain2                  strain2                 </param>
+                    <param name="location">   CAN2:13                  CAN2:13                   CAN2:13                  CAN2:13                  CAN2:13                 </param>
                 </group>
 
             </group>

--- a/iCubLisboa01/hardware/inertials/right_leg-eb8-IMU.xml
+++ b/iCubLisboa01/hardware/inertials/right_leg-eb8-IMU.xml
@@ -30,17 +30,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">       r_upper_leg_imu_acc_1    r_upper_leg_imu_gyro_1    r_upper_leg_imu_eul_1    r_upper_leg_imu_mag_1    r_upper_leg_imu_stat_1
-                    </param>
-
-                    <param name="type">     eoas_imu_acc  eoas_imu_gyr  eoas_imu_eul  eoas_imu_mag   eoas_imu_status
-                    </param>
-                    <param name="boardType"> strain2       strain2      strain2       strain2        strain2
-                    </param>
-
-
-                    <param name="location">  CAN2:13       CAN2:13      CAN2:13       CAN2:13        CAN2:13
-                    </param>
+                    <param name="id">         r_upper_leg_imu_acc_1    r_upper_leg_imu_gyro_1    r_upper_leg_imu_eul_1    r_upper_leg_imu_mag_1    r_upper_leg_imu_stat_1 </param>
+                    <param name="sensorName"> r_leg_ft_imu             r_leg_ft_imu              r_leg_ft_imu             r_leg_ft_imu             r_leg_ft_imu           </param>
+                    <param name="type">       eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status        </param>
+                    <param name="boardType">  strain2                  strain2                   strain2                  strain2                  strain2                </param>
+                    <param name="location">   CAN2:13                  CAN2:13                   CAN2:13                  CAN2:13                  CAN2:13                </param>
                 </group>
 
             </group>

--- a/iCubLisboa01/hardware/inertials/right_leg-eb9-IMU.xml
+++ b/iCubLisboa01/hardware/inertials/right_leg-eb9-IMU.xml
@@ -30,17 +30,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">       r_lower_leg_imu_acc_2    r_lower_leg_imu_gyro_2    r_lower_leg_imu_eul_2    r_lower_leg_imu_mag_2    r_lower_leg_imu_stat_2
-                    </param>
-
-                    <param name="type">     eoas_imu_acc  eoas_imu_gyr  eoas_imu_eul  eoas_imu_mag   eoas_imu_status
-                    </param>
-                    <param name="boardType"> strain2       strain2      strain2       strain2        strain2
-                    </param>
-
-
-                    <param name="location">  CAN2:13       CAN2:13      CAN2:13       CAN2:13        CAN2:13
-                    </param>
+                    <param name="id">         r_lower_leg_imu_acc_2    r_lower_leg_imu_gyro_2    r_lower_leg_imu_eul_2    r_lower_leg_imu_mag_2    r_lower_leg_imu_stat_2  </param>
+                    <param name="sensorName"> r_foot_ft_imu            r_foot_ft_imu             r_foot_ft_imu            r_foot_ft_imu            r_foot_ft_imu           </param>
+                    <param name="type">       eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status         </param>
+                    <param name="boardType">  strain2                  strain2                   strain2                  strain2                  strain2                 </param>
+                    <param name="location">   CAN2:13                  CAN2:13                   CAN2:13                  CAN2:13                  CAN2:13                 </param>
                 </group>
 
             </group>

--- a/iCubLisboa01/wrappers/inertials/alljoints-inertials_remapper.xml
+++ b/iCubLisboa01/wrappers/inertials/alljoints-inertials_remapper.xml
@@ -4,7 +4,7 @@
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_remapper" type="multipleanalogsensorsremapper">
         <param name="OrientationSensorsNames">
-            (head_imu_0 l_leg_ft l_foot_ft r_leg_ft r_foot_ft)
+            (head_imu_0 l_leg_ft_imu l_foot_ft_imu r_leg_ft_imu r_foot_ft_imu)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubLisboa01/wrappers/inertials/alljoints-inertials_wrapper.xml
+++ b/iCubLisboa01/wrappers/inertials/alljoints-inertials_wrapper.xml
@@ -5,7 +5,7 @@
     <param name="period">      10                           </param>
     <param name="name"> /${portprefix}/alljoints/inertials   </param>
 
-    <action phase="startup" level="15" type="attach">
+    <action phase="startup" level="10" type="attach">
         <paramlist name="networks">
             <elem name="FirstStrain"> alljoints-inertials_remapper </elem>
         </paramlist>

--- a/iCubPrague01/hardware/inertials/head-inertial.xml
+++ b/iCubPrague01/hardware/inertials/head-inertial.xml
@@ -30,15 +30,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">           rfeimu_acc      rfeimu_gyro     rfeimu_mag      rfeimu_status
-                    </param>
-                    <param name="sensorName">   head_imu_0          head_imu_0          head_imu_0          head_imu_0 </param>
-                    <param name="type">         eoas_imu_acc    eoas_imu_gyr    eoas_imu_mag    eoas_imu_status
-                    </param>
-                    <param name="boardType">    rfe             rfe             rfe             rfe
-                    </param>
-                    <param name="location">     CAN1:1          CAN1:1          CAN1:1          CAN1:1
-                    </param>
+                    <param name="id">           rfeimu_acc      rfeimu_gyro     rfeimu_mag      rfeimu_status    </param>
+                    <param name="sensorName">   head_imu_0      head_imu_0      head_imu_0      head_imu_0       </param>
+                    <param name="type">         eoas_imu_acc    eoas_imu_gyr    eoas_imu_mag    eoas_imu_status  </param>
+                    <param name="boardType">    rfe             rfe             rfe             rfe              </param>
+                    <param name="location">     CAN1:1          CAN1:1          CAN1:1          CAN1:1           </param>
                 </group>
 
             </group>

--- a/iCubPrague01/hardware/inertials/left_leg-eb6-IMU.xml
+++ b/iCubPrague01/hardware/inertials/left_leg-eb6-IMU.xml
@@ -30,17 +30,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">       l_upper_leg_imu_acc_1    l_upper_leg_imu_gyro_1    l_upper_leg_imu_eul_1    l_upper_leg_imu_mag_1    l_upper_leg_imu_stat_1
-                    </param>
-
-                    <param name="type">     eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status
-                    </param>
-
-                    <param name="boardType"> strain2       strain2      strain2       strain2        strain2
-                    </param>
-
-                    <param name="location">  CAN2:13       CAN2:13      CAN2:13       CAN2:13        CAN2:13
-                    </param>
+                    <param name="id">         l_upper_leg_imu_acc_1    l_upper_leg_imu_gyro_1    l_upper_leg_imu_eul_1    l_upper_leg_imu_mag_1    l_upper_leg_imu_stat_1 </param>
+                    <param name="sensorName"> l_leg_ft_imu             l_leg_ft_imu              l_leg_ft_imu             l_leg_ft_imu             l_leg_ft_imu           </param>
+                    <param name="type">       eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status        </param>
+                    <param name="boardType">  strain2                  strain2                   strain2                  strain2                  strain2                </param>
+                    <param name="location">   CAN2:13                  CAN2:13                   CAN2:13                  CAN2:13                  CAN2:13                </param>
                 </group>
 
             </group>

--- a/iCubPrague01/hardware/inertials/left_leg-eb7-IMU.xml
+++ b/iCubPrague01/hardware/inertials/left_leg-eb7-IMU.xml
@@ -30,17 +30,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">       l_lower_leg_imu_acc_2    l_lower_leg_imu_gyro_2    l_lower_leg_imu_eul_2    l_lower_leg_imu_mag_2    l_lower_leg_imu_stat_2
-                    </param>
-
-                    <param name="type">     eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status
-                    </param>
-
-                    <param name="boardType"> strain2       strain2      strain2       strain2        strain2
-                    </param>
-
-                    <param name="location">  CAN2:13       CAN2:13      CAN2:13       CAN2:13        CAN2:13
-                    </param>
+                    <param name="id">         l_lower_leg_imu_acc_2    l_lower_leg_imu_gyro_2    l_lower_leg_imu_eul_2    l_lower_leg_imu_mag_2    l_lower_leg_imu_stat_2  </param>
+                    <param name="sensorName"> l_foot_ft_imu            l_foot_ft_imu             l_foot_ft_imu            l_foot_ft_imu            l_foot_ft_imu           </param>
+                    <param name="type">       eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status         </param>
+                    <param name="boardType">  strain2                  strain2                   strain2                  strain2                  strain2                 </param>
+                    <param name="location">   CAN2:13                  CAN2:13                   CAN2:13                  CAN2:13                  CAN2:13                 </param>
                 </group>
 
             </group>

--- a/iCubPrague01/hardware/inertials/right_leg-eb8-IMU.xml
+++ b/iCubPrague01/hardware/inertials/right_leg-eb8-IMU.xml
@@ -30,17 +30,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">       r_upper_leg_imu_acc_1    r_upper_leg_imu_gyro_1    r_upper_leg_imu_eul_1    r_upper_leg_imu_mag_1    r_upper_leg_imu_stat_1
-                    </param>
-
-                    <param name="type">     eoas_imu_acc  eoas_imu_gyr  eoas_imu_eul  eoas_imu_mag   eoas_imu_status
-                    </param>
-                    <param name="boardType"> strain2       strain2      strain2       strain2        strain2
-                    </param>
-
-
-                    <param name="location">  CAN2:13       CAN2:13      CAN2:13       CAN2:13        CAN2:13
-                    </param>
+                    <param name="id">         r_upper_leg_imu_acc_1    r_upper_leg_imu_gyro_1    r_upper_leg_imu_eul_1    r_upper_leg_imu_mag_1    r_upper_leg_imu_stat_1 </param>
+                    <param name="sensorName"> r_leg_ft_imu             r_leg_ft_imu              r_leg_ft_imu             r_leg_ft_imu             r_leg_ft_imu           </param>
+                    <param name="type">       eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status        </param>
+                    <param name="boardType">  strain2                  strain2                   strain2                  strain2                  strain2                </param>
+                    <param name="location">   CAN2:13                  CAN2:13                   CAN2:13                  CAN2:13                  CAN2:13                </param>
                 </group>
 
             </group>

--- a/iCubPrague01/hardware/inertials/right_leg-eb9-IMU.xml
+++ b/iCubPrague01/hardware/inertials/right_leg-eb9-IMU.xml
@@ -30,17 +30,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">       r_lower_leg_imu_acc_2    r_lower_leg_imu_gyro_2    r_lower_leg_imu_eul_2    r_lower_leg_imu_mag_2    r_lower_leg_imu_stat_2
-                    </param>
-
-                    <param name="type">     eoas_imu_acc  eoas_imu_gyr  eoas_imu_eul  eoas_imu_mag   eoas_imu_status
-                    </param>
-                    <param name="boardType"> strain2       strain2      strain2       strain2        strain2
-                    </param>
-
-
-                    <param name="location">  CAN2:13       CAN2:13      CAN2:13       CAN2:13        CAN2:13
-                    </param>
+                    <param name="id">         r_lower_leg_imu_acc_2    r_lower_leg_imu_gyro_2    r_lower_leg_imu_eul_2    r_lower_leg_imu_mag_2    r_lower_leg_imu_stat_2  </param>
+                    <param name="sensorName"> r_foot_ft_imu            r_foot_ft_imu             r_foot_ft_imu            r_foot_ft_imu            r_foot_ft_imu           </param>
+                    <param name="type">       eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status         </param>
+                    <param name="boardType">  strain2                  strain2                   strain2                  strain2                  strain2                 </param>
+                    <param name="location">   CAN2:13                  CAN2:13                   CAN2:13                  CAN2:13                  CAN2:13                 </param>
                 </group>
 
             </group>

--- a/iCubPrague01/wrappers/inertials/alljoints-inertials_remapper.xml
+++ b/iCubPrague01/wrappers/inertials/alljoints-inertials_remapper.xml
@@ -4,7 +4,7 @@
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_remapper" type="multipleanalogsensorsremapper">
         <param name="OrientationSensorsNames">
-            (head_imu_0 l_leg_ft l_foot_ft r_leg_ft r_foot_ft)
+            (head_imu_0 l_leg_ft_imu l_foot_ft_imu r_leg_ft_imu r_foot_ft_imu)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubPrague01/wrappers/inertials/alljoints-inertials_wrapper.xml
+++ b/iCubPrague01/wrappers/inertials/alljoints-inertials_wrapper.xml
@@ -5,7 +5,7 @@
     <param name="period">      10                           </param>
     <param name="name"> /${portprefix}/alljoints/inertials   </param>
 
-    <action phase="startup" level="15" type="attach">
+    <action phase="startup" level="10" type="attach">
         <paramlist name="networks">
             <elem name="FirstStrain"> alljoints-inertials_remapper </elem>
         </paramlist>

--- a/iCubShanghai01/hardware/inertials/head-inertial.xml
+++ b/iCubShanghai01/hardware/inertials/head-inertial.xml
@@ -30,15 +30,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">           rfeimu_acc      rfeimu_gyro     rfeimu_mag      rfeimu_status
-                    </param>
-                    <param name="sensorName">   head_imu_0          head_imu_0          head_imu_0          head_imu_0 </param>
-                    <param name="type">         eoas_imu_acc    eoas_imu_gyr    eoas_imu_mag    eoas_imu_status
-                    </param>
-                    <param name="boardType">    rfe             rfe             rfe             rfe
-                    </param>
-                    <param name="location">     CAN1:1          CAN1:1          CAN1:1          CAN1:1
-                    </param>
+                    <param name="id">           rfeimu_acc      rfeimu_gyro     rfeimu_mag      rfeimu_status    </param>
+                    <param name="sensorName">   head_imu_0      head_imu_0      head_imu_0      head_imu_0       </param>
+                    <param name="type">         eoas_imu_acc    eoas_imu_gyr    eoas_imu_mag    eoas_imu_status  </param>
+                    <param name="boardType">    rfe             rfe             rfe             rfe              </param>
+                    <param name="location">     CAN1:1          CAN1:1          CAN1:1          CAN1:1           </param>
                 </group>
 
             </group>

--- a/iCubShanghai01/hardware/inertials/left_leg-eb6-IMU.xml
+++ b/iCubShanghai01/hardware/inertials/left_leg-eb6-IMU.xml
@@ -30,17 +30,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">       l_upper_leg_imu_acc_1    l_upper_leg_imu_gyro_1    l_upper_leg_imu_eul_1    l_upper_leg_imu_mag_1    l_upper_leg_imu_stat_1
-                    </param>
-
-                    <param name="type">     eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status
-                    </param>
-
-                    <param name="boardType"> strain2       strain2      strain2       strain2        strain2
-                    </param>
-
-                    <param name="location">  CAN2:13       CAN2:13      CAN2:13       CAN2:13        CAN2:13
-                    </param>
+                    <param name="id">         l_upper_leg_imu_acc_1    l_upper_leg_imu_gyro_1    l_upper_leg_imu_eul_1    l_upper_leg_imu_mag_1    l_upper_leg_imu_stat_1 </param>
+                    <param name="sensorName"> l_leg_ft_imu             l_leg_ft_imu              l_leg_ft_imu             l_leg_ft_imu             l_leg_ft_imu           </param>
+                    <param name="type">       eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status        </param>
+                    <param name="boardType">  strain2                  strain2                   strain2                  strain2                  strain2                </param>
+                    <param name="location">   CAN2:13                  CAN2:13                   CAN2:13                  CAN2:13                  CAN2:13                </param>
                 </group>
 
             </group>

--- a/iCubShanghai01/hardware/inertials/left_leg-eb7-IMU.xml
+++ b/iCubShanghai01/hardware/inertials/left_leg-eb7-IMU.xml
@@ -30,17 +30,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">       l_lower_leg_imu_acc_2    l_lower_leg_imu_gyro_2    l_lower_leg_imu_eul_2    l_lower_leg_imu_mag_2    l_lower_leg_imu_stat_2
-                    </param>
-
-                    <param name="type">     eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status
-                    </param>
-
-                    <param name="boardType"> strain2       strain2      strain2       strain2        strain2
-                    </param>
-
-                    <param name="location">  CAN2:13       CAN2:13      CAN2:13       CAN2:13        CAN2:13
-                    </param>
+                    <param name="id">         l_lower_leg_imu_acc_2    l_lower_leg_imu_gyro_2    l_lower_leg_imu_eul_2    l_lower_leg_imu_mag_2    l_lower_leg_imu_stat_2  </param>
+                    <param name="sensorName"> l_foot_ft_imu            l_foot_ft_imu             l_foot_ft_imu            l_foot_ft_imu            l_foot_ft_imu           </param>
+                    <param name="type">       eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status         </param>
+                    <param name="boardType">  strain2                  strain2                   strain2                  strain2                  strain2                 </param>
+                    <param name="location">   CAN2:13                  CAN2:13                   CAN2:13                  CAN2:13                  CAN2:13                 </param>
                 </group>
 
             </group>

--- a/iCubShanghai01/hardware/inertials/right_leg-eb8-IMU.xml
+++ b/iCubShanghai01/hardware/inertials/right_leg-eb8-IMU.xml
@@ -30,17 +30,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">       r_upper_leg_imu_acc_1    r_upper_leg_imu_gyro_1    r_upper_leg_imu_eul_1    r_upper_leg_imu_mag_1    r_upper_leg_imu_stat_1
-                    </param>
-
-                    <param name="type">     eoas_imu_acc  eoas_imu_gyr  eoas_imu_eul  eoas_imu_mag   eoas_imu_status
-                    </param>
-                    <param name="boardType"> strain2       strain2      strain2       strain2        strain2
-                    </param>
-
-
-                    <param name="location">  CAN2:13       CAN2:13      CAN2:13       CAN2:13        CAN2:13
-                    </param>
+                    <param name="id">         r_upper_leg_imu_acc_1    r_upper_leg_imu_gyro_1    r_upper_leg_imu_eul_1    r_upper_leg_imu_mag_1    r_upper_leg_imu_stat_1 </param>
+                    <param name="sensorName"> r_leg_ft_imu             r_leg_ft_imu              r_leg_ft_imu             r_leg_ft_imu             r_leg_ft_imu           </param>
+                    <param name="type">       eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status        </param>
+                    <param name="boardType">  strain2                  strain2                   strain2                  strain2                  strain2                </param>
+                    <param name="location">   CAN2:13                  CAN2:13                   CAN2:13                  CAN2:13                  CAN2:13                </param>
                 </group>
 
             </group>

--- a/iCubShanghai01/hardware/inertials/right_leg-eb9-IMU.xml
+++ b/iCubShanghai01/hardware/inertials/right_leg-eb9-IMU.xml
@@ -30,17 +30,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">       r_lower_leg_imu_acc_2    r_lower_leg_imu_gyro_2    r_lower_leg_imu_eul_2    r_lower_leg_imu_mag_2    r_lower_leg_imu_stat_2
-                    </param>
-
-                    <param name="type">     eoas_imu_acc  eoas_imu_gyr  eoas_imu_eul  eoas_imu_mag   eoas_imu_status
-                    </param>
-                    <param name="boardType"> strain2       strain2      strain2       strain2        strain2
-                    </param>
-
-
-                    <param name="location">  CAN2:13       CAN2:13      CAN2:13       CAN2:13        CAN2:13
-                    </param>
+                    <param name="id">         r_lower_leg_imu_acc_2    r_lower_leg_imu_gyro_2    r_lower_leg_imu_eul_2    r_lower_leg_imu_mag_2    r_lower_leg_imu_stat_2  </param>
+                    <param name="sensorName"> r_foot_ft_imu            r_foot_ft_imu             r_foot_ft_imu            r_foot_ft_imu            r_foot_ft_imu           </param>
+                    <param name="type">       eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status         </param>
+                    <param name="boardType">  strain2                  strain2                   strain2                  strain2                  strain2                 </param>
+                    <param name="location">   CAN2:13                  CAN2:13                   CAN2:13                  CAN2:13                  CAN2:13                 </param>
                 </group>
 
             </group>

--- a/iCubShanghai01/wrappers/inertials/alljoints-inertials_remapper.xml
+++ b/iCubShanghai01/wrappers/inertials/alljoints-inertials_remapper.xml
@@ -4,7 +4,7 @@
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_remapper" type="multipleanalogsensorsremapper">
         <param name="OrientationSensorsNames">
-            (head_imu_0 l_leg_ft l_foot_ft r_leg_ft r_foot_ft)
+            (head_imu_0 l_leg_ft_imu l_foot_ft_imu r_leg_ft_imu r_foot_ft_imu)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubShanghai01/wrappers/inertials/alljoints-inertials_wrapper.xml
+++ b/iCubShanghai01/wrappers/inertials/alljoints-inertials_wrapper.xml
@@ -5,7 +5,7 @@
     <param name="period">      10                           </param>
     <param name="name"> /${portprefix}/alljoints/inertials   </param>
 
-    <action phase="startup" level="15" type="attach">
+    <action phase="startup" level="10" type="attach">
         <paramlist name="networks">
             <elem name="FirstStrain"> alljoints-inertials_remapper </elem>
         </paramlist>

--- a/iCubShenzhen01/hardware/inertials/left_leg-eb6-IMU.xml
+++ b/iCubShenzhen01/hardware/inertials/left_leg-eb6-IMU.xml
@@ -30,17 +30,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">       l_upper_leg_imu_acc_1    l_upper_leg_imu_gyro_1    l_upper_leg_imu_eul_1    l_upper_leg_imu_mag_1    l_upper_leg_imu_stat_1
-                    </param>
-
-                    <param name="type">     eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status
-                    </param>
-
-                    <param name="boardType"> strain2       strain2      strain2       strain2        strain2
-                    </param>
-
-                    <param name="location">  CAN2:13       CAN2:13      CAN2:13       CAN2:13        CAN2:13
-                    </param>
+                    <param name="id">         l_upper_leg_imu_acc_1    l_upper_leg_imu_gyro_1    l_upper_leg_imu_eul_1    l_upper_leg_imu_mag_1    l_upper_leg_imu_stat_1 </param>
+                    <param name="sensorName"> l_leg_ft_imu             l_leg_ft_imu              l_leg_ft_imu             l_leg_ft_imu             l_leg_ft_imu           </param>
+                    <param name="type">       eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status        </param>
+                    <param name="boardType">  strain2                  strain2                   strain2                  strain2                  strain2                </param>
+                    <param name="location">   CAN2:13                  CAN2:13                   CAN2:13                  CAN2:13                  CAN2:13                </param>
                 </group>
 
             </group>

--- a/iCubShenzhen01/hardware/inertials/left_leg-eb7-IMU.xml
+++ b/iCubShenzhen01/hardware/inertials/left_leg-eb7-IMU.xml
@@ -28,19 +28,13 @@
                         <param name="build">            9                   </param>
                     </group>
                 </group>
-
+                
                 <group name="SENSORS">
-                    <param name="id">       l_lower_leg_imu_acc_2    l_lower_leg_imu_gyro_2    l_lower_leg_imu_eul_2    l_lower_leg_imu_mag_2    l_lower_leg_imu_stat_2
-                    </param>
-
-                    <param name="type">     eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status
-                    </param>
-
-                    <param name="boardType"> strain2       strain2      strain2       strain2        strain2
-                    </param>
-
-                    <param name="location">  CAN2:13       CAN2:13      CAN2:13       CAN2:13        CAN2:13
-                    </param>
+                    <param name="id">         l_lower_leg_imu_acc_2    l_lower_leg_imu_gyro_2    l_lower_leg_imu_eul_2    l_lower_leg_imu_mag_2    l_lower_leg_imu_stat_2  </param>
+                    <param name="sensorName"> l_foot_ft_imu            l_foot_ft_imu             l_foot_ft_imu            l_foot_ft_imu            l_foot_ft_imu           </param>
+                    <param name="type">       eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status         </param>
+                    <param name="boardType">  strain2                  strain2                   strain2                  strain2                  strain2                 </param>
+                    <param name="location">   CAN2:13                  CAN2:13                   CAN2:13                  CAN2:13                  CAN2:13                 </param>
                 </group>
 
             </group>

--- a/iCubShenzhen01/hardware/inertials/right_leg-eb8-IMU.xml
+++ b/iCubShenzhen01/hardware/inertials/right_leg-eb8-IMU.xml
@@ -30,17 +30,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">       r_upper_leg_imu_acc_1    r_upper_leg_imu_gyro_1    r_upper_leg_imu_eul_1    r_upper_leg_imu_mag_1    r_upper_leg_imu_stat_1
-                    </param>
-
-                    <param name="type">     eoas_imu_acc  eoas_imu_gyr  eoas_imu_eul  eoas_imu_mag   eoas_imu_status
-                    </param>
-                    <param name="boardType"> strain2       strain2      strain2       strain2        strain2
-                    </param>
-
-
-                    <param name="location">  CAN2:13       CAN2:13      CAN2:13       CAN2:13        CAN2:13
-                    </param>
+                    <param name="id">         r_upper_leg_imu_acc_1    r_upper_leg_imu_gyro_1    r_upper_leg_imu_eul_1    r_upper_leg_imu_mag_1    r_upper_leg_imu_stat_1 </param>
+                    <param name="sensorName"> r_leg_ft_imu             r_leg_ft_imu              r_leg_ft_imu             r_leg_ft_imu             r_leg_ft_imu           </param>
+                    <param name="type">       eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status        </param>
+                    <param name="boardType">  strain2                  strain2                   strain2                  strain2                  strain2                </param>
+                    <param name="location">   CAN2:13                  CAN2:13                   CAN2:13                  CAN2:13                  CAN2:13                </param>
                 </group>
 
             </group>

--- a/iCubShenzhen01/hardware/inertials/right_leg-eb9-IMU.xml
+++ b/iCubShenzhen01/hardware/inertials/right_leg-eb9-IMU.xml
@@ -30,17 +30,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">       r_lower_leg_imu_acc_2    r_lower_leg_imu_gyro_2    r_lower_leg_imu_eul_2    r_lower_leg_imu_mag_2    r_lower_leg_imu_stat_2
-                    </param>
-
-                    <param name="type">     eoas_imu_acc  eoas_imu_gyr  eoas_imu_eul  eoas_imu_mag   eoas_imu_status
-                    </param>
-                    <param name="boardType"> strain2       strain2      strain2       strain2        strain2
-                    </param>
-
-
-                    <param name="location">  CAN2:13       CAN2:13      CAN2:13       CAN2:13        CAN2:13
-                    </param>
+                    <param name="id">         r_lower_leg_imu_acc_2    r_lower_leg_imu_gyro_2    r_lower_leg_imu_eul_2    r_lower_leg_imu_mag_2    r_lower_leg_imu_stat_2  </param>
+                    <param name="sensorName"> r_foot_ft_imu            r_foot_ft_imu             r_foot_ft_imu            r_foot_ft_imu            r_foot_ft_imu           </param>
+                    <param name="type">       eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status         </param>
+                    <param name="boardType">  strain2                  strain2                   strain2                  strain2                  strain2                 </param>
+                    <param name="location">   CAN2:13                  CAN2:13                   CAN2:13                  CAN2:13                  CAN2:13                 </param>
                 </group>
 
             </group>

--- a/iCubShenzhen01/wrappers/inertials/alljoints-inertials_remapper.xml
+++ b/iCubShenzhen01/wrappers/inertials/alljoints-inertials_remapper.xml
@@ -4,7 +4,7 @@
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_remapper" type="multipleanalogsensorsremapper">
         <param name="OrientationSensorsNames">
-            (head_imu_0 l_leg_ft l_foot_ft r_leg_ft r_foot_ft)
+            (head_imu_0 l_leg_ft_imu l_foot_ft_imu r_leg_ft_imu r_foot_ft_imu)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubShenzhen01/wrappers/inertials/alljoints-inertials_wrapper.xml
+++ b/iCubShenzhen01/wrappers/inertials/alljoints-inertials_wrapper.xml
@@ -5,7 +5,7 @@
     <param name="period">      10                           </param>
     <param name="name"> /${portprefix}/alljoints/inertials   </param>
 
-    <action phase="startup" level="15" type="attach">
+    <action phase="startup" level="10" type="attach">
         <paramlist name="networks">
             <elem name="FirstStrain"> alljoints-inertials_remapper </elem>
         </paramlist>

--- a/iCubValparaiso01/hardware/inertials/head-inertial.xml
+++ b/iCubValparaiso01/hardware/inertials/head-inertial.xml
@@ -30,15 +30,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">           rfeimu_acc      rfeimu_gyro     rfeimu_mag      rfeimu_status
-                    </param>
-                    <param name="sensorName">   head_imu_0          head_imu_0          head_imu_0          head_imu_0 </param>
-                    <param name="type">         eoas_imu_acc    eoas_imu_gyr    eoas_imu_mag    eoas_imu_status
-                    </param>
-                    <param name="boardType">    rfe             rfe             rfe             rfe
-                    </param>
-                    <param name="location">     CAN1:1          CAN1:1          CAN1:1          CAN1:1
-                    </param>
+                    <param name="id">           rfeimu_acc      rfeimu_gyro     rfeimu_mag      rfeimu_status    </param>
+                    <param name="sensorName">   head_imu_0      head_imu_0      head_imu_0      head_imu_0       </param>
+                    <param name="type">         eoas_imu_acc    eoas_imu_gyr    eoas_imu_mag    eoas_imu_status  </param>
+                    <param name="boardType">    rfe             rfe             rfe             rfe              </param>
+                    <param name="location">     CAN1:1          CAN1:1          CAN1:1          CAN1:1           </param>
                 </group>
 
             </group>

--- a/iCubValparaiso01/hardware/inertials/left_leg-eb6-IMU.xml
+++ b/iCubValparaiso01/hardware/inertials/left_leg-eb6-IMU.xml
@@ -30,17 +30,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">       l_upper_leg_imu_acc_1    l_upper_leg_imu_gyro_1    l_upper_leg_imu_eul_1    l_upper_leg_imu_mag_1    l_upper_leg_imu_stat_1
-                    </param>
-
-                    <param name="type">     eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status
-                    </param>
-
-                    <param name="boardType"> strain2       strain2      strain2       strain2        strain2
-                    </param>
-
-                    <param name="location">  CAN2:13       CAN2:13      CAN2:13       CAN2:13        CAN2:13
-                    </param>
+                    <param name="id">         l_upper_leg_imu_acc_1    l_upper_leg_imu_gyro_1    l_upper_leg_imu_eul_1    l_upper_leg_imu_mag_1    l_upper_leg_imu_stat_1 </param>
+                    <param name="sensorName"> l_leg_ft_imu             l_leg_ft_imu              l_leg_ft_imu             l_leg_ft_imu             l_leg_ft_imu           </param>
+                    <param name="type">       eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status        </param>
+                    <param name="boardType">  strain2                  strain2                   strain2                  strain2                  strain2                </param>
+                    <param name="location">   CAN2:13                  CAN2:13                   CAN2:13                  CAN2:13                  CAN2:13                </param>
                 </group>
 
             </group>

--- a/iCubValparaiso01/hardware/inertials/left_leg-eb7-IMU.xml
+++ b/iCubValparaiso01/hardware/inertials/left_leg-eb7-IMU.xml
@@ -30,17 +30,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">       l_lower_leg_imu_acc_2    l_lower_leg_imu_gyro_2    l_lower_leg_imu_eul_2    l_lower_leg_imu_mag_2    l_lower_leg_imu_stat_2
-                    </param>
-
-                    <param name="type">     eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status
-                    </param>
-
-                    <param name="boardType"> strain2       strain2      strain2       strain2        strain2
-                    </param>
-
-                    <param name="location">  CAN2:13       CAN2:13      CAN2:13       CAN2:13        CAN2:13
-                    </param>
+                    <param name="id">         l_lower_leg_imu_acc_2    l_lower_leg_imu_gyro_2    l_lower_leg_imu_eul_2    l_lower_leg_imu_mag_2    l_lower_leg_imu_stat_2  </param>
+                    <param name="sensorName"> l_foot_ft_imu            l_foot_ft_imu             l_foot_ft_imu            l_foot_ft_imu            l_foot_ft_imu           </param>
+                    <param name="type">       eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status         </param>
+                    <param name="boardType">  strain2                  strain2                   strain2                  strain2                  strain2                 </param>
+                    <param name="location">   CAN2:13                  CAN2:13                   CAN2:13                  CAN2:13                  CAN2:13                 </param>
                 </group>
 
             </group>

--- a/iCubValparaiso01/hardware/inertials/right_leg-eb8-IMU.xml
+++ b/iCubValparaiso01/hardware/inertials/right_leg-eb8-IMU.xml
@@ -30,17 +30,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">       r_upper_leg_imu_acc_1    r_upper_leg_imu_gyro_1    r_upper_leg_imu_eul_1    r_upper_leg_imu_mag_1    r_upper_leg_imu_stat_1
-                    </param>
-
-                    <param name="type">     eoas_imu_acc  eoas_imu_gyr  eoas_imu_eul  eoas_imu_mag   eoas_imu_status
-                    </param>
-                    <param name="boardType"> strain2       strain2      strain2       strain2        strain2
-                    </param>
-
-
-                    <param name="location">  CAN2:13       CAN2:13      CAN2:13       CAN2:13        CAN2:13
-                    </param>
+                    <param name="id">         r_upper_leg_imu_acc_1    r_upper_leg_imu_gyro_1    r_upper_leg_imu_eul_1    r_upper_leg_imu_mag_1    r_upper_leg_imu_stat_1 </param>
+                    <param name="sensorName"> r_leg_ft_imu             r_leg_ft_imu              r_leg_ft_imu             r_leg_ft_imu             r_leg_ft_imu           </param>
+                    <param name="type">       eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status        </param>
+                    <param name="boardType">  strain2                  strain2                   strain2                  strain2                  strain2                </param>
+                    <param name="location">   CAN2:13                  CAN2:13                   CAN2:13                  CAN2:13                  CAN2:13                </param>
                 </group>
 
             </group>

--- a/iCubValparaiso01/hardware/inertials/right_leg-eb9-IMU.xml
+++ b/iCubValparaiso01/hardware/inertials/right_leg-eb9-IMU.xml
@@ -30,17 +30,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">       r_lower_leg_imu_acc_2    r_lower_leg_imu_gyro_2    r_lower_leg_imu_eul_2    r_lower_leg_imu_mag_2    r_lower_leg_imu_stat_2
-                    </param>
-
-                    <param name="type">     eoas_imu_acc  eoas_imu_gyr  eoas_imu_eul  eoas_imu_mag   eoas_imu_status
-                    </param>
-                    <param name="boardType"> strain2       strain2      strain2       strain2        strain2
-                    </param>
-
-
-                    <param name="location">  CAN2:13       CAN2:13      CAN2:13       CAN2:13        CAN2:13
-                    </param>
+                    <param name="id">         r_lower_leg_imu_acc_2    r_lower_leg_imu_gyro_2    r_lower_leg_imu_eul_2    r_lower_leg_imu_mag_2    r_lower_leg_imu_stat_2  </param>
+                    <param name="sensorName"> r_foot_ft_imu            r_foot_ft_imu             r_foot_ft_imu            r_foot_ft_imu            r_foot_ft_imu           </param>
+                    <param name="type">       eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status         </param>
+                    <param name="boardType">  strain2                  strain2                   strain2                  strain2                  strain2                 </param>
+                    <param name="location">   CAN2:13                  CAN2:13                   CAN2:13                  CAN2:13                  CAN2:13                 </param>
                 </group>
 
             </group>

--- a/iCubValparaiso01/wrappers/inertials/alljoints-inertials_remapper.xml
+++ b/iCubValparaiso01/wrappers/inertials/alljoints-inertials_remapper.xml
@@ -4,7 +4,7 @@
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_remapper" type="multipleanalogsensorsremapper">
         <param name="OrientationSensorsNames">
-            (head_imu_0 l_leg_ft l_foot_ft r_leg_ft r_foot_ft)
+            (head_imu_0 l_leg_ft_imu l_foot_ft_imu r_leg_ft_imu r_foot_ft_imu)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubValparaiso01/wrappers/inertials/alljoints-inertials_wrapper.xml
+++ b/iCubValparaiso01/wrappers/inertials/alljoints-inertials_wrapper.xml
@@ -5,7 +5,7 @@
     <param name="period">      10                           </param>
     <param name="name"> /${portprefix}/alljoints/inertials   </param>
 
-    <action phase="startup" level="15" type="attach">
+    <action phase="startup" level="10" type="attach">
         <paramlist name="networks">
             <elem name="FirstStrain"> alljoints-inertials_remapper </elem>
         </paramlist>

--- a/iCubWaterloo01/hardware/inertials/head-inertial.xml
+++ b/iCubWaterloo01/hardware/inertials/head-inertial.xml
@@ -30,15 +30,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">           rfeimu_acc      rfeimu_gyro     rfeimu_mag      rfeimu_status
-                    </param>
-                    <param name="sensorName">   head_imu_0          head_imu_0          head_imu_0          head_imu_0 </param>
-                    <param name="type">         eoas_imu_acc    eoas_imu_gyr    eoas_imu_mag    eoas_imu_status
-                    </param>
-                    <param name="boardType">    rfe             rfe             rfe             rfe
-                    </param>
-                    <param name="location">     CAN1:1          CAN1:1          CAN1:1          CAN1:1
-                    </param>
+                    <param name="id">           rfeimu_acc      rfeimu_gyro     rfeimu_mag      rfeimu_status    </param>
+                    <param name="sensorName">   head_imu_0      head_imu_0      head_imu_0      head_imu_0       </param>
+                    <param name="type">         eoas_imu_acc    eoas_imu_gyr    eoas_imu_mag    eoas_imu_status  </param>
+                    <param name="boardType">    rfe             rfe             rfe             rfe              </param>
+                    <param name="location">     CAN1:1          CAN1:1          CAN1:1          CAN1:1           </param>
                 </group>
 
             </group>

--- a/iCubWaterloo01/hardware/inertials/left_leg-eb6-IMU.xml
+++ b/iCubWaterloo01/hardware/inertials/left_leg-eb6-IMU.xml
@@ -30,17 +30,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">       l_upper_leg_imu_acc_1    l_upper_leg_imu_gyro_1    l_upper_leg_imu_eul_1    l_upper_leg_imu_mag_1    l_upper_leg_imu_stat_1
-                    </param>
-
-                    <param name="type">     eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status
-                    </param>
-
-                    <param name="boardType"> strain2       strain2      strain2       strain2        strain2
-                    </param>
-
-                    <param name="location">  CAN2:13       CAN2:13      CAN2:13       CAN2:13        CAN2:13
-                    </param>
+                    <param name="id">         l_upper_leg_imu_acc_1    l_upper_leg_imu_gyro_1    l_upper_leg_imu_eul_1    l_upper_leg_imu_mag_1    l_upper_leg_imu_stat_1 </param>
+                    <param name="sensorName"> l_leg_ft_imu             l_leg_ft_imu              l_leg_ft_imu             l_leg_ft_imu             l_leg_ft_imu           </param>
+                    <param name="type">       eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status        </param>
+                    <param name="boardType">  strain2                  strain2                   strain2                  strain2                  strain2                </param>
+                    <param name="location">   CAN2:13                  CAN2:13                   CAN2:13                  CAN2:13                  CAN2:13                </param>
                 </group>
 
             </group>

--- a/iCubWaterloo01/hardware/inertials/left_leg-eb7-IMU.xml
+++ b/iCubWaterloo01/hardware/inertials/left_leg-eb7-IMU.xml
@@ -30,17 +30,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">       l_lower_leg_imu_acc_2    l_lower_leg_imu_gyro_2    l_lower_leg_imu_eul_2    l_lower_leg_imu_mag_2    l_lower_leg_imu_stat_2
-                    </param>
-
-                    <param name="type">     eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status
-                    </param>
-
-                    <param name="boardType"> strain2       strain2      strain2       strain2        strain2
-                    </param>
-
-                    <param name="location">  CAN2:13       CAN2:13      CAN2:13       CAN2:13        CAN2:13
-                    </param>
+                    <param name="id">         l_lower_leg_imu_acc_2    l_lower_leg_imu_gyro_2    l_lower_leg_imu_eul_2    l_lower_leg_imu_mag_2    l_lower_leg_imu_stat_2  </param>
+                    <param name="sensorName"> l_foot_ft_imu            l_foot_ft_imu             l_foot_ft_imu            l_foot_ft_imu            l_foot_ft_imu           </param>
+                    <param name="type">       eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status         </param>
+                    <param name="boardType">  strain2                  strain2                   strain2                  strain2                  strain2                 </param>
+                    <param name="location">   CAN2:13                  CAN2:13                   CAN2:13                  CAN2:13                  CAN2:13                 </param>
                 </group>
 
             </group>

--- a/iCubWaterloo01/hardware/inertials/right_leg-eb8-IMU.xml
+++ b/iCubWaterloo01/hardware/inertials/right_leg-eb8-IMU.xml
@@ -30,17 +30,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">       r_upper_leg_imu_acc_1    r_upper_leg_imu_gyro_1    r_upper_leg_imu_eul_1    r_upper_leg_imu_mag_1    r_upper_leg_imu_stat_1
-                    </param>
-
-                    <param name="type">     eoas_imu_acc  eoas_imu_gyr  eoas_imu_eul  eoas_imu_mag   eoas_imu_status
-                    </param>
-                    <param name="boardType"> strain2       strain2      strain2       strain2        strain2
-                    </param>
-
-
-                    <param name="location">  CAN2:13       CAN2:13      CAN2:13       CAN2:13        CAN2:13
-                    </param>
+                    <param name="id">         r_upper_leg_imu_acc_1    r_upper_leg_imu_gyro_1    r_upper_leg_imu_eul_1    r_upper_leg_imu_mag_1    r_upper_leg_imu_stat_1 </param>
+                    <param name="sensorName"> r_leg_ft_imu             r_leg_ft_imu              r_leg_ft_imu             r_leg_ft_imu             r_leg_ft_imu           </param>
+                    <param name="type">       eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status        </param>
+                    <param name="boardType">  strain2                  strain2                   strain2                  strain2                  strain2                </param>
+                    <param name="location">   CAN2:13                  CAN2:13                   CAN2:13                  CAN2:13                  CAN2:13                </param>
                 </group>
 
             </group>

--- a/iCubWaterloo01/hardware/inertials/right_leg-eb9-IMU.xml
+++ b/iCubWaterloo01/hardware/inertials/right_leg-eb9-IMU.xml
@@ -30,17 +30,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">       r_lower_leg_imu_acc_2    r_lower_leg_imu_gyro_2    r_lower_leg_imu_eul_2    r_lower_leg_imu_mag_2    r_lower_leg_imu_stat_2
-                    </param>
-
-                    <param name="type">     eoas_imu_acc  eoas_imu_gyr  eoas_imu_eul  eoas_imu_mag   eoas_imu_status
-                    </param>
-                    <param name="boardType"> strain2       strain2      strain2       strain2        strain2
-                    </param>
-
-
-                    <param name="location">  CAN2:13       CAN2:13      CAN2:13       CAN2:13        CAN2:13
-                    </param>
+                    <param name="id">         r_lower_leg_imu_acc_2    r_lower_leg_imu_gyro_2    r_lower_leg_imu_eul_2    r_lower_leg_imu_mag_2    r_lower_leg_imu_stat_2  </param>
+                    <param name="sensorName"> r_foot_ft_imu            r_foot_ft_imu             r_foot_ft_imu            r_foot_ft_imu            r_foot_ft_imu           </param>
+                    <param name="type">       eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status         </param>
+                    <param name="boardType">  strain2                  strain2                   strain2                  strain2                  strain2                 </param>
+                    <param name="location">   CAN2:13                  CAN2:13                   CAN2:13                  CAN2:13                  CAN2:13                 </param>
                 </group>
 
             </group>

--- a/iCubWaterloo01/wrappers/inertials/alljoints-inertials_remapper.xml
+++ b/iCubWaterloo01/wrappers/inertials/alljoints-inertials_remapper.xml
@@ -4,7 +4,7 @@
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_remapper" type="multipleanalogsensorsremapper">
         <param name="OrientationSensorsNames">
-            (head_imu_0 l_leg_ft l_foot_ft r_leg_ft r_foot_ft)
+            (head_imu_0 l_leg_ft_imu l_foot_ft_imu r_leg_ft_imu r_foot_ft_imu)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubWaterloo01/wrappers/inertials/alljoints-inertials_wrapper.xml
+++ b/iCubWaterloo01/wrappers/inertials/alljoints-inertials_wrapper.xml
@@ -5,7 +5,7 @@
     <param name="period">      10                           </param>
     <param name="name"> /${portprefix}/alljoints/inertials   </param>
 
-    <action phase="startup" level="15" type="attach">
+    <action phase="startup" level="10" type="attach">
         <paramlist name="networks">
             <elem name="FirstStrain"> alljoints-inertials_remapper </elem>
         </paramlist>

--- a/iCubZagreb01/hardware/inertials/head-inertial.xml
+++ b/iCubZagreb01/hardware/inertials/head-inertial.xml
@@ -30,15 +30,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">           rfeimu_acc      rfeimu_gyro     rfeimu_mag      rfeimu_status
-                    </param>
-                    <param name="sensorName">   head_imu_0          head_imu_0          head_imu_0          head_imu_0 </param>
-                    <param name="type">         eoas_imu_acc    eoas_imu_gyr    eoas_imu_mag    eoas_imu_status
-                    </param>
-                    <param name="boardType">    rfe             rfe             rfe             rfe
-                    </param>
-                    <param name="location">     CAN1:1          CAN1:1          CAN1:1          CAN1:1
-                    </param>
+                    <param name="id">           rfeimu_acc      rfeimu_gyro     rfeimu_mag      rfeimu_status    </param>
+                    <param name="sensorName">   head_imu_0      head_imu_0      head_imu_0      head_imu_0       </param>
+                    <param name="type">         eoas_imu_acc    eoas_imu_gyr    eoas_imu_mag    eoas_imu_status  </param>
+                    <param name="boardType">    rfe             rfe             rfe             rfe              </param>
+                    <param name="location">     CAN1:1          CAN1:1          CAN1:1          CAN1:1           </param>
                 </group>
 
             </group>

--- a/iCubZagreb01/hardware/inertials/left_leg-eb6-IMU.xml
+++ b/iCubZagreb01/hardware/inertials/left_leg-eb6-IMU.xml
@@ -30,17 +30,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">       l_upper_leg_imu_acc_1    l_upper_leg_imu_gyro_1    l_upper_leg_imu_eul_1    l_upper_leg_imu_mag_1    l_upper_leg_imu_stat_1
-                    </param>
-
-                    <param name="type">     eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status
-                    </param>
-
-                    <param name="boardType"> strain2       strain2      strain2       strain2        strain2
-                    </param>
-
-                    <param name="location">  CAN2:13       CAN2:13      CAN2:13       CAN2:13        CAN2:13
-                    </param>
+                    <param name="id">         l_upper_leg_imu_acc_1    l_upper_leg_imu_gyro_1    l_upper_leg_imu_eul_1    l_upper_leg_imu_mag_1    l_upper_leg_imu_stat_1 </param>
+                    <param name="sensorName"> l_leg_ft_imu             l_leg_ft_imu              l_leg_ft_imu             l_leg_ft_imu             l_leg_ft_imu           </param>
+                    <param name="type">       eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status        </param>
+                    <param name="boardType">  strain2                  strain2                   strain2                  strain2                  strain2                </param>
+                    <param name="location">   CAN2:13                  CAN2:13                   CAN2:13                  CAN2:13                  CAN2:13                </param>
                 </group>
 
             </group>

--- a/iCubZagreb01/hardware/inertials/left_leg-eb7-IMU.xml
+++ b/iCubZagreb01/hardware/inertials/left_leg-eb7-IMU.xml
@@ -30,17 +30,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">       l_lower_leg_imu_acc_2    l_lower_leg_imu_gyro_2    l_lower_leg_imu_eul_2    l_lower_leg_imu_mag_2    l_lower_leg_imu_stat_2
-                    </param>
-
-                    <param name="type">     eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status
-                    </param>
-
-                    <param name="boardType"> strain2       strain2      strain2       strain2        strain2
-                    </param>
-
-                    <param name="location">  CAN2:13       CAN2:13      CAN2:13       CAN2:13        CAN2:13
-                    </param>
+                    <param name="id">         l_lower_leg_imu_acc_2    l_lower_leg_imu_gyro_2    l_lower_leg_imu_eul_2    l_lower_leg_imu_mag_2    l_lower_leg_imu_stat_2  </param>
+                    <param name="sensorName"> l_foot_ft_imu            l_foot_ft_imu             l_foot_ft_imu            l_foot_ft_imu            l_foot_ft_imu           </param>
+                    <param name="type">       eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status         </param>
+                    <param name="boardType">  strain2                  strain2                   strain2                  strain2                  strain2                 </param>
+                    <param name="location">   CAN2:13                  CAN2:13                   CAN2:13                  CAN2:13                  CAN2:13                 </param>
                 </group>
 
             </group>

--- a/iCubZagreb01/hardware/inertials/right_leg-eb8-IMU.xml
+++ b/iCubZagreb01/hardware/inertials/right_leg-eb8-IMU.xml
@@ -30,17 +30,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">       r_upper_leg_imu_acc_1    r_upper_leg_imu_gyro_1    r_upper_leg_imu_eul_1    r_upper_leg_imu_mag_1    r_upper_leg_imu_stat_1
-                    </param>
-
-                    <param name="type">     eoas_imu_acc  eoas_imu_gyr  eoas_imu_eul  eoas_imu_mag   eoas_imu_status
-                    </param>
-                    <param name="boardType"> strain2       strain2      strain2       strain2        strain2
-                    </param>
-
-
-                    <param name="location">  CAN2:13       CAN2:13      CAN2:13       CAN2:13        CAN2:13
-                    </param>
+                    <param name="id">         r_upper_leg_imu_acc_1    r_upper_leg_imu_gyro_1    r_upper_leg_imu_eul_1    r_upper_leg_imu_mag_1    r_upper_leg_imu_stat_1 </param>
+                    <param name="sensorName"> r_leg_ft_imu             r_leg_ft_imu              r_leg_ft_imu             r_leg_ft_imu             r_leg_ft_imu           </param>
+                    <param name="type">       eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status        </param>
+                    <param name="boardType">  strain2                  strain2                   strain2                  strain2                  strain2                </param>
+                    <param name="location">   CAN2:13                  CAN2:13                   CAN2:13                  CAN2:13                  CAN2:13                </param>
                 </group>
 
             </group>

--- a/iCubZagreb01/hardware/inertials/right_leg-eb9-IMU.xml
+++ b/iCubZagreb01/hardware/inertials/right_leg-eb9-IMU.xml
@@ -30,17 +30,11 @@
                 </group>
 
                 <group name="SENSORS">
-                    <param name="id">       r_lower_leg_imu_acc_2    r_lower_leg_imu_gyro_2    r_lower_leg_imu_eul_2    r_lower_leg_imu_mag_2    r_lower_leg_imu_stat_2
-                    </param>
-
-                    <param name="type">     eoas_imu_acc  eoas_imu_gyr  eoas_imu_eul  eoas_imu_mag   eoas_imu_status
-                    </param>
-                    <param name="boardType"> strain2       strain2      strain2       strain2        strain2
-                    </param>
-
-
-                    <param name="location">  CAN2:13       CAN2:13      CAN2:13       CAN2:13        CAN2:13
-                    </param>
+                    <param name="id">         r_lower_leg_imu_acc_2    r_lower_leg_imu_gyro_2    r_lower_leg_imu_eul_2    r_lower_leg_imu_mag_2    r_lower_leg_imu_stat_2  </param>
+                    <param name="sensorName"> r_foot_ft_imu            r_foot_ft_imu             r_foot_ft_imu            r_foot_ft_imu            r_foot_ft_imu           </param>
+                    <param name="type">       eoas_imu_acc             eoas_imu_gyr              eoas_imu_eul             eoas_imu_mag             eoas_imu_status         </param>
+                    <param name="boardType">  strain2                  strain2                   strain2                  strain2                  strain2                 </param>
+                    <param name="location">   CAN2:13                  CAN2:13                   CAN2:13                  CAN2:13                  CAN2:13                 </param>
                 </group>
 
             </group>

--- a/iCubZagreb01/wrappers/inertials/alljoints-inertials_remapper.xml
+++ b/iCubZagreb01/wrappers/inertials/alljoints-inertials_remapper.xml
@@ -4,7 +4,7 @@
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_remapper" type="multipleanalogsensorsremapper">
         <param name="OrientationSensorsNames">
-            (head_imu_0 l_leg_ft l_foot_ft r_leg_ft r_foot_ft)
+            (head_imu_0 l_leg_ft_imu l_foot_ft_imu r_leg_ft_imu r_foot_ft_imu)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/iCubZagreb01/wrappers/inertials/alljoints-inertials_wrapper.xml
+++ b/iCubZagreb01/wrappers/inertials/alljoints-inertials_wrapper.xml
@@ -5,7 +5,7 @@
     <param name="period">      10                           </param>
     <param name="name"> /${portprefix}/alljoints/inertials   </param>
 
-    <action phase="startup" level="15" type="attach">
+    <action phase="startup" level="10" type="attach">
         <paramlist name="networks">
             <elem name="FirstStrain"> alljoints-inertials_remapper </elem>
         </paramlist>


### PR DESCRIPTION
This PR should partially solve https://github.com/robotology/robots-configuration/issues/636. It adds:

- `sensorName` tag for all the ergoCub/iCub that exposes the IMU data from the FT sensors;
- the sensor name will be of type `<part>_ft_imu` and the simulated models will be aligned accordingly;
- as per https://github.com/robotology/robots-configuration/issues/377, I modified the nws attach level to 10, while previously was set at 15, the same level as the detach phase.