### PR TITLE
Cleanup yarprobotinterface conf files for ergoCub

### DIFF
--- a/ergoCubSN000/ergocub.xml
+++ b/ergoCubSN000/ergocub.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<robot name="ergoCubSN000" xmlns:xi="http://www.w3.org/2001/XInclude">
+
+    <params>
+        <xi:include href="hardware/electronics/pc104.xml" />
+    </params>
+
+    <devices>
+
+    <!-- POS4 -->
+    <xi:include href="wrappers/POS/right_hand-pos_wrapper4.xml" />
+    <xi:include href="hardware/POS/right_hand-pos4.xml" />
+    <xi:include href="wrappers/POS/left_hand-pos_wrapper4.xml" />
+    <xi:include href="hardware/POS/left_hand-pos4.xml" />
+
+    <!-- POS2 -->
+    <xi:include href="wrappers/POS/right_hand-pos_wrapper2.xml" />
+    <xi:include href="hardware/POS/right_hand-pos2.xml" />
+    <xi:include href="wrappers/POS/left_hand-pos_wrapper2.xml" />
+    <xi:include href="hardware/POS/left_hand-pos2.xml" />
+
+    <!-- motor controllers wrappers -->
+    <xi:include href="wrappers/motorControl/left_leg-mc_wrapper.xml" />
+    <xi:include href="wrappers/motorControl/right_leg-mc_wrapper.xml" />
+
+    <xi:include href="wrappers/motorControl/left_leg-mc_remapper.xml" />
+    <xi:include href="wrappers/motorControl/right_leg-mc_remapper.xml" />
+
+    <xi:include href="wrappers/motorControl/right_arm-mc_wrapper.xml" />
+
+    <xi:include href="wrappers/motorControl/right_arm-mc_remapper.xml" />
+
+    <xi:include href="wrappers/motorControl/left_arm-mc_wrapper.xml" />
+    <xi:include href="wrappers/motorControl/left_arm-mc_remapper.xml" />
+
+    <xi:include href="wrappers/motorControl/torso-mc_wrapper.xml" />
+    <xi:include href="wrappers/motorControl/torso-mc_remapper.xml" />
+
+    <xi:include href="wrappers/motorControl/head-mc_wrapper.xml" />
+    <xi:include href="wrappers/motorControl/head-mc_remapper.xml" />
+
+    <!-- HEAD -->
+    <xi:include href="hardware/motorControl/head-eb20-j0_1-mc.xml" />
+    <xi:include href="hardware/motorControl/head-eb21-j2_3-mc.xml" />
+
+    <!-- TORSO -->
+    <xi:include href="hardware/motorControl/torso-eb5-j0_2-mc.xml" />
+
+    <!-- LEFT ARM -->
+    <xi:include href="hardware/motorControl/left_arm-eb2-j0_1-mc.xml" />
+    <xi:include href="hardware/motorControl/left_arm-eb4-j2_3-mc.xml" />
+    <xi:include href="hardware/motorControl/left_arm-eb31-j4_6-mc.xml" />
+    <xi:include href="hardware/motorControl/left_arm-eb23-j7_10-mc.xml" />
+    <xi:include href="hardware/motorControl/left_arm-eb25-j11_12-mc.xml" />
+
+    <!-- RIGHT ARM -->
+    <xi:include href="hardware/motorControl/right_arm-eb1-j0_1-mc.xml" />
+    <xi:include href="hardware/motorControl/right_arm-eb3-j2_3-mc.xml" />
+    <xi:include href="hardware/motorControl/right_arm-eb30-j4_6-mc.xml" />
+    <xi:include href="hardware/motorControl/right_arm-eb22-j7_10-mc.xml" />
+    <xi:include href="hardware/motorControl/right_arm-eb24-j11_12-mc.xml" />
+
+    <!-- LEFT LEG -->
+    <xi:include href="hardware/motorControl/left_leg-eb8-j0_3-mc.xml" />
+    <xi:include href="hardware/motorControl/left_leg-eb9-j4_5-mc.xml" />
+
+    <!-- RIGHT LEG -->
+    <xi:include href="hardware/motorControl/right_leg-eb6-j0_3-mc.xml" />
+    <xi:include href="hardware/motorControl/right_leg-eb7-j4_5-mc.xml" />
+
+    <!-- FT SENSORS -->
+    <xi:include href="hardware/FT/left_arm-eb2-j0_1-strain.xml" />
+    <xi:include href="hardware/FT/right_arm-eb1-j0_1-strain.xml" />
+    <xi:include href="hardware/FT/left_leg-eb9-j4_5-strain.xml" />
+    <xi:include href="hardware/FT/right_leg-eb7-j4_5-strain.xml" />
+    <xi:include href="hardware/FT/left_leg-eb8-j0_3-strain.xml" />
+    <xi:include href="hardware/FT/right_leg-eb6-j0_3-strain.xml" />
+
+    <!-- FT SENSORS - REMAPPERS -->
+    <xi:include href="wrappers/FT/left_leg-FT_remapper.xml" />
+    <xi:include href="wrappers/FT/right_leg-FT_remapper.xml" />
+
+    <!-- FT SENSORS - MULTIPLE ANALOG SENSOR SERVERS -->
+    <xi:include href="wrappers/FT/left_arm-FT_wrapper.xml" />
+    <xi:include href="wrappers/FT/right_arm-FT_wrapper.xml" />
+    <xi:include href="wrappers/FT/left_leg-FT_wrapper.xml" />
+    <xi:include href="wrappers/FT/right_leg-FT_wrapper.xml" />
+
+    <!-- INERTIAL SENSOR -->
+    <xi:include href="wrappers/inertials/head-imuFilter_wrapper.xml" />
+    <xi:include href="wrappers/inertials/head-imuFilter.xml" />
+    <xi:include href="wrappers/inertials/head-inertials_wrapper.xml" />
+    <xi:include href="hardware/inertials/head-inertial.xml" />
+    <xi:include href="hardware/inertials/waist-inertial.xml" />
+    <xi:include href="wrappers/inertials/waist-inertials_wrapper.xml" />
+
+    <!-- IMU - MTB4 BOARDS
+    <xi:include href="hardware/inertials/left_arm-eb4-j2_3-inertial.xml" />
+    <xi:include href="wrappers/inertials/left_arm-inertials_wrapper.xml" />
+    <xi:include href="hardware/inertials/right_arm-eb3-j2_3-inertial.xml" />
+    <xi:include href="wrappers/inertials/right_arm-inertials_wrapper.xml" /> -->
+
+    <!-- FT SENSORS - IMU -->
+    <xi:include href="hardware/inertials/left_arm-eb2-j0_1-inertial.xml" />
+    <xi:include href="hardware/inertials/right_arm-eb1-j0_1-inertial.xml" />
+    <xi:include href="hardware/inertials/left_leg-eb8-j0_3-inertial.xml" />
+    <xi:include href="hardware/inertials/right_leg-eb6-j0_3-inertial.xml" />
+    <xi:include href="hardware/inertials/left_leg-eb9-j4_5-inertial.xml" />
+    <xi:include href="hardware/inertials/right_leg-eb7-j4_5-inertial.xml" />
+
+    <!-- FT SENSORS - IMU - MULTIPLE ANALOG SENSOR SERVERS -->
+    <xi:include href="wrappers/inertials/left_arm-imu_wrapper.xml" />
+    <xi:include href="wrappers/inertials/right_arm-imu_wrapper.xml" />
+    <xi:include href="wrappers/inertials/left_leg-imu_wrapper.xml" />
+    <xi:include href="wrappers/inertials/right_leg-imu_wrapper.xml" />
+    <xi:include href="wrappers/inertials/left_foot-imu_wrapper.xml" />
+    <xi:include href="wrappers/inertials/right_foot-imu_wrapper.xml" />
+    <xi:include href="wrappers/inertials/alljoints-inertials_wrapper.xml" />
+    <xi:include href="wrappers/inertials/alljoints-inertials_remapper.xml" />
+
+    <!-- BATTERY BAT -->
+    <!-- <xi:include href="wrappers/battery/battery_bat.xml" /> -->
+    <!-- <xi:include href="hardware/battery/battery_bat.xml" /> -->
+
+    <!-- BATTERY BMS -->
+    <xi:include href="wrappers/battery/battery_bms.xml" />
+    <xi:include href="hardware/battery/battery_bms.xml" />
+
+    <!-- CALIBRATORS -->
+    <xi:include href="calibrators/torso-calib.xml" />
+    <xi:include href="calibrators/left_leg-calib.xml" />
+    <xi:include href="calibrators/right_leg-calib.xml" />
+    <xi:include href="calibrators/left_arm-calib.xml" />
+    <xi:include href="calibrators/right_arm-calib.xml" />
+    <xi:include href="calibrators/head-calib.xml" />
+
+    <!-- ROS2 Wrappers -->
+    <!--m<xi:include href="wrappers/inertials/imu_ros2.xml" /> -->
+    <xi:include href="wrappers/motorControl/alljoints-mc_remapper.xml" enabled_by="enable_ros2" disabled_by="disable_ros2" />
+    <xi:include href="wrappers/motorControl/alljoints-mc_nws_ros2.xml" enabled_by="enable_ros2" disabled_by="disable_ros2" />
+    <xi:include href="wrappers/FT/left_arm-FT_nws_ros2.xml" enabled_by="enable_ros2" disabled_by="disable_ros2" />
+    <xi:include href="wrappers/FT/right_arm-FT_nws_ros2.xml" enabled_by="enable_ros2" disabled_by="disable_ros2" />
+    <xi:include href="wrappers/FT/left_foot-FT_nws_ros2.xml" enabled_by="enable_ros2" disabled_by="disable_ros2" />
+    <xi:include href="wrappers/FT/right_foot-FT_nws_ros2.xml" enabled_by="enable_ros2" disabled_by="disable_ros2" />
+
+    <!-- ESTIMATORS -->
+    <xi:include href="estimators/wholebodydynamics.xml" disabled_by="disable_wholebodynamics" />
+
+  </devices>
+</robot>

--- a/ergoCubSN000/yarprobotinterface.ini
+++ b/ergoCubSN000/yarprobotinterface.ini
@@ -1,2 +1,2 @@
-config ./ergocub_all.xml
+config ./ergocub.xml
 

--- a/ergoCubSN001/ergocub.xml
+++ b/ergoCubSN001/ergocub.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<robot name="ergoCubSN001" xmlns:xi="http://www.w3.org/2001/XInclude">
+
+    <params>
+        <xi:include href="hardware/electronics/pc104.xml" />
+    </params>
+
+    <devices>
+
+    <!-- POS4 -->
+    <xi:include href="wrappers/POS/right_hand-pos_wrapper4.xml" />
+    <xi:include href="hardware/POS/right_hand-pos4.xml" />
+    <xi:include href="wrappers/POS/left_hand-pos_wrapper4.xml" />
+    <xi:include href="hardware/POS/left_hand-pos4.xml" />
+
+    <!-- POS2 -->
+    <xi:include href="wrappers/POS/right_hand-pos_wrapper2.xml" />
+    <xi:include href="hardware/POS/right_hand-pos2.xml" />
+    <xi:include href="wrappers/POS/left_hand-pos_wrapper2.xml" />
+    <xi:include href="hardware/POS/left_hand-pos2.xml" />
+
+    <!-- motor controllers wrappers -->
+    <xi:include href="wrappers/motorControl/left_leg-mc_wrapper.xml" />
+    <xi:include href="wrappers/motorControl/right_leg-mc_wrapper.xml" />
+
+    <xi:include href="wrappers/motorControl/left_leg-mc_remapper.xml" />
+    <xi:include href="wrappers/motorControl/right_leg-mc_remapper.xml" />
+
+    <xi:include href="wrappers/motorControl/right_arm-mc_wrapper.xml" />
+
+    <xi:include href="wrappers/motorControl/right_arm-mc_remapper.xml" />
+
+    <xi:include href="wrappers/motorControl/left_arm-mc_wrapper.xml" />
+    <xi:include href="wrappers/motorControl/left_arm-mc_remapper.xml" />
+
+    <xi:include href="wrappers/motorControl/torso-mc_wrapper.xml" />
+    <xi:include href="wrappers/motorControl/torso-mc_remapper.xml" />
+
+    <xi:include href="wrappers/motorControl/head-mc_wrapper.xml" />
+    <xi:include href="wrappers/motorControl/head-mc_remapper.xml" />
+
+    <!-- HEAD -->
+    <xi:include href="hardware/motorControl/head-eb20-j0_1-mc.xml" />
+    <xi:include href="hardware/motorControl/head-eb21-j2_3-mc.xml" />
+
+    <!-- TORSO -->
+    <xi:include href="hardware/motorControl/torso-eb5-j0_2-mc.xml" />
+
+    <!-- LEFT ARM -->
+    <xi:include href="hardware/motorControl/left_arm-eb2-j0_1-mc.xml" />
+    <xi:include href="hardware/motorControl/left_arm-eb4-j2_3-mc.xml" />
+    <xi:include href="hardware/motorControl/left_arm-eb31-j4_6-mc.xml" />
+    <xi:include href="hardware/motorControl/left_arm-eb23-j7_10-mc.xml" />
+    <xi:include href="hardware/motorControl/left_arm-eb25-j11_12-mc.xml" />
+
+    <!-- RIGHT ARM -->
+    <xi:include href="hardware/motorControl/right_arm-eb1-j0_1-mc.xml" />
+    <xi:include href="hardware/motorControl/right_arm-eb3-j2_3-mc.xml" />
+    <xi:include href="hardware/motorControl/right_arm-eb30-j4_6-mc.xml" />
+    <xi:include href="hardware/motorControl/right_arm-eb22-j7_10-mc.xml" />
+    <xi:include href="hardware/motorControl/right_arm-eb24-j11_12-mc.xml" />
+
+    <!-- LEFT LEG -->
+    <xi:include href="hardware/motorControl/left_leg-eb8-j0_3-mc.xml" />
+    <xi:include href="hardware/motorControl/left_leg-eb9-j4_5-mc.xml" />
+
+    <!-- RIGHT LEG -->
+    <xi:include href="hardware/motorControl/right_leg-eb6-j0_3-mc.xml" />
+    <xi:include href="hardware/motorControl/right_leg-eb7-j4_5-mc.xml" />
+
+    <!-- FT SENSORS -->
+    <xi:include href="hardware/FT/left_arm-eb2-j0_1-strain.xml" />
+    <xi:include href="hardware/FT/right_arm-eb1-j0_1-strain.xml" />
+    <xi:include href="hardware/FT/left_leg-eb9-j4_5-strain.xml" />
+    <xi:include href="hardware/FT/right_leg-eb7-j4_5-strain.xml" />
+    <xi:include href="hardware/FT/left_leg-eb8-j0_3-strain.xml" />
+    <xi:include href="hardware/FT/right_leg-eb6-j0_3-strain.xml" />
+
+    <!-- FT SENSORS - REMAPPERS -->
+    <xi:include href="wrappers/FT/left_leg-FT_remapper.xml" />
+    <xi:include href="wrappers/FT/right_leg-FT_remapper.xml" />
+
+    <!-- FT SENSORS - MULTIPLE ANALOG SENSOR SERVERS -->
+    <xi:include href="wrappers/FT/left_arm-FT_wrapper.xml" />
+    <xi:include href="wrappers/FT/right_arm-FT_wrapper.xml" />
+    <xi:include href="wrappers/FT/left_leg-FT_wrapper.xml" />
+    <xi:include href="wrappers/FT/right_leg-FT_wrapper.xml" />
+
+    <!-- INERTIAL SENSOR -->
+    <xi:include href="wrappers/inertials/head-imuFilter_wrapper.xml" />
+    <xi:include href="wrappers/inertials/head-imuFilter.xml" />
+    <xi:include href="wrappers/inertials/head-inertials_wrapper.xml" />
+    <xi:include href="hardware/inertials/head-inertial.xml" />
+    <xi:include href="hardware/inertials/waist-inertial.xml" />
+    <xi:include href="wrappers/inertials/waist-inertials_wrapper.xml" />
+
+    <!-- IMU - MTB4 BOARDS
+    <xi:include href="hardware/inertials/left_arm-eb4-j2_3-inertial.xml" />
+    <xi:include href="wrappers/inertials/left_arm-inertials_wrapper.xml" />
+    <xi:include href="hardware/inertials/right_arm-eb3-j2_3-inertial.xml" />
+    <xi:include href="wrappers/inertials/right_arm-inertials_wrapper.xml" /> -->
+
+    <!-- FT SENSORS - IMU -->
+    <xi:include href="hardware/inertials/left_arm-eb2-j0_1-inertial.xml" />
+    <xi:include href="hardware/inertials/right_arm-eb1-j0_1-inertial.xml" />
+    <xi:include href="hardware/inertials/left_leg-eb8-j0_3-inertial.xml" />
+    <xi:include href="hardware/inertials/right_leg-eb6-j0_3-inertial.xml" />
+    <xi:include href="hardware/inertials/left_leg-eb9-j4_5-inertial.xml" />
+    <xi:include href="hardware/inertials/right_leg-eb7-j4_5-inertial.xml" />
+
+    <!-- FT SENSORS - IMU - MULTIPLE ANALOG SENSOR SERVERS -->
+    <xi:include href="wrappers/inertials/left_arm-imu_wrapper.xml" />
+    <xi:include href="wrappers/inertials/right_arm-imu_wrapper.xml" />
+    <xi:include href="wrappers/inertials/left_leg-imu_wrapper.xml" />
+    <xi:include href="wrappers/inertials/right_leg-imu_wrapper.xml" />
+    <xi:include href="wrappers/inertials/left_foot-imu_wrapper.xml" />
+    <xi:include href="wrappers/inertials/right_foot-imu_wrapper.xml" />
+    <xi:include href="wrappers/inertials/alljoints-inertials_wrapper.xml" />
+    <xi:include href="wrappers/inertials/alljoints-inertials_remapper.xml" />
+
+    <!-- BATTERY BAT -->
+    <xi:include href="wrappers/battery/battery_bat.xml" />
+    <xi:include href="hardware/battery/battery_bat.xml" />
+
+    <!-- BATTERY BMS -->
+    <xi:include href="wrappers/battery/battery_bms.xml" />
+    <xi:include href="hardware/battery/battery_bms.xml" />
+
+    <!-- CALIBRATORS -->
+    <xi:include href="calibrators/torso-calib.xml" />
+    <xi:include href="calibrators/left_leg-calib.xml" />
+    <xi:include href="calibrators/right_leg-calib.xml" />
+    <xi:include href="calibrators/left_arm-calib.xml" />
+    <xi:include href="calibrators/right_arm-calib.xml" />
+    <xi:include href="calibrators/head-calib.xml" />
+
+    <!-- ROS2 Wrappers -->
+    <!--m<xi:include href="wrappers/inertials/imu_ros2.xml" /> -->
+    <xi:include href="wrappers/motorControl/alljoints-mc_remapper.xml" enabled_by="enable_ros2" disabled_by="disable_ros2" />
+    <xi:include href="wrappers/motorControl/alljoints-mc_nws_ros2.xml" enabled_by="enable_ros2" disabled_by="disable_ros2" />
+    <xi:include href="wrappers/FT/left_arm-FT_nws_ros2.xml" enabled_by="enable_ros2" disabled_by="disable_ros2" />
+    <xi:include href="wrappers/FT/right_arm-FT_nws_ros2.xml" enabled_by="enable_ros2" disabled_by="disable_ros2" />
+    <xi:include href="wrappers/FT/left_foot-FT_nws_ros2.xml" enabled_by="enable_ros2" disabled_by="disable_ros2" />
+    <xi:include href="wrappers/FT/right_foot-FT_nws_ros2.xml" enabled_by="enable_ros2" disabled_by="disable_ros2" />
+
+    <!-- ESTIMATORS -->
+    <xi:include href="estimators/wholebodydynamics.xml" disabled_by="disable_wholebodynamics" />
+
+  </devices>
+</robot>

--- a/ergoCubSN001/yarprobotinterface.ini
+++ b/ergoCubSN001/yarprobotinterface.ini
@@ -1,2 +1,2 @@
-config ./ergocub_all.xml
+config ./ergocub.xml
 

--- a/ergoCubSN002/ergocub.xml
+++ b/ergoCubSN002/ergocub.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<robot name="ergoCubSN002" xmlns:xi="http://www.w3.org/2001/XInclude">
+
+    <params>
+        <xi:include href="hardware/electronics/pc104.xml" />
+    </params>
+
+    <devices>
+
+    <!-- POS4 -->
+    <xi:include href="wrappers/POS/right_hand-pos_wrapper4.xml" />
+    <xi:include href="hardware/POS/right_hand-pos4.xml" />
+    <xi:include href="wrappers/POS/left_hand-pos_wrapper4.xml" />
+    <xi:include href="hardware/POS/left_hand-pos4.xml" />
+
+    <!-- POS2 -->
+    <xi:include href="wrappers/POS/right_hand-pos_wrapper2.xml" />
+    <xi:include href="hardware/POS/right_hand-pos2.xml" />
+    <xi:include href="wrappers/POS/left_hand-pos_wrapper2.xml" />
+    <xi:include href="hardware/POS/left_hand-pos2.xml" />
+
+    <!-- motor controllers wrappers -->
+    <xi:include href="wrappers/motorControl/left_leg-mc_wrapper.xml" />
+    <xi:include href="wrappers/motorControl/right_leg-mc_wrapper.xml" />
+
+    <xi:include href="wrappers/motorControl/left_leg-mc_remapper.xml" />
+    <xi:include href="wrappers/motorControl/right_leg-mc_remapper.xml" />
+
+    <xi:include href="wrappers/motorControl/right_arm-mc_wrapper.xml" />
+
+    <xi:include href="wrappers/motorControl/right_arm-mc_remapper.xml" />
+
+    <xi:include href="wrappers/motorControl/left_arm-mc_wrapper.xml" />
+    <xi:include href="wrappers/motorControl/left_arm-mc_remapper.xml" />
+
+    <xi:include href="wrappers/motorControl/torso-mc_wrapper.xml" />
+    <xi:include href="wrappers/motorControl/torso-mc_remapper.xml" />
+
+    <xi:include href="wrappers/motorControl/head-mc_wrapper.xml" />
+    <xi:include href="wrappers/motorControl/head-mc_remapper.xml" />
+
+    <!-- HEAD -->
+    <xi:include href="hardware/motorControl/head-eb20-j0_1-mc.xml" />
+    <xi:include href="hardware/motorControl/head-eb21-j2_3-mc.xml" />
+
+    <!-- TORSO -->
+    <xi:include href="hardware/motorControl/torso-eb5-j0_2-mc.xml" />
+
+    <!-- LEFT ARM -->
+    <xi:include href="hardware/motorControl/left_arm-eb2-j0_1-mc.xml" />
+    <xi:include href="hardware/motorControl/left_arm-eb4-j2_3-mc.xml" />
+    <xi:include href="hardware/motorControl/left_arm-eb31-j4_6-mc.xml" />
+    <xi:include href="hardware/motorControl/left_arm-eb23-j7_10-mc.xml" />
+    <xi:include href="hardware/motorControl/left_arm-eb25-j11_12-mc.xml" />
+
+    <!-- RIGHT ARM -->
+    <xi:include href="hardware/motorControl/right_arm-eb1-j0_1-mc.xml" />
+    <xi:include href="hardware/motorControl/right_arm-eb3-j2_3-mc.xml" />
+    <xi:include href="hardware/motorControl/right_arm-eb30-j4_6-mc.xml" />
+    <xi:include href="hardware/motorControl/right_arm-eb22-j7_10-mc.xml" />
+    <xi:include href="hardware/motorControl/right_arm-eb24-j11_12-mc.xml" />
+
+    <!-- LEFT LEG -->
+    <xi:include href="hardware/motorControl/left_leg-eb8-j0_3-mc.xml" />
+    <xi:include href="hardware/motorControl/left_leg-eb9-j4_5-mc.xml" />
+
+    <!-- RIGHT LEG -->
+    <xi:include href="hardware/motorControl/right_leg-eb6-j0_3-mc.xml" />
+    <xi:include href="hardware/motorControl/right_leg-eb7-j4_5-mc.xml" />
+
+    <!-- FT SENSORS -->
+    <xi:include href="hardware/FT/left_arm-eb2-j0_1-strain.xml" />
+    <xi:include href="hardware/FT/right_arm-eb1-j0_1-strain.xml" />
+    <xi:include href="hardware/FT/left_leg-eb9-j4_5-strain.xml" />
+    <xi:include href="hardware/FT/right_leg-eb7-j4_5-strain.xml" />
+    <xi:include href="hardware/FT/left_leg-eb8-j0_3-strain.xml" />
+    <xi:include href="hardware/FT/right_leg-eb6-j0_3-strain.xml" />
+
+    <!-- FT SENSORS - REMAPPERS -->
+    <xi:include href="wrappers/FT/left_leg-FT_remapper.xml" />
+    <xi:include href="wrappers/FT/right_leg-FT_remapper.xml" />
+
+    <!-- FT SENSORS - MULTIPLE ANALOG SENSOR SERVERS -->
+    <xi:include href="wrappers/FT/left_arm-FT_wrapper.xml" />
+    <xi:include href="wrappers/FT/right_arm-FT_wrapper.xml" />
+    <xi:include href="wrappers/FT/left_leg-FT_wrapper.xml" />
+    <xi:include href="wrappers/FT/right_leg-FT_wrapper.xml" />
+
+    <!-- INERTIAL SENSOR -->
+    <xi:include href="wrappers/inertials/head-imuFilter_wrapper.xml" />
+    <xi:include href="wrappers/inertials/head-imuFilter.xml" />
+    <xi:include href="wrappers/inertials/head-inertials_wrapper.xml" />
+    <xi:include href="hardware/inertials/head-inertial.xml" />
+    <xi:include href="hardware/inertials/waist-inertial.xml" />
+    <xi:include href="wrappers/inertials/waist-inertials_wrapper.xml" />
+
+    <!-- IMU - MTB4 BOARDS
+    <xi:include href="hardware/inertials/left_arm-eb4-j2_3-inertial.xml" />
+    <xi:include href="wrappers/inertials/left_arm-inertials_wrapper.xml" />
+    <xi:include href="hardware/inertials/right_arm-eb3-j2_3-inertial.xml" />
+    <xi:include href="wrappers/inertials/right_arm-inertials_wrapper.xml" /> -->
+
+    <!-- FT SENSORS - IMU -->
+    <xi:include href="hardware/inertials/left_arm-eb2-j0_1-inertial.xml" />
+    <xi:include href="hardware/inertials/right_arm-eb1-j0_1-inertial.xml" />
+    <xi:include href="hardware/inertials/left_leg-eb8-j0_3-inertial.xml" />
+    <xi:include href="hardware/inertials/right_leg-eb6-j0_3-inertial.xml" />
+    <xi:include href="hardware/inertials/left_leg-eb9-j4_5-inertial.xml" />
+    <xi:include href="hardware/inertials/right_leg-eb7-j4_5-inertial.xml" />
+
+    <!-- FT SENSORS - IMU - MULTIPLE ANALOG SENSOR SERVERS -->
+    <xi:include href="wrappers/inertials/left_arm-imu_wrapper.xml" />
+    <xi:include href="wrappers/inertials/right_arm-imu_wrapper.xml" />
+    <xi:include href="wrappers/inertials/left_leg-imu_wrapper.xml" />
+    <xi:include href="wrappers/inertials/right_leg-imu_wrapper.xml" />
+    <xi:include href="wrappers/inertials/left_foot-imu_wrapper.xml" />
+    <xi:include href="wrappers/inertials/right_foot-imu_wrapper.xml" />
+    <xi:include href="wrappers/inertials/alljoints-inertials_wrapper.xml" />
+    <xi:include href="wrappers/inertials/alljoints-inertials_remapper.xml" />
+
+    <!-- BATTERY BAT -->
+    <xi:include href="wrappers/battery/battery_bat.xml" />
+    <xi:include href="hardware/battery/battery_bat.xml" />
+
+    <!-- BATTERY BMS -->
+    <xi:include href="wrappers/battery/battery_bms.xml" />
+    <xi:include href="hardware/battery/battery_bms.xml" />
+
+    <!-- CALIBRATORS -->
+    <xi:include href="calibrators/torso-calib.xml" />
+    <xi:include href="calibrators/left_leg-calib.xml" />
+    <xi:include href="calibrators/right_leg-calib.xml" />
+    <xi:include href="calibrators/left_arm-calib.xml" />
+    <xi:include href="calibrators/right_arm-calib.xml" />
+    <xi:include href="calibrators/head-calib.xml" />
+
+    <!-- ROS2 Wrappers -->
+    <!--m<xi:include href="wrappers/inertials/imu_ros2.xml" /> -->
+    <xi:include href="wrappers/motorControl/alljoints-mc_remapper.xml" enabled_by="enable_ros2" disabled_by="disable_ros2" />
+    <xi:include href="wrappers/motorControl/alljoints-mc_nws_ros2.xml" enabled_by="enable_ros2" disabled_by="disable_ros2" />
+    <xi:include href="wrappers/FT/left_arm-FT_nws_ros2.xml" enabled_by="enable_ros2" disabled_by="disable_ros2" />
+    <xi:include href="wrappers/FT/right_arm-FT_nws_ros2.xml" enabled_by="enable_ros2" disabled_by="disable_ros2" />
+    <xi:include href="wrappers/FT/left_foot-FT_nws_ros2.xml" enabled_by="enable_ros2" disabled_by="disable_ros2" />
+    <xi:include href="wrappers/FT/right_foot-FT_nws_ros2.xml" enabled_by="enable_ros2" disabled_by="disable_ros2" />
+
+    <!-- ESTIMATORS -->
+    <xi:include href="estimators/wholebodydynamics.xml" disabled_by="disable_wholebodynamics" />
+
+  </devices>
+</robot>

--- a/ergoCubSN002/yarprobotinterface.ini
+++ b/ergoCubSN002/yarprobotinterface.ini
@@ -1,2 +1,2 @@
-config ./ergocub_all.xml
+config ./ergocub.xml
 


### PR DESCRIPTION
Fix https://github.com/robotology/robots-configuration/issues/641 . 

The changes in the PR are the one described in https://github.com/robotology/robots-configuration/issues/641#issue-2239652775 . I actually used the same ergocub.xml for all ergoCub robots, with the following differences:
* Each robot, has a different `robot name=` attribute.
* In `ergoCubSN00`, the following lines are commented:
~~~
    <!-- BATTERY BAT -->
    <!-- <xi:include href="wrappers/battery/battery_bat.xml" /> -->
    <!-- <xi:include href="hardware/battery/battery_bat.xml" /> -->
~~~
I am not sure why this happening, but to avoid regression I left these lines commented also in the new `ergocub.xml`
* In `ergoCubSN001`, there was also a `<xi:include href="wrappers/motorControl/head-mc-slow_wrapper.xml" />` line that is not in other robots. Is this actually used? For the time being, I did not included that in the PR.

To avoid regressions, this PR does not remove any existing `ergocub_***.xml` files. Once the new `ergocub.xml` are tested and working, we can remove the `ergocub_***.xml` files in a follow up PR.