### PR TITLE
[ergoCubSN002] Tune the velocity-acceleration KF on the ergoCubSN002 on the legs torso and arms (no wrist)

### DIFF
--- a/ergoCubSN002/hardware/motorControl/left_arm-eb2-j0_1-mc.xml
+++ b/ergoCubSN002/hardware/motorControl/left_arm-eb2-j0_1-mc.xml
@@ -148,15 +148,16 @@
 
     <!-- kalman filter parameters - vel & acc estimation -->
     <group name="KALMAN_FILTER">
-        <param name="kalmanFilterEnabled">          1              1            </param>
-        <param name="x0">                           0              0            </param>
-        <param name="x1">                           0              0            </param>
-        <param name="x2">                           0              0            </param>
-        <param name="Q0">                           0.0001         0.0001       </param>
-        <param name="Q1">                           0.01           0.01         </param>
-        <param name="Q2">                           10             10           </param>
-        <param name="R">                            0.001          0.001        </param>
-        <param name="P0">                           0.000099       0.000099     </param>
+        <!--   l_shoulder_pitch l_shoulder_roll  -->
+        <param name="kalmanFilterEnabled">          1 1             </param>
+        <param name="x0">                           0 0             </param>
+        <param name="x1">                           0 0             </param>
+        <param name="x2">                           0 0             </param>
+        <param name="Q0">                           0.0013982697765677586 0.2036941310200119             </param>
+        <param name="Q1">                           0.000501099038747999 0.002338984056940109             </param>
+        <param name="Q2">                           23.889466673922787 24.59035459114527             </param>
+        <param name="R">                            4.7011628080032985e-08 0.6123859552105727             </param>
+        <param name="P0">                           8.850472115793434e-07 0.002128502042163944             </param>
     </group>
 
 </device>

--- a/ergoCubSN002/hardware/motorControl/left_arm-eb4-j2_3-mc.xml
+++ b/ergoCubSN002/hardware/motorControl/left_arm-eb4-j2_3-mc.xml
@@ -148,15 +148,15 @@
 
     <!-- kalman filter parameters - vel & acc estimation -->
     <group name="KALMAN_FILTER">
-        <param name="kalmanFilterEnabled">          1              1            </param>
-        <param name="x0">                           0              0            </param>
-        <param name="x1">                           0              0            </param>
-        <param name="x2">                           0              0            </param>
-        <param name="Q0">                           0.0001         0.0001       </param>
-        <param name="Q1">                           0.01           0.01         </param>
-        <param name="Q2">                           10             10           </param>
-        <param name="R">                            0.001          0.001        </param>
-        <param name="P0">                           0.000099       0.000099     </param>
+        <!--   l_shoulder_yaw l_elbow  -->
+        <param name="kalmanFilterEnabled">          1 1             </param>
+        <param name="x0">                           0 0             </param>
+        <param name="x1">                           0 0             </param>
+        <param name="x2">                           0 0             </param>
+        <param name="Q0">                           0.2756684257802634 0.24011183680211734             </param>
+        <param name="Q1">                           0.03904775806867904 0.009264685585729036             </param>
+        <param name="Q2">                           21.849246173875898 17.647257654493373             </param>
+        <param name="R">                            0.003015579996567686 2.0995366637460022             </param>
+        <param name="P0">                           0.005356139078526773 0.0034677361489434968             </param>
     </group>
-
 </device>

--- a/ergoCubSN002/hardware/motorControl/left_leg-eb8-j0_3-mc.xml
+++ b/ergoCubSN002/hardware/motorControl/left_leg-eb8-j0_3-mc.xml
@@ -149,15 +149,16 @@
 
     <!-- kalman filter parameters - vel & acc estimation -->
     <group name="KALMAN_FILTER">
-        <param name="kalmanFilterEnabled">          1              1            1            1          </param>
-        <param name="x0">                           0              0            0            0          </param>
-        <param name="x1">                           0              0            0            0          </param>
-        <param name="x2">                           0              0            0            0          </param>
-        <param name="Q0">                           0.0001         0.0001       0.0001       0.0001     </param>
-        <param name="Q1">                           0.01           0.01         0.01         0.01       </param>
-        <param name="Q2">                           10             10           10           10         </param>
-        <param name="R">                            0.001          0.001        0.001        0.001      </param>
-        <param name="P0">                           0.000099       0.000099     0.000099     0.000099   </param>
+        <!--   r_hip_pitch r_hip_roll r_hip_yaw r_knee  -->
+        <param name="kalmanFilterEnabled">          1 1 1 1             </param>
+        <param name="x0">                           0 0 0 0             </param>
+        <param name="x1">                           0 0 0 0             </param>
+        <param name="x2">                           0 0 0 0             </param>
+        <param name="Q0">                           8.694943028700485e-06 0.02299342017313577 5.975309759890053e-05 0.002794584633576471             </param>
+        <param name="Q1">                           0.03153414073716983 0.01315420400220786 0.003715031081672895 18.189126215815822             </param>
+        <param name="Q2">                           24.825700767466543 23.923499006956707 23.41797219027951 23.91783157509112             </param>
+        <param name="R">                            1.0808050166041467e-05 0.0002582883448288 0.0007343297845812892 0.0010151704179573824             </param>
+        <param name="P0">                           24.777097627155744 0.0003600638495648639 0.27246072693310697 24.964497730011175             </param>
     </group>
 
   </device>

--- a/ergoCubSN002/hardware/motorControl/left_leg-eb9-j4_5-mc.xml
+++ b/ergoCubSN002/hardware/motorControl/left_leg-eb9-j4_5-mc.xml
@@ -145,16 +145,17 @@
         <param name="deadZone">           0.0049      0.0049                      </param>
     </group>
 
-      <group name="KALMAN_FILTER">
-        <param name="kalmanFilterEnabled">        1            1          </param>
-        <param name="x0">                         0            0          </param>
-        <param name="x1">                         0            0          </param>
-        <param name="x2">                         0            0          </param>
-        <param name="Q0">                         0.0001       0.0001     </param>
-        <param name="Q1">                         0.01         0.01       </param>
-        <param name="Q2">                         10           10         </param>
-        <param name="R">                          0.001        0.001      </param>
-        <param name="P0">                         0.000099     0.000099   </param>
+    <group name="KALMAN_FILTER">
+        <!--   l_ankle_pitch l_ankle_roll  -->
+        <param name="kalmanFilterEnabled">          1 1             </param>
+        <param name="x0">                           0 0             </param>
+        <param name="x1">                           0 0             </param>
+        <param name="x2">                           0 0             </param>
+        <param name="Q0">                           4.12757331245975e-05 0.0005183153268715309             </param>
+        <param name="Q1">                           0.001116964905379183 4.509214333909854e-05             </param>
+        <param name="Q2">                           24.04514971535973 24.633769492062207             </param>
+        <param name="R">                            0.003405703420277709 0.0028263715927911433             </param>
+        <param name="P0">                           0.012275195953601945 0.0018151762665663265             </param>
     </group>
 
 </device>

--- a/ergoCubSN002/hardware/motorControl/right_arm-eb1-j0_1-mc.xml
+++ b/ergoCubSN002/hardware/motorControl/right_arm-eb1-j0_1-mc.xml
@@ -150,15 +150,16 @@
 
     <!-- kalman filter parameters - vel & acc estimation -->
     <group name="KALMAN_FILTER">
-        <param name="kalmanFilterEnabled">          1              1            </param>
-        <param name="x0">                           0              0            </param>
-        <param name="x1">                           0              0            </param>
-        <param name="x2">                           0              0            </param>
-        <param name="Q0">                           0.0001         0.0001       </param>
-        <param name="Q1">                           0.01           0.01         </param>
-        <param name="Q2">                           10             10           </param>
-        <param name="R">                            0.001          0.001        </param>
-        <param name="P0">                           0.000099       0.000099     </param>
+        <!--   r_shoulder_pitch r_shoulder_roll  -->
+        <param name="kalmanFilterEnabled">          1 1             </param>
+        <param name="x0">                           0 0             </param>
+        <param name="x1">                           0 0             </param>
+        <param name="x2">                           0 0             </param>
+        <param name="Q0">                           0.13833218659752797 0.02496498679008257             </param>
+        <param name="Q1">                           0.0005609958935385298 0.0006741162031216767             </param>
+        <param name="Q2">                           24.751618945684292 7.089049176661524             </param>
+        <param name="R">                            0.16073791920934014 0.191050883655292             </param>
+        <param name="P0">                           0.001149718101396471 0.00459807602310151             </param>
     </group>
 
   </device>

--- a/ergoCubSN002/hardware/motorControl/right_arm-eb3-j2_3-mc.xml
+++ b/ergoCubSN002/hardware/motorControl/right_arm-eb3-j2_3-mc.xml
@@ -150,15 +150,16 @@
 
     <!-- kalman filter parameters - vel & acc estimation -->
     <group name="KALMAN_FILTER">
-        <param name="kalmanFilterEnabled">          1              1            </param>
-        <param name="x0">                           0              0            </param>
-        <param name="x1">                           0              0            </param>
-        <param name="x2">                           0              0            </param>
-        <param name="Q0">                           0.0001         0.0001       </param>
-        <param name="Q1">                           0.01           0.01         </param>
-        <param name="Q2">                           10             10           </param>
-        <param name="R">                            0.001          0.001        </param>
-        <param name="P0">                           0.000099       0.000099     </param>
+        <!--   r_shoulder_yaw r_elbow  -->
+        <param name="kalmanFilterEnabled">          1 1             </param>
+        <param name="x0">                           0 0             </param>
+        <param name="x1">                           0 0             </param>
+        <param name="x2">                           0 0             </param>
+        <param name="Q0">                           0.009915605595929808 0.3552624223658944             </param>
+        <param name="Q1">                           1.0741346214220888e-05 0.003424062256619634             </param>
+        <param name="Q2">                           19.0376844416694 21.531691817600407             </param>
+        <param name="R">                            0.005766247216038234 1.48090787578863             </param>
+        <param name="P0">                           0.0005652829757605873 0.009204540998227043             </param>
     </group>
 
   </device>

--- a/ergoCubSN002/hardware/motorControl/right_leg-eb6-j0_3-mc.xml
+++ b/ergoCubSN002/hardware/motorControl/right_leg-eb6-j0_3-mc.xml
@@ -149,15 +149,16 @@
 
     <!-- kalman filter parameters - vel & acc estimation -->
     <group name="KALMAN_FILTER">
-        <param name="kalmanFilterEnabled">          1              1            1            1          </param>
-        <param name="x0">                           0              0            0            0          </param>
-        <param name="x1">                           0              0            0            0          </param>
-        <param name="x2">                           0              0            0            0          </param>
-        <param name="Q0">                           0.0001         0.0001       0.0001       0.0001     </param>
-        <param name="Q1">                           0.01           0.01         0.01         0.01       </param>
-        <param name="Q2">                           10             10           10           10         </param>
-        <param name="R">                            0.001          0.001        0.001        0.001      </param>
-        <param name="P0">                           0.000099       0.000099     0.000099     0.000099   </param>
+        <!--   r_hip_pitch r_hip_roll r_hip_yaw r_knee  -->
+        <param name="kalmanFilterEnabled">          1 1 1 1             </param>
+        <param name="x0">                           0 0 0 0             </param>
+        <param name="x1">                           0 0 0 0             </param>
+        <param name="x2">                           0 0 0 0             </param>
+        <param name="Q0">                           8.694943028700485e-06 0.02299342017313577 5.975309759890053e-05 0.002794584633576471             </param>
+        <param name="Q1">                           0.03153414073716983 0.01315420400220786 0.003715031081672895 18.189126215815822             </param>
+        <param name="Q2">                           24.825700767466543 23.923499006956707 23.41797219027951 23.91783157509112             </param>
+        <param name="R">                            1.0808050166041467e-05 0.0002582883448288 0.0007343297845812892 0.0010151704179573824             </param>
+        <param name="P0">                           24.777097627155744 0.0003600638495648639 0.27246072693310697 24.964497730011175             </param>
     </group>
 
   </device>

--- a/ergoCubSN002/hardware/motorControl/right_leg-eb7-j4_5-mc.xml
+++ b/ergoCubSN002/hardware/motorControl/right_leg-eb7-j4_5-mc.xml
@@ -145,16 +145,16 @@
         <param name="deadZone">                 0.011              0.011              </param>
     </group>
 
-  <group name="KALMAN_FILTER">
-        <param name="kalmanFilterEnabled">        1            1          </param>
-        <param name="x0">                         0            0          </param>
-        <param name="x1">                         0            0          </param>
-        <param name="x2">                         0            0          </param>
-        <param name="Q0">                         0.0001       0.0001     </param>
-        <param name="Q1">                         0.01         0.01       </param>
-        <param name="Q2">                         10           10         </param>
-        <param name="R">                          0.001        0.001      </param>
-        <param name="P0">                         0.000099     0.000099   </param>
+    <group name="KALMAN_FILTER">
+        <!--   r_ankle_pitch r_ankle_roll  -->
+        <param name="kalmanFilterEnabled">          1 1             </param>
+        <param name="x0">                           0 0             </param>
+        <param name="x1">                           0 0             </param>
+        <param name="x2">                           0 0             </param>
+        <param name="Q0">                           5.131500755615346e-06 0.00016486542874413732             </param>
+        <param name="Q1">                           0.0002394581180587153 5.9446836582113574e-05             </param>
+        <param name="Q2">                           24.800150622078803 24.471668575822928             </param>
+        <param name="R">                            2.0531857814388692e-05 0.003329749020748807             </param>
+        <param name="P0">                           0.003343795067559131 0.38134537532629503             </param>
     </group>
-    
 </device>

--- a/ergoCubSN002/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/ergoCubSN002/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -127,4 +127,16 @@
         <param name="deadZone">             0.0049      0.0049      0.0049  </param>
     </group>
 
+    <group name="KALMAN_FILTER">
+        <!--   torso_roll torso_pitch torso_yaw  -->
+        <param name="kalmanFilterEnabled">          1 1 1             </param>
+        <param name="x0">                           0 0 0             </param>
+        <param name="x1">                           0 0 0             </param>
+        <param name="x2">                           0 0 0             </param>
+        <param name="Q0">                           0.0002531597161334673 0.0007201042934751647 0.00024269663493518243             </param>
+        <param name="Q1">                           0.022162080623563264 0.008036781145026697 0.006910957225514555             </param>
+        <param name="Q2">                           23.988142473281066 24.78174797120868 24.400697067208775             </param>
+        <param name="R">                            0.0007037200315177511 0.003027567532311685 0.013873538944015959             </param>
+        <param name="P0">                           0.021233364199551377 0.0017943885448779256 0.31787791884813843             </param>
+    </group>
 </device>


### PR DESCRIPTION
This PR tunes the gains of the Kalman filter for the joint velocities and acceleration in the EMS.



The filter has been tuned by an automatic procedure that is explained in https://github.com/ami-iit/component_bipedal-locomotion/issues/157

Here are some results for several joints, with both datasets collected while the robot was walking:


## Velocity [rad/s]

|Joint | With the gains proposed | The value currently saved in robots-configuration |
|:----:|:-----------:|:------------:|
| torso roll |  ![image](https://github.com/robotology/robots-configuration/assets/16744101/3b7b9fed-08c8-4ede-af55-4ea54252812c) | ![image](https://github.com/robotology/robots-configuration/assets/16744101/78b00a84-f83f-4581-9111-539f57efbdcb) |
|l hip roll | ![image](https://github.com/robotology/robots-configuration/assets/16744101/9edf0b76-6ab7-4c0d-a3fb-f2075fc97bc1) | ![image](https://github.com/robotology/robots-configuration/assets/16744101/8eeeb94b-af66-4b30-9fb4-db8011e1cd0f) |


## Acceleration [rad/s^2]

|Joint | With the gains proposed | The value currently saved in robots-configuration |
|:----:|:-----------:|:------------:|
| torso roll |  ![image](https://github.com/robotology/robots-configuration/assets/16744101/c8b2ca45-b862-4621-825c-fa01c3879695) | ![image](https://github.com/robotology/robots-configuration/assets/16744101/4860e954-c781-40c4-8db7-4fccfb9c1992) |
|l hip roll | ![image](https://github.com/robotology/robots-configuration/assets/16744101/126cec91-9173-4fa3-8c3a-e581660b957c) | ![image](https://github.com/robotology/robots-configuration/assets/16744101/2d277c48-a144-41c5-9624-9e3339582a13) |


> [!IMPORTANT]  
> According to the plots, the velocity/acceleration of the torso roll appears smoother. This is likely because the original configuration did not enable the Kalman filter for the torso roll.

cc @isorrentino @DanielePucci 