### PR TITLE
[ergoCubSN002] Increase the low level frequency to 1kHz

### DIFF
--- a/ergoCubSN002/estimators/wholebodydynamics.xml
+++ b/ergoCubSN002/estimators/wholebodydynamics.xml
@@ -17,7 +17,7 @@
   <param name="forceTorqueFilterCutoffInHz">3.0</param>
   <param name="jointVelFilterCutoffInHz">3.0</param> <!-- used if useJointVelocity is set to true -->
   <param name="jointAccFilterCutoffInHz">3.0</param> <!-- used if useJointAcceleration is set to true -->
-  <param name="devicePeriodInSeconds">0.002</param>
+  <param name="devicePeriodInSeconds">0.001</param>
   <param name="useSkinForContacts">false</param>
   <param name="publishNetExternalWrenches">true</param>
   <!--<param name="assume_fixed">root_link</param>-->

--- a/ergoCubSN002/hardware/FT/left_arm-eb2-j0_1-strain.xml
+++ b/ergoCubSN002/hardware/FT/left_arm-eb2-j0_1-strain.xml
@@ -1,4 +1,3 @@
-
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
@@ -40,7 +39,7 @@
 
             <group name="SETTINGS">        
                 <param name="enabledSensors">       l_arm_ft               </param>
-                <param name="ftPeriod">             2         		                    </param>
+                <param name="ftPeriod">             1         		                    </param>
                 <param name="temperaturePeriod">    1000      		                   </param>
                 <param name="useCalibration">       true      		              </param>           
             </group>       

--- a/ergoCubSN002/hardware/FT/left_leg-eb8-j0_3-strain.xml
+++ b/ergoCubSN002/hardware/FT/left_leg-eb8-j0_3-strain.xml
@@ -39,7 +39,7 @@
 
             <group name="SETTINGS">
                 <param name="enabledSensors">       l_leg_ft              </param>
-                <param name="ftPeriod">             2         		                    </param>
+                <param name="ftPeriod">             1         		                    </param>
                 <param name="temperaturePeriod">    1000      		                   </param>
                 <param name="useCalibration">       true      		              </param>
             </group>

--- a/ergoCubSN002/hardware/FT/left_leg-eb9-j4_5-strain.xml
+++ b/ergoCubSN002/hardware/FT/left_leg-eb9-j4_5-strain.xml
@@ -38,8 +38,8 @@
             </group>
 
             <group name="SETTINGS">        
-                <param name="enabledSensors">       l_foot_rear_ft          l_foot_front_ft      </param>
-                <param name="ftPeriod">             2         		 2                     </param>
+                <param name="enabledSensors">       l_foot_rear_ft       l_foot_front_ft      </param>
+                <param name="ftPeriod">             1         		 1                     </param>
                 <param name="temperaturePeriod">    1000      		 1000                    </param>
                 <param name="useCalibration">       true      		 true                 </param>           
             </group>       

--- a/ergoCubSN002/hardware/FT/right_arm-eb1-j0_1-strain.xml
+++ b/ergoCubSN002/hardware/FT/right_arm-eb1-j0_1-strain.xml
@@ -40,7 +40,7 @@
 
             <group name="SETTINGS">        
                 <param name="enabledSensors">       r_arm_ft               </param>
-                <param name="ftPeriod">             2         		                    </param>
+                <param name="ftPeriod">             1         		                    </param>
                 <param name="temperaturePeriod">    1000      		                   </param>
                 <param name="useCalibration">       true      		              </param>           
             </group>       

--- a/ergoCubSN002/hardware/FT/right_leg-eb6-j0_3-strain.xml
+++ b/ergoCubSN002/hardware/FT/right_leg-eb6-j0_3-strain.xml
@@ -39,7 +39,7 @@
 
             <group name="SETTINGS">
                 <param name="enabledSensors">       r_leg_ft           </param>
-                <param name="ftPeriod">             2         		                    </param>
+                <param name="ftPeriod">             1         		                    </param>
                 <param name="temperaturePeriod">    1000      		                   </param>
                 <param name="useCalibration">       true      		              </param>
             </group>

--- a/ergoCubSN002/hardware/FT/right_leg-eb7-j4_5-strain.xml
+++ b/ergoCubSN002/hardware/FT/right_leg-eb7-j4_5-strain.xml
@@ -39,7 +39,7 @@
 
             <group name="SETTINGS">        
                 <param name="enabledSensors">       r_foot_rear_ft          r_foot_front_ft       </param>
-                <param name="ftPeriod">             2         		 2                     </param>
+                <param name="ftPeriod">             1         		 1                        </param>
                 <param name="temperaturePeriod">    1000      		 1000                    </param>
                 <param name="useCalibration">       true      		 true                 </param>           
             </group>       

--- a/ergoCubSN002/hardware/electronics/head-eb20-j0_1-eln.xml
+++ b/ergoCubSN002/hardware/electronics/head-eb20-j0_1-eln.xml
@@ -22,7 +22,7 @@
                 <param name="maxTimeOfRXactivity">      400                 </param>
                 <param name="maxTimeOfDOactivity">      300                 </param>
                 <param name="maxTimeOfTXactivity">      300                 </param>
-                <param name="TXrateOfRegularROPs">      2                   </param>
+                <param name="TXrateOfRegularROPs">      1                   </param>
             </group>
         </group>
 

--- a/ergoCubSN002/hardware/electronics/head-eb21-j2_3-eln.xml
+++ b/ergoCubSN002/hardware/electronics/head-eb21-j2_3-eln.xml
@@ -22,7 +22,7 @@
                 <param name="maxTimeOfRXactivity">      400                 </param>
                 <param name="maxTimeOfDOactivity">      300                 </param>
                 <param name="maxTimeOfTXactivity">      300                 </param>
-                <param name="TXrateOfRegularROPs">      2                   </param>
+                <param name="TXrateOfRegularROPs">      1                   </param>
             </group>
         </group>
 

--- a/ergoCubSN002/hardware/electronics/left_arm-eb2-j0_1-eln.xml
+++ b/ergoCubSN002/hardware/electronics/left_arm-eb2-j0_1-eln.xml
@@ -22,7 +22,7 @@
                 <param name="maxTimeOfRXactivity">      400                 </param>
                 <param name="maxTimeOfDOactivity">      300                 </param>   
                 <param name="maxTimeOfTXactivity">      300                 </param>                
-                <param name="TXrateOfRegularROPs">      2                   </param> 
+                <param name="TXrateOfRegularROPs">      1                   </param> 
             </group>              
         </group>                 
         

--- a/ergoCubSN002/hardware/electronics/left_arm-eb23-j7_10-eln.xml
+++ b/ergoCubSN002/hardware/electronics/left_arm-eb23-j7_10-eln.xml
@@ -22,7 +22,7 @@
                 <param name="maxTimeOfRXactivity">      400                 </param>
                 <param name="maxTimeOfDOactivity">      300                 </param>
                 <param name="maxTimeOfTXactivity">      300                 </param>
-                <param name="TXrateOfRegularROPs">      2                   </param>
+                <param name="TXrateOfRegularROPs">      1                   </param>
             </group>
         </group>
 

--- a/ergoCubSN002/hardware/electronics/left_arm-eb25-j11_12-eln.xml
+++ b/ergoCubSN002/hardware/electronics/left_arm-eb25-j11_12-eln.xml
@@ -22,7 +22,7 @@
                 <param name="maxTimeOfRXactivity">      400                           </param>
                 <param name="maxTimeOfDOactivity">      300                           </param>
                 <param name="maxTimeOfTXactivity">      300                           </param>
-                <param name="TXrateOfRegularROPs">      2                             </param>
+                <param name="TXrateOfRegularROPs">      1                             </param>
             </group>
         </group>
 

--- a/ergoCubSN002/hardware/electronics/left_arm-eb31-j4_6-eln.xml
+++ b/ergoCubSN002/hardware/electronics/left_arm-eb31-j4_6-eln.xml
@@ -22,7 +22,7 @@
                 <param name="maxTimeOfRXactivity">      400                 </param>
                 <param name="maxTimeOfDOactivity">      300                 </param>
                 <param name="maxTimeOfTXactivity">      300                 </param>
-                <param name="TXrateOfRegularROPs">      2                   </param>
+                <param name="TXrateOfRegularROPs">      1                   </param>
             </group>
         </group>
 

--- a/ergoCubSN002/hardware/electronics/left_arm-eb4-j2_3-eln.xml
+++ b/ergoCubSN002/hardware/electronics/left_arm-eb4-j2_3-eln.xml
@@ -22,7 +22,7 @@
                 <param name="maxTimeOfRXactivity">      400                 </param>
                 <param name="maxTimeOfDOactivity">      300                 </param>   
                 <param name="maxTimeOfTXactivity">      300                 </param>                
-                <param name="TXrateOfRegularROPs">      2                   </param> 
+                <param name="TXrateOfRegularROPs">      1                   </param> 
             </group>              
         </group>                 
         

--- a/ergoCubSN002/hardware/electronics/left_leg-eb8-j0_3-eln.xml
+++ b/ergoCubSN002/hardware/electronics/left_leg-eb8-j0_3-eln.xml
@@ -22,7 +22,7 @@
                 <param name="maxTimeOfRXactivity">      300                 </param>
                 <param name="maxTimeOfDOactivity">      350                 </param>   
                 <param name="maxTimeOfTXactivity">      350                 </param>                
-                <param name="TXrateOfRegularROPs">      2                   </param> 
+                <param name="TXrateOfRegularROPs">      1                   </param> 
             </group>              
         </group>                 
         

--- a/ergoCubSN002/hardware/electronics/left_leg-eb9-j4_5-eln.xml
+++ b/ergoCubSN002/hardware/electronics/left_leg-eb9-j4_5-eln.xml
@@ -22,7 +22,7 @@
                 <param name="maxTimeOfRXactivity">      400                 </param>
                 <param name="maxTimeOfDOactivity">      300                 </param>   
                 <param name="maxTimeOfTXactivity">      300                 </param>                
-                <param name="TXrateOfRegularROPs">      2                   </param> 
+                <param name="TXrateOfRegularROPs">      1                   </param> 
             </group>              
         </group>                 
         

--- a/ergoCubSN002/hardware/electronics/pc104.xml
+++ b/ergoCubSN002/hardware/electronics/pc104.xml
@@ -7,7 +7,7 @@
         <param name="PC104IpAddress">           10.0.1.104      </param>
         <param name="PC104IpPort">              12345           </param>
         <param name="PC104TXrate">              1               </param> 
-        <param name="PC104RXrate">              2               </param>
+        <param name="PC104RXrate">              1               </param>
     </group>
 
         <group name="DEBUG">

--- a/ergoCubSN002/hardware/electronics/right_arm-eb1-j0_1-eln.xml
+++ b/ergoCubSN002/hardware/electronics/right_arm-eb1-j0_1-eln.xml
@@ -22,7 +22,7 @@
                 <param name="maxTimeOfRXactivity">      400                 </param>
                 <param name="maxTimeOfDOactivity">      300                 </param>   
                 <param name="maxTimeOfTXactivity">      300                 </param>                
-                <param name="TXrateOfRegularROPs">      2                   </param> 
+                <param name="TXrateOfRegularROPs">      1                   </param> 
             </group>              
         </group>                 
         

--- a/ergoCubSN002/hardware/electronics/right_arm-eb22-j7_10-eln.xml
+++ b/ergoCubSN002/hardware/electronics/right_arm-eb22-j7_10-eln.xml
@@ -22,7 +22,7 @@
                 <param name="maxTimeOfRXactivity">      400                           </param>
                 <param name="maxTimeOfDOactivity">      300                           </param>
                 <param name="maxTimeOfTXactivity">      300                           </param>
-                <param name="TXrateOfRegularROPs">      2                             </param>
+                <param name="TXrateOfRegularROPs">      1                             </param>
             </group>
         </group>
 

--- a/ergoCubSN002/hardware/electronics/right_arm-eb24-j11_12-eln.xml
+++ b/ergoCubSN002/hardware/electronics/right_arm-eb24-j11_12-eln.xml
@@ -22,7 +22,7 @@
                 <param name="maxTimeOfRXactivity">      400                           </param>
                 <param name="maxTimeOfDOactivity">      300                           </param>
                 <param name="maxTimeOfTXactivity">      300                           </param>
-                <param name="TXrateOfRegularROPs">      2                             </param>
+                <param name="TXrateOfRegularROPs">      1                             </param>
             </group>
         </group>
 

--- a/ergoCubSN002/hardware/electronics/right_arm-eb3-j2_3-eln.xml
+++ b/ergoCubSN002/hardware/electronics/right_arm-eb3-j2_3-eln.xml
@@ -22,7 +22,7 @@
                 <param name="maxTimeOfRXactivity">      400                 </param>
                 <param name="maxTimeOfDOactivity">      300                 </param>   
                 <param name="maxTimeOfTXactivity">      300                 </param>                
-                <param name="TXrateOfRegularROPs">      2                   </param> 
+                <param name="TXrateOfRegularROPs">      1                   </param> 
             </group>              
         </group>                 
         

--- a/ergoCubSN002/hardware/electronics/right_arm-eb30-j4_6-eln.xml
+++ b/ergoCubSN002/hardware/electronics/right_arm-eb30-j4_6-eln.xml
@@ -22,7 +22,7 @@
                 <param name="maxTimeOfRXactivity">      400                 </param>
                 <param name="maxTimeOfDOactivity">      300                 </param>
                 <param name="maxTimeOfTXactivity">      300                 </param>
-                <param name="TXrateOfRegularROPs">      2                   </param>
+                <param name="TXrateOfRegularROPs">      1                   </param>
             </group>
         </group>
 

--- a/ergoCubSN002/hardware/electronics/right_leg-eb6-j0_3-eln.xml
+++ b/ergoCubSN002/hardware/electronics/right_leg-eb6-j0_3-eln.xml
@@ -22,7 +22,7 @@
                 <param name="maxTimeOfRXactivity">      300                 </param>
                 <param name="maxTimeOfDOactivity">      350                 </param>   
                 <param name="maxTimeOfTXactivity">      350                 </param>                
-                <param name="TXrateOfRegularROPs">      2                   </param> 
+                <param name="TXrateOfRegularROPs">      1                   </param> 
             </group>              
         </group>                 
         

--- a/ergoCubSN002/hardware/electronics/right_leg-eb7-j4_5-eln.xml
+++ b/ergoCubSN002/hardware/electronics/right_leg-eb7-j4_5-eln.xml
@@ -22,7 +22,7 @@
                 <param name="maxTimeOfRXactivity">      400                 </param>
                 <param name="maxTimeOfDOactivity">      300                 </param>   
                 <param name="maxTimeOfTXactivity">      300                 </param>                
-                <param name="TXrateOfRegularROPs">      2                   </param> 
+                <param name="TXrateOfRegularROPs">      1                   </param> 
             </group>              
         </group>                 
         

--- a/ergoCubSN002/hardware/electronics/torso-eb5-j0_2-eln.xml
+++ b/ergoCubSN002/hardware/electronics/torso-eb5-j0_2-eln.xml
@@ -22,7 +22,7 @@
                 <param name="maxTimeOfRXactivity">      400                 </param>
                 <param name="maxTimeOfDOactivity">      300                 </param>   
                 <param name="maxTimeOfTXactivity">      300                 </param>                
-                <param name="TXrateOfRegularROPs">      2                   </param> 
+                <param name="TXrateOfRegularROPs">      1                   </param> 
             </group>              
         </group>                 
         

--- a/ergoCubSN002/wrappers/motorControl/head-mc_wrapper.xml
+++ b/ergoCubSN002/wrappers/motorControl/head-mc_wrapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="head-mc_nws_yarp" type="controlBoard_nws_yarp">
-    <param name="period"> 0.002  </param>
+    <param name="period"> 0.001  </param>
     <param name="name"> /ergocub/head   </param>
     <action phase="startup" level="10" type="attach">
             <param name="device">  head-mc_remapper </param>

--- a/ergoCubSN002/wrappers/motorControl/left_arm-mc_wrapper.xml
+++ b/ergoCubSN002/wrappers/motorControl/left_arm-mc_wrapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mc_nws_yarp" type="controlBoard_nws_yarp">
-    <param name="period"> 0.002  </param>
+    <param name="period"> 0.001  </param>
     <param name="name"> /ergocub/left_arm </param>
     <action phase="startup" level="10" type="attach">
         <param name="device"> left_arm-mc_remapper </param>

--- a/ergoCubSN002/wrappers/motorControl/left_leg-mc_wrapper.xml
+++ b/ergoCubSN002/wrappers/motorControl/left_leg-mc_wrapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-mc_nws_yarp" type="controlBoard_nws_yarp">
-    <param name="period"> 0.002  </param>
+    <param name="period"> 0.001  </param>
     <param name="name"> /ergocub/left_leg </param>
     <action phase="startup" level="10" type="attach">
         <param name="device"> left_leg-mc_remapper </param>

--- a/ergoCubSN002/wrappers/motorControl/right_arm-mc_wrapper.xml
+++ b/ergoCubSN002/wrappers/motorControl/right_arm-mc_wrapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-mc_nws_yarp" type="controlBoard_nws_yarp">
-    <param name="period"> 0.002  </param>
+    <param name="period"> 0.001  </param>
     <param name="name"> /ergocub/right_arm </param>
     <action phase="startup" level="10" type="attach">
         <param name="device"> right_arm-mc_remapper </param>

--- a/ergoCubSN002/wrappers/motorControl/right_leg-mc_wrapper.xml
+++ b/ergoCubSN002/wrappers/motorControl/right_leg-mc_wrapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-mc_nws_yarp" type="controlBoard_nws_yarp">
-    <param name="period"> 0.002  </param>
+    <param name="period"> 0.001  </param>
     <param name="name"> /ergocub/right_leg </param>
     <action phase="startup" level="10" type="attach">
         <param name="device"> right_leg-mc_remapper </param>

--- a/ergoCubSN002/wrappers/motorControl/torso-mc_wrapper.xml
+++ b/ergoCubSN002/wrappers/motorControl/torso-mc_wrapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="torso-mc_nws_yarp" type="controlBoard_nws_yarp">
-    <param name="period"> 0.002  </param>
+    <param name="period"> 0.001  </param>
     <param name="name"> /ergocub/torso </param>
     <action phase="startup" level="10" type="attach">
         <param name="device"> torso-mc_remapper </param>


### PR DESCRIPTION
This PR increases the wbd frequency and the associated devices to 1kHz. This PR has been tested with the latest devel firmware in devel https://github.com/robotology/icub-firmware-build/commit/10d4984af397f7b9d456cad317bee56d0b6cfa92.

Thanks to this PR we were also able to increase the frequency of the walking (from 500Hz to 1kHz)
