### PR TITLE
Rename alljoints-inertials port to avoid using portprefix

### DIFF
--- a/ergoCubSN000/wrappers/inertials/alljoints-inertials_wrapper.xml
+++ b/ergoCubSN000/wrappers/inertials/alljoints-inertials_wrapper.xml
@@ -3,7 +3,7 @@
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_wrapper" type="multipleanalogsensorsserver">
     <param name="period">      10                           </param>
-    <param name="name"> /${portprefix}/alljoints/inertials   </param>
+    <param name="name"> /ergocub/alljoints/inertials   </param>
 
     <action phase="startup" level="10" type="attach">
         <paramlist name="networks">

--- a/ergoCubSN001/wrappers/inertials/alljoints-inertials_wrapper.xml
+++ b/ergoCubSN001/wrappers/inertials/alljoints-inertials_wrapper.xml
@@ -3,7 +3,7 @@
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_wrapper" type="multipleanalogsensorsserver">
     <param name="period">      10                           </param>
-    <param name="name"> /${portprefix}/alljoints/inertials   </param>
+    <param name="name"> /ergocub/alljoints/inertials   </param>
 
     <action phase="startup" level="10" type="attach">
         <paramlist name="networks">

--- a/ergoCubSN002/wrappers/inertials/alljoints-inertials_wrapper.xml
+++ b/ergoCubSN002/wrappers/inertials/alljoints-inertials_wrapper.xml
@@ -3,7 +3,7 @@
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_wrapper" type="multipleanalogsensorsserver">
     <param name="period">      10                           </param>
-    <param name="name"> /${portprefix}/alljoints/inertials   </param>
+    <param name="name"> /ergocub/alljoints/inertials   </param>
 
     <action phase="startup" level="10" type="attach">
         <paramlist name="networks">

--- a/iCubGenova07/wrappers/inertials/alljoints-inertials_wrapper.xml
+++ b/iCubGenova07/wrappers/inertials/alljoints-inertials_wrapper.xml
@@ -3,7 +3,7 @@
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_wrapper" type="multipleanalogsensorsserver">
     <param name="period">      10                           </param>
-    <param name="name"> /${portprefix}/alljoints/inertials   </param>
+    <param name="name"> /icub/alljoints/inertials   </param>
 
     <action phase="startup" level="10" type="attach">
         <paramlist name="networks">

--- a/iCubGenova11/wrappers/inertials/alljoints-inertials_wrapper.xml
+++ b/iCubGenova11/wrappers/inertials/alljoints-inertials_wrapper.xml
@@ -3,7 +3,7 @@
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_wrapper" type="multipleanalogsensorsserver">
     <param name="period">      10                           </param>
-    <param name="name"> /${portprefix}/alljoints/inertials   </param>
+    <param name="name"> /icub/alljoints/inertials   </param>
 
     <action phase="startup" level="10" type="attach">
         <paramlist name="networks">

--- a/iCubLisboa01/wrappers/inertials/alljoints-inertials_wrapper.xml
+++ b/iCubLisboa01/wrappers/inertials/alljoints-inertials_wrapper.xml
@@ -3,7 +3,7 @@
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_wrapper" type="multipleanalogsensorsserver">
     <param name="period">      10                           </param>
-    <param name="name"> /${portprefix}/alljoints/inertials   </param>
+    <param name="name"> /icub/alljoints/inertials   </param>
 
     <action phase="startup" level="10" type="attach">
         <paramlist name="networks">

--- a/iCubPrague01/wrappers/inertials/alljoints-inertials_wrapper.xml
+++ b/iCubPrague01/wrappers/inertials/alljoints-inertials_wrapper.xml
@@ -3,7 +3,7 @@
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_wrapper" type="multipleanalogsensorsserver">
     <param name="period">      10                           </param>
-    <param name="name"> /${portprefix}/alljoints/inertials   </param>
+    <param name="name"> /icub/alljoints/inertials   </param>
 
     <action phase="startup" level="10" type="attach">
         <paramlist name="networks">

--- a/iCubShanghai01/wrappers/inertials/alljoints-inertials_wrapper.xml
+++ b/iCubShanghai01/wrappers/inertials/alljoints-inertials_wrapper.xml
@@ -3,7 +3,7 @@
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_wrapper" type="multipleanalogsensorsserver">
     <param name="period">      10                           </param>
-    <param name="name"> /${portprefix}/alljoints/inertials   </param>
+    <param name="name"> /icub/alljoints/inertials   </param>
 
     <action phase="startup" level="10" type="attach">
         <paramlist name="networks">

--- a/iCubShenzhen01/wrappers/inertials/alljoints-inertials_wrapper.xml
+++ b/iCubShenzhen01/wrappers/inertials/alljoints-inertials_wrapper.xml
@@ -3,7 +3,7 @@
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_wrapper" type="multipleanalogsensorsserver">
     <param name="period">      10                           </param>
-    <param name="name"> /${portprefix}/alljoints/inertials   </param>
+    <param name="name"> /icub}/alljoints/inertials   </param>
 
     <action phase="startup" level="10" type="attach">
         <paramlist name="networks">

--- a/iCubShenzhen01/wrappers/inertials/alljoints-inertials_wrapper.xml
+++ b/iCubShenzhen01/wrappers/inertials/alljoints-inertials_wrapper.xml
@@ -3,7 +3,7 @@
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_wrapper" type="multipleanalogsensorsserver">
     <param name="period">      10                           </param>
-    <param name="name"> /icub}/alljoints/inertials   </param>
+    <param name="name"> /icub/alljoints/inertials   </param>
 
     <action phase="startup" level="10" type="attach">
         <paramlist name="networks">

--- a/iCubValparaiso01/wrappers/inertials/alljoints-inertials_wrapper.xml
+++ b/iCubValparaiso01/wrappers/inertials/alljoints-inertials_wrapper.xml
@@ -3,7 +3,7 @@
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_wrapper" type="multipleanalogsensorsserver">
     <param name="period">      10                           </param>
-    <param name="name"> /${portprefix}/alljoints/inertials   </param>
+    <param name="name"> /icub/alljoints/inertials   </param>
 
     <action phase="startup" level="10" type="attach">
         <paramlist name="networks">

--- a/iCubWaterloo01/wrappers/inertials/alljoints-inertials_wrapper.xml
+++ b/iCubWaterloo01/wrappers/inertials/alljoints-inertials_wrapper.xml
@@ -3,7 +3,7 @@
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_wrapper" type="multipleanalogsensorsserver">
     <param name="period">      10                           </param>
-    <param name="name"> /${portprefix}/alljoints/inertials   </param>
+    <param name="name"> /icub/alljoints/inertials   </param>
 
     <action phase="startup" level="10" type="attach">
         <paramlist name="networks">

--- a/iCubZagreb01/wrappers/inertials/alljoints-inertials_wrapper.xml
+++ b/iCubZagreb01/wrappers/inertials/alljoints-inertials_wrapper.xml
@@ -3,7 +3,7 @@
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_wrapper" type="multipleanalogsensorsserver">
     <param name="period">      10                           </param>
-    <param name="name"> /${portprefix}/alljoints/inertials   </param>
+    <param name="name"> /icub/alljoints/inertials   </param>
 
     <action phase="startup" level="10" type="attach">
         <paramlist name="networks">


### PR DESCRIPTION
With:

- https://github.com/robotology/robots-configuration/pull/632

I added the possibility of reading the Euler angles streamed by the IMUs wrapped up in a single port. I named the port as `/${portprefix}/alljoints/inertials` following what I've done and tested in simulation. Unfortunately, while working on the real robot, I found that the `portprefix` is not always defined in the configuration files and, if defined, is not always `icub` or `ergocub`. For example, on `ergoCubSN000`, that port is named `/ergoCubSN000/alljoints/inertials`.

This PR introduces the fix to have all the port names. I also made the change for the iCubs that expose those measurements. 

