### PR TITLE
ergoCubSN001-002: Update amcbdlc and amc versions

### DIFF
--- a/ergoCubSN001/hardware/motorControl/left_arm-eb31-j4_6-mc_service.xml
+++ b/ergoCubSN001/hardware/motorControl/left_arm-eb31-j4_6-mc_service.xml
@@ -21,8 +21,8 @@
                 </group>
                 <group name="FIRMWARE">
                     <param name="major">            2           3       </param>
-                    <param name="minor">            0           0       </param>
-                    <param name="build">            13          3       </param>
+                    <param name="minor">            1           1       </param>
+                    <param name="build">            0           0       </param>
                 </group>
             </group>
 

--- a/ergoCubSN001/hardware/motorControl/right_arm-eb30-j4_6-mc_service.xml
+++ b/ergoCubSN001/hardware/motorControl/right_arm-eb30-j4_6-mc_service.xml
@@ -21,8 +21,8 @@
                 </group>
                 <group name="FIRMWARE">
                     <param name="major">            2           3       </param>
-                    <param name="minor">            0           0       </param>
-                    <param name="build">            13          3       </param>
+                    <param name="minor">            1           1       </param>
+                    <param name="build">            0           0      </param>
                 </group>
             </group>
 

--- a/ergoCubSN002/hardware/motorControl/left_arm-eb31-j4_6-mc_service.xml
+++ b/ergoCubSN002/hardware/motorControl/left_arm-eb31-j4_6-mc_service.xml
@@ -21,8 +21,8 @@
                 </group>
                 <group name="FIRMWARE">
                     <param name="major">            2           3       </param>
-                    <param name="minor">            0           0       </param>
-                    <param name="build">            13          3       </param>
+                    <param name="minor">            1           1       </param>
+                    <param name="build">            0           0       </param>
                 </group>
             </group>
 

--- a/ergoCubSN002/hardware/motorControl/right_arm-eb30-j4_6-mc_service.xml
+++ b/ergoCubSN002/hardware/motorControl/right_arm-eb30-j4_6-mc_service.xml
@@ -21,8 +21,8 @@
                 </group>
                 <group name="FIRMWARE">
                     <param name="major">            2           3       </param>
-                    <param name="minor">            0           0       </param>
-                    <param name="build">            13          3       </param>
+                    <param name="minor">            0           1       </param>
+                    <param name="build">            13          0       </param>
                 </group>
             </group>
 

--- a/ergoCubSN002/hardware/motorControl/right_arm-eb30-j4_6-mc_service.xml
+++ b/ergoCubSN002/hardware/motorControl/right_arm-eb30-j4_6-mc_service.xml
@@ -21,8 +21,8 @@
                 </group>
                 <group name="FIRMWARE">
                     <param name="major">            2           3       </param>
-                    <param name="minor">            0           1       </param>
-                    <param name="build">            13          0       </param>
+                    <param name="minor">            1           1       </param>
+                    <param name="build">            0          0       </param>
                 </group>
             </group>
 


### PR DESCRIPTION
In relation to the latest PRs in icub-firmware (https://github.com/robotology/icub-firmware/pull/523) and icub-firmware-build (https://github.com/robotology/icub-firmware-build/pull/165), this PR updates the boards as per title:

AMC2C : 3.1
AMCBLDC: 2.1