### PR TITLE
Add files for 3encoders setup aksim+amo

### DIFF
--- a/experimentalSetups/threeEncodersJoint/calibrators/three-encoders-setup-calib.xml
+++ b/experimentalSetups/threeEncodersJoint/calibrators/three-encoders-setup-calib.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="three-encoders-setup-calibrator" type="parametricCalibratorEth">
+                <xi:include href="../general.xml" />
+                
+        <group name="GENERAL">
+            <param name="joints"> 1 </param> <!-- the number of joints of the robot part -->
+            <param name="deviceName"> threeEncodersSetupCalib </param>
+        </group>
+
+<group name="HOME">
+    <param name="positionHome">                         0                        </param>
+    <param name="velocityHome">                         20                       </param>
+</group>                                                              
+                                                                      
+                                                                      
+                                                                      
+<group name="CALIBRATION">                                            
+<!--                                                small                          -->
+<param name="calibrationType">                      12                       </param>
+                                                                                      <!--
+<param name="calibration1">                         58233                    </param> --> 
+<param name="calibration1">                         20934                    </param> <!-- 20934 amo (12) -4200 (10)  63820 aksim2-->
+<param name="calibration2">                         0                        </param> 
+<param name="calibration3">                         0                        </param> 
+                                                                      
+                                                                      
+<param name="calibration4">                         0                        </param>
+<param name="calibration5">                         0                        </param>
+<param name="calibrationZero">                      0                        </param> <!-- -100(10)-->
+<param name="calibrationDelta">                     0                        </param>
+                                                                      
+<param name="startupPosition">                      0                        </param>
+<param name="startupVelocity">                      30                       </param>
+<param name="startupMaxPwm">                        4000                     </param>
+<param name="startupPosThreshold">                  2                        </param>
+</group>
+
+ <!-- check old calibrator for the correct sequence, then ask to Randazz -->
+        <param name="CALIB_ORDER"> (0)  </param>
+
+        <action phase="startup" level="10" type="calibrate">
+            <param name="target">three-encoders-setup-mc_remapper</param>
+        </action>
+
+        <action phase="interrupt1" level="1" type="park">
+            <param name="target">three-encoders-setup-mc_remapper</param>
+        </action>
+
+        <action phase="interrupt3" level="1" type="abort" />
+
+    </device>

--- a/experimentalSetups/threeEncodersJoint/firmwareupdater.ini
+++ b/experimentalSetups/threeEncodersJoint/firmwareupdater.ini
@@ -1,0 +1,2 @@
+[DRIVERS]
+ETH "eth"

--- a/experimentalSetups/threeEncodersJoint/general.xml
+++ b/experimentalSetups/threeEncodersJoint/general.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="threeEncoders" build="1">
+  
+  <group name="GENERAL">
+      <param name="skipCalibration">    false  </param>
+      <param name="useRawEncoderData">  false  </param>
+      <param name="useLimitedPWM">      false  </param>
+      <param name="verbose">            false  </param>
+  </group>
+</params>

--- a/experimentalSetups/threeEncodersJoint/hardware/electronics/pc104.xml
+++ b/experimentalSetups/threeEncodersJoint/hardware/electronics/pc104.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="threeEncoders" build="1">
+
+    <group name="PC104">
+        <param name="PC104IpAddress">           10.0.1.104      </param>
+        <param name="PC104IpPort">              12345           </param>
+        <param name="PC104TXrate">              1               </param> 
+        <param name="PC104RXrate">              5               </param>
+    </group>
+
+</params>
+

--- a/experimentalSetups/threeEncodersJoint/hardware/electronics/three-encoders-setup-eln.xml
+++ b/experimentalSetups/threeEncodersJoint/hardware/electronics/three-encoders-setup-eln.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="three-encoders-setup" build="1">
+
+    <xi:include href="./pc104.xml" />
+    
+    <group name="ETH_BOARD">
+   
+        <group name="ETH_BOARD_PROPERTIES">
+            <param name="IpAddress">                10.0.1.1                </param>
+            <param name="IpPort">                   12345                   </param>
+            <param name="Type">                     ems4                    </param>
+            <param name="maxSizeRXpacket">          768                     </param>
+            <param name="maxSizeROP">               384                     </param>
+        </group>
+
+        <group name="ETH_BOARD_SETTINGS">
+            <param name="Name">                     "three-encoders-setup"        </param> 
+            <group name="RUNNINGMODE">
+                <param name="period">                   1000                </param>
+                <param name="maxTimeOfRXactivity">      400                 </param>
+                <param name="maxTimeOfDOactivity">      300                 </param>   
+                <param name="maxTimeOfTXactivity">      300                 </param>                
+                <param name="TXrateOfRegularROPs">      5                   </param> 
+            </group>              
+        </group>                 
+        
+        <group name="ETH_BOARD_ACTIONS">
+            <group name="MONITOR_ITS_PRESENCE">
+                <param name="enabled">                  true                </param> 
+                <param name="timeout">                  0.020               </param> 
+                <param name="periodOfMissingReport">    60.0                </param> 
+            </group>
+        </group>
+
+    </group>  
+
+</params>

--- a/experimentalSetups/threeEncodersJoint/hardware/mechanicals/three-encoders-setup-mec.xml
+++ b/experimentalSetups/threeEncodersJoint/hardware/mechanicals/three-encoders-setup-mec.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="three-encoders-setup" build="1">
+    <group name="GENERAL">
+        <param name="MotioncontrolVersion"> 6 </param>
+        <param name="Joints"> 1 </param> 
+        <param name="AxisMap">              0                         </param>   
+        <param name="AxisName">             "three_encoders_joint"    </param>
+        <param name="AxisType">             "revolute"                </param>
+        <param name="Encoder">              182.044                   </param>
+        <param name="fullscalePWM">         32000                     </param>
+        <param name="ampsToSensor">         1000.0                    </param>
+        <param name="Gearbox_M2J">          100                       </param>
+        <param name="Gearbox_E2J">          1                         </param> <!--64 when using AMO  1 when using aksim (is the number of sectors)-->
+        <param name="useMotorSpeedFbk">     1                         </param> 
+        <param name="MotorType">            "MOOG_C2900576"           </param>
+        <param name="Verbose"> 0 </param>                    
+    </group>                                                 
+                                                             
+    <group name="LIMITS">                                    
+        <param name="hardwareJntPosMax">    180                  </param>
+        <param name="hardwareJntPosMin">    -180                  </param>
+        <param name="rotorPosMin">          0                    </param> 
+        <param name="rotorPosMax">          0                    </param>
+    </group>                                                 
+                                                             
+    <group name="2FOC">                                      
+        <param name="Verbose">              0                    </param>
+        <param name="AutoCalibration">      0                    </param>
+        <param name="HasHallSensor">        0                    </param>
+        <param name="HasTempSensor">        0                    </param>
+        <param name="HasRotorEncoder">      1                    </param>
+        <param name="HasRotorEncoderIndex"> 1                    </param>
+        <param name="HasSpeedEncoder">      0                    </param>
+        <param name="RotorIndexOffset">     230                 </param>
+        <param name="MotorPoles">           20                   </param>
+   </group>
+
+    <group name="COUPLINGS"> 
+        <param name ="matrixJ2M"> 
+            1.000    0.000    0.000    0.000
+            0.000    1.000    0.000    0.000
+            0.000    0.000    1.000    0.000
+            0.000    0.000    0.000    1.000   
+        </param>
+
+        <param name ="matrixM2J"> 
+            1.000    0.000    0.000    0.000
+            0.000    1.000    0.000    0.000
+            0.000    0.000    1.000    0.000
+            0.000    0.000    0.000    1.000   
+        </param>
+       
+        <param name ="matrixE2J">  
+            1.00    0.00    0.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00    0.00    0.00
+            0.00    0.00    1.00    0.00    0.00    0.00
+            0.00    0.00    0.00    1.00    0.00    0.00   
+        </param>
+    </group>                
+    
+    <group name="JOINTSET_CFG"> 
+        <param name= "numberofsets"> 1 </param>
+        <group name="JOINTSET_0">
+            <param name="listofjoints">  0             </param>
+            <param name="constraint">    none          </param>
+            <param name="param1">        0             </param>
+            <param name="param2">        0             </param>
+        </group> 
+    </group>                     
+ 
+</params>

--- a/experimentalSetups/threeEncodersJoint/hardware/motorControl/three-encoders-setup-mc.xml
+++ b/experimentalSetups/threeEncodersJoint/hardware/motorControl/three-encoders-setup-mc.xml
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="three-encoders-setup-mc" type="embObjMotionControl">
+
+    <xi:include href="../../general.xml" />
+    <xi:include href="../../hardware/electronics/three-encoders-setup-eln.xml" />
+    <xi:include href="../../hardware/mechanicals/three-encoders-setup-mec.xml" />
+    <xi:include href="./three-encoders-setup-mc_service.xml" />
+
+    <!-- joint number                           0                -->
+    <!-- joint name -->
+    <group name="LIMITS">
+        <param name="jntPosMax">                180                 </param>
+        <param name="jntPosMin">                -180                 </param>
+        <param name="jntVelMax">                100               </param>
+        <param name="motorNominalCurrents">     5000                </param>
+        <param name="motorPeakCurrents">        10000               </param>
+        <param name="motorOverloadCurrents">    15000               </param>
+        <param name="motorPwmLimit">            32000               </param>
+    </group>
+
+    <group name="TIMEOUTS">
+        <param name="velocity">                 100                 </param>
+    </group>
+
+    <group name="IMPEDANCE">
+        <param name="stiffness">                0                   </param>
+        <param name="damping">                  0                   </param>
+    </group>
+
+    <group name="CONTROLS">
+        <param name="positionControl">          POS_PID_DEFAULT     </param>
+        <param name="velocityControl">          POS_PID_DEFAULT     </param>
+        <param name="mixedControl">             POS_PID_DEFAULT     </param>
+        <param name="torqueControl">            TRQ_PID_DEFAULT     </param>
+        <param name="currentPid">               2FOC_CUR_CONTROL    </param>
+        <param name="speedPid">                 2FOC_VEL_CONTROL    </param>
+    </group>
+
+
+    <!-- default position PID: begin -->
+
+    <group name="POS_PID_DEFAULT">
+        <param name="controlLaw">             minjerk               </param>
+        <param name="outputType">             pwm                   </param>
+        <param name="fbkControlUnits">        metric_units          </param>
+        <param name="outputControlUnits">     machine_units         </param>
+        <param name="kp">           500              </param>
+        <param name="kd">           0                </param>
+        <param name="ki">           100              </param>
+        <param name="maxOutput">    32000           </param>
+        <param name="maxInt">       3000           </param>
+        <param name="stictionUp">   0              </param>
+        <param name="stictionDown"> 0              </param>
+        <param name="kff">          0              </param>
+    </group>
+
+    <!-- default position PID: end -->
+
+
+    <!-- default torque PID: begin -->
+    <group name="TRQ_PID_DEFAULT">
+        <param name="controlLaw">          torque                   </param>
+        <param name="outputType">          current                  </param>
+        <param name="fbkControlUnits">     machine_units            </param>
+        <param name="outputControlUnits">  machine_units            </param>
+        <param name="kp">              1.8    </param>
+        <param name="kd">              0    </param>
+        <param name="ki">              0    </param>
+        <param name="maxOutput">     2000    </param>
+        <param name="maxInt">        1000    </param>
+        <param name="ko">              0.55    </param>
+        <param name="stictionUp">      0    </param>
+        <param name="stictionDown">    0    </param>
+        <param name="kff">             0    </param>
+        <param name="kbemf">           0   </param>
+        <param name="filterType">      3    </param>
+        <param name="ktau">            0    </param>
+        <param name="viscousPos">   1.0     </param>
+        <param name="viscousNeg">   1.0     </param>
+        <param name="coulombPos">   0.0     </param>
+        <param name="coulombNeg">   0.0     </param>
+    </group>
+    <!-- default torque PID: end -->
+
+
+    <!-- other default PIDs: begin -->
+
+    <group name="2FOC_CUR_CONTROL">
+        <param name="controlLaw">           low_lev_current     </param>
+        <param name="fbkControlUnits">      machine_units       </param>
+        <param name="outputControlUnits">   machine_units       </param>
+        <param name="kp">                   8          </param>
+        <param name="kd">                   0          </param>
+        <param name="ki">                   2          </param>
+        <param name="shift">                10         </param>
+        <param name="maxOutput">            32000      </param>
+        <param name="maxInt">               32000      </param>
+        <param name="kff">                  0          </param>
+    </group>
+
+    <group name="2FOC_VEL_CONTROL">
+        <param name="controlLaw">           low_lev_speed       </param>
+        <param name="fbkControlUnits">      machine_units       </param>
+        <param name="outputControlUnits">   machine_units       </param>
+        <param name="kff">                  0         </param>
+        <param name="kp">                   12        </param>
+        <param name="kd">                   0         </param>
+        <param name="ki">                   16        </param>
+        <param name="shift">                10        </param>
+        <param name="maxOutput">            32000     </param>
+        <param name="maxInt">               32000     </param>
+    </group>
+
+    <!-- other default PIDs: end -->
+
+
+    <!-- custom PIDs: begin -->
+    <!-- custom PIDs: end -->
+
+    <group name="OTHER_CONTROL_PARAMETERS">
+        <param name="deadZone">             0.0049    </param>
+    </group>
+
+</device>

--- a/experimentalSetups/threeEncodersJoint/hardware/motorControl/three-encoders-setup-mc_service.xml
+++ b/experimentalSetups/threeEncodersJoint/hardware/motorControl/three-encoders-setup-mc_service.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE params PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<params xmlns:xi="http://www.w3.org/2001/XInclude" robot="three-encoders-setup" build="1">
+
+    <group name="SERVICE">
+        
+        <param name="type"> eomn_serv_MC_foc </param> 
+    
+        <group name="PROPERTIES">
+        
+            <group name="ETHBOARD">
+                <param name="type">                 ems4        </param> 
+            </group>          
+
+            <group name="CANBOARDS"> 
+                <param name="type">                 foc         </param> 
+                <group name="PROTOCOL">
+                    <param name="major">            1           </param>    
+                    <param name="minor">            6           </param>     
+                </group>                    
+                <group name="FIRMWARE">
+                    <param name="major">            0           </param>    
+                    <param name="minor">            0           </param> 
+                    <param name="build">            0           </param>
+                </group>
+            </group>
+            
+            
+
+            <group name="JOINTMAPPING">
+
+                <group name="ACTUATOR">
+                    <!--                            setup                     -->
+                    <param name="type">             foc        </param>
+                    <param name="port">             CAN1:1:0            </param>
+                </group>                                           
+                    
+                <!-- Aksim2 Encoder-->
+                <!-- <group name="ENCODER1">                            
+                    <param name="type">             aksim2              </param>  
+                    <param name="port">             CONN:P8             </param>
+                    <param name="position">         atjoint             </param>
+                    <param name="resolution">       -524288             </param> 
+                    <param name="tolerance">        0.703               </param>  
+                </group>      -->
+                
+                <!-- AMO Encoder 16384 if using calib12 or 10 (x64 is defined in mech file at E2J)-->
+	            <group name="ENCODER1">                            
+                    <param name="type">             amo           </param>  
+                    <param name="port">             CONN:P6       </param>
+                    <param name="position">         atjoint       </param>
+                    <param name="resolution">       -1048576      </param> 
+                    <param name="tolerance">        0.703         </param>  
+                </group>     
+	                                                  
+                <group name="ENCODER2">                            
+                    <param name="type">             mrie                </param>
+                    <param name="port">             CAN1:1:0            </param>
+                    <param name="position">         atmotor             </param>
+                    <param name="resolution">       -15040               </param>
+                    <param name="tolerance">        3.6                 </param>  
+                </group> 
+ 
+            </group>    
+            
+           
+            
+        </group>
+           
+    </group>
+    
+  
+</params>

--- a/experimentalSetups/threeEncodersJoint/telemetry/telemetry.xml
+++ b/experimentalSetups/threeEncodersJoint/telemetry/telemetry.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="telemetryDeviceDumper" type="telemetryDeviceDumper">
+        <param name="axesNames">(three_encoders_joint)</param> <!--shoulder_pitch, shoulder_roll, shoulder_yaw, elbow-->
+        <param name="logIEncoders">true</param>
+        <param name="logITorqueControl">false</param>
+        <param name="logIMotorEncoders">true</param>
+        <param name="logIControlMode">false</param>
+        <param name="logIInteractionMode">false</param>
+        <param name="logIPidControl">false</param>
+        <param name="logIAmplifierControl">true</param>
+        <param name="logIRawValuesPublisher">true</param>
+        <param name="saveBufferManagerConfiguration">true</param>
+        <param name="experimentName">three_encoders_joint_amo_sequence_calib12</param>
+        <param name="path">./three_encoders_joint_telemetry_data/</param>
+        <param name="n_samples">800000</param>
+        <param name="save_periodically">false</param>
+        <param name="save_period">1000.0</param>
+        <param name="log_period">0.002</param>
+        <!-- <param name="data_threshold">50000</param> -->
+        <param name="auto_save">true</param>
+        <param name="yarp_robot_name">ergoCubSN002S</param>
+        <param name="rawValuesPublisherRemoteName">/fakedevicetest/raw_data</param>
+
+        <action phase="startup" level="15" type="attach">
+            <paramlist name="networks">
+                <!-- motorcontrol and virtual torque sensors -->
+                <!-- <elem name="upper_arm_joints1">upper_arm-eb1-j0_1-mc</elem> -->
+                <elem name="upper_arm_joints1">three-encoders-setup-mc</elem>
+            </paramlist>
+        </action>
+
+        <action phase="shutdown" level="2" type="detach" />
+
+    </device>

--- a/experimentalSetups/threeEncodersJoint/three-encoders-setup.xml
+++ b/experimentalSetups/threeEncodersJoint/three-encoders-setup.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<robot name="three-encoder-setup" build="1" portprefix="threeEncoders" xmlns:xi="http://www.w3.org/2001/XInclude">
+
+  <devices>
+    <params>
+    <xi:include href="hardware/electronics/pc104.xml" />
+    </params>
+
+    <!-- motor controllers wrappers -->
+    <xi:include href="wrappers/motorControl/three-encoders-setup-mc_wrapper.xml" />
+    <xi:include href="wrappers/motorControl/three-encoders-setup-mc_remapper.xml" />
+    <!-- nws wrapper -->
+    <xi:include href="wrappers/motorControl/three-encoders-setup-rawval-nws_wrapper.xml" />
+
+    <!-- TORSO -->
+    <xi:include href="hardware/motorControl/three-encoders-setup-mc.xml" />
+
+    <!--  CALIBRATORS -->
+    <xi:include href="calibrators/three-encoders-setup-calib.xml" />
+
+    <!-- ROBOMETRY -->
+    <xi:include href="telemetry/telemetry.xml" />
+
+  </devices>
+</robot>

--- a/experimentalSetups/threeEncodersJoint/wrappers/motorControl/three-encoders-setup-mc_remapper.xml
+++ b/experimentalSetups/threeEncodersJoint/wrappers/motorControl/three-encoders-setup-mc_remapper.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="three-encoders-setup-mc_remapper" type="controlboardremapper">
+    <param name="axesNames">(three_encoders_joint)</param>
+    <param name="joints"> 1 </param>
+    <action phase="startup" level="5" type="attach">
+        <paramlist name="networks">
+            <elem name="three-encoders-setup_joints">  three-encoders-setup-mc </elem>
+        </paramlist>
+    </action>
+    <action phase="shutdown" level="20" type="detach" />
+</device>

--- a/experimentalSetups/threeEncodersJoint/wrappers/motorControl/three-encoders-setup-mc_wrapper.xml
+++ b/experimentalSetups/threeEncodersJoint/wrappers/motorControl/three-encoders-setup-mc_wrapper.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="three-encoders-setup-mc_nws_yarp" type="controlBoard_nws_yarp">
+    <param name="period"> 0.002  </param>
+    <param name="name"> /threeEncoders/three-encoders-setup </param>
+    <action phase="startup" level="10" type="attach">
+        <param name="device"> three-encoders-setup-mc_remapper </param>
+    </action>
+    <action phase="shutdown" level="15" type="detach" />
+</device>

--- a/experimentalSetups/threeEncodersJoint/wrappers/motorControl/three-encoders-setup-rawval-nws_wrapper.xml
+++ b/experimentalSetups/threeEncodersJoint/wrappers/motorControl/three-encoders-setup-rawval-nws_wrapper.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="three-encoders-setup-rawval_nws_yarp" type="rawValuesPublisherServer">
+    <param name="name"> /fakedevicetest/raw_data </param>
+    <param name="period"> 2 </param>
+    <action phase="startup" level="10" type="attach">
+        <paramlist name="networks">
+            <elem name="device"> three-encoders-setup-mc </elem>
+        </paramlist>
+    </action>
+    <action phase="shutdown" level="15" type="detach" />
+</device>

--- a/experimentalSetups/threeEncodersJoint/yarpScopeFile.xml
+++ b/experimentalSetups/threeEncodersJoint/yarpScopeFile.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<portscope rows="2" columns="2" carrier="fast_tcp"><!--fast_tcp-->
+      <plot gridx="0"
+          gridy="0"
+          hspan="1"
+          vspan="1"
+          minval="-10000"
+	    maxval="10000"
+          title="Joint Position"
+          bgcolor="LightSlateGrey">
+          <graph remote="/threeEncoders/three-encoders-setup/stateExt:o/split0:o"
+                index="0"
+                color="Red"
+                title="Joint position"
+                type="lines"
+                size="3" />
+      </plot>
+      <plot gridx="1"
+          gridy="0"
+          hspan="1"
+          vspan="1"
+          title="Motor Position"
+          minval="-500000"
+          maxval="500000"
+          bgcolor="LightSlateGrey">
+          <graph remote="/threeEncoders/three-encoders-setup/stateExt:o/split6:o"
+                index="0"
+                color="Magenta"
+                title="Motor position"
+	          type="lines"
+	          size="3"	/>
+      </plot>
+      <plot gridx="0"
+          gridy="1"
+          hspan="1"
+          vspan="1"
+          title="Current Plot"
+          minval="-20"
+          maxval="20"
+          bgcolor="LightSlateGrey">
+          <graph remote="/threeEncoders/three-encoders-setup/stateExt:o/split16:o"
+               index="0"
+               color="Cyan"
+	         title="Current"
+	         type="lines"
+	         size="3"/>
+      </plot>
+      <plot gridx="1"
+          gridy="1"
+          hspan="1"
+          vspan="1"
+          title="Joint speed Plot"
+          minval="-100"
+          maxval="100"
+          bgcolor="LightSlateGrey">
+          <graph remote="/threeEncoders/three-encoders-setup/stateExt:o/split2:o"
+               index="0"
+               color="Green"
+               title="Joint Velocity"
+	         type="lines"
+	         size="3"/>
+      </plot>
+<!--
+    <plot gridx="2"
+          gridy="0"
+          hspan="1"
+          vspan="1"
+          title="Motor position Plot"
+          bgcolor="LightSlateGrey">
+    <graph remote="/icub/5-setup/stateExt:o/split6:o"
+               index="0"
+               color="Green"
+               title="Motor position"
+               type="lines"
+               size="3" />
+    </plot>
+    <plot gridx="2"
+          gridy="1"
+          hspan="1"
+          vspan="1"
+          title="Motor speed Plot"
+          bgcolor="LightSlateGrey">
+    <graph remote="/icub/5-setup/stateExt:o/split8:o"
+               index="0"
+               color="Green"
+               title="Motor velocity"
+               type="lines"
+               size="3" />
+	</plot>
+-->
+</portscope>

--- a/experimentalSetups/threeEncodersJoint/yarpmotorgui.ini
+++ b/experimentalSetups/threeEncodersJoint/yarpmotorgui.ini
@@ -1,0 +1,7 @@
+//name of the robot          
+robot threeEncoders      
+//parts to be opened by the GUI            
+parts (three-encoders-setup)               
+ 
+ //DO NOT REMOVE THIS LINE    
+ 

--- a/experimentalSetups/threeEncodersJoint/yarprobotinterface.ini
+++ b/experimentalSetups/threeEncodersJoint/yarprobotinterface.ini
@@ -1,0 +1,2 @@
+config ./three-encoders-setup.xml
+


### PR DESCRIPTION
This PR adds the configuration files for working with the bench setup made with 2 encoders at the joint (plus the one at the motor) that can be easily switched for checking the raw values with the 2 types of magnetic encoders