### PR TITLE
iCubErzelli02 - align left camera conf file to use COLOR 

### DIFF
--- a/iCubErzelli02/camera/dragonfly2_config_right_bayer_640_480.ini
+++ b/iCubErzelli02/camera/dragonfly2_config_right_bayer_640_480.ini
@@ -1,5 +1,5 @@
-device dragonfly2raw
-capabilities RAW
+device dragonfly2
+capabilities COLOR
 width 640
 height 480
 video_type 3


### PR DESCRIPTION
During the last demo @ Stanford with iCubErzelli02, there was the need to use the `dragonfly2_config_right_bayer_640_480.ini` file since the vision modules are based on 640x480 resolution and the default file (without bayer) is 320x240. It turns out that the conf file for the right camera was using the `dragonfly2raw` device with RAW capabilities, while the left one uses the `dragonfly2` with COLOR.

cc @ddetommaso 