### PR TITLE
[ergoCubSN002] Add missing amc2c boards in network.ergoCubSN002.xml

### DIFF
--- a/ergoCubSN002/network.ergoCubSN002.xml
+++ b/ergoCubSN002/network.ergoCubSN002.xml
@@ -102,7 +102,7 @@
             <connected bus="CAN" />
         </board>
 
-	    <board type='mtb4' name="mtb4.1">
+	<board type='mtb4c' name="mtb4.1">
             <ondevice>ETH</ondevice>
             <ataddress ip="10.0.1.4" canbus="2" canadr="1"  />
             <connected bus="CAN" />
@@ -138,7 +138,7 @@
 			<connected bus="ETH" prev="10.0.1.25"/>
         </board>
 
-        <board type='amc2c' name="left_arm-eb31-j4_6">
+        <board type='amc' name="left_arm-eb31-j4_6">
             <ondevice>ETH</ondevice>
             <ataddress ip="10.0.1.31" />
 			<connected bus="ETH" prev="10.0.1.25"/>
@@ -202,7 +202,7 @@
             <connected bus="CAN" />
         </board>
 
-	    <board type='mtb4' name="mtb4.1">
+	<board type='mtb4c' name="mtb4.1">
             <ondevice>ETH</ondevice>
             <ataddress ip="10.0.1.3" canbus="2" canadr="1"  />
             <connected bus="CAN" />
@@ -238,7 +238,7 @@
 			<connected bus="ETH" prev="10.0.1.24"/>
         </board>
 
-        <board type='amc2c' name="right_arm-eb30-j4_6">
+        <board type='amc' name="right_arm-eb30-j4_6">
             <ondevice>ETH</ondevice>
             <ataddress ip="10.0.1.30" />
 			<connected bus="ETH" prev="10.0.1.24"/>


### PR DESCRIPTION
See https://github.com/robotology/icub-firmware-build/issues/176#issuecomment-2514964433 for details. I am not sure this is the correct solution, but I guess opening a PR with a concrete proposal for a change would make it easier to discuss about this.

@valegagge @marcoaccame @AntonioConsilvio @MSECode @S-Dafarra 