### PR TITLE
Add config files for the ankle-setup calibration

### DIFF
--- a/experimentalSetups/ankleSetup/ankle-setup.xml
+++ b/experimentalSetups/ankleSetup/ankle-setup.xml
@@ -19,10 +19,10 @@
     <!--  CALIBRATORS  -->
     <xi:include href="calibrators/ankle-setup-calib.xml" /> 
 
-    <!-- ROBOMETRY -->
-    <xi:include href="telemetry/telemetry.xml" />
-    <!-- nws wrapper -->
-    <xi:include href="wrappers/motorControl/ankle-setup-rawval-nws_wrapper.xml" />
+    <!-- ROBOMETRY 
+    <xi:include href="telemetry/telemetry.xml" /> -->
+    <!-- nws wrapper 
+    <xi:include href="wrappers/motorControl/ankle-setup-rawval-nws_wrapper.xml" /> -->
 
   </devices>
 </robot>

--- a/experimentalSetups/ankleSetup/calibrators/ankle-setup-calib.xml
+++ b/experimentalSetups/ankleSetup/calibrators/ankle-setup-calib.xml
@@ -19,9 +19,9 @@
                                                                       
 <group name="CALIBRATION">                                            
 <!--                                                small                          -->
-<param name="calibrationType">                      5                       </param>
-<param name="calibration1">                         1600                   </param> <!-- 20934 amo (12) -4200 (10)  63820 aksim2-->
-<param name="calibration2">                         17816                        </param> 
+<param name="calibrationType">                      5                        </param>
+<param name="calibration1">                         1600                     </param> <!-- 20934 amo (12) -4200 (10)  63820 aksim2-->
+<param name="calibration2">                         0                     </param> 
 <param name="calibration3">                         0                        </param> 
                                                                       
                                                                       

--- a/experimentalSetups/ankleSetup/general.xml
+++ b/experimentalSetups/ankleSetup/general.xml
@@ -4,7 +4,7 @@
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="ankleSetup" build="1">
   
   <group name="GENERAL">
-      <param name="skipCalibration">    false  </param>
+      <param name="skipCalibration">    true  </param>
       <param name="useRawEncoderData">  false  </param>
       <param name="useLimitedPWM">      false  </param>
       <param name="verbose">            false  </param>

--- a/experimentalSetups/ankleSetup/hardware/motorControl/ankle-setup-mc_service.xml
+++ b/experimentalSetups/ankleSetup/hardware/motorControl/ankle-setup-mc_service.xml
@@ -38,11 +38,11 @@
                     
                 <!-- Aksim2 Encoder-->
                  <group name="ENCODER1">                            
-                    <param name="type">             none              </param>  
-                    <param name="port">             CONN:P8             </param>
-                    <param name="position">         atjoint             </param>
-                    <param name="resolution">       -524288             </param> 
-                    <param name="tolerance">        0.703               </param>  
+                    <param name="type">             none                 </param>  
+                    <param name="port">             none             </param>
+                    <param name="position">         none              </param>
+                    <param name="resolution">       none                 </param> 
+                    <param name="tolerance">        none                  </param>  
                 </group>
 
                 <!-- MECAPION_APM-SA01ACN-8 Encoder-->


### PR DESCRIPTION
This PR modifies the configuration files for the ankle-setup. <br>
These files are currently used on the `icub` laptop in the mechatronics lab and are used to calibrate the setup with a modified calibration 5 (calibration is WIP, only tested on the EMS related to the setup).

related issue: [icub-tech-iit/five/#281](https://github.com/icub-tech-iit/five/issues/281)