### PR TITLE
R1SN003: Move POS devices on top and calibrators on bottom, tune finger pids

### DIFF
--- a/R1SN003/R1.xml
+++ b/R1SN003/R1.xml
@@ -4,6 +4,18 @@
 <robot name="R1SN003" build="1" portprefix="cer" xmlns:xi="http://www.w3.org/2001/XInclude">
 <devices>
 
+    <!-- POS4 -->
+    <xi:include href="wrappers/POS/right_hand-pos_wrapper4.xml" disabled_by="disable_right_hand" />
+    <xi:include href="hardware/POS/right_hand-pos4.xml" disabled_by="disable_right_hand" />
+    <xi:include href="wrappers/POS/left_hand-pos_wrapper4.xml" disabled_by="disable_left_hand" />
+    <xi:include href="hardware/POS/left_hand-pos4.xml" disabled_by="disable_left_hand" /> 
+
+    <!-- POS2 -->
+    <xi:include href="wrappers/POS/right_hand-pos_wrapper2.xml" disabled_by="disable_right_hand" />
+    <xi:include href="hardware/POS/right_hand-pos2.xml" disabled_by="disable_right_hand" />
+    <xi:include href="wrappers/POS/left_hand-pos_wrapper2.xml" disabled_by="disable_left_hand" />
+    <xi:include href="hardware/POS/left_hand-pos2.xml" disabled_by="disable_left_hand" /> 
+
     <!-- ODOMETRY -->
     <xi:include href="hardware/odometry/odometry.xml" disabled_by="disable_odometry" />
     <xi:include href="wrappers/odometry/odometry_nws_yarp.xml" disabled_by="disable_odometry" />
@@ -33,18 +45,6 @@
     <xi:include href="wrappers/motorControl/cer_torso-mc_remapper.xml" disabled_by="disable_torso" />
     <xi:include href="wrappers/motorControl/cer_torso-mc_wrapper.xml" disabled_by="disable_torso" /> 
 
-    <!-- POS4 -->
-    <xi:include href="wrappers/POS/right_hand-pos_wrapper4.xml" disabled_by="disable_right_hand" />
-    <xi:include href="hardware/POS/right_hand-pos4.xml" disabled_by="disable_right_hand" />
-    <xi:include href="wrappers/POS/left_hand-pos_wrapper4.xml" disabled_by="disable_left_hand" />
-    <xi:include href="hardware/POS/left_hand-pos4.xml" disabled_by="disable_left_hand" /> 
-
-    <!-- POS2 -->
-    <xi:include href="wrappers/POS/right_hand-pos_wrapper2.xml" disabled_by="disable_right_hand" />
-    <xi:include href="hardware/POS/right_hand-pos2.xml" disabled_by="disable_right_hand" />
-    <xi:include href="wrappers/POS/left_hand-pos_wrapper2.xml" disabled_by="disable_left_hand" />
-    <xi:include href="hardware/POS/left_hand-pos2.xml" disabled_by="disable_left_hand" /> 
-
     <!-- LEFT ARM -->
     <xi:include href="wrappers/motorControl/left_arm-mc_wrapper.xml" disabled_by="disable_left_arm" />
     <xi:include href="wrappers/motorControl/left_arm-mc_remapper.xml" disabled_by="disable_left_arm disable_left_hand" />
@@ -72,19 +72,11 @@
     <xi:include href="wrappers/motorControl/cer_head-mc_remapper.xml" disabled_by="disable_head"/>
     <xi:include href="wrappers/motorControl/cer_head-mc_wrapper.xml" disabled_by="disable_head"/>
 
-    <!--  CALIBRATORS -->
-    <xi:include href="calibrators/cer_torso-calib.xml" disabled_by="disable_torso"/> 
-    <xi:include href="calibrators/cer_head-calib.xml" disabled_by="disable_head"/>
-    <xi:include href="calibrators/cer_base-calib.xml" disabled_by="disable_base"/>
-    <xi:include href="calibrators/left_arm-calib.xml" disabled_by="disable_left_arm" />
-    <xi:include href="calibrators/right_arm-calib.xml" disabled_by="disable_right_arm" />
-
     <!-- SKIN-->
 <!--<xi:include href="wrappers/skin/right_arm-skin_wrapper.xml" />
     <xi:include href="hardware/skin/right_arm-eb7-j2_3-skin.xml" />
     <xi:include href="wrappers/skin/left_arm-skin_wrapper.xml" />
-    <xi:include href="hardware/skin/left_arm-eb4-j2_3-skin.xml" />
--->
+    <xi:include href="hardware/skin/left_arm-eb4-j2_3-skin.xml" /> -->
 
 <!-- IMU - MTB4 BOARDS
     <xi:include href="hardware/inertials/left_arm-eb4-j2_3-inertial.xml" disabled_by="disable_left_arm" />
@@ -111,6 +103,13 @@
     <!--  ROS -->
     <xi:include href="wrappers/motorControl/cer_alljoints_remapper.xml" enabled_by="enable_ros2" disabled_by="disable_base disable_head disable_left_arm disable_left_hand disable_right_arm disable_right_hand disable_torso"/>
     <xi:include href="wrappers/motorControl/cer_alljoints_ros2_wrapper.xml" enabled_by="enable_ros2" disabled_by="disable_base disable_head disable_left_arm disable_left_hand disable_right_arm disable_right_hand disable_torso"/>
+
+    <!--  CALIBRATORS -->
+    <xi:include href="calibrators/cer_torso-calib.xml" disabled_by="disable_torso"/> 
+    <xi:include href="calibrators/cer_head-calib.xml" disabled_by="disable_head"/>
+    <xi:include href="calibrators/cer_base-calib.xml" disabled_by="disable_base"/>
+    <xi:include href="calibrators/left_arm-calib.xml" disabled_by="disable_left_arm" />
+    <xi:include href="calibrators/right_arm-calib.xml" disabled_by="disable_right_arm" />
 
     <!-- BATTERY -->
     <xi:include href="wrappers/battery/r1battery.xml" enabled_by="enable_battery" disabled_by="disable_battery" />

--- a/R1SN003/hardware/motorControl/left_arm-eb23-j7_10-mc.xml
+++ b/R1SN003/hardware/motorControl/left_arm-eb23-j7_10-mc.xml
@@ -48,9 +48,9 @@
         <param name="outputType">               pwm             </param>
         <param name="fbkControlUnits">          metric_units    </param>
         <param name="outputControlUnits">       machine_units   </param>
-        <param name="kp">                       -19.8       -11.3       -10.5       -12.4    </param>
-        <param name="kd">                       -2.82       -1.34       -1.55       -1.51       </param>
-        <param name="ki">                       -9.14       -11.7       -21.22      -16.9     </param>
+        <param name="kp">                       -15         -22         -22         -18     </param>
+        <param name="kd">                       -2          -4          -4          -3      </param>
+        <param name="ki">                       -5          -18         -18         -20     </param>
         <param name="maxOutput">                1350        1350        1350        1350    </param>
         <param name="maxInt">                   1000        1000        1000        1000    </param>
         <param name="stictionUp">               0           0           0           0       </param>

--- a/R1SN003/hardware/motorControl/right_arm-eb22-j7_10-mc.xml
+++ b/R1SN003/hardware/motorControl/right_arm-eb22-j7_10-mc.xml
@@ -48,9 +48,9 @@
         <param name="outputType">               pwm             </param>
         <param name="fbkControlUnits">          metric_units    </param>
         <param name="outputControlUnits">       machine_units   </param>
-        <param name="kp">                       -12.9       -11.3       -10.5       -11    </param>
-        <param name="kd">                       -1.76       -1.34       -1.55       -0.9       </param>
-        <param name="ki">                       -10.4       -11.7       -22.9       -17     </param>
+        <param name="kp">                       -15         -22         -22         -18     </param>
+        <param name="kd">                       -2          -4           -4         -3      </param>
+        <param name="ki">                       -5          -18         -18         -20     </param>
         <param name="maxOutput">                1350        1350        1350        1350    </param>
         <param name="maxInt">                   1000        1000        1000        1000    </param>
         <param name="stictionUp">               0           0           0           0       </param>


### PR DESCRIPTION
This PR aims to fix an issue in which the calibrator devices are not able to read the finger data if the latter start streaming data too late. By moving the former on top of the yarprobotinterface file, and the latter on bottom, this issue gets solved, like in ergoCub.

Additionally, the Position PIDs of the fingers are properly tuned.

cc @fbrand-new @randaz81 