### PR TITLE
Disable firmware check for amc2c board

### DIFF
--- a/R1SN003/hardware/motorControl/left_arm-eb31-j4_6-mc_service.xml
+++ b/R1SN003/hardware/motorControl/left_arm-eb31-j4_6-mc_service.xml
@@ -20,9 +20,9 @@
                     <param name="minor">            0           0       </param>
                 </group>
                 <group name="FIRMWARE">
-                    <param name="major">            2           3       </param>
+                    <param name="major">            2           0       </param>
                     <param name="minor">            0           0       </param>
-                    <param name="build">            13          4       </param>
+                    <param name="build">            13          0       </param>
                 </group>
             </group>
 

--- a/R1SN003/hardware/motorControl/right_arm-eb30-j4_6-mc_service.xml
+++ b/R1SN003/hardware/motorControl/right_arm-eb30-j4_6-mc_service.xml
@@ -20,9 +20,9 @@
                     <param name="minor">            0           0       </param>
                 </group>
                 <group name="FIRMWARE">
-                    <param name="major">            2           3       </param>
+                    <param name="major">            2           0       </param>
                     <param name="minor">            0           0       </param>
-                    <param name="build">            13          4       </param>
+                    <param name="build">            13          0       </param>
                 </group>
             </group>
 


### PR DESCRIPTION
The robot is currently using a fw version greater than 3.0.4. 
This PR disables the firmware check, otherwise yarprobotinterface will not start.