### PR TITLE
Correct `amcfoc` files to run a motor and update old lego setups

### DIFF
--- a/experimentalSetups/lego_setup_amc_advfoc/hardware/motorControl/setup-eb2-j0_2-mc_service.xml
+++ b/experimentalSetups/lego_setup_amc_advfoc/hardware/motorControl/setup-eb2-j0_2-mc_service.xml
@@ -104,7 +104,7 @@
                 </group>
                 <group name="FIRMWARE">
                     <param name="major">            3       2           </param>
-                    <param name="minor">            1       0           </param>
+                    <param name="minor">            6       0           </param>
                     <param name="build">            0       10          </param>
                 </group>
             </group>

--- a/experimentalSetups/lego_setup_amc_amcbldc/hardware/mechanicals/wrist-eb2-j0_2-mec.xml
+++ b/experimentalSetups/lego_setup_amc_amcbldc/hardware/mechanicals/wrist-eb2-j0_2-mec.xml
@@ -11,16 +11,16 @@
         <param name="Encoder">          182.044         </param>
         <param name="fullscalePWM">     32000           </param>
         <param name="ampsToSensor">     1000.0          </param>
-        <param name="Gearbox_M2J">     -384.44          </param>
-        <param name="Gearbox_E2J">      1.778           </param>
+        <param name="Gearbox_M2J">     -196             </param>
+        <param name="Gearbox_E2J">      1               </param>
         <param name="useMotorSpeedFbk"> 0               </param>
-        <param name="MotorType">        "BLL_MOOG"      </param>
-        <param name="Verbose">          0   </param>
+        <param name="MotorType">        "FAULHABER"     </param>
+        <param name="Verbose">          0               </param>
     </group>
 
     <group name="LIMITS">
-        <param name="hardwareJntPosMax">     180           </param>
-        <param name="hardwareJntPosMin">     -180           </param>
+        <param name="hardwareJntPosMax">     180          </param>
+        <param name="hardwareJntPosMin">     -180         </param>
         <param name="rotorPosMin">           0            </param>
         <param name="rotorPosMax">           0            </param>
     </group>

--- a/experimentalSetups/lego_setup_amc_amcbldc/hardware/motorControl/wrist-eb2-j0_2-mc_service.xml
+++ b/experimentalSetups/lego_setup_amc_amcbldc/hardware/motorControl/wrist-eb2-j0_2-mc_service.xml
@@ -21,8 +21,8 @@
                 </group>
                 <group name="FIRMWARE">
                     <param name="major">            2           </param>
-                    <param name="minor">            0           </param>
-                    <param name="build">            4           </param>
+                    <param name="minor">            1           </param>
+                    <param name="build">            0           </param>
                 </group>
             </group>
 
@@ -34,9 +34,9 @@
                 </group>
 
                 <group name="ENCODER1">
-                    <param name="type">             eomc_enc_aea      </param>
+                    <param name="type">             aea3              </param>
                     <param name="port">             CONN:J5_X1        </param>
-                    <param name="position">         eomc_pos_atjoint  </param>
+                    <param name="position">         atjoint           </param>
                     <param name="resolution">       4096              </param>
                     <param name="tolerance">        0.4               </param>
                 </group>

--- a/experimentalSetups/lego_setup_amcfoc_advfoc/hardware/motorControl/setup-eb2-j0_0-mc.xml
+++ b/experimentalSetups/lego_setup_amcfoc_advfoc/hardware/motorControl/setup-eb2-j0_0-mc.xml
@@ -13,21 +13,21 @@
     <!-- joint name -->
     <group name="LIMITS">
         <param name="jntPosMax">                180                 </param>
-        <param name="jntPosMin">                -180                 </param>
-        <param name="jntVelMax">                90                 </param>
-        <param name="motorNominalCurrents">     1000               </param>
-        <param name="motorPeakCurrents">        1500               </param>
-        <param name="motorOverloadCurrents">    2000               </param>
-        <param name="motorPwmLimit">            16000              </param>
+        <param name="jntPosMin">                -180                </param>
+        <param name="jntVelMax">                90                  </param>
+        <param name="motorNominalCurrents">     1000                </param>
+        <param name="motorPeakCurrents">        1500                </param>
+        <param name="motorOverloadCurrents">    2000                </param>
+        <param name="motorPwmLimit">            16000               </param>
     </group>
 
     <group name="TIMEOUTS">
-        <param name="velocity">                 100                </param>
+        <param name="velocity">                 100                 </param>
     </group>
 
     <group name="IMPEDANCE">
-        <param name="stiffness">                0                  </param>
-        <param name="damping">                  0                  </param>
+        <param name="stiffness">                0                   </param>
+        <param name="damping">                  0                   </param>
     </group>
 
     <group name="CONTROLS">
@@ -43,18 +43,18 @@
     <!-- default position PID: begin -->
 
     <group name="POS_PID_DEFAULT">
-        <param name="controlLaw">             minjerk                </param>
-        <param name="outputType">             current                </param>
-        <param name="fbkControlUnits">        metric_units           </param>
-        <param name="outputControlUnits">     machine_units          </param>
-        <param name="kp">                    -30                     </param>
-        <param name="kd">                    -10                     </param>
-        <param name="ki">                    -100                    </param>
-        <param name="maxOutput">              500                    </param>
-        <param name="maxInt">                 200                    </param>
-        <param name="stictionUp">             0                      </param>
-        <param name="stictionDown">           0                      </param>
-        <param name="kff">                    0                      </param>
+        <param name="controlLaw">             minjerk               </param>
+        <param name="outputType">             pwm                   </param>
+        <param name="fbkControlUnits">        metric_units          </param>
+        <param name="outputControlUnits">     machine_units         </param>
+        <param name="kp">                     200                   </param>
+        <param name="kd">                     0                     </param>
+        <param name="ki">                     40                    </param>
+        <param name="maxOutput">              1600                  </param>
+        <param name="maxInt">                 1600                  </param>
+        <param name="stictionUp">             0                     </param>
+        <param name="stictionDown">           0                     </param>
+        <param name="kff">                    0                     </param>
     </group>
 
     <!-- default position PID: end -->
@@ -66,9 +66,9 @@
         <param name="controlLaw">           low_lev_current          </param>
         <param name="fbkControlUnits">      machine_units            </param>
         <param name="outputControlUnits">   machine_units            </param>
-        <param name="kp">                   2                        </param>
+        <param name="kp">                   0                        </param>
         <param name="kd">                   0                        </param>
-        <param name="ki">                   500                      </param>
+        <param name="ki">                   0                        </param>
         <param name="shift">                0                        </param>
         <param name="maxOutput">            32000                    </param>
         <param name="maxInt">               32000                    </param>

--- a/experimentalSetups/lego_setup_amcfoc_advfoc/hardware/motorControl/setup-eb2-j0_0-mc_service.xml
+++ b/experimentalSetups/lego_setup_amcfoc_advfoc/hardware/motorControl/setup-eb2-j0_0-mc_service.xml
@@ -4,90 +4,7 @@
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="setup" build="1">
 
     <group name="SERVICE">
-
-        
-        <!--
-            templates: description
-
-            the group templates is not parsed by icub-main and contains xml snapshots that help to compose the MC service
-            
-            we can test two MC service types (advfoc and foc) with a number of actuator boards (amcbldc and amc2c). 
-            the controlling ETH board shall be:
-            - amc for both the advfoc and foc MC service types;
-            - ems for the single case of foc MC service type
-           
-            so, you need to:
-            1. pick up a type (either eomn_serv_MC_advfoc or eomn_serv_MC_foc)
-            2. for the given type pick up the wanted ACTUATOR:
-               - advfoc.ACTUATOR-01-amc2c-icc: the amc uses ICC to communicate w/ its second core
-               - advfoc.ACTUATOR-02-amc2c-can: the amc uses CAN to communicate w/ its second core
-               - advfoc.ACTUATOR-03-amcbldc-can: the amc uses CAN to communicate w/ an amcbldc
-               - foc.ACTUATOR-01-amcbldc: the amc uses CAN to communicate w/ an amcbldc w/ legacy foc mode
-                 note: this mode is also available if we use an ems instead of the amc
-            3. for the eomn_serv_MC_foc w/ amcbldc also put the amcbldc in first position as in the following
-            
-                <group name="CANBOARDS">
-                    <param name="type">                 amcbldc amc2c       </param> 
-                    <group name="PROTOCOL">
-                        <param name="major">            2       2           </param>
-                        <param name="minor">            0       0           </param>
-                    </group>
-                    <group name="FIRMWARE">
-                        <param name="major">            2       3           </param>
-                        <param name="minor">            0       0           </param>
-                        <param name="build">            9       0           </param>
-                    </group>
-                </group>                   
-        
-         -->
- 
-        <!-- 
-            templates: code snippets
-
-        <group name="templates">
-      
-            <group name="advfoc">
-            
-                <param name="type"> eomn_serv_MC_advfoc </param>
-
-                <group name="ACTUATOR-01-amc2c-icc">
-                    <param name="type">             eomc_act_advfoc     </param>
-                    <param name="onboard">          amc2c               </param>
-                    <param name="port">             ICC1:3              </param>                               
-                </group>    
-
-                <group name="ACTUATOR-02-amc2c-can">
-                    <param name="type">             eomc_act_advfoc     </param>
-                    <param name="onboard">          amc2c               </param>
-                    <param name="port">             CAN1:3              </param>                               
-                </group>                    
-
-                <group name="ACTUATOR-03-amcbldc-can">
-                    <param name="type">             eomc_act_advfoc     </param>
-                    <param name="onboard">          amcbldc             </param>
-                    <param name="port">             CAN1:1              </param>                               
-                </group> 
-                
-            </group>
-        
-
-            <group name="foc">
-            
-                <param name="type"> eomn_serv_MC_foc </param>  
-                
-                <group name="ACTUATOR-01-amcbldc">
-                    <param name="type">             eomc_act_foc        </param>
-                    <param name="onboard">          amcbldc             </param>
-                    <param name="port">             CAN1:1              </param>                               
-                </group>  
-                
-            </group>
-            
-        </group>
-
-         -->    
-    
-
+  
         <param name="type"> eomn_serv_MC_advfoc                       </param>
 
         <group name="PROPERTIES">
@@ -103,7 +20,7 @@
                     <param name="minor">            0                 </param>
                 </group>
                 <group name="FIRMWARE">
-                    <param name="major">            0                 </param>   <!--put correct version number -->
+                    <param name="major">            0                 </param>
                     <param name="minor">            0                 </param>
                     <param name="build">            0                 </param>
                 </group>


### PR DESCRIPTION
Correct `amcfoc` files to run a motor and update old lego setups:
- put correct PID values for the amcfoc for the actual FW present, using pwm control
- updated `amc` and `amcbld` xml files with mechanical values and FW version