### PR TITLE
Remove the mention to the credential manager in the local workflow

### DIFF
--- a/.github/local-workflow-tech.md
+++ b/.github/local-workflow-tech.md
@@ -17,24 +17,15 @@ Technicalities underlying the fast-pace local workflow
 - Switch to the branch corresponding to the robot (e.g., `devel-ergoCubSN???`).
 
 ## 🔲 Set the default committer
-- Fine-grained PAT can be scoped to work on a specified organization and only on a specified repository.
-- To store credentials locally, one needs to issue the following, once the fork is cloned locally:
+- In order to push to the ``icub-tech`` fork without password, it is necessary to get a PAT from the maintainer. Then, issue the following commands:
   ```console
   git config --local user.name "icub-tech-iit-bot"
   git config --local user.email "icub-tech@iit.it"
-  git config --local credential.https://github.com/icub-tech-iit/robots-configuration.git.helper store
+  PAT=<insert the PAT here>
+  git remote set-url icub-tech https://x-access-token:${PAT}@github.com/icub-tech-iit/robots-configuration.git
   ```
   ⚠️ Note the use of the option `--local` to avoid impacting Git globally on the system.
-- In order to push without password, the PAT needs to be provided. The credentials will be stored plainly under `~/.git-credentials`. No worries though, as this PAT has a very narrowed use and impacts a fork that is backed up anyhow by the upstream repository.
-- The PAT can be stored manually in `~/.git-credentials` with the format `https://icub-tech-iit-bot:${PAT}@github`. Alternatively, when attempting to push the first time, it is enough to use `icub-tech-iit-bot` as user and specifying the `PAT` as password. This will be stored in the `~/.git-credentials` file automatically.
-- ⚠️  Being the local system shared, no one else should store his/her PAT in the same file.
 - The PAT is set to have no expiration. However, it can be revoked at any time by the maintainer.
-
-> [!tip]
-> Instead of relying on the credential helper, one can resort to a simpler method:
-> ```console
-> git remote set-url icub-tech https://x-access-token:${PAT}@github.com/icub-tech-iit/robots-configuration.git
-> ```
 
 ## 🔲 Ensure that the author information is specified explicitly at commit time
 - We do rely on [Git hoooks](../.githooks).


### PR DESCRIPTION
It was causing issues when trying to push to another fork.