### PR TITLE
[iCubGenova11] Disable right hand fingers adduction

### DIFF
--- a/iCubGenova11/calibrators/right_arm-calib.xml
+++ b/iCubGenova11/calibrators/right_arm-calib.xml
@@ -33,7 +33,7 @@
 </group>
 
 
-	<param name="CALIB_ORDER">(0 1 2 3) (4) (5 6 7) (8 9 11 13) (10 12 14 15)</param>
+	<param name="CALIB_ORDER">(0 1 2 3) (4) (5 6) (8 9 11 13) (10 12 14 15)</param>
 	<!-- <param name="CALIB_ORDER">(0 1 2 3) (4) (5 6 7) (8 9 11 13) (10 12 14 15)</param> -->
 
 		<action phase="startup" level="10" type="calibrate">


### PR DESCRIPTION
## What changes:

This PR remove the right fingers adduction joint from calibration due malfunctioning.

The repair takes too long to be carried out in the short term. So for now I will remove the joint from calibration to avoid more damage.

- https://github.com/robotology/icub-tech-support/issues/2148