### PR TITLE
Best effort execution mode for RX, DO and TX phases of ETH boards

### DIFF
--- a/experimentalSetups/lego_setup_amc_advfoc/hardware/electronics/setup-eb2-j0_2-eln.xml
+++ b/experimentalSetups/lego_setup_amc_advfoc/hardware/electronics/setup-eb2-j0_2-eln.xml
@@ -17,22 +17,42 @@
 
         <group name="ETH_BOARD_SETTINGS">
             <param name="Name">                     "setup-eb2-j0_2"        </param>
+
             <group name="RUNNINGMODE">
+
+                <!-- execution can be [synchronized, besteffort]. 
+                 -->  
+                <param name="execution">                synchronized        </param>                
                 <param name="period">                   1000                </param>
+                <param name="safetygap">                150                 </param>
                 <param name="maxTimeOfRXactivity">      400                 </param>
                 <param name="maxTimeOfDOactivity">      300                 </param>
                 <param name="maxTimeOfTXactivity">      300                 </param>
                 <param name="TXrateOfRegularROPs">      5                   </param>
+
+
                 <group name="LOGGING">
+
                     <group name="IMMEDIATE">
-                        <param name="emitRXDOTXoverflow">       true        </param>
+
+                        <param name="emitRXDOTXoverflow">       false </param>
+                        <param name="emitPERIODoverflow">       true  </param>
+
                     </group>
+
                     <group name="PERIODIC">
-                        <param name="period">                   10          </param>                   
-                        <param name="emitRXDOTXstatistics">     false        </param>
+
+                        <param name="period">                  10.0        </param>                     
+                        <param name="emitRXDOTXstatistics">    true        </param>                   
+                        <param name="emitPERIODminavgmax">     true        </param>                   
+                        <param name="emitPERIODhistogram">     true        </param>
+
                     </group>
+
                 </group>
+
             </group>
+            
         </group>
 
         <group name="ETH_BOARD_ACTIONS">

--- a/experimentalSetups/lego_setup_ems_amcbldc/hardware/electronics/wrist-eb2-j0_2-eln.xml
+++ b/experimentalSetups/lego_setup_ems_amcbldc/hardware/electronics/wrist-eb2-j0_2-eln.xml
@@ -17,13 +17,42 @@
 
         <group name="ETH_BOARD_SETTINGS">
             <param name="Name">                     "wrist-eb2-j0_2"        </param>
+
             <group name="RUNNINGMODE">
+
+                <!-- execution can be [synchronized, besteffort]. 
+                 -->  
+                <param name="execution">                synchronized        </param>                
                 <param name="period">                   1000                </param>
+                <param name="safetygap">                150                 </param>
                 <param name="maxTimeOfRXactivity">      400                 </param>
                 <param name="maxTimeOfDOactivity">      300                 </param>
                 <param name="maxTimeOfTXactivity">      300                 </param>
                 <param name="TXrateOfRegularROPs">      5                   </param>
+
+
+                <group name="LOGGING">
+
+                    <group name="IMMEDIATE">
+
+                        <param name="emitRXDOTXoverflow">       false </param>
+                        <param name="emitPERIODoverflow">       true  </param>
+
+                    </group>
+
+                    <group name="PERIODIC">
+
+                        <param name="period">                  10.0        </param>                     
+                        <param name="emitRXDOTXstatistics">    true        </param>                   
+                        <param name="emitPERIODminavgmax">     true        </param>                   
+                        <param name="emitPERIODhistogram">     true        </param>
+
+                    </group>
+
+                </group>
+
             </group>
+            
         </group>
 
         <group name="ETH_BOARD_ACTIONS">

--- a/iCubTemplates/iCubTemplateV6_0/hardware/electronics/body_part--ebX-jA_B-eln.xml
+++ b/iCubTemplates/iCubTemplateV6_0/hardware/electronics/body_part--ebX-jA_B-eln.xml
@@ -53,20 +53,25 @@
                        of late phases.                       
                        You should use this mode if you want synchronous execution so that some actuations to motors do not drift inside the period 
 
-                          -------               ----------                   ----------
-                         | RX    |             | DO       |                 | TX       |
-                          -------               ----------                   ----------
-                         |---------------------|----------------------------|------------------------------------|
-                         | maxTimeOfRXactivity | maxTimeOfDOactivity        | maxTimeOfTXactivity                | 
-                           slot for RX           slot for DO                  slot for TX  
-                         Figure. Typical synchronized execution w/out overflow
+                          -------     --------          ------      --------   ---------         ------       --
+                         | RX    |   | DO     |        | TX   |    | RX      | | DO      |       | TX   |    | RX
+                          -------     --------          ------      ---------   ---------         ------      ---
+                         ^           ^                 ^           ^           ^                 ^           ^ 
+                         o-----------d-----------------t-----------o-----------d-----------------t-----------o----------
+                         | period n                                | period n+1                              | period n+2
+                         |-rx budget-|-do budget-------|-tx budget-|-rx budget-|-do budget-------|-tx budget-| ... 
+ 
+                         Figure. Typical synchronized execution w/out overflow. Note that teh values of rx/do/tx budget are onfigurable w/ parameters
+                                 maxTimeOfRXactivity, maxTimeOfDoactivity and maxTimeOfTXactivity                        
 
-                          -----------------------  ----------                ----------
-                         | RX                    || DO       |              | TX       |
-                          -----------------------  ----------                ----------
-                         |---------------------|----------------------------|------------------------------------|
-                         | maxTimeOfRXactivity | maxTimeOfDOactivity        | maxTimeOfTXactivity                | 
-                           slot for RX           slot for DO                  slot for TX  
+                          --------------  --------      ------      --------   ---------         ------       --
+                         | RX           || DO     |    | TX   |    | RX      | | DO      |       | TX   |    | RX
+                          --------------  --------      ------      ---------   ---------         ------      ---
+                         ^           ^^^^^             ^           ^           ^                 ^           ^ 
+                         o-----------d-----------------t-----------o-----------d-----------------t-----------o----------
+                         | period n                                | period n+1                              | period n+2
+                         |-rx budget-|-do budget-------|-tx budget-|-rx budget-|-do budget-------|-tx budget-| ...  
+                           
                          Figure. Typical synchronized execution w/ overflow of RX
 
                        In section LOGGING.IMMEDIATE, the param emitRXDOTXoverflow enables or disables warnings emitted by the board when any phase 
@@ -86,22 +91,22 @@
                        You should use this mode if you have difficulties to determine correct slots for the synchronized execution mode and you can accept
                        some drifts of execution inside the period.
 
-                          -------  ----------  ----------
-                         | RX    || DO       || TX       |
-                          -------  ----------  ----------
-                          -----------------------  ----------  ----------
-                         | RX                    || DO       || TX       |
-                          -----------------------  ----------  ---------- 
-                         |---------------------------------------------------------------------------------------|
-                         | period                                                                                | 
+                          -------  --------  ------                 ------------------  ---------  ------     --
+                         | RX    || DO     || TX   |               | RX               || DO      || TX   |   | RX
+                          -------  --------  ------                 ------------------  ---------  ------     ---
+                         ^                                         ^                                         ^
+                         o-----------------------------------------o-----------------------------------------o----------
+                         | period n                                | period n+1                              | period n+2                                                                             | 
 
                          Figure. Typical best effort execution w/out overflow
 
-                          -----------------------  ----------  ----------  -------  -------  ----------
-                         | RX                    || DO       || TX       || RX    || DO    || TX       |      
-                          -----------------------  ----------  ----------  -------  -------  ----------
-                         |-----------------------------------------|-----------------------------------------|
-                         | period n                                | period n+1                              |
+                          -----------------------------  -------------  ------  -------  ------  ------       --
+                         | RX                          || DO          || TX   || RX    || DO   || TX   |     | RX
+                          -----------------------------  -------------  ------  -------  ------  ------       ---
+                         ^                                         ^^^^^^^^^^^^^ (activation remains valid)  ^
+                         o-----------------------------------------o-----------------------------------------o----------
+                         | period n                                | period n+1                              | period n+2   
+                         
                          Figure. Typical best effort execution w/ overflow to next period (shortened for sake of displaying)
 
                        In section LOGGING.IMMEDIATE, the param emitRXDOTXoverflow enables or disables warnings emitted by the board when any phase 

--- a/iCubTemplates/iCubTemplateV6_0/hardware/electronics/body_part--ebX-jA_B-eln.xml
+++ b/iCubTemplates/iCubTemplateV6_0/hardware/electronics/body_part--ebX-jA_B-eln.xml
@@ -40,25 +40,120 @@
             <param name="Name">                     "body_part-ebX-jA_B" </param>
 
             <!-- This group contains values for configuration of the times of the board when in RUNNING mode  -->
+            
             <group name="RUNNINGMODE">
 
-                <!-- The period in microseconds of the control loop. IT MUST BE 1000 -->
-                <param name="period">                   1000                </param>
+                <!-- execution can be [synchronized, besteffort]. 
+                
+                     - synchronized
+                      
+                       In such a mode each phase RX, DO, TX executes inside exact time slots that are
+                       [0, maxTimeOfRXactivity), [maxTimeOfRXactivity, maxTimeOfRXactivity+maxTimeOfDOactivity) and [maxTimeOfRXactivity+maxTimeOfDOactivity, period)
+                       If any phase seldom overflows outside its time slot, the mode insures re synchronization to the slots by means of immediate execution
+                       of late phases.                       
+                       You should use this mode if you want synchonous execution so that some actuations to motors do not drift inside the period 
 
-                <!-- The time of the period in microseconds dedicated to the RX activity. Default is 400, range is [5, 990]. 
-                     Very important: t must be period = maxTimeOfRXactivity + maxTimeOfDOactivity + maxTimeOfDOactivity 
+                          -------               ----------                   ----------
+                         | RX    |             | DO       |                 | TX       |
+                          -------               ----------                   ----------
+                         |---------------------|----------------------------|------------------------------------|
+                         | maxTimeOfRXactivity | maxTimeOfDOactivity        | maxTimeOfTXactivity                | 
+                           slot for RX           slot for DO                  slot for TX  
+                         Figure. Typical synchronized execution w/out overflow
+
+                          -----------------------  ----------                ----------
+                         | RX                    || DO       |              | TX       |
+                          -----------------------  ----------                ----------
+                         |---------------------|----------------------------|------------------------------------|
+                         | maxTimeOfRXactivity | maxTimeOfDOactivity        | maxTimeOfTXactivity                | 
+                           slot for RX           slot for DO                  slot for TX  
+                         Figure. Typical synchronized execution w/ overflow of RX
+
+                       In section LOGGING.IMMEDIATE, the param emitRXDOTXoverflow enables or disables warnings emitted by the board when any phase 
+                       overflows beyond its max time of activity.
+                       Similarly, the param emitPERIODoverflow enables or disables warnings emitted by the board when the complete period overflows.
+                       Advised logging settings are:
+                       - LOGGING.IMMEDIATE.emitRXDOTXoverflow = true and LOGGING.IMMEDIATE.emitPERIODoverflow = false 
+                       - or even LOGGING.IMMEDIATE.emitRXDOTXoverflow = false if you want to get rid of some annoying overflow warnings (w/ some risks
+                         to lose visibility of the wanted motor control rate).
+                       
+ 
+                     - besteffort 
+                     
+                       In such a mode the activation is done exactly at start of the period and then phases RX, DO and TX executes as fast as they can.
+                       If the three of them seldom overflow outside the period, the mode insures re synchronization to the start of period by means of 
+                       immediate execution of a new burst.                       
+                       You should use this mode if you have difficulties to determine correct slots for the synchronized execution mode and you can accept
+                       some drifts of execution inside the period.
+
+                          -------  ----------  ----------
+                         | RX    || DO       || TX       |
+                          -------  ----------  ----------
+                          -----------------------  ----------  ----------
+                         | RX                    || DO       || TX       |
+                          -----------------------  ----------  ---------- 
+                         |---------------------------------------------------------------------------------------|
+                         | period                                                                                | 
+
+                         Figure. Typical best effort execution w/out overflow
+
+                          -----------------------  ----------  ----------  -------  -------  ----------
+                         | RX                    || DO       || TX       || RX    || DO    || TX       |      
+                          -----------------------  ----------  ----------  -------  -------  ----------
+                         |-----------------------------------------|-----------------------------------------|
+                         | period n                                | period n+1                              |
+                         Figure. Typical best effort execution w/ overflow to next period (shorted for sake of displaying)
+
+                       In section LOGGING.IMMEDIATE, the param emitRXDOTXoverflow enables or disables warnings emitted by the board when any phase 
+                       overflows beyond its max time of activity.
+                       Similarly, the param emitPERIODoverflow enables or disables warnings emitted by the board when the complete period overflows.
+                       Advised logging settings are:
+                       - LOGGING.IMMEDIATE.emitRXDOTXoverflow = false and LOGGING.IMMEDIATE.emitPERIODoverflow = true 
+                       It is dangerous to set LOGGING.IMMEDIATE.emitPERIODoverflow = false because it may hide the failure to maintain
+                       the target motor control rate. 
+                       
+                       It's synchronized by default if the param is not specified.
+
+                 -->  
+
+                <param name="execution">                synchronized        </param>
+
+
+                <!-- The following parameters express the time in us that is dedicated to the processing activities.
+                     They are: period, maxTimeOfRXactivity, maxTimeOfDOactivity, maxTimeOfTXactivity, safetygap     
+                  -->
+                  
+                <!-- The duration [in us] of the execution cycle that includes the three activities RX, DO and TX. 
+                     So far, it is locked to be only 1000.  
+                     Very important: it must be period = maxTimeOfRXactivity + maxTimeOfDOactivity + maxTimeOfTXactivity
+                  -->
+                <param name="period">                   1000                </param>               
+
+                <!-- The max time [in us] of the execution cycle dedicated to the RX activity. Default is 400, range is [5, 990].
+                     In case LOGGING.IMMEDIATE.emitRXDOTXoverflow = true, if the execution time of the RX exceeds maxTimeOfRXactivity then a warning message is emitted.                
+                     In case of execution = synchronized the value maxTimeOfRXactivity is used to start the execution of the DO phase so that it is inside the slot
+                     [maxTimeOfRXactivity, maxTimeOfRXactivity+maxTimeOfDOactivity).
                   -->
                 <param name="maxTimeOfRXactivity">      400                 </param>
 
-                <!-- The time of the period in microseconds dedicated to the DO activity. Default is 400, range is [5, 990]. 
-                     Very important: t must be period = maxTimeOfRXactivity + maxTimeOfDOactivity + maxTimeOfDOactivity 
+                <!-- The max time [in us] of the execution cycle dedicated to the DO activity. Default is 400, range is [5, 990]. 
+                     In case LOGGING.IMMEDIATE.emitRXDOTXoverflow = true, if the execution time of the DO exceeds maxTimeOfDOactivity then a warning message is emitted.  
+                     In case of execution = synchronized the value maxTimeOfDOactivity is used to start the execution of the TX phase so that it is inside the slot
+                     [maxTimeOfRXactivity+maxTimeOfDOactivity, period).
                   -->
                 <param name="maxTimeOfDOactivity">      300                 </param>  
 
-                <!-- The time of the period in microseconds dedicated to the TX activity. Default is 400, range is [5, 990]. 
-                     Very important: t must be period = maxTimeOfRXactivity + maxTimeOfDOactivity + maxTimeOfDOactivity 
+                <!-- The max time [in us] of the execution cycle dedicated to the TX activity. Default is 400, range is [5, 990]. 
+                     In case LOGGING.IMMEDIATE.emitRXDOTXoverflow = true, if the execution time of the TX exceeds maxTimeOfTXactivity then a warning message is emitted. 
                   -->
-                <param name="maxTimeOfTXactivity">      300                 </param>    
+                <param name="maxTimeOfTXactivity">      300                 </param>  
+                
+                <!-- Amount of time [in us] of the execution cycle that should be left availaale for system processing.
+                     It is used just for diagnostics purposes and it does not count in triggering of activities. 
+                     For instance if LOGGING.IMMEDIATE.emitPERIODoverflow is true and the execution time is > (period-safetygap) a warning message is emitted
+                     It's 0 by default if the param is not specified.
+                  -->
+                <param name="safetygap">                100                 </param>                   
 
                 <!-- The period in multiples of RUNNINGMODE::period with which the ETH boards transmits the regular ROPs. Its range is [1, 20] and if out of bound it is clipped to limits. 
                      The recommended value is 5 (3 for boards which support skin). IMPORTANT: reply ROPs and diagnostics ROPs are transmitted ASAP with 1 ms granularity.
@@ -72,24 +167,66 @@
                   -->              
                 <param name="TXrateOfRegularROPs">      5                   </param> 
 
-                <!-- Contains enabling / disabling of logging that must be emitted immediately as soon as the condition appears --> 
+                
                 <group name="LOGGING">
+                
+                    <!-- Contains enabling / disabling of logging that must be emitted immediately as soon as the condition appears
+                         If the group or a param is not present, the default values are always false or 0.0, except for LOGGING.IMMEDIATE.emitRXDOTXoverflow that is true.
+                      --> 
+                    
                     <group name="IMMEDIATE">
 
-                        <!-- Enable / disable the emission of diagnostics related to the measured execution time of RX higher than the configured
-                            maxTimeOfRXactivity and similarly for DO and TX. It's true by default if the LOGGING group is not present. -->
+                        <!-- Enables / disables the emission of warning diagnostics related to the measured execution time of RX higher than the configured
+                             maxTimeOfRXactivity and similarly for DO and TX. 
+                             It's true by default if the param is not specified. 
+                          -->
                         <param name="emitRXDOTXoverflow">       true        </param>
+                        
+                        <!-- enables / disables the emission of warning diagnostics that alert that the measured execution time of the complete period (RX, DO, TX) 
+                             is higher than the configured period - safetygap
+                             It's false by default if the param is not specified.
+                          -->
+                        <param name="emitPERIODoverflow">       true        </param>
+                    
                     </group>
                     
                     <!-- Contains enabling / disabling of logging that must be emitted periodically -->
+                    
                     <group name="PERIODIC">
                     
-                        <!-- The period expressed in seconds in the interval [1.0, 600.0] -->
-                        <param name="period">                   10          </param>
+                        <!-- The period of the emission of periodic diagnostics expressed in seconds in the interval [1.0, 600.0]. 
+                             If 0.0 every periodic transmission is disabled 
+                             It's 0.0 by default if the param is not specified.
+                          -->
+                        <param name="period">                   10.0          </param>
+ 
+                        <!-- enables / disables the periodic emission of info diagnostics about to the statistics of the execution time of the RX, DO and TX phase
+                             in the form of minimum, average and maximum values. 
+                             The legacy param emitRXDOTXstatistics is just an alias. When both are present, emitRXDOTXminavgmax wins.
+                             It's false by default if the param is not specified.
+                          -->                        
+                        <param name="emitRXDOTXminavgmax">      true        </param>
                         
-                        <!-- Enable / disable the periodic emission of diagnostics about to the statistics of the execution time of the RX, DO and TX phase
-                            in the form of minimum, average and maximum values. It's false by default if the LOGGING group is not present. -->                        
-                        <param name="emitRXDOTXstatistics">     false        </param>
+                        <!-- legacy name of emitRXDOTXminavgmax. When both are present emitRXDOTXminavgmax wins.
+                             It's false by default if the param is not specified.
+                          -->                        
+                        <param name="emitRXDOTXstatistics">     true        </param>
+                    
+                        <!-- enables / disables the periodic emission of info diagnostics about to the statistics of the execution time of the complete period (RX, DO, TX)
+                             in the form of minimum, average and maximum values.
+                             It's false by default if the LOGGING group is not present or if the param is not specified.
+                          -->                        
+                        <param name="emitPERIODminavgmax">      true        </param>
+
+                        <!-- enables / disables the periodic emission of info diagnostics about to the statistics of the execution time of the complete period (RX, DO, TX)
+                             in the form of a probability density function in 8 bins of period/4 us each. 
+                             For period = 1000: [0, 250), [250, 500), [500, 750), [750, 1000), [1000, 1250), [1250, 1500), [1500, 1750), [1750, +oo)
+                             So, just for example, if over PERIODIC.period seconds the RX-DO-TX cycles lasts 70% of the times exactly 400 us, 20% of the times exactly 600 us 
+                             and only 10% of the times exactly 800 us, then the reported values will be [0, 70, 20, 10, 0, 0, 0, 0].
+                             It's false by default if the param is not specified.
+                          -->                        
+                        <param name="emitPERIODhistogram">     true        </param>
+                    
                     </group>
 
                 </group>

--- a/iCubTemplates/iCubTemplateV6_0/hardware/electronics/body_part--ebX-jA_B-eln.xml
+++ b/iCubTemplates/iCubTemplateV6_0/hardware/electronics/body_part--ebX-jA_B-eln.xml
@@ -49,9 +49,9 @@
                       
                        In such a mode each phase RX, DO, TX executes inside exact time slots that are
                        [0, maxTimeOfRXactivity), [maxTimeOfRXactivity, maxTimeOfRXactivity+maxTimeOfDOactivity) and [maxTimeOfRXactivity+maxTimeOfDOactivity, period)
-                       If any phase seldom overflows outside its time slot, the mode insures re synchronization to the slots by means of immediate execution
+                       If any phase seldom overflows outside its time slot, the mode ensures re synchronization to the slots by means of immediate execution
                        of late phases.                       
-                       You should use this mode if you want synchonous execution so that some actuations to motors do not drift inside the period 
+                       You should use this mode if you want synchronous execution so that some actuations to motors do not drift inside the period 
 
                           -------               ----------                   ----------
                          | RX    |             | DO       |                 | TX       |
@@ -81,7 +81,7 @@
                      - besteffort 
                      
                        In such a mode the activation is done exactly at start of the period and then phases RX, DO and TX executes as fast as they can.
-                       If the three of them seldom overflow outside the period, the mode insures re synchronization to the start of period by means of 
+                       If the three of them seldom overflow outside the period, the mode ensures re synchronization to the start of period by means of 
                        immediate execution of a new burst.                       
                        You should use this mode if you have difficulties to determine correct slots for the synchronized execution mode and you can accept
                        some drifts of execution inside the period.
@@ -102,7 +102,7 @@
                           -----------------------  ----------  ----------  -------  -------  ----------
                          |-----------------------------------------|-----------------------------------------|
                          | period n                                | period n+1                              |
-                         Figure. Typical best effort execution w/ overflow to next period (shorted for sake of displaying)
+                         Figure. Typical best effort execution w/ overflow to next period (shortened for sake of displaying)
 
                        In section LOGGING.IMMEDIATE, the param emitRXDOTXoverflow enables or disables warnings emitted by the board when any phase 
                        overflows beyond its max time of activity.
@@ -148,7 +148,7 @@
                   -->
                 <param name="maxTimeOfTXactivity">      300                 </param>  
                 
-                <!-- Amount of time [in us] of the execution cycle that should be left availaale for system processing.
+                <!-- Amount of time [in us] of the execution cycle that should be left available for system processing.
                      It is used just for diagnostics purposes and it does not count in triggering of activities. 
                      For instance if LOGGING.IMMEDIATE.emitPERIODoverflow is true and the execution time is > (period-safetygap) a warning message is emitted
                      It's 0 by default if the param is not specified.
@@ -200,7 +200,7 @@
                           -->
                         <param name="period">                   10.0          </param>
  
-                        <!-- enables / disables the periodic emission of info diagnostics about to the statistics of the execution time of the RX, DO and TX phase
+                        <!-- enables / disables the periodic emission of info diagnostics about the statistics of the execution time of the RX, DO and TX phase
                              in the form of minimum, average and maximum values. 
                              The legacy param emitRXDOTXstatistics is just an alias. When both are present, emitRXDOTXminavgmax wins.
                              It's false by default if the param is not specified.
@@ -212,13 +212,13 @@
                           -->                        
                         <param name="emitRXDOTXstatistics">     true        </param>
                     
-                        <!-- enables / disables the periodic emission of info diagnostics about to the statistics of the execution time of the complete period (RX, DO, TX)
+                        <!-- enables / disables the periodic emission of info diagnostics about the statistics of the execution time of the complete period (RX, DO, TX)
                              in the form of minimum, average and maximum values.
                              It's false by default if the LOGGING group is not present or if the param is not specified.
                           -->                        
                         <param name="emitPERIODminavgmax">      true        </param>
 
-                        <!-- enables / disables the periodic emission of info diagnostics about to the statistics of the execution time of the complete period (RX, DO, TX)
+                        <!-- enables / disables the periodic emission of info diagnostics about the statistics of the execution time of the complete period (RX, DO, TX)
                              in the form of a probability density function in 8 bins of period/4 us each. 
                              For period = 1000: [0, 250), [250, 500), [500, 750), [750, 1000), [1000, 1250), [1250, 1500), [1500, 1750), [1750, +oo)
                              So, just for example, if over PERIODIC.period seconds the RX-DO-TX cycles lasts 70% of the times exactly 400 us, 20% of the times exactly 600 us 


### PR DESCRIPTION
This PR adds configurability for the best effort mode for the execution of the RX, Do and TX phases for all ETH boards and for improved logging of the execution cycle.
 
The new parameters, if not present, are considered by icub-main with the default values.


## Associated PRs
- https://github.com/robotology/icub-firmware/pull/617
- https://github.com/robotology/icub-firmware-shared/pull/115
- https://github.com/robotology/icub-main/pull/1030
- https://github.com/robotology/robots-configuration/pull/746
- https://github.com/robotology/icub-firmware-build/pull/215

## Description

The full description of the new `best effort` mode and of how the ETH board computes measures about the execution cycles is in here:
- https://github.com/robotology/icub-firmware/pull/617

The above measures are used for both execution overflow immediate signaling or for periodic emission of execution statistics.

In here we show how to fully configure and enable / disable the emission of such diagnostics messages.

See the following.

```xml
<group name="RUNNINGMODE">

    <!-- execution can be [synchronized, besteffort]. 
    
         - synchronized
          
           In such a mode each phase RX, DO, TX executes inside exact time slots that are
           [0, maxTimeOfRXactivity), [maxTimeOfRXactivity, maxTimeOfRXactivity+maxTimeOfDOactivity) and [maxTimeOfRXactivity+maxTimeOfDOactivity, period)
           If any phase seldom overflows outside its time slot, the mode ensures re synchronization to the slots by means of immediate execution
           of late phases.                       
           You should use this mode if you want synchronous execution so that some actuations to motors do not drift inside the period 

              -------     --------          ------      --------   ---------         ------       --
             | RX    |   | DO     |        | TX   |    | RX      | | DO      |       | TX   |    | RX
              -------     --------          ------      ---------   ---------         ------      ---
             ^           ^                 ^           ^           ^                 ^           ^ 
             o-----------d-----------------t-----------o-----------d-----------------t-----------o----------
             | period n                                | period n+1                              | period n+2
             |-rx budget-|-do budget-------|-tx budget-|-rx budget-|-do budget-------|-tx budget-| ... 

             Figure. Typical synchronized execution w/out overflow. Note that teh values of rx/do/tx budget are onfigurable w/ parameters
                     maxTimeOfRXactivity, maxTimeOfDoactivity and maxTimeOfTXactivity                        

              --------------  --------      ------      --------   ---------         ------       --
             | RX           || DO     |    | TX   |    | RX      | | DO      |       | TX   |    | RX
              --------------  --------      ------      ---------   ---------         ------      ---
             ^           ^^^^^             ^           ^           ^                 ^           ^ 
             o-----------d-----------------t-----------o-----------d-----------------t-----------o----------
             | period n                                | period n+1                              | period n+2
             |-rx budget-|-do budget-------|-tx budget-|-rx budget-|-do budget-------|-tx budget-| ...  
               
             Figure. Typical synchronized execution w/ overflow of RX

           In section LOGGING.IMMEDIATE, the param emitRXDOTXoverflow enables or disables warnings emitted by the board when any phase 
           overflows beyond its max time of activity.
           Similarly, the param emitPERIODoverflow enables or disables warnings emitted by the board when the complete period overflows.
           Advised logging settings are:
           - LOGGING.IMMEDIATE.emitRXDOTXoverflow = true and LOGGING.IMMEDIATE.emitPERIODoverflow = false 
           - or even LOGGING.IMMEDIATE.emitRXDOTXoverflow = false if you want to get rid of some annoying overflow warnings (w/ some risks
             to lose visibility of the wanted motor control rate).
           

         - besteffort 
         
           In such a mode the activation is done exactly at start of the period and then phases RX, DO and TX executes as fast as they can.
           If the three of them seldom overflow outside the period, the mode ensures re synchronization to the start of period by means of 
           immediate execution of a new burst.                       
           You should use this mode if you have difficulties to determine correct slots for the synchronized execution mode and you can accept
           some drifts of execution inside the period.

              -------  --------  ------                 ------------------  ---------  ------     --
             | RX    || DO     || TX   |               | RX               || DO      || TX   |   | RX
              -------  --------  ------                 ------------------  ---------  ------     ---
             ^                                         ^                                         ^
             o-----------------------------------------o-----------------------------------------o----------
             | period n                                | period n+1                              | period n+2                                                                             | 

             Figure. Typical best effort execution w/out overflow

              -----------------------------  -------------  ------  -------  ------  ------       --
             | RX                          || DO          || TX   || RX    || DO   || TX   |     | RX
              -----------------------------  -------------  ------  -------  ------  ------       ---
             ^                                         ^^^^^^^^^^^^^ (activation remains valid)  ^
             o-----------------------------------------o-----------------------------------------o----------
             | period n                                | period n+1                              | period n+2   
             
             Figure. Typical best effort execution w/ overflow to next period (shortened for sake of displaying)

           In section LOGGING.IMMEDIATE, the param emitRXDOTXoverflow enables or disables warnings emitted by the board when any phase 
           overflows beyond its max time of activity.
           Similarly, the param emitPERIODoverflow enables or disables warnings emitted by the board when the complete period overflows.
           Advised logging settings are:
           - LOGGING.IMMEDIATE.emitRXDOTXoverflow = false and LOGGING.IMMEDIATE.emitPERIODoverflow = true 
           It is dangerous to set LOGGING.IMMEDIATE.emitPERIODoverflow = false because it may hide the failure to maintain
           the target motor control rate. 
           
           It's synchronized by default if the param is not specified.

     -->  

    <param name="execution">                synchronized        </param>


    <!-- The following parameters express the time in us that is dedicated to the processing activities.
         They are: period, maxTimeOfRXactivity, maxTimeOfDOactivity, maxTimeOfTXactivity, safetygap     
      -->
      
    <!-- The duration [in us] of the execution cycle that includes the three activities RX, DO and TX. 
         So far, it is locked to be only 1000.  
         Very important: it must be period = maxTimeOfRXactivity + maxTimeOfDOactivity + maxTimeOfTXactivity
      -->
    <param name="period">                   1000                </param>               

    <!-- The max time [in us] of the execution cycle dedicated to the RX activity. Default is 400, range is [5, 990].
         In case LOGGING.IMMEDIATE.emitRXDOTXoverflow = true, if the execution time of the RX exceeds maxTimeOfRXactivity then a warning message is emitted.                
         In case of execution = synchronized the value maxTimeOfRXactivity is used to start the execution of the DO phase so that it is inside the slot
         [maxTimeOfRXactivity, maxTimeOfRXactivity+maxTimeOfDOactivity).
      -->
    <param name="maxTimeOfRXactivity">      400                 </param>

    <!-- The max time [in us] of the execution cycle dedicated to the DO activity. Default is 400, range is [5, 990]. 
         In case LOGGING.IMMEDIATE.emitRXDOTXoverflow = true, if the execution time of the DO exceeds maxTimeOfDOactivity then a warning message is emitted.  
         In case of execution = synchronized the value maxTimeOfDOactivity is used to start the execution of the TX phase so that it is inside the slot
         [maxTimeOfRXactivity+maxTimeOfDOactivity, period).
      -->
    <param name="maxTimeOfDOactivity">      300                 </param>  

    <!-- The max time [in us] of the execution cycle dedicated to the TX activity. Default is 400, range is [5, 990]. 
         In case LOGGING.IMMEDIATE.emitRXDOTXoverflow = true, if the execution time of the TX exceeds maxTimeOfTXactivity then a warning message is emitted. 
      -->
    <param name="maxTimeOfTXactivity">      300                 </param>  
    
    <!-- Amount of time [in us] of the execution cycle that should be left available for system processing.
         It is used just for diagnostics purposes and it does not count in triggering of activities. 
         For instance if LOGGING.IMMEDIATE.emitPERIODoverflow is true and the execution time is > (period-safetygap) a warning message is emitted
         It's 0 by default if the param is not specified.
      -->
    <param name="safetygap">                100                 </param>                   

    <!-- The period in multiples of RUNNINGMODE::period with which the ETH boards transmits the regular ROPs. Its range is [1, 20] and if out of bound it is clipped to limits. 
         The recommended value is 5 (3 for boards which support skin). IMPORTANT: reply ROPs and diagnostics ROPs are transmitted ASAP with 1 ms granularity.
                      
         This number is related to many other system parameters: (1) the ETH_BOARD::ETH_BOARD_SETTINGS::regularsTXrate of other boards; (2) the PC104::PC104RXrate decoding 
         rate inside PC104; (3) rate of the wrappers which typically is 10 ms. 
         A value of PC104::PC104RXrate = 1 for every board is possible, but it adds extra useless effort in the CPU of PC104 to decode many UDP packets. 
         The effort is useless because the information carried by regular ROPs is read by wrappers typically at 10 ms rate.
         hence, any value lower than the rate of wrappers is enough. The only exception is for presence of skin, where it is required a lower value so that the ETH 
         board can consume the CAN packets sent by the CAN boards without losing info (if it happens, diagnostics messages are sent which complain about loss of skin data).  
      -->              
    <param name="TXrateOfRegularROPs">      5                   </param> 

    
    <group name="LOGGING">
    
        <!-- Contains enabling / disabling of logging that must be emitted immediately as soon as the condition appears
             If the group or a param is not present, the default values are always false or 0.0, except for LOGGING.IMMEDIATE.emitRXDOTXoverflow that is true.
          --> 
        
        <group name="IMMEDIATE">

            <!-- Enables / disables the emission of warning diagnostics related to the measured execution time of RX higher than the configured
                 maxTimeOfRXactivity and similarly for DO and TX. 
                 It's true by default if the param is not specified. 
              -->
            <param name="emitRXDOTXoverflow">       true        </param>
            
            <!-- enables / disables the emission of warning diagnostics that alert that the measured execution time of the complete period (RX, DO, TX) 
                 is higher than the configured period - safetygap
                 It's false by default if the param is not specified.
              -->
            <param name="emitPERIODoverflow">       true        </param>
        
        </group>
        
        <!-- Contains enabling / disabling of logging that must be emitted periodically -->
        
        <group name="PERIODIC">
        
            <!-- The period of the emission of periodic diagnostics expressed in seconds in the interval [1.0, 600.0]. 
                 If 0.0 every periodic transmission is disabled 
                 It's 0.0 by default if the param is not specified.
              -->
            <param name="period">                   10.0          </param>

            <!-- enables / disables the periodic emission of info diagnostics about the statistics of the execution time of the RX, DO and TX phase
                 in the form of minimum, average and maximum values. 
                 The legacy param emitRXDOTXstatistics is just an alias. When both are present, emitRXDOTXminavgmax wins.
                 It's false by default if the param is not specified.
              -->                        
            <param name="emitRXDOTXminavgmax">      true        </param>
            
            <!-- legacy name of emitRXDOTXminavgmax. When both are present emitRXDOTXminavgmax wins.
                 It's false by default if the param is not specified.
              -->                        
            <param name="emitRXDOTXstatistics">     true        </param>
        
            <!-- enables / disables the periodic emission of info diagnostics about the statistics of the execution time of the complete period (RX, DO, TX)
                 in the form of minimum, average and maximum values.
                 It's false by default if the LOGGING group is not present or if the param is not specified.
              -->                        
            <param name="emitPERIODminavgmax">      true        </param>

            <!-- enables / disables the periodic emission of info diagnostics about the statistics of the execution time of the complete period (RX, DO, TX)
                 in the form of a probability density function in 8 bins of period/4 us each. 
                 For period = 1000: [0, 250), [250, 500), [500, 750), [750, 1000), [1000, 1250), [1250, 1500), [1500, 1750), [1750, +oo)
                 So, just for example, if over PERIODIC.period seconds the RX-DO-TX cycles lasts 70% of the times exactly 400 us, 20% of the times exactly 600 us 
                 and only 10% of the times exactly 800 us, then the reported values will be [0, 70, 20, 10, 0, 0, 0, 0].
                 It's false by default if the param is not specified.
              -->                        
            <param name="emitPERIODhistogram">     true        </param>
        
        </group>

    </group>

</group> 

```
Code Listing. Configurability of the `ETH_BOARD.RUNNINGMODE` group.


## Mergeability

This PR is useful only when all the associated PRs are merged but does not harm if `icub-main` is not able to parse the new params. Moreover, so far the change of xml is applied only to the template file and to the lego setup used for the tests. 

So, the PR can be safely merged as the first of the list of associated PRs.
