### PR TITLE
[R1SN003] change calib values for right hand 

### DIFF
--- a/R1SN003/calibrators/right_arm-calib.xml
+++ b/R1SN003/calibrators/right_arm-calib.xml
@@ -22,7 +22,7 @@
 			<param name="calibration2">	           0                 0              0           0         0             0              0            0            0           0            0           0           0          </param>
 			<param name="calibration3">            0                 0              0           0         0             0              0            0            0           0            1           0           0          </param>
 			<param name="calibration4">            0                 0              0           0         0             0              0            0            32768       0            0           0           0          </param>
-			<param name="calibration5">            0                 0              0           0         0             0              0            0            61900       0            54650       5800        36700      </param>
+			<param name="calibration5">            0                 0              0           0         0             0              0            0            61900       0            54950       6100        37500      </param>
 			<param name="calibrationZero">         35               -15            -52         -5         0             0              0            0            0           0            0           0           0          </param>
 			<param name="calibrationDelta">        0                 0              0           0         0             0              0            0            0           0            0           0           0          </param>
 			<param name="startupPosition">         34                50             -10         90        0.0           0.0            0.0          0.0          5.0         5.0          5.0         5.0         5.0        </param>


### PR DESCRIPTION
[R1SN003] change calib values for right hand.

See the reference issue:
- https://github.com/robotology/icub-tech-support/issues/2212

<img width="2087" height="412" alt="image" src="https://github.com/user-attachments/assets/0f3f442d-e094-49a8-96f8-ed822f6e1de4" />
In the photo, the file on the right shows the new calibration values.