### PR TITLE
Disable all fingers due to issues with tendons awaiting for support

### DIFF
--- a/iCubGenova11/calibrators/left_arm-calib.xml
+++ b/iCubGenova11/calibrators/left_arm-calib.xml
@@ -31,7 +31,7 @@
 			<param name="startupPosThreshold">    2          2          2          2         90     90     90    90    90    90    90    90    90     90     90    90    </param>
 		</group>
 
-		<param name="CALIB_ORDER">(0 1 2 3) (4) (5 6 )</param>
+		<param name="CALIB_ORDER">(0 1 2 3) (4) (5 6)</param>
        	<!-- <param name="CALIB_ORDER">(0 1 2 3) (4) (5 6 7) (8 9 11 13) (10 12 14 15)</param> -->
 		<action phase="startup" level="10" type="calibrate">
 		    <param name="target">left_arm-mc_remapper</param>

--- a/iCubGenova11/calibrators/left_arm-calib.xml
+++ b/iCubGenova11/calibrators/left_arm-calib.xml
@@ -31,7 +31,7 @@
 			<param name="startupPosThreshold">    2          2          2          2         90     90     90    90    90    90    90    90    90     90     90    90    </param>
 		</group>
 
-		<param name="CALIB_ORDER">(0 1 2 3) (4) (5 6 7) (8 9 11 13) (10 12 14 15)</param>
+		<param name="CALIB_ORDER">(0 1 2 3) (4) (5 6 )</param>
        	<!-- <param name="CALIB_ORDER">(0 1 2 3) (4) (5 6 7) (8 9 11 13) (10 12 14 15)</param> -->
 		<action phase="startup" level="10" type="calibrate">
 		    <param name="target">left_arm-mc_remapper</param>

--- a/iCubGenova11/calibrators/right_arm-calib.xml
+++ b/iCubGenova11/calibrators/right_arm-calib.xml
@@ -33,7 +33,7 @@
 </group>
 
 
-	<param name="CALIB_ORDER">(0 1 2 3) (4) (5 6) (8 9 11 13) (10 12 14 15)</param>
+	<param name="CALIB_ORDER">(0 1 2 3) (4) (5 6) </param>
 	<!-- <param name="CALIB_ORDER">(0 1 2 3) (4) (5 6 7) (8 9 11 13) (10 12 14 15)</param> -->
 
 		<action phase="startup" level="10" type="calibrate">

--- a/iCubGenova11/calibrators/right_arm-calib.xml
+++ b/iCubGenova11/calibrators/right_arm-calib.xml
@@ -33,7 +33,7 @@
 </group>
 
 
-	<param name="CALIB_ORDER">(0 1 2 3) (4) (5 6) </param>
+	<param name="CALIB_ORDER">(0 1 2 3) (4) (5 6)</param>
 	<!-- <param name="CALIB_ORDER">(0 1 2 3) (4) (5 6 7) (8 9 11 13) (10 12 14 15)</param> -->
 
 		<action phase="startup" level="10" type="calibrate">


### PR DESCRIPTION
This PR disables all hand/finger joints on iCubGenova11 since we have some problems with the tendons.
Therefore, in order to do not damage the motors it is safer to keep all of the finger disabled for now.