### PR TITLE
Kbemf (back EMF constant) added to templates.

### DIFF
--- a/iCubTemplates/iCubTemplateV6_0/hardware/mechanicals/body_part-ebX-jA_B-mec.xml
+++ b/iCubTemplates/iCubTemplateV6_0/hardware/mechanicals/body_part-ebX-jA_B-mec.xml
@@ -61,6 +61,7 @@
         <param name="HasSpeedEncoder">       0    </param> <!-- It is as an alternative to rotorEncoder. It is not used for FOC controller. -->
         <param name="RotorIndexOffset">      0    </param> <!-- Rotor index offset between first electric sector and encoder index [degree] -->
         <param name="MotorPoles">            1    </param> <!--  Number of poles of motor -->
+        <param name="Kbemf">                 0    </param> <!--  Back EMF constant of the motor in machine units -->
     </group>
 
     <group name="COUPLINGS"> 


### PR DESCRIPTION
[2foc Kbemf (back EMF constant) has been added to templates in hardware/mechanicals.](https://github.com/robotology/robots-configuration/pull/751)