### PR TITLE
[iCubGenova11] Fix fineCalibrationChecker config file

### DIFF
--- a/iCubGenova11/checker/fineCalibrationCheckerConfig.xml
+++ b/iCubGenova11/checker/fineCalibrationCheckerConfig.xml
@@ -13,6 +13,8 @@
         <!--<param name="calibrationDeltas">(1.0, -9.2, -14.2, 0 )</param> --> <!--right_arm-->
         <param name="calibrationDeltas">(0, -9.2, -17.1, -2.7 )</param> <!--left_arm-->
         <param name="encoderResolutions">(262144, 262144, 262144, 262144)</param> <!--2^18 raw encoder resolution-->
+        <param name="axesSigns">(-1, -1, 1, -1)</param>
+        <!-- <param name="axesSigns">(1, 1, -1, 1)</param> --> <!--right_arm-->
 
 
         <action phase="startup" level="15" type="attach">


### PR DESCRIPTION
Without this parameter, on iCubGenova11 the yarprobotinterface doesn't start.

cc @MSECode @Nicogene 