### PR TITLE
iCubGenova11 hard limits precise values updated from CAD (torso and legs).

### DIFF
--- a/iCubGenova11/hardware/mechanicals/left_leg-eb6-j0_3-mec.xml
+++ b/iCubGenova11/hardware/mechanicals/left_leg-eb6-j0_3-mec.xml
@@ -9,20 +9,21 @@
         <param name="AxisName">     "l_hip_pitch"   "l_hip_roll"    "l_hip_yaw"   "l_knee"     </param>
         <param name="AxisType">       "revolute"    "revolute"    "revolute"  "revolute"       </param>
         <param name="Encoder">         182.044       182.044       182.044       182.044       </param>     
-        <param name="fullscalePWM">   32000         32000         32000         32000    </param>
-        <param name="ampsToSensor">     1000.0        1000.0        1000.0           1000.0      </param>
+        <param name="fullscalePWM">   32000         32000         32000         32000          </param>
+        <param name="ampsToSensor">     1000.0        1000.0        1000.0           1000.0    </param>
         <param name="Gearbox_M2J">   	-150.0         100.0        -100.0         -100.0      </param>
         <param name="Gearbox_E2J">   	1             1             1              1           </param>
         <param name="useMotorSpeedFbk"> 1             1             1              1           </param>
-        <param name="MotorType">       "BLL_MOOG"     "BLL_MOOG"   "BLL_MOOG"    "BLL_MOOG"   </param>
+        <param name="MotorType">       "BLL_MOOG"     "BLL_MOOG"   "BLL_MOOG"    "BLL_MOOG"    </param>
         <param name="Verbose">0</param>
     </group>
     
     <group name="LIMITS">
-        <param name="hardwareJntPosMax">    92            92            72            0     </param>
-        <param name="hardwareJntPosMin">   -30           -15           -72         -100     </param>
-        <param name="rotorPosMin">           0             0             0            0     </param> 
-        <param name="rotorPosMax">           0             0             0            0     </param>
+        <!--                                    0             	1            2          3           -->
+        <param name="hardwareJntPosMax">      134.49          121.12        81.06       4.12   </param>
+        <param name="hardwareJntPosMin">      -46.49          -21.12       -81.06    -125.12   </param>
+        <param name="rotorPosMin">              0               0            0          0      </param> 
+        <param name="rotorPosMax">              0               0            0          0      </param>
     </group>
 
     <group name="2FOC">

--- a/iCubGenova11/hardware/mechanicals/left_leg-eb6-j0_3-mec.xml
+++ b/iCubGenova11/hardware/mechanicals/left_leg-eb6-j0_3-mec.xml
@@ -4,25 +4,25 @@
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="iCubGenova11" build="1">
     <group name="GENERAL">
         <param name="MotioncontrolVersion"> 6 </param>
-        <param name="Joints"> 4 </param> 
+        <param name="Joints"> 4 </param>
         <param name="AxisMap">               0             1             2             3       </param>
         <param name="AxisName">     "l_hip_pitch"   "l_hip_roll"    "l_hip_yaw"   "l_knee"     </param>
         <param name="AxisType">       "revolute"    "revolute"    "revolute"  "revolute"       </param>
-        <param name="Encoder">         182.044       182.044       182.044       182.044       </param>     
+        <param name="Encoder">         182.044       182.044       182.044       182.044       </param>
         <param name="fullscalePWM">   32000         32000         32000         32000          </param>
         <param name="ampsToSensor">     1000.0        1000.0        1000.0           1000.0    </param>
-        <param name="Gearbox_M2J">   	-150.0         100.0        -100.0         -100.0      </param>
-        <param name="Gearbox_E2J">   	1             1             1              1           </param>
+        <param name="Gearbox_M2J">      -150.0         100.0        -100.0         -100.0      </param>
+        <param name="Gearbox_E2J">      1             1             1              1           </param>
         <param name="useMotorSpeedFbk"> 1             1             1              1           </param>
         <param name="MotorType">       "BLL_MOOG"     "BLL_MOOG"   "BLL_MOOG"    "BLL_MOOG"    </param>
         <param name="Verbose">0</param>
     </group>
-    
+
     <group name="LIMITS">
-        <!--                                    0             	1            2          3           -->
+        <!--                                    0               1            2          3           -->
         <param name="hardwareJntPosMax">      134.49          121.12        81.06       4.12   </param>
         <param name="hardwareJntPosMin">      -46.49          -21.12       -81.06    -125.12   </param>
-        <param name="rotorPosMin">              0               0            0          0      </param> 
+        <param name="rotorPosMin">              0               0            0          0      </param>
         <param name="rotorPosMax">              0               0            0          0      </param>
     </group>
 
@@ -36,59 +36,59 @@
         <param name="MotorPoles">            8             8             8             8       </param>
    </group>
 
-    <group name="COUPLINGS"> 
-                                
-        <param name ="matrixJ2M"> 
+    <group name="COUPLINGS">
+
+        <param name ="matrixJ2M">
             1.00    0.00    0.00    0.00
             0.00    1.00    0.00    0.00
             0.00    0.00    1.00    0.00
-            0.00    0.00    0.00    1.00   
-        </param>
-       
-        <param name ="matrixM2J"> 
-            1.00    0.00    0.00    0.00
-            0.00    1.00    0.00    0.00
-            0.00    0.00    1.00    0.00
-            0.00    0.00    0.00    1.00   
+            0.00    0.00    0.00    1.00
         </param>
 
-        <param name ="matrixE2J">  
+        <param name ="matrixM2J">
+            1.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00
+            0.00    0.00    1.00    0.00
+            0.00    0.00    0.00    1.00
+        </param>
+
+        <param name ="matrixE2J">
             1.00    0.00    0.00    0.00    0.00    0.00
             0.00    1.00    0.00    0.00    0.00    0.00
             0.00    0.00    1.00    0.00    0.00    0.00
-            0.00    0.00    0.00    1.00    0.00    0.00   
+            0.00    0.00    0.00    1.00    0.00    0.00
         </param>
-                
-    </group>    
 
-    <group name="JOINTSET_CFG"> 
+    </group>
+
+    <group name="JOINTSET_CFG">
         <param name= "numberofsets"> 4 </param>
         <group name="JOINTSET_0">
-            <param name="listofjoints">  0             </param>
-            <param name="constraint">    none          </param>
-            <param name="param1">        0             </param>
-            <param name="param2">        0             </param>
-        </group> 
+            <param name="listofjoints">   0            </param>
+            <param name="constraint">     none         </param>
+            <param name="param1">         0            </param>
+            <param name="param2">         0            </param>
+        </group>
         <group name="JOINTSET_1">
-            <param name="listofjoints">   1             </param>
-            <param name="constraint">     none          </param>
-            <param name="param1">         0             </param>
-            <param name="param2">         0             </param>
-        </group> 
+            <param name="listofjoints">   1            </param>
+            <param name="constraint">     none         </param>
+            <param name="param1">         0            </param>
+            <param name="param2">         0            </param>
+        </group>
         <group name="JOINTSET_2">
-            <param name="listofjoints">   2             </param>
-            <param name="constraint">     none          </param>
-            <param name="param1">         0             </param>
-            <param name="param2">         0             </param>
-        </group> 
+            <param name="listofjoints">   2            </param>
+            <param name="constraint">     none         </param>
+            <param name="param1">         0            </param>
+            <param name="param2">         0            </param>
+        </group>
         <group name="JOINTSET_3">
-            <param name="listofjoints">   3             </param>
-            <param name="constraint">     none          </param>
-            <param name="param1">         0             </param>
-            <param name="param2">         0             </param>
-        </group> 
-    </group>                          
-    
+            <param name="listofjoints">   3            </param>
+            <param name="constraint">     none         </param>
+            <param name="param1">         0            </param>
+            <param name="param2">         0            </param>
+        </group>
+    </group>
+
 
 
 </params>

--- a/iCubGenova11/hardware/mechanicals/left_leg-eb7-j4_5-mec.xml
+++ b/iCubGenova11/hardware/mechanicals/left_leg-eb7-j4_5-mec.xml
@@ -4,7 +4,7 @@
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="iCubGenova11" build="1">
     <group name="GENERAL">
         <param name="MotioncontrolVersion"> 6 </param>
-        <param name="Joints">  2  </param>  
+        <param name="Joints">  2  </param>
         <param name="AxisMap">               0             1       </param>
         <param name="AxisName">   "l_ankle_pitch"  "l_ankle_roll"  </param>
         <param name="AxisType">       "revolute"    "revolute"     </param>
@@ -12,7 +12,7 @@
         <param name="fullscalePWM">   32000         32000          </param>
         <param name="ampsToSensor">     1000.0       1000.0        </param>
         <param name="Gearbox_M2J">     100.00        100.00        </param>
-        <param name="Gearbox_E2J">   	1             1            </param>
+        <param name="Gearbox_E2J">      1             1            </param>
         <param name="MotorType">     "BLL_MOOG"   "BLL_MOOG"       </param>
         <param name="useMotorSpeedFbk"> 1             1            </param>
         <param name="Verbose"> 0 </param>
@@ -21,10 +21,10 @@
     <group name="LIMITS">
         <param name="hardwareJntPosMax">    35.00         26.06    </param>
         <param name="hardwareJntPosMin">   -35.00        -26.06    </param>
-        <param name="rotorPosMin">           0             0       </param> 
+        <param name="rotorPosMin">           0             0       </param>
         <param name="rotorPosMax">           0             0       </param>
     </group>
-    
+
     <group name="2FOC">
         <param name="HasHallSensor">         1             1   </param>
         <param name="HasTempSensor">         0             0   </param>
@@ -35,45 +35,45 @@
         <param name="MotorPoles">            8             8   </param>
     </group>
 
-    <group name="COUPLINGS"> 
-                                
-        <param name ="matrixJ2M"> 
+    <group name="COUPLINGS">
+
+        <param name ="matrixJ2M">
             1.00    0.00    0.00    0.00
             0.00    1.00    0.00    0.00
             0.00    0.00    1.00    0.00
-            0.00    0.00    0.00    1.00   
-        </param>
-       
-        <param name ="matrixM2J"> 
-            1.00    0.00    0.00    0.00
-            0.00    1.00    0.00    0.00
-            0.00    0.00    1.00    0.00
-            0.00    0.00    0.00    1.00   
+            0.00    0.00    0.00    1.00
         </param>
 
-        <param name ="matrixE2J">  
+        <param name ="matrixM2J">
+            1.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00
+            0.00    0.00    1.00    0.00
+            0.00    0.00    0.00    1.00
+        </param>
+
+        <param name ="matrixE2J">
             1.00    0.00    0.00    0.00    0.00    0.00
             0.00    1.00    0.00    0.00    0.00    0.00
             0.00    0.00    1.00    0.00    0.00    0.00
-            0.00    0.00    0.00    1.00    0.00    0.00   
+            0.00    0.00    0.00    1.00    0.00    0.00
         </param>
-                
-    </group>    
-    
-    <group name="JOINTSET_CFG"> 
+
+    </group>
+
+    <group name="JOINTSET_CFG">
         <param name= "numberofsets"> 2 </param>
         <group name="JOINTSET_0">
-            <param name="listofjoints">  0             </param>
-            <param name="constraint">    none          </param>
-            <param name="param1">        0             </param>
-            <param name="param2">        0             </param>
-        </group> 
+            <param name="listofjoints">   0             </param>
+            <param name="constraint">     none          </param>
+            <param name="param1">         0             </param>
+            <param name="param2">         0             </param>
+        </group>
         <group name="JOINTSET_1">
             <param name="listofjoints">   1             </param>
             <param name="constraint">     none          </param>
             <param name="param1">         0             </param>
             <param name="param2">         0             </param>
-        </group> 
-    </group>                          
+        </group>
+    </group>
 
 </params>

--- a/iCubGenova11/hardware/mechanicals/left_leg-eb7-j4_5-mec.xml
+++ b/iCubGenova11/hardware/mechanicals/left_leg-eb7-j4_5-mec.xml
@@ -5,24 +5,24 @@
     <group name="GENERAL">
         <param name="MotioncontrolVersion"> 6 </param>
         <param name="Joints">  2  </param>  
-        <param name="AxisMap">               0             1   </param>
+        <param name="AxisMap">               0             1       </param>
         <param name="AxisName">   "l_ankle_pitch"  "l_ankle_roll"  </param>
-        <param name="AxisType">       "revolute"    "revolute" </param>
-        <param name="Encoder">         182.044       182.044   </param>
-        <param name="fullscalePWM">   32000         32000        </param>
-        <param name="ampsToSensor">     1000.0       1000.0          </param>
-        <param name="Gearbox_M2J">     100.00        100.00    </param>
-        <param name="Gearbox_E2J">   	1             1        </param>
-        <param name="MotorType">     "BLL_MOOG"   "BLL_MOOG"   </param>
-        <param name="useMotorSpeedFbk"> 1             1        </param>
+        <param name="AxisType">       "revolute"    "revolute"     </param>
+        <param name="Encoder">         182.044       182.044       </param>
+        <param name="fullscalePWM">   32000         32000          </param>
+        <param name="ampsToSensor">     1000.0       1000.0        </param>
+        <param name="Gearbox_M2J">     100.00        100.00        </param>
+        <param name="Gearbox_E2J">   	1             1            </param>
+        <param name="MotorType">     "BLL_MOOG"   "BLL_MOOG"       </param>
+        <param name="useMotorSpeedFbk"> 1             1            </param>
         <param name="Verbose"> 0 </param>
     </group>
 
     <group name="LIMITS">
-        <param name="hardwareJntPosMax">          30.00         20.00   </param>
-        <param name="hardwareJntPosMin">         -30.00        -20.00   </param>
-        <param name="rotorPosMin">                 0             0      </param> 
-        <param name="rotorPosMax">                 0             0      </param>
+        <param name="hardwareJntPosMax">    35.00         26.06    </param>
+        <param name="hardwareJntPosMin">   -35.00        -26.06    </param>
+        <param name="rotorPosMin">           0             0       </param> 
+        <param name="rotorPosMax">           0             0       </param>
     </group>
     
     <group name="2FOC">

--- a/iCubGenova11/hardware/mechanicals/right_leg-eb8-j0_3-mec.xml
+++ b/iCubGenova11/hardware/mechanicals/right_leg-eb8-j0_3-mec.xml
@@ -11,19 +11,19 @@
         <param name="AxisType">       "revolute"    "revolute"   "revolute"  "revolute"    </param>        
         <param name="Encoder">         182.044       182.044       182.044       182.044   </param>
         <param name="fullscalePWM">     32000         32000         32000         32000    </param>
-        <param name="ampsToSensor">     1000.0        1000.0        1000.0        1000.0      </param>
-        <param name="Gearbox_M2J">      150.00      -100.00       100.00        100.00   </param>
+        <param name="ampsToSensor">     1000.0        1000.0        1000.0        1000.0   </param>
+        <param name="Gearbox_M2J">      150.00      -100.00       100.00        100.00     </param>
         <param name="Gearbox_E2J">   	1             1             1              1       </param>
         <param name="useMotorSpeedFbk"> 1             1             1              1       </param>
-        <param name="MotorType">       "BLL_MOOG"     "BLL_MOOG"   "BLL_MOOG"  "BLL_MOOG" </param>
+        <param name="MotorType">       "BLL_MOOG"     "BLL_MOOG"   "BLL_MOOG"  "BLL_MOOG"  </param>
 
         <param name="Verbose">		0    	</param>
     </group>
     
     <group name="LIMITS">
-        <!--                                    0             	1            2          3         -->
-        <param name="hardwareJntPosMax">        92              92           72          0     </param>
-        <param name="hardwareJntPosMin">       -30             -15          -72       -100     </param>
+        <!--                                    0             	1            2          3           -->
+        <param name="hardwareJntPosMax">      134.49          121.12        81.06       4.12   </param>
+        <param name="hardwareJntPosMin">      -46.49          -21.12       -81.06    -125.12   </param>
         <param name="rotorPosMin">              0               0            0          0      </param> 
         <param name="rotorPosMax">              0               0            0          0      </param>
     </group>

--- a/iCubGenova11/hardware/mechanicals/right_leg-eb8-j0_3-mec.xml
+++ b/iCubGenova11/hardware/mechanicals/right_leg-eb8-j0_3-mec.xml
@@ -4,27 +4,27 @@
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="iCubGenova11" build="1">
     <group name="GENERAL">
         <param name="MotioncontrolVersion"> 6 </param>
-        <param name="Joints"> 4 </param> 
+        <param name="Joints"> 4 </param>
 
         <param name="AxisMap">               0             1             2             3   </param>
         <param name="AxisName">     "r_hip_pitch"   "r_hip_roll"    "r_hip_yaw"   "r_knee" </param>
-        <param name="AxisType">       "revolute"    "revolute"   "revolute"  "revolute"    </param>        
+        <param name="AxisType">       "revolute"    "revolute"   "revolute"  "revolute"    </param>
         <param name="Encoder">         182.044       182.044       182.044       182.044   </param>
         <param name="fullscalePWM">     32000         32000         32000         32000    </param>
         <param name="ampsToSensor">     1000.0        1000.0        1000.0        1000.0   </param>
         <param name="Gearbox_M2J">      150.00      -100.00       100.00        100.00     </param>
-        <param name="Gearbox_E2J">   	1             1             1              1       </param>
+        <param name="Gearbox_E2J">      1             1             1              1       </param>
         <param name="useMotorSpeedFbk"> 1             1             1              1       </param>
         <param name="MotorType">       "BLL_MOOG"     "BLL_MOOG"   "BLL_MOOG"  "BLL_MOOG"  </param>
 
-        <param name="Verbose">		0    	</param>
+        <param name="Verbose">      0       </param>
     </group>
-    
+
     <group name="LIMITS">
-        <!--                                    0             	1            2          3           -->
+        <!--                                    0               1            2          3           -->
         <param name="hardwareJntPosMax">      134.49          121.12        81.06       4.12   </param>
         <param name="hardwareJntPosMin">      -46.49          -21.12       -81.06    -125.12   </param>
-        <param name="rotorPosMin">              0               0            0          0      </param> 
+        <param name="rotorPosMin">              0               0            0          0      </param>
         <param name="rotorPosMax">              0               0            0          0      </param>
     </group>
 
@@ -38,56 +38,56 @@
         <param name="MotorPoles">            8             8             8             8   </param>
    </group>
 
-    <group name="COUPLINGS"> 
-                                
-        <param name ="matrixJ2M"> 
+    <group name="COUPLINGS">
+
+        <param name ="matrixJ2M">
             1.00    0.00    0.00    0.00
             0.00    1.00    0.00    0.00
             0.00    0.00    1.00    0.00
-            0.00    0.00    0.00    1.00   
-        </param>
-       
-        <param name ="matrixM2J"> 
-            1.00    0.00    0.00    0.00
-            0.00    1.00    0.00    0.00
-            0.00    0.00    1.00    0.00
-            0.00    0.00    0.00    1.00   
+            0.00    0.00    0.00    1.00
         </param>
 
-        <param name ="matrixE2J">  
+        <param name ="matrixM2J">
+            1.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00
+            0.00    0.00    1.00    0.00
+            0.00    0.00    0.00    1.00
+        </param>
+
+        <param name ="matrixE2J">
             1.00    0.00    0.00    0.00    0.00    0.00
             0.00    1.00    0.00    0.00    0.00    0.00
             0.00    0.00    1.00    0.00    0.00    0.00
-            0.00    0.00    0.00    1.00    0.00    0.00   
+            0.00    0.00    0.00    1.00    0.00    0.00
         </param>
-                
-    </group>    
 
-    <group name="JOINTSET_CFG"> 
+    </group>
+
+    <group name="JOINTSET_CFG">
         <param name= "numberofsets"> 4 </param>
         <group name="JOINTSET_0">
-            <param name="listofjoints">  0             </param>
-            <param name="constraint">    none          </param>
-            <param name="param1">        0             </param>
-            <param name="param2">        0             </param>
-        </group> 
+            <param name="listofjoints">   0             </param>
+            <param name="constraint">     none          </param>
+            <param name="param1">         0             </param>
+            <param name="param2">         0             </param>
+        </group>
         <group name="JOINTSET_1">
             <param name="listofjoints">   1             </param>
             <param name="constraint">     none          </param>
             <param name="param1">         0             </param>
             <param name="param2">         0             </param>
-        </group> 
+        </group>
         <group name="JOINTSET_2">
             <param name="listofjoints">   2             </param>
             <param name="constraint">     none          </param>
             <param name="param1">         0             </param>
             <param name="param2">         0             </param>
-        </group> 
+        </group>
         <group name="JOINTSET_3">
             <param name="listofjoints">   3             </param>
             <param name="constraint">     none          </param>
             <param name="param1">         0             </param>
             <param name="param2">         0             </param>
-        </group> 
-    </group>                          
+        </group>
+    </group>
 </params>

--- a/iCubGenova11/hardware/mechanicals/right_leg-eb9-j4_5-mec.xml
+++ b/iCubGenova11/hardware/mechanicals/right_leg-eb9-j4_5-mec.xml
@@ -4,7 +4,7 @@
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="iCubGenova11" build="1">
     <group name="GENERAL">
         <param name="MotioncontrolVersion"> 6 </param>
-        <param name="Joints">  2  </param>  
+        <param name="Joints">  2  </param>
         <param name="AxisMap">               0             1       </param>
         <param name="AxisName">   "r_ankle_pitch"  "r_ankle_roll"  </param>
         <param name="AxisType">       "revolute"    "revolute"     </param>
@@ -21,7 +21,7 @@
     <group name="LIMITS">
         <param name="hardwareJntPosMax">    35.00         26.06    </param>
         <param name="hardwareJntPosMin">   -35.00        -26.06    </param>
-        <param name="rotorPosMin">           0             0       </param> 
+        <param name="rotorPosMin">           0             0       </param>
         <param name="rotorPosMax">           0             0       </param>
     </group>
 
@@ -35,38 +35,38 @@
         <param name="MotorPoles">            8             8       </param>
     </group>
 
-    <group name="COUPLINGS"> 
-                                
-        <param name ="matrixJ2M"> 
+    <group name="COUPLINGS">
+
+        <param name ="matrixJ2M">
             1.00    0.00    0.00    0.00
             0.00    1.00    0.00    0.00
             0.00    0.00    1.00    0.00
-            0.00    0.00    0.00    1.00   
-        </param>
-       
-        <param name ="matrixM2J"> 
-            1.00    0.00    0.00    0.00
-            0.00    1.00    0.00    0.00
-            0.00    0.00    1.00    0.00
-            0.00    0.00    0.00    1.00   
+            0.00    0.00    0.00    1.00
         </param>
 
-        <param name ="matrixE2J">  
+        <param name ="matrixM2J">
+            1.00    0.00    0.00    0.00
+            0.00    1.00    0.00    0.00
+            0.00    0.00    1.00    0.00
+            0.00    0.00    0.00    1.00
+        </param>
+
+        <param name ="matrixE2J">
             1.00    0.00    0.00    0.00    0.00    0.00
             0.00    1.00    0.00    0.00    0.00    0.00
             0.00    0.00    1.00    0.00    0.00    0.00
-            0.00    0.00    0.00    1.00    0.00    0.00   
+            0.00    0.00    0.00    1.00    0.00    0.00
         </param>
-                
-    </group> 
+
+    </group>
 
     <group name="JOINTSET_CFG">
         <param name= "numberofsets"> 2 </param>
         <group name="JOINTSET_0">
-            <param name="listofjoints">  0             </param>
-            <param name="constraint">    none          </param>
-            <param name="param1">        0             </param>
-            <param name="param2">        0             </param>
+            <param name="listofjoints">   0             </param>
+            <param name="constraint">     none          </param>
+            <param name="param1">         0             </param>
+            <param name="param2">         0             </param>
         </group>
         <group name="JOINTSET_1">
             <param name="listofjoints">   1             </param>
@@ -75,6 +75,6 @@
             <param name="param2">         0             </param>
         </group>
     </group>
-   
+
 
 </params>

--- a/iCubGenova11/hardware/mechanicals/right_leg-eb9-j4_5-mec.xml
+++ b/iCubGenova11/hardware/mechanicals/right_leg-eb9-j4_5-mec.xml
@@ -9,8 +9,8 @@
         <param name="AxisName">   "r_ankle_pitch"  "r_ankle_roll"  </param>
         <param name="AxisType">       "revolute"    "revolute"     </param>
         <param name="Encoder">        182.044        182.044       </param>
-        <param name="fullscalePWM">   32000         32000        </param>
-        <param name="ampsToSensor">     1000.0       1000.0         </param>
+        <param name="fullscalePWM">   32000         32000          </param>
+        <param name="ampsToSensor">     1000.0       1000.0        </param>
         <param name="Gearbox_M2J">   -100.00        -100.00        </param>
         <param name="Gearbox_E2J">      1.00           1.00        </param>
         <param name="MotorType">     "BLL_MOOG"   "BLL_MOOG"       </param>
@@ -19,10 +19,10 @@
     </group>
 
     <group name="LIMITS">
-        <param name="hardwareJntPosMax">              30            20     </param>
-        <param name="hardwareJntPosMin">             -30           -20     </param>
-        <param name="rotorPosMin">                     0             0     </param> 
-        <param name="rotorPosMax">                     0             0     </param>
+        <param name="hardwareJntPosMax">    35.00         26.06    </param>
+        <param name="hardwareJntPosMin">   -35.00        -26.06    </param>
+        <param name="rotorPosMin">           0             0       </param> 
+        <param name="rotorPosMax">           0             0       </param>
     </group>
 
     <group name="2FOC">

--- a/iCubGenova11/hardware/mechanicals/torso-eb5-j0_2-mec.xml
+++ b/iCubGenova11/hardware/mechanicals/torso-eb5-j0_2-mec.xml
@@ -19,7 +19,7 @@
     </group>
 
     <group name="LIMITS">
-        <param name="hardwareJntPosMax">    60.84         42.80         70           </param>
+        <param name="hardwareJntPosMax">    60.84         42.80         70.00        </param>
         <param name="hardwareJntPosMin">   -60.84        -42.80        -25.00        </param>
         <param name="rotorPosMin">           0             0             0           </param>
         <param name="rotorPosMax">           0             0             0           </param>

--- a/iCubGenova11/hardware/mechanicals/torso-eb5-j0_2-mec.xml
+++ b/iCubGenova11/hardware/mechanicals/torso-eb5-j0_2-mec.xml
@@ -4,24 +4,24 @@
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="iCubGenova11" build="1">
     <group name="GENERAL">
         <param name="MotioncontrolVersion"> 6 </param>
-        <param name="Joints"> 3 </param> 
-        <param name="AxisMap">               2             0             1           </param>   
+        <param name="Joints"> 3 </param>
+        <param name="AxisMap">               2             0             1           </param>
         <param name="AxisName">      "torso_yaw" "torso_roll" "torso_pitch"          </param>
         <param name="AxisType">       "revolute"    "revolute" "revolute"            </param>
         <param name="Encoder">         182.044       182.044       182.044           </param>
         <param name="fullscalePWM">   32000         32000         32000              </param>
         <param name="ampsToSensor">     1000.0       1000.0        1000.0            </param>
         <param name="Gearbox_M2J">    -100.00       -100.00      -100.00             </param>
-        <param name="Gearbox_E2J">   	1             1             1                </param>
-        <param name="useMotorSpeedFbk"> 1             1             1                </param> 
+        <param name="Gearbox_E2J">      1             1             1                </param>
+        <param name="useMotorSpeedFbk"> 1             1             1                </param>
         <param name="MotorType">       "BLL_MOOG"     "BLL_MOOG"   "BLL_MOOG"        </param>
-        <param name="Verbose">		0	</param>
+        <param name="Verbose">      0   </param>
     </group>
 
     <group name="LIMITS">
         <param name="hardwareJntPosMax">    60.84         42.80         70           </param>
         <param name="hardwareJntPosMin">   -60.84        -42.80        -25.00        </param>
-        <param name="rotorPosMin">           0             0             0           </param> 
+        <param name="rotorPosMin">           0             0             0           </param>
         <param name="rotorPosMax">           0             0             0           </param>
     </group>
 
@@ -35,40 +35,40 @@
         <param name="MotorPoles">            8             8             8           </param>
    </group>
 
-    <group name="COUPLINGS"> 
+    <group name="COUPLINGS">
 
-        <param name ="matrixJ2M"> 
+        <param name ="matrixJ2M">
             0.500   -0.500    0.000    0.000
             0.500    0.500    0.000    0.000
             0.000    0.000    1.000    0.000
-            0.000    0.000    0.000    1.000   
+            0.000    0.000    0.000    1.000
         </param>
 
         <!-- alfa=22/80=0,275; 2*alfa= 0.55 -->
-        <param name ="matrixM2J"> 
+        <param name ="matrixM2J">
             0.500    0.500    0.000    0.000
            -0.500    0.500    0.000    0.000
             0.275    0.275    0.550    0.000
-            0.000    0.000    0.000    1.000   
+            0.000    0.000    0.000    1.000
         </param>
-       
-        <param name ="matrixE2J">  
+
+        <param name ="matrixE2J">
             1.00    0.00    0.00    0.00    0.00    0.00
             0.00    1.00    0.00    0.00    0.00    0.00
             0.00    0.00    1.00    0.00    0.00    0.00
-            0.00    0.00    0.00    1.00    0.00    0.00   
+            0.00    0.00    0.00    1.00    0.00    0.00
         </param>
-        
-    </group>                
-    
-    <group name="JOINTSET_CFG"> 
+
+    </group>
+
+    <group name="JOINTSET_CFG">
         <param name= "numberofsets"> 1 </param>
         <group name="JOINTSET_0">
             <param name="listofjoints">  0 1 2         </param>
             <param name="constraint">    none          </param>
             <param name="param1">        0             </param>
             <param name="param2">        0             </param>
-        </group> 
-    </group>                     
- 
+        </group>
+    </group>
+
 </params>

--- a/iCubGenova11/hardware/mechanicals/torso-eb5-j0_2-mec.xml
+++ b/iCubGenova11/hardware/mechanicals/torso-eb5-j0_2-mec.xml
@@ -9,7 +9,7 @@
         <param name="AxisName">      "torso_yaw" "torso_roll" "torso_pitch"          </param>
         <param name="AxisType">       "revolute"    "revolute" "revolute"            </param>
         <param name="Encoder">         182.044       182.044       182.044           </param>
-        <param name="fullscalePWM">   32000         32000         32000            </param>
+        <param name="fullscalePWM">   32000         32000         32000              </param>
         <param name="ampsToSensor">     1000.0       1000.0        1000.0            </param>
         <param name="Gearbox_M2J">    -100.00       -100.00      -100.00             </param>
         <param name="Gearbox_E2J">   	1             1             1                </param>
@@ -19,10 +19,10 @@
     </group>
 
     <group name="LIMITS">
-        <param name="hardwareJntPosMax">    50            30            70        </param>
-        <param name="hardwareJntPosMin">   -50           -30           -20        </param>
-        <param name="rotorPosMin">           0             0             0        </param> 
-        <param name="rotorPosMax">           0             0             0        </param>
+        <param name="hardwareJntPosMax">    60.84         42.80         70           </param>
+        <param name="hardwareJntPosMin">   -60.84        -42.80        -25.00        </param>
+        <param name="rotorPosMin">           0             0             0           </param> 
+        <param name="rotorPosMax">           0             0             0           </param>
     </group>
 
     <group name="2FOC">


### PR DESCRIPTION
We save these values also because they are important for absolute encoders fine calibration.