### PR TITLE
Fix right forearm Erzelli02 - working configuration set

### DIFF
--- a/iCubErzelli02/calibrators/right_arm-calib.xml
+++ b/iCubErzelli02/calibrators/right_arm-calib.xml
@@ -9,30 +9,31 @@
 		    <param name="joints">16</param> <!-- the number of joints of the robot part -->
 		    <param name="deviceName"> Right_Arm_Calibrator </param>
 		</group>
-<!-- joint logical number           0         1        2         3      4      5      6     7     8     9    10    11    12     13     14    15 -->
+<!-- joint logical number               0         1        2         3      4      5      6     7     8     9    10    11    12     13     14    15 -->
 <group name="HOME">
-	<param name="positionHome">        -30       30        0        45      0      0     0     35    65     0     0     0     0      0      0     0     </param>
-	<param name="velocityHome">        10        10        10       10     30     30     30    60    30    30    30    30    30     30     30    30     </param>
+	<param name="positionHome">        -30       30        0        45     0      0     0     35      15     5      50     0     5      0      5     5    </param>
+	<param name="velocityHome">        10        10        10       10     30     30    30    60      60     60      60    30    30     30     30    30    </param>
 </group>
 
 
 <group name="CALIBRATION">
-	<param name="calibrationType">       12        12       12        12     5      12     12    7     7     6     6     6     6      6      6     6    </param>
-	<param name="calibration1">          31759     17727    24991     56095  1500   19950  17720 0     0     0     0     0     0      0      0     0    </param>
-	<param name="calibration2">	         0         0        0         0      16384  0      0     0     0     9102  9102  9102  9102   9102   9102  3640 </param>
-	<param name="calibration3">	         0         0        0	      0	     0	    0      0     0     0    -1     1    -1     1     -1      1    -1    </param>
-	<param name="calibration4">          0         0        0         0      0      0      0     2400  530   247   305   253   483    255    510   495  </param>
-	<param name="calibration5">          0         0        0         0      0      0      0     2500  3600  12    0     0     0      2      0     70   </param>
-	<param name="calibrationZero">       0         0        0         0      0      0      0     0     0     0     0     0     0      0      0     0    </param>
-	<param name="calibrationDelta">      0         0        0         0      0      0      0     0     0     0     0     0     0      0      0     0    </param>
-
-	<param name="startupPosition">      -35        30       0         50     0      0      0     25    30    0     0     0     0      0      0     0    </param>
-	<param name="startupVelocity">       10        10       10        10     30     30     30    60    100   100   100   100   100    100    100   100  </param>
-	<param name="startupMaxPwm">         2000      2000     2000      2000   1500   0      0     0     0     0     0     0     0      0      0     0    </param>
-	<param name="startupPosThreshold">   2         2        2         2      90     90     90    90    90    90    90    90    90     90     90    90   </param>
+<!-- joint logical number                0                   1              2             3        4                  5                6                7                   8                    9                     10                   11                   12                  13                    14             15        -->
+<!--                           "r_shoulder_pitch"  "r_shoulder_roll" "r_shoulder_yaw" "r_elbow"  "wrist_prosup"    "wrist_pitch"        "wrist_yaw"      "hand_finger"      "thumb_oppose"       "thumb_proximal"      "thumb_distal"      "index_proximal"    "index_distal"    "middle_proximal"    "middle_distal"   "pinky"       -->
+	<param name="calibrationType">       12                  12             12           12        5                  12                12               7                   7                    6                     6                   6                   6                  6                    6              6    </param>
+	<param name="calibration1">          31759               17727          24991        56095     500                20390             -17040           0                   0                    0                     0                   0                   0                  0                    0              0    </param>
+	<param name="calibration2">	         0                   0              0            0         16384              0                 0                0                   0                    9102                  18204               9102                9102               9102                 9102           9102 </param>
+	<param name="calibration3">	         0                   0              0	         0	        0	              0                 0                0                    0                    -1                    1                  -1                   1                  -1                   1              -1     </param>
+	<param name="calibration4">          0                   0              0            0         0                  0                 0                2313                850                  255                   48                  255                 495                255                  510            49   </param>
+	<param name="calibration5">          0                   0              0            0         0                  0                 0                2490                4444                 28                    224                 0                   21                 12                   20             620   </param>
+	<param name="calibrationZero">       0                   0              0            0         0                  0                 0                0                   0                    0                     0                   0                   0                  0                    0              0    </param>
+	<param name="calibrationDelta">      0                   0              0            0         0                  0                 0                0                   0                    0                     0                   0                   0                  0                    0              0    </param>
+	<param name="startupPosition">      -35                  30             0            50        0                 0                 0                15                   15                   3                     50                  0                   3                  0                    3              5    </param>
+	<param name="startupVelocity">       10                  10             10           10        30                30                 30              10                   100                  100                   100                 100                 100                100                  100            100  </param>
+	<param name="startupMaxPwm">         2000                2000           2000         2000      1500               0                 0                0                   1000                 1000                  2600                1000                1000               1000                 1000           1000 </param>
+	<param name="startupPosThreshold">   2                   2              2            2         180                90                90               90                  90                   200                   200                 200                 200                200                  200            200  </param>
 </group>
 
-<param name="CALIB_ORDER">(0 1 2 3) (4) (5 6 7) (8 9 11 13) (10 12 14 15) </param>
+<param name="CALIB_ORDER">(0 1 2 3) (4) (5 6 7) (8 9) (10) (11 13) (12 14) (15) </param>
 		<action phase="startup" level="10" type="calibrate">
 		    <param name="target">right_arm-mc_remapper</param>
 		</action>

--- a/iCubErzelli02/hardware/mechanicals/right_arm-eb27-j4_7-mec.xml
+++ b/iCubErzelli02/hardware/mechanicals/right_arm-eb27-j4_7-mec.xml
@@ -21,7 +21,7 @@
     </group>
     
     <group name="LIMITS">
-        <param name="hardwareJntPosMax">         90          30             35             60          </param>
+        <param name="hardwareJntPosMax">         90          30             35             70          </param>
         <param name="hardwareJntPosMin">        -90         -80            -15             10          </param> 
         <param name="rotorPosMax">              0           0               0              0           </param>
         <param name="rotorPosMin">              0           0               0              0           </param> 

--- a/iCubErzelli02/hardware/mechanicals/right_arm-eb28-j8_11-mec.xml
+++ b/iCubErzelli02/hardware/mechanicals/right_arm-eb28-j8_11-mec.xml
@@ -13,18 +13,20 @@
         <param name="Encoder">                  182.044          182.044            182.044          182.044         </param>    
         <param name="fullscalePWM">             3360             3360               3360            3360             </param>
         <param name="ampsToSensor">             1000.0           1000.0             1000.0          1000.0           </param>
-        <param name="Gearbox_M2J">              256                256                256           256              </param>
+        <param name="Gearbox_M2J">              256               256                256           256              </param>
         <param name="Gearbox_E2J">   	        1                 1                   1              1               </param>
         <param name="useMotorSpeedFbk">         0                 0                   0              0               </param>
         <param name="MotorType">                "DC"             "DC"                "DC"           "DC"             </param>
-        <param name="Verbose">                  0                                                                    </param>
+        <param name="Verbose">                  1                 1                   1                1                </param>
     </group>
     
     <group name="LIMITS">
         <param name="hardwareJntPosMax">       90          90             180              90            </param>
         <param name="hardwareJntPosMin">       10           0              0                0            </param>
-        <param name="rotorPosMin">              0           0         -5120             -5120            </param> 
-        <param name="rotorPosMax">              0           0         70000            32000             </param>
+        <!-- <param name="rotorPosMin">              0           0         -5120             -5120            </param> 
+        <param name="rotorPosMax">              0           0         70000            32000             </param> -->
+      <param name="rotorPosMin">              0           0             -5120            -5120        </param> 
+        <param name="rotorPosMax">              0            0           35000          32000            </param>
     </group>
 
     <group name="COUPLINGS"> 

--- a/iCubErzelli02/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
+++ b/iCubErzelli02/hardware/mechanicals/right_arm-eb29-j12_15-mec.xml
@@ -23,8 +23,8 @@
     <group name="LIMITS">
         <param name="hardwareJntPosMax">        180                 90                180                 270          </param>
         <param name="hardwareJntPosMin">          0                  0                  0                   0          </param> 
-        <param name="rotorPosMin">           -65000              -5120              -5120               -5120          </param> 
-        <param name="rotorPosMax">             5120              32000              65000               65000          </param>
+        <param name="rotorPosMin">                0              -5120              -5120                -510          </param> 
+        <param name="rotorPosMax">                0              32000              65000               65000          </param>
     </group>
 
     <group name="COUPLINGS"> 

--- a/iCubErzelli02/hardware/motorControl/right_arm-eb28-j8_11-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/right_arm-eb28-j8_11-mc.xml
@@ -18,7 +18,7 @@
         <param name="motorOverloadCurrents">    2000                2000                2000                2000                </param>
         <param name="motorNominalCurrents">      600                600                 600                 600                 </param>
         <param name="motorPeakCurrents">        1000                1000                1000                1000                </param>
-        <param name="motorPwmLimit">            3360                3360                3360                3360                </param>
+        <param name="motorPwmLimit">            1000                1000                3000                3360                </param>
     </group>
 
     <group name="TIMEOUTS">
@@ -47,11 +47,11 @@
         <param name="outputType">           pwm                       </param>
         <param name="fbkControlUnits">      metric_units              </param> 
         <param name="outputControlUnits">   machine_units             </param>
-        <param name="kp">                   -500.0      500.0       -500.0      500.0       </param>
+        <param name="kp">                   -500.0      500.0       -600.0      200.0       </param>
         <param name="kd">                   0.0         0.0         0.0         0.0         </param>
-        <param name="ki">                   -50.0       50.0        -50.0       50.0        </param>
-        <param name="maxOutput">            3360        3360        3360        3360        </param>
-        <param name="maxInt">               3360        3360        3360        3360        </param>
+        <param name="ki">                   -50.0       50.0        -250.0      20.0        </param>
+        <param name="maxOutput">            1000        1000        2600        1000        </param>
+        <param name="maxInt">               1000        1000        1000        1000        </param>
         <param name="stictionUp">           0           0           0           0           </param>
         <param name="stictionDown">         0           0           0           0           </param>
         <param name="kff">                  0           0           0           0           </param>

--- a/iCubErzelli02/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
+++ b/iCubErzelli02/hardware/motorControl/right_arm-eb29-j12_15-mc.xml
@@ -44,9 +44,9 @@
         <param name="outputType">             pwm                       </param>
         <param name="fbkControlUnits">        metric_units              </param>
         <param name="outputControlUnits">     machine_units             </param>
-        <param name="kp">                500.0       500.0      -500.0       200.0       </param>
+        <param name="kp">                120.0       120.0      -300.0       120.0       </param>
         <param name="kd">                0.0         0.0         0.0         0.0         </param>
-        <param name="ki">                50.0        50.0       -50.0        20.0        </param>
+        <param name="ki">                2.0         2.0        -30.0        2.0        </param>
         <param name="maxOutput">         3360        3360        3360        3360        </param>
         <param name="maxInt">            3360        3360        3360        3360        </param>
         <param name="stictionUp">        0           0           0           0           </param>

--- a/iCubErzelli02/hardware/motorControl/right_arm-eb29-j12_15-mc_service.xml
+++ b/iCubErzelli02/hardware/motorControl/right_arm-eb29-j12_15-mc_service.xml
@@ -43,7 +43,7 @@
                     <param name="type">             mais                mais                mais                mais                    </param>  
                     <param name="port">             MAIS:indexdistal    MAIS:mediumproximal MAIS:mediumdistal   MAIS:littlefingers      </param>
                     <param name="position">         atjoint             atjoint             atjoint             atjoint                 </param>
-                    <param name="resolution">          65535            65535               65535              65535                    </param> <!-- 65535:this value will change by fw during calibration (type 6) --> 
+                    <param name="resolution">        65535              65535               65535              65535                    </param> <!-- 65535:this value will change by fw during calibration (type 6) --> 
                     <param name="tolerance">         0                  0                   0                  0                        </param>  
                 </group>        
                 

--- a/iCubErzelli02/yarpmotorgui.ini
+++ b/iCubErzelli02/yarpmotorgui.ini
@@ -1,0 +1,7 @@
+//name of the robot          
+robot icub      
+//parts to be opened by the GUI            
+parts (head torso left_arm right_arm)               
+ 
+ //DO NOT REMOVE THIS LINE    
+ 


### PR DESCRIPTION
This PR introduces fixes that have been applied to `iCubErzelli02` after the electrical and mechanical fixes that have been applied to the right forearm restoring its functionalities.
Particular attention should be pointed to the following changes:
- startUpPositions and homePositions for all thumb joints that are mandatory for accessing a correct calibration
- hardware limit for the `hand_finger`  joint that has been set in order to prevent it to exceed the hw boundaries when close to the sw limits since that joint encoder tends to flicker quite a lot
- rotor limits for the `thumb_distal`, mandatory for keeping the cable in the pulley in the correct limits
- PID coefficients have been changed for improving the smoothness of the movement

cc: @pattacini @valegagge @ddetommaso 