### PR TITLE
Fix Pilsen ergoCubSN003

### DIFF
--- a/ergoCubSN003/calibrators/torso-calib.xml
+++ b/ergoCubSN003/calibrators/torso-calib.xml
@@ -33,7 +33,7 @@
                                                                                                    
 <param name="startupPosition">                      0                       0                      0                       </param>
 <param name="startupVelocity">                      10                      10                     10                      </param>
-<param name="startupMaxPwm">                        5500                    16000                  5500                    </param>
+<param name="startupMaxPwm">                        5500                    8000                  5500                    </param>
 <param name="startupPosThreshold">                  2                       2                      2                       </param>
 </group>
 

--- a/ergoCubSN003/estimators/wholebodydynamics.xml
+++ b/ergoCubSN003/estimators/wholebodydynamics.xml
@@ -3,12 +3,10 @@
 
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="wholebodydynamics" type="wholebodydynamics">
-  <!-- <param name="axesNames">(torso_pitch,torso_roll,torso_yaw,neck_pitch, neck_roll,neck_yaw,l_shoulder_pitch,l_shoulder_roll,l_shoulder_yaw,l_elbow,l_wrist_roll,l_wrist_pitch,l_wrist_yaw,r_shoulder_pitch,r_shoulder_roll,r_shoulder_yaw,r_elbow,r_wrist_roll,r_wrist_pitch,r_wrist_yaw,l_hip_pitch,l_hip_roll,l_hip_yaw,l_knee,l_ankle_pitch,l_ankle_roll,r_hip_pitch,r_hip_roll,r_hip_yaw,r_knee,r_ankle_pitch,r_ankle_roll)</param> -->
-    <param name="axesNames">(torso_pitch,torso_roll,torso_yaw,neck_pitch, neck_roll,neck_yaw,l_shoulder_pitch,l_shoulder_roll,l_shoulder_yaw,l_elbow,l_wrist_roll,l_wrist_pitch,l_wrist_yaw,l_hip_pitch,l_hip_roll,l_hip_yaw,l_knee,l_ankle_pitch,l_ankle_roll,r_hip_pitch,r_hip_roll,r_hip_yaw,r_knee,r_ankle_pitch,r_ankle_roll)</param>
+  <param name="axesNames">(torso_pitch,torso_roll,torso_yaw,neck_pitch, neck_roll,neck_yaw,l_shoulder_pitch,l_shoulder_roll,l_shoulder_yaw,l_elbow,l_wrist_roll,l_wrist_pitch,l_wrist_yaw,r_shoulder_pitch,r_shoulder_roll,r_shoulder_yaw,r_elbow,r_wrist_roll,r_wrist_pitch,r_wrist_yaw,l_hip_pitch,l_hip_roll,l_hip_yaw,l_knee,l_ankle_pitch,l_ankle_roll,r_hip_pitch,r_hip_roll,r_hip_yaw,r_knee,r_ankle_pitch,r_ankle_roll)</param>
   <param name="modelFile">model.urdf</param>
   <param name="fixedFrameGravity">(0,0,-9.81)</param>
-  <!-- <param name="defaultContactFrames">(r_hand_palm,root_link,l_foot_front,l_foot_rear,r_foot_front,r_foot_rear,l_upper_leg,r_upper_leg)</param> -->
-  <param name="defaultContactFrames">(root_link,l_foot_front,l_foot_rear,r_foot_front,r_foot_rear,l_upper_leg,r_upper_leg)</param> 
+  <param name="defaultContactFrames">(r_hand_palm,root_link,l_foot_front,l_foot_rear,r_foot_front,r_foot_rear,l_upper_leg,r_upper_leg)</param> 
   <param name="imuFrameName">waist_imu_0</param>
   <param name="publishOnROS">true</param>
   <param name="forceTorqueEstimateConfidence">2</param>
@@ -37,14 +35,13 @@
   <group name="GRAVITY_COMPENSATION">
     <param name="enableGravityCompensation">true</param>
     <param name="gravityCompensationBaseLink">root_link</param>
-    <!-- <param name="gravityCompensationAxesNames">(torso_pitch,torso_roll,torso_yaw,neck_pitch,neck_roll,neck_yaw,l_shoulder_pitch,l_shoulder_roll,l_shoulder_yaw,r_shoulder_pitch,r_shoulder_roll,r_shoulder_yaw,l_hip_pitch,l_hip_roll,l_hip_yaw,l_knee,l_ankle_pitch,l_ankle_roll,r_hip_pitch,r_hip_roll,r_hip_yaw,r_knee,r_ankle_pitch,r_ankle_roll)</param> -->
-    <param name="gravityCompensationAxesNames">(torso_pitch,torso_roll,torso_yaw,neck_pitch,neck_roll,neck_yaw,l_shoulder_pitch,l_shoulder_roll,l_shoulder_yaw,l_hip_pitch,l_hip_roll,l_hip_yaw,l_knee,l_ankle_pitch,l_ankle_roll,r_hip_pitch,r_hip_roll,r_hip_yaw,r_knee,r_ankle_pitch,r_ankle_roll)</param>
+    <param name="gravityCompensationAxesNames">(torso_pitch,torso_roll,torso_yaw,neck_pitch,neck_roll,neck_yaw,l_shoulder_pitch,l_shoulder_roll,l_shoulder_yaw,r_shoulder_pitch,r_shoulder_roll,r_shoulder_yaw,l_hip_pitch,l_hip_roll,l_hip_yaw,l_knee,l_ankle_pitch,l_ankle_roll,r_hip_pitch,r_hip_roll,r_hip_yaw,r_knee,r_ankle_pitch,r_ankle_roll)</param>
   </group>
 
 
   <group name="WBD_OUTPUT_EXTERNAL_WRENCH_PORTS">
     <param name="/wholeBodyDynamics/left_arm/cartesianEndEffectorWrench:o">(l_hand_palm,l_hand_palm,root_link)</param>
-    <!-- <param name="/wholeBodyDynamics/right_arm/cartesianEndEffectorWrench:o">(r_hand_palm,r_hand_palm,root_link)</param> -->
+    <param name="/wholeBodyDynamics/right_arm/cartesianEndEffectorWrench:o">(r_hand_palm,r_hand_palm,root_link)</param>
     <param name="/wholeBodyDynamics/left_leg/cartesianEndEffectorWrench:o">(l_upper_leg,l_upper_leg,root_link)</param>
     <param name="/wholeBodyDynamics/right_leg/cartesianEndEffectorWrench:o">(r_upper_leg,r_upper_leg,root_link)</param>
     <param name="/wholeBodyDynamics/left_foot_front/cartesianEndEffectorWrench:o">(l_foot_front,l_sole,l_sole)</param>
@@ -62,9 +59,9 @@
       <elem name="left_upper_arm-j0">left_arm-eb2-j0_1-mc</elem>
       <elem name="left_upper_arm-j2">left_arm-eb4-j2_3-mc</elem>
       <elem name="left_lower_arm">left_arm-eb31-j4_6-mc</elem>
-      <!-- <elem name="right_upper_arm-j0">right_arm-eb1-j0_1-mc</elem>
+      <elem name="right_upper_arm-j0">right_arm-eb1-j0_1-mc</elem>
       <elem name="right_upper_arm-j2">right_arm-eb3-j2_3-mc</elem>
-      <elem name="right_lower_arm">right_arm-eb30-j4_6-mc</elem> -->
+      <elem name="right_lower_arm">right_arm-eb30-j4_6-mc</elem>
       <elem name="left_upper_leg-j0">left_leg-eb8-j0_3-mc</elem>
       <elem name="left_lower_leg-j2">left_leg-eb9-j4_5-mc</elem>
       <elem name="right_upper_leg-j0">right_leg-eb6-j0_3-mc</elem>
@@ -76,7 +73,7 @@
       <elem name="l_leg_ft_sensors">left_leg-FT_remapper</elem>
       <elem name="r_leg_ft_sensors">right_leg-FT_remapper</elem>
       <elem name="l_arm_ft_sensors">left_arm-eb2-j0_1-strain</elem>
-      <!-- <elem name="r_arm_ft_sensors">right_arm-eb1-j0_1-strain</elem> -->
+      <elem name="r_arm_ft_sensors">right_arm-eb1-j0_1-strain</elem>
     </paramlist>
   </action>
 

--- a/ergoCubSN003/hardware/motorControl/torso-eb5-j0_2-mc.xml
+++ b/ergoCubSN003/hardware/motorControl/torso-eb5-j0_2-mc.xml
@@ -16,9 +16,9 @@
         <param name="jntPosMax">                23                  45                  43                  </param>
         <param name="jntPosMin">                -23                 -18                 -43                 </param>
         <param name="jntVelMax">                120                 120                 120                 </param>
-        <param name="motorNominalCurrents">     5000                5000                5000               </param>
-        <param name="motorPeakCurrents">        10000               10000               10000               </param>
-        <param name="motorOverloadCurrents">    15000               15000               15000               </param>
+        <param name="motorNominalCurrents">     5000                6000                5000               </param>
+        <param name="motorPeakCurrents">        10000               26000               10000               </param>
+        <param name="motorOverloadCurrents">    15000               26000               15000               </param>
         <param name="motorPwmLimit">            16000               16000               16000               </param>
         <param name="hardwareTemperatureLimits"> 110                110                   110               </param>
         <param name="warningTemperatureLimits">  90                 90                    90                </param>    <!-- keep commented until TemperatureSensorType is not ENABLE by setting it different from NONE-->


### PR DESCRIPTION
In this PR, I changed the configuration file to update:
 1. the current limits 
 2. PWM limits in calibration
 3. re-enable the right arm WBD configuration. @martinaxgloria @MSECode 
 
 The current limits have been updated given the motor characteristics:
 
<img width="1296" height="1015" alt="image" src="https://github.com/user-attachments/assets/02eb7c47-d627-404a-bafd-03b5d738a870" />

<img width="1509" height="218" alt="image" src="https://github.com/user-attachments/assets/f87be34b-3f21-479d-a39c-33c9df06c016" />



 
In addition, during the calibration phase, we need to reduce the PWM limit to `8000`.

The reasoning is as follows:

- The maximum current is `26 A`, but we use `20 A` as a safety margin.
- The motor resistance is approximately `0.4 Ω`, so:

  `20 × 0.4 = 8 V`

- Since the input voltage is approximately `40 V`, rescaling this value to our PWM unit gives `8000`.

Please note that the raw `MAXPWM` value is `32000`.

cc @fgarini @pattacini 