### PR TITLE
Cleanup for ergoCubSNxxx remappers

### DIFF
--- a/ergoCubSN000/wrappers/motorControl/alljoints-mc_remapper.xml
+++ b/ergoCubSN000/wrappers/motorControl/alljoints-mc_remapper.xml
@@ -9,7 +9,6 @@
     <!-- <!-\- These are the parameters with torso_pitch removed -\-> -->
     <!-- <param name="axesNames">(neck_pitch,neck_roll,neck_yaw,camera_tilt,l_shoulder_pitch,l_shoulder_roll,l_shoulder_yaw,l_elbow,l_wrist_yaw,l_wrist_roll,l_wrist_pitch,l_thumb_add,l_thumb_oc,l_index_add,l_index_oc,l_middle_oc,l_ring_pinky_oc,r_shoulder_pitch,r_shoulder_roll,r_shoulder_yaw,r_elbow,r_wrist_yaw,r_wrist_roll,r_wrist_pitch,r_thumb_add,r_thumb_oc,r_index_add,r_index_oc,r_middle_oc,r_ring_pinky_oc,torso_roll,torso_yaw,l_hip_pitch,l_hip_roll,l_hip_yaw,l_knee,l_ankle_pitch,l_ankle_roll,r_hip_pitch,r_hip_roll,r_hip_yaw,r_knee,r_ankle_pitch,r_ankle_roll)</param> -->
 
-    <param name="joints"> 45 </param>
     <action phase="startup" level="6" type="attach">
         <paramlist name="networks">
             <elem name="head_joints">       head-mc_remapper </elem>

--- a/ergoCubSN000/wrappers/motorControl/head-mc_remapper.xml
+++ b/ergoCubSN000/wrappers/motorControl/head-mc_remapper.xml
@@ -2,11 +2,7 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="head-mc_remapper" type="controlboardremapper">
-    <paramlist name="networks">
-        <elem name="head_joints1">(  0  1  0  1 )</elem>
-        <elem name="head_joints2">(  2  3  0  1 )</elem>
-    </paramlist>
-    <param name="joints"> 4                   </param>
+    <param name="axesNames">(neck_pitch,neck_roll,neck_yaw,camera_tilt)</param>
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">
             <elem name="head_joints1">  head-eb20-j0_1-mc </elem>

--- a/ergoCubSN000/wrappers/motorControl/left_arm-mc_remapper.xml
+++ b/ergoCubSN000/wrappers/motorControl/left_arm-mc_remapper.xml
@@ -3,7 +3,6 @@
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mc_remapper" type="controlboardremapper">
     <param name="axesNames">(l_shoulder_pitch,l_shoulder_roll,l_shoulder_yaw,l_elbow,l_wrist_yaw,l_wrist_roll,l_wrist_pitch,l_thumb_add,l_thumb_oc,l_index_add,l_index_oc,l_middle_oc,l_ring_pinky_oc)</param>
-    <param name="joints"> 13 </param>
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">
             <elem name="left_arm_joints1"> left_arm-eb2-j0_1-mc   </elem>

--- a/ergoCubSN000/wrappers/motorControl/left_leg-mc_remapper.xml
+++ b/ergoCubSN000/wrappers/motorControl/left_leg-mc_remapper.xml
@@ -1,11 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-mc_remapper" type="controlboardremapper">
-    <paramlist name="networks">
-        <elem name="left_leg_joints1">(  0  3  0  3 )</elem>
-        <elem name="left_leg_joints2">(  4  5  0  1 )</elem>
-    </paramlist>
-    <param name="joints"> 6                   </param>
+    <param name="axesNames">(l_hip_pitch,l_hip_roll,l_hip_yaw,l_knee,l_ankle_pitch,l_ankle_roll)</param>
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">
             <elem name="left_leg_joints1">  left_leg-eb8-j0_3-mc </elem>

--- a/ergoCubSN000/wrappers/motorControl/right_arm-mc_remapper.xml
+++ b/ergoCubSN000/wrappers/motorControl/right_arm-mc_remapper.xml
@@ -3,7 +3,6 @@
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-mc_remapper" type="controlboardremapper">
     <param name="axesNames">(r_shoulder_pitch,r_shoulder_roll,r_shoulder_yaw,r_elbow,r_wrist_yaw,r_wrist_roll,r_wrist_pitch,r_thumb_add,r_thumb_oc,r_index_add,r_index_oc,r_middle_oc,r_ring_pinky_oc)</param>
-    <param name="joints"> 13 </param>
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">
             <elem name="right_arm_joints1"> right_arm-eb1-j0_1-mc    </elem>

--- a/ergoCubSN000/wrappers/motorControl/right_leg-mc_remapper.xml
+++ b/ergoCubSN000/wrappers/motorControl/right_leg-mc_remapper.xml
@@ -1,11 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-mc_remapper" type="controlboardremapper">
-    <paramlist name="networks">
-        <elem name="right_leg_joints1">(  0  3 0 3 )</elem>
-        <elem name="right_leg_joints2">(  4  5 0 1 )</elem>
-    </paramlist>
-    <param name="joints"> 6                   </param>
+    <param name="axesNames">(r_hip_pitch,r_hip_roll,r_hip_yaw,r_knee,r_ankle_pitch,r_ankle_roll)</param>
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">
             <elem name="right_leg_joints1">  right_leg-eb6-j0_3-mc </elem>

--- a/ergoCubSN000/wrappers/motorControl/right_upperarm-mc_remapper.xml
+++ b/ergoCubSN000/wrappers/motorControl/right_upperarm-mc_remapper.xml
@@ -3,7 +3,6 @@
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_upperarm-mc_remapper" type="controlboardremapper">
     <param name="axesNames">(r_shoulder_pitch,r_shoulder_roll,r_shoulder_yaw,r_elbow)</param>
-    <param name="joints"> 4 </param>
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">
             <elem name="right_arm_joints1"> right_arm-eb1-j0_1-mc    </elem>

--- a/ergoCubSN000/wrappers/motorControl/torso-mc_remapper.xml
+++ b/ergoCubSN000/wrappers/motorControl/torso-mc_remapper.xml
@@ -8,7 +8,6 @@
     
     <!-- This are the parametes with torso_pitch not exposed outside of the yarprobotinterface 
     <param name="axesNames">(torso_roll,torso_yaw)</param> -->
-    <param name="joints"> 3 </param>
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">
             <elem name="torso_joints">  torso-eb5-j0_2-mc </elem>

--- a/ergoCubSN001/wrappers/motorControl/alljoints-mc_remapper.xml
+++ b/ergoCubSN001/wrappers/motorControl/alljoints-mc_remapper.xml
@@ -9,7 +9,6 @@
     <!-- <!-\- These are the parameters with torso_pitch removed -\-> -->
     <!-- <param name="axesNames">(neck_pitch,neck_roll,neck_yaw,camera_tilt,l_shoulder_pitch,l_shoulder_roll,l_shoulder_yaw,l_elbow,l_wrist_yaw,l_wrist_roll,l_wrist_pitch,l_thumb_add,l_thumb_oc,l_index_add,l_index_oc,l_middle_oc,l_ring_pinky_oc,r_shoulder_pitch,r_shoulder_roll,r_shoulder_yaw,r_elbow,r_wrist_yaw,r_wrist_roll,r_wrist_pitch,r_thumb_add,r_thumb_oc,r_index_add,r_index_oc,r_middle_oc,r_ring_pinky_oc,torso_roll,torso_yaw,l_hip_pitch,l_hip_roll,l_hip_yaw,l_knee,l_ankle_pitch,l_ankle_roll,r_hip_pitch,r_hip_roll,r_hip_yaw,r_knee,r_ankle_pitch,r_ankle_roll)</param> -->
 
-    <param name="joints"> 45 </param>
     <action phase="startup" level="6" type="attach">
         <paramlist name="networks">
             <elem name="head_joints">       head-mc_remapper </elem>

--- a/ergoCubSN001/wrappers/motorControl/head-mc_remapper.xml
+++ b/ergoCubSN001/wrappers/motorControl/head-mc_remapper.xml
@@ -2,11 +2,7 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="head-mc_remapper" type="controlboardremapper">
-    <paramlist name="networks">
-        <elem name="head_joints1">(  0  2  0  2 )</elem>
-        <elem name="head_joints2">(  3  3  0  0 )</elem>
-    </paramlist>
-    <param name="joints"> 4                   </param>
+    <param name="axesNames">(neck_pitch,neck_roll,neck_yaw,camera_tilt)</param>
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">
             <elem name="head_joints1">  head-eb20-j0_2-mc </elem>

--- a/ergoCubSN001/wrappers/motorControl/left_arm-mc_remapper.xml
+++ b/ergoCubSN001/wrappers/motorControl/left_arm-mc_remapper.xml
@@ -3,7 +3,6 @@
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mc_remapper" type="controlboardremapper">
     <param name="axesNames">(l_shoulder_pitch,l_shoulder_roll,l_shoulder_yaw,l_elbow,l_wrist_yaw,l_wrist_roll,l_wrist_pitch,l_thumb_add,l_thumb_oc,l_index_add,l_index_oc,l_middle_oc,l_ring_pinky_oc)</param>
-    <param name="joints"> 13 </param>
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">
             <elem name="left_arm_joints1"> left_arm-eb2-j0_1-mc   </elem>

--- a/ergoCubSN001/wrappers/motorControl/left_leg-mc_remapper.xml
+++ b/ergoCubSN001/wrappers/motorControl/left_leg-mc_remapper.xml
@@ -1,11 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-mc_remapper" type="controlboardremapper">
-    <paramlist name="networks">
-        <elem name="left_leg_joints1">(  0  3  0  3 )</elem>
-        <elem name="left_leg_joints2">(  4  5  0  1 )</elem>
-    </paramlist>
-    <param name="joints"> 6                   </param>
+    <param name="axesNames">(l_hip_pitch,l_hip_roll,l_hip_yaw,l_knee,l_ankle_pitch,l_ankle_roll)</param>
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">
             <elem name="left_leg_joints1">  left_leg-eb8-j0_3-mc </elem>

--- a/ergoCubSN001/wrappers/motorControl/right_arm-mc_remapper.xml
+++ b/ergoCubSN001/wrappers/motorControl/right_arm-mc_remapper.xml
@@ -3,7 +3,6 @@
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-mc_remapper" type="controlboardremapper">
     <param name="axesNames">(r_shoulder_pitch,r_shoulder_roll,r_shoulder_yaw,r_elbow,r_wrist_yaw,r_wrist_roll,r_wrist_pitch,r_thumb_add,r_thumb_oc,r_index_add,r_index_oc,r_middle_oc,r_ring_pinky_oc)</param>
-    <param name="joints"> 13 </param>
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">
             <elem name="right_arm_joints1"> right_arm-eb1-j0_1-mc    </elem>

--- a/ergoCubSN001/wrappers/motorControl/right_leg-mc_remapper.xml
+++ b/ergoCubSN001/wrappers/motorControl/right_leg-mc_remapper.xml
@@ -1,11 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-mc_remapper" type="controlboardremapper">
-    <paramlist name="networks">
-        <elem name="right_leg_joints1">(  0  3 0 3 )</elem>
-        <elem name="right_leg_joints2">(  4  5 0 1 )</elem>
-    </paramlist>
-    <param name="joints"> 6                   </param>
+    <param name="axesNames">(r_hip_pitch,r_hip_roll,r_hip_yaw,r_knee,r_ankle_pitch,r_ankle_roll)</param>
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">
             <elem name="right_leg_joints1">  right_leg-eb6-j0_3-mc </elem>

--- a/ergoCubSN001/wrappers/motorControl/torso-mc_remapper.xml
+++ b/ergoCubSN001/wrappers/motorControl/torso-mc_remapper.xml
@@ -8,7 +8,6 @@
     
     <!-- This are the parametes with torso_pitch not exposed outside of the yarprobotinterface 
     <param name="axesNames">(torso_roll,torso_yaw)</param> -->
-    <param name="joints"> 3 </param>
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">
             <elem name="torso_joints">  torso-eb5-j0_2-mc </elem>

--- a/ergoCubSN002/wrappers/motorControl/alljoints-mc_remapper.xml
+++ b/ergoCubSN002/wrappers/motorControl/alljoints-mc_remapper.xml
@@ -9,7 +9,6 @@
     <!-- <!-\- These are the parameters with torso_pitch removed -\-> -->
     <!-- <param name="axesNames">(neck_pitch,neck_roll,neck_yaw,camera_tilt,l_shoulder_pitch,l_shoulder_roll,l_shoulder_yaw,l_elbow,l_wrist_yaw,l_wrist_roll,l_wrist_pitch,l_thumb_add,l_thumb_oc,l_index_add,l_index_oc,l_middle_oc,l_ring_pinky_oc,r_shoulder_pitch,r_shoulder_roll,r_shoulder_yaw,r_elbow,r_wrist_yaw,r_wrist_roll,r_wrist_pitch,r_thumb_add,r_thumb_oc,r_index_add,r_index_oc,r_middle_oc,r_ring_pinky_oc,torso_roll,torso_yaw,l_hip_pitch,l_hip_roll,l_hip_yaw,l_knee,l_ankle_pitch,l_ankle_roll,r_hip_pitch,r_hip_roll,r_hip_yaw,r_knee,r_ankle_pitch,r_ankle_roll)</param> -->
 
-    <param name="joints"> 45 </param>
     <action phase="startup" level="6" type="attach">
         <paramlist name="networks">
             <elem name="head_joints">       head-mc_remapper </elem>

--- a/ergoCubSN002/wrappers/motorControl/head-mc_remapper.xml
+++ b/ergoCubSN002/wrappers/motorControl/head-mc_remapper.xml
@@ -2,11 +2,7 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="head-mc_remapper" type="controlboardremapper">
-    <paramlist name="networks">
-        <elem name="head_joints1">(  0  2  0  2 )</elem>
-        <elem name="head_joints2">(  3  3  0  0 )</elem>
-    </paramlist>
-    <param name="joints"> 4                   </param>
+    <param name="axesNames">(neck_pitch,neck_roll,neck_yaw,camera_tilt)</param>
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">
             <elem name="head_joints1">  head-eb20-j0_2-mc </elem>

--- a/ergoCubSN002/wrappers/motorControl/left_arm-mc_remapper.xml
+++ b/ergoCubSN002/wrappers/motorControl/left_arm-mc_remapper.xml
@@ -3,7 +3,6 @@
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mc_remapper" type="controlboardremapper">
     <param name="axesNames">(l_shoulder_pitch,l_shoulder_roll,l_shoulder_yaw,l_elbow,l_wrist_yaw,l_wrist_roll,l_wrist_pitch,l_thumb_add,l_thumb_oc,l_index_add,l_index_oc,l_middle_oc,l_ring_pinky_oc)</param>
-    <param name="joints"> 13 </param>
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">
             <elem name="left_arm_joints1"> left_arm-eb2-j0_1-mc   </elem>

--- a/ergoCubSN002/wrappers/motorControl/left_leg-mc_remapper.xml
+++ b/ergoCubSN002/wrappers/motorControl/left_leg-mc_remapper.xml
@@ -1,11 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-mc_remapper" type="controlboardremapper">
-    <paramlist name="networks">
-        <elem name="left_leg_joints1">(  0  3  0  3 )</elem>
-        <elem name="left_leg_joints2">(  4  5  0  1 )</elem>
-    </paramlist>
-    <param name="joints"> 6                   </param>
+    <param name="axesNames">(l_hip_pitch,l_hip_roll,l_hip_yaw,l_knee,l_ankle_pitch,l_ankle_roll)</param>
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">
             <elem name="left_leg_joints1">  left_leg-eb8-j0_3-mc </elem>

--- a/ergoCubSN002/wrappers/motorControl/right_arm-mc_remapper.xml
+++ b/ergoCubSN002/wrappers/motorControl/right_arm-mc_remapper.xml
@@ -3,7 +3,6 @@
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-mc_remapper" type="controlboardremapper">
     <param name="axesNames">(r_shoulder_pitch,r_shoulder_roll,r_shoulder_yaw,r_elbow,r_wrist_yaw,r_wrist_roll,r_wrist_pitch,r_thumb_add,r_thumb_oc,r_index_add,r_index_oc,r_middle_oc,r_ring_pinky_oc)</param>
-    <param name="joints"> 13 </param>
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">
             <elem name="right_arm_joints1"> right_arm-eb1-j0_1-mc    </elem>

--- a/ergoCubSN002/wrappers/motorControl/right_leg-mc_remapper.xml
+++ b/ergoCubSN002/wrappers/motorControl/right_leg-mc_remapper.xml
@@ -1,11 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-mc_remapper" type="controlboardremapper">
-    <paramlist name="networks">
-        <elem name="right_leg_joints1">(  0  3 0 3 )</elem>
-        <elem name="right_leg_joints2">(  4  5 0 1 )</elem>
-    </paramlist>
-    <param name="joints"> 6                   </param>
+    <param name="axesNames">(r_hip_pitch,r_hip_roll,r_hip_yaw,r_knee,r_ankle_pitch,r_ankle_roll)</param>
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">
             <elem name="right_leg_joints1">  right_leg-eb6-j0_3-mc </elem>

--- a/ergoCubSN002/wrappers/motorControl/torso-mc_remapper.xml
+++ b/ergoCubSN002/wrappers/motorControl/torso-mc_remapper.xml
@@ -8,7 +8,6 @@
     
     <!-- This are the parametes with torso_pitch not exposed outside of the yarprobotinterface 
     <param name="axesNames">(torso_roll,torso_yaw)</param> -->
-    <param name="joints"> 3 </param>
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">
             <elem name="torso_joints">  torso-eb5-j0_2-mc </elem>

--- a/ergoCubSN003/wrappers/motorControl/alljoints-mc_remapper.xml
+++ b/ergoCubSN003/wrappers/motorControl/alljoints-mc_remapper.xml
@@ -9,7 +9,6 @@
     <!-- <!-\- These are the parameters with torso_pitch removed -\-> -->
     <!-- <param name="axesNames">(neck_pitch,neck_roll,neck_yaw,camera_tilt,l_shoulder_pitch,l_shoulder_roll,l_shoulder_yaw,l_elbow,l_wrist_yaw,l_wrist_roll,l_wrist_pitch,l_thumb_add,l_thumb_oc,l_index_add,l_index_oc,l_middle_oc,l_ring_pinky_oc,r_shoulder_pitch,r_shoulder_roll,r_shoulder_yaw,r_elbow,r_wrist_yaw,r_wrist_roll,r_wrist_pitch,r_thumb_add,r_thumb_oc,r_index_add,r_index_oc,r_middle_oc,r_ring_pinky_oc,torso_roll,torso_yaw,l_hip_pitch,l_hip_roll,l_hip_yaw,l_knee,l_ankle_pitch,l_ankle_roll,r_hip_pitch,r_hip_roll,r_hip_yaw,r_knee,r_ankle_pitch,r_ankle_roll)</param> -->
 
-    <param name="joints"> 45 </param>
     <action phase="startup" level="6" type="attach">
         <paramlist name="networks">
             <elem name="head_joints">       head-mc_remapper </elem>

--- a/ergoCubSN003/wrappers/motorControl/head-mc_remapper.xml
+++ b/ergoCubSN003/wrappers/motorControl/head-mc_remapper.xml
@@ -2,11 +2,7 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="head-mc_remapper" type="controlboardremapper">
-    <paramlist name="networks">
-        <elem name="head_joints1">(  0  2  0  2 )</elem>
-        <elem name="head_joints2">(  3  3  0  0 )</elem>
-    </paramlist>
-    <param name="joints"> 4                   </param>
+    <param name="axesNames">(neck_pitch,neck_roll,neck_yaw,camera_tilt)</param>
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">
             <elem name="head_joints1">  head-eb20-j0_2-mc </elem>

--- a/ergoCubSN003/wrappers/motorControl/left_arm-mc_remapper.xml
+++ b/ergoCubSN003/wrappers/motorControl/left_arm-mc_remapper.xml
@@ -3,7 +3,6 @@
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mc_remapper" type="controlboardremapper">
     <param name="axesNames">(l_shoulder_pitch,l_shoulder_roll,l_shoulder_yaw,l_elbow,l_wrist_yaw,l_wrist_roll,l_wrist_pitch,l_thumb_add,l_thumb_oc,l_index_add,l_index_oc,l_middle_oc,l_ring_pinky_oc)</param>
-    <param name="joints"> 13 </param>
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">
             <elem name="left_arm_joints1"> left_arm-eb2-j0_1-mc   </elem>

--- a/ergoCubSN003/wrappers/motorControl/left_leg-mc_remapper.xml
+++ b/ergoCubSN003/wrappers/motorControl/left_leg-mc_remapper.xml
@@ -1,11 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-mc_remapper" type="controlboardremapper">
-    <paramlist name="networks">
-        <elem name="left_leg_joints1">(  0  3  0  3 )</elem>
-        <elem name="left_leg_joints2">(  4  5  0  1 )</elem>
-    </paramlist>
-    <param name="joints"> 6                   </param>
+    <param name="axesNames">(l_hip_pitch,l_hip_roll,l_hip_yaw,l_knee,l_ankle_pitch,l_ankle_roll)</param>
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">
             <elem name="left_leg_joints1">  left_leg-eb8-j0_3-mc </elem>

--- a/ergoCubSN003/wrappers/motorControl/right_arm-mc_remapper.xml
+++ b/ergoCubSN003/wrappers/motorControl/right_arm-mc_remapper.xml
@@ -3,7 +3,6 @@
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-mc_remapper" type="controlboardremapper">
     <param name="axesNames">(r_shoulder_pitch,r_shoulder_roll,r_shoulder_yaw,r_elbow,r_wrist_yaw,r_wrist_roll,r_wrist_pitch,r_thumb_add,r_thumb_oc,r_index_add,r_index_oc,r_middle_oc,r_ring_pinky_oc)</param>
-    <param name="joints"> 13 </param>
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">
             <elem name="right_arm_joints1"> right_arm-eb1-j0_1-mc    </elem>

--- a/ergoCubSN003/wrappers/motorControl/right_leg-mc_remapper.xml
+++ b/ergoCubSN003/wrappers/motorControl/right_leg-mc_remapper.xml
@@ -1,11 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-mc_remapper" type="controlboardremapper">
-    <paramlist name="networks">
-        <elem name="right_leg_joints1">(  0  3 0 3 )</elem>
-        <elem name="right_leg_joints2">(  4  5 0 1 )</elem>
-    </paramlist>
-    <param name="joints"> 6                   </param>
+    <param name="axesNames">(r_hip_pitch,r_hip_roll,r_hip_yaw,r_knee,r_ankle_pitch,r_ankle_roll)</param>
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">
             <elem name="right_leg_joints1">  right_leg-eb6-j0_3-mc </elem>

--- a/ergoCubSN003/wrappers/motorControl/torso-mc_remapper.xml
+++ b/ergoCubSN003/wrappers/motorControl/torso-mc_remapper.xml
@@ -8,7 +8,6 @@
     
     <!-- This are the parametes with torso_pitch not exposed outside of the yarprobotinterface 
     <param name="axesNames">(torso_roll,torso_yaw)</param> -->
-    <param name="joints"> 3 </param>
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">
             <elem name="torso_joints">  torso-eb5-j0_2-mc </elem>

--- a/tests/dry-run/check-xml/schemas/remapper.xsd
+++ b/tests/dry-run/check-xml/schemas/remapper.xsd
@@ -4,38 +4,11 @@
   <xs:element name="device">
     <xs:complexType>
       <xs:sequence>
-        <xs:choice>
-          <xs:element name="paramlist">
-            <xs:complexType>
-              <xs:sequence>
-                <xs:element minOccurs="1" maxOccurs="unbounded" name="elem">
-                  <xs:complexType>
-                    <xs:simpleContent>
-                      <xs:extension base="xs:string">
-                        <xs:attribute name="name" type="xs:string" use="required" />
-                      </xs:extension>
-                    </xs:simpleContent>
-                  </xs:complexType>
-                </xs:element>
-              </xs:sequence>
-              <xs:attribute name="name" type="xs:string" use="required" fixed="networks"/>
-            </xs:complexType>
-          </xs:element>
-          <xs:element name="param">
-            <xs:complexType>
-              <xs:simpleContent>
-                <xs:extension base="xs:string">
-                  <xs:attribute name="name" type="xs:string" use="required" fixed="axesNames" />
-                </xs:extension>
-              </xs:simpleContent>
-            </xs:complexType>
-          </xs:element>
-        </xs:choice>
         <xs:element name="param">
           <xs:complexType>
             <xs:simpleContent>
               <xs:extension base="xs:string">
-                <xs:attribute name="name" type="xs:string" use="required" fixed="joints" />
+                <xs:attribute name="name" type="xs:string" use="required" fixed="axesNames" />
               </xs:extension>
             </xs:simpleContent>
           </xs:complexType>


### PR DESCRIPTION
This PR is a cleanup, prepared by a script, for ergoCub remapper files, with no functional changes. 
It's valid for both YARP 3.x and 4.x series.

In these modified remapper files, the joint numeric indices (deprecated syntax, will be removed soon) have been replaced by joint names, and the parameter `joints` (number of joints) has been removed because it is no longer used.
