### PR TITLE
remapper cleanup for R1SN003

### DIFF
--- a/R1SN003/wrappers/motorControl/cer_alljoints_remapper.xml
+++ b/R1SN003/wrappers/motorControl/cer_alljoints_remapper.xml
@@ -1,17 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_all_joints_mc_remapper" type="controlboardremapper">
-    <paramlist name="networks">
-        <elem name="base">(            0  1   0  1 )</elem>
-        <elem name="head">(            2  3   0  1 )</elem>
-        <elem name="torso">(           4  6   0  2 )</elem>
-        <elem name="torso_yaw">(       7  7   3  3 )</elem>
-        <elem name="right_arm">(       8  14  0  6 )</elem>
-        <elem name="left_arm">(        15 21  0  6 )</elem>
-    <!--    <elem name="right_hand">(      22 23  0  1 )</elem>  -->
-    <!--    <elem name="left_hand">(       24 25  0  1 )</elem>  -->
-    </paramlist>
-    <param name="joints"> 22 </param>
+    <param name="axesNames">(mobile_base_l_wheel_joint,mobile_base_r_wheel_joint,neck_pitch_joint,neck_yaw_joint,torso_heave_eq_joint,torso_pitch_eq_joint,torso_roll_eq_joint,torso_yaw_joint,r_shoulder_pitch,r_shoulder_roll,r_shoulder_yaw,r_elbow,r_wrist_yaw,r_wrist_roll,r_wrist_pitch,l_shoulder_pitch,l_shoulder_roll,l_shoulder_yaw,l_elbow,l_wrist_yaw,l_wrist_roll,l_wrist_pitch)</param>
     <action phase="startup" level="6" type="attach">
         <paramlist name="networks">
             <elem name="head">            cer_head_mc               </elem>
@@ -19,9 +9,7 @@
             <elem name="torso_yaw">       cer_torso_mc              </elem>
             <elem name="base">            cer_mobile_base_mc        </elem>
             <elem name="right_arm">       right_arm_no_hand_mc_remapper  </elem>
-     <!--       <elem name="right_hand">      right_hand_mc         </elem>  -->
             <elem name="left_arm">        left_arm_no_hand_mc_remapper   </elem>
-     <!--       <elem name="left_hand">       left_hand_mc          </elem>  -->
         </paramlist>
     </action>
     <action phase="shutdown" level="19" type="detach" />

--- a/R1SN003/wrappers/motorControl/cer_base-mc_remapper.xml
+++ b/R1SN003/wrappers/motorControl/cer_base-mc_remapper.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_mobile_base_mc_remapper" type="controlboardremapper">
-    <paramlist name="networks">
-        <elem name="FirstSetOfJoints">( 0  1  0  1 )</elem>
-    </paramlist>
-    <param name="joints"> 2 </param>
+    <param name="axesNames">(mobile_base_l_wheel_joint,mobile_base_r_wheel_joint)</param>
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">
             <elem name="FirstSetOfJoints"> cer_mobile_base_mc </elem>

--- a/R1SN003/wrappers/motorControl/cer_head-mc_remapper.xml
+++ b/R1SN003/wrappers/motorControl/cer_head-mc_remapper.xml
@@ -1,11 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_head_mc_remapper" type="controlboardremapper">
-    <paramlist name="networks">
-        <!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
-        <elem name="FirstSetOfJoints">( 0  1  0  1 )</elem>
-    </paramlist>
-    <param name="joints"> 2 </param>
+    <param name="axesNames">(neck_pitch_joint,neck_yaw_joint)</param>
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">
             <elem name="FirstSetOfJoints"> cer_head_mc </elem>

--- a/R1SN003/wrappers/motorControl/cer_torso-mc_remapper.xml
+++ b/R1SN003/wrappers/motorControl/cer_torso-mc_remapper.xml
@@ -1,11 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_torso_mc_remapper" type="controlboardremapper">
-    <paramlist name="networks">
-        <elem name="FirstSetOfJoints">( 0  2  0  2 )</elem>
-        <elem name="SecondSetOfJoints">( 3  3  3  3 )</elem>
-    </paramlist>
-    <param name="joints"> 4 </param>
+    <param name="axesNames">(torso_heave_eq_joint,torso_pitch_eq_joint,torso_roll_eq_joint,torso_yaw_joint)</param>
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">
             <elem name="FirstSetOfJoints">  cer_torso_equivalent_mc </elem>

--- a/R1SN003/wrappers/motorControl/cer_torso_tripod-mc_remapper.xml
+++ b/R1SN003/wrappers/motorControl/cer_torso_tripod-mc_remapper.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_torso_tripod_mc_remapper" type="controlboardremapper">
-    <paramlist name="networks">
-        <elem name="FirstSetOfJoints">(  0  2  0  2 )</elem>
-    </paramlist>
-    <param name="joints"> 3                  </param>
+    <param name="axesNames">(torso_tripod_0,torso_tripod_1,torso_tripod_2)</param>
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">
             <elem name="FirstSetOfJoints"> cer_torso_mc </elem>

--- a/R1SN003/wrappers/motorControl/left_arm-mc_remapper.xml
+++ b/R1SN003/wrappers/motorControl/left_arm-mc_remapper.xml
@@ -3,7 +3,6 @@
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mc_remapper" type="controlboardremapper">
     <param name="axesNames">(l_shoulder_pitch,l_shoulder_roll,l_shoulder_yaw,l_elbow,l_wrist_yaw,l_wrist_roll,l_wrist_pitch,l_thumb_add,l_thumb_oc,l_index_add,l_index_oc,l_middle_oc,l_ring_pinky_oc)</param>
-    <param name="joints"> 13 </param>
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">
             <elem name="left_arm_joints1"> left_arm-eb2-j0_1-mc   </elem>

--- a/R1SN003/wrappers/motorControl/left_arm_no_hand-mc_remapper.xml
+++ b/R1SN003/wrappers/motorControl/left_arm_no_hand-mc_remapper.xml
@@ -3,7 +3,6 @@
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm_no_hand_mc_remapper" type="controlboardremapper">
     <param name="axesNames">(l_shoulder_pitch,l_shoulder_roll,l_shoulder_yaw,l_elbow,l_wrist_yaw,l_wrist_roll,l_wrist_pitch)</param>
-    <param name="joints"> 7 </param>
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">
             <elem name="left_arm_joints1"> left_arm-eb2-j0_1-mc   </elem>

--- a/R1SN003/wrappers/motorControl/right_arm-mc_remapper.xml
+++ b/R1SN003/wrappers/motorControl/right_arm-mc_remapper.xml
@@ -3,7 +3,6 @@
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-mc_remapper" type="controlboardremapper">
     <param name="axesNames">(r_shoulder_pitch,r_shoulder_roll,r_shoulder_yaw,r_elbow,r_wrist_yaw,r_wrist_roll,r_wrist_pitch,r_thumb_add,r_thumb_oc,r_index_add,r_index_oc,r_middle_oc,r_ring_pinky_oc)</param>
-    <param name="joints"> 13 </param>
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">
             <elem name="right_arm_joints1"> right_arm-eb5-j0_1-mc    </elem>

--- a/R1SN003/wrappers/motorControl/right_arm_no_hand-mc_remapper.xml
+++ b/R1SN003/wrappers/motorControl/right_arm_no_hand-mc_remapper.xml
@@ -3,7 +3,6 @@
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm_no_hand_mc_remapper" type="controlboardremapper">
     <param name="axesNames">(r_shoulder_pitch,r_shoulder_roll,r_shoulder_yaw,r_elbow,r_wrist_yaw,r_wrist_roll,r_wrist_pitch)</param>
-    <param name="joints"> 7 </param>
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">
             <elem name="right_arm_joints1"> right_arm-eb5-j0_1-mc    </elem>


### PR DESCRIPTION
Updated remapper files for R1SN003

Already tested on the robot

Can be merged asap please? It's critical for YARP 4.1 (under development) already deployed on the robot